### PR TITLE
fix: rename conversionRate to minConversionRate in DepositCurrencyAdded event

### DIFF
--- a/contracts/interfaces/IEscrow.sol
+++ b/contracts/interfaces/IEscrow.sol
@@ -75,7 +75,7 @@ interface IEscrow {
     event DepositPaymentMethodAdded(uint256 indexed depositId, bytes32 indexed paymentMethod, bytes32 indexed payeeDetails, address intentGatingService);
     event DepositPaymentMethodRemoved(uint256 indexed depositId, bytes32 indexed paymentMethod);
 
-    event DepositCurrencyAdded(uint256 indexed depositId, bytes32 indexed paymentMethod, bytes32 indexed currency, uint256 conversionRate);
+    event DepositCurrencyAdded(uint256 indexed depositId, bytes32 indexed paymentMethod, bytes32 indexed currency, uint256 minConversionRate);
     event DepositCurrencyRemoved(uint256 indexed depositId, bytes32 indexed paymentMethod, bytes32 indexed currencyCode);        
 
     event DepositFundsAdded(uint256 indexed depositId, address indexed depositor, uint256 amount);

--- a/test/escrow/escrow.spec.ts
+++ b/test/escrow/escrow.spec.ts
@@ -352,13 +352,13 @@ describe("Escrow", () => {
       expect(events[0].args.depositId).to.equal(0);
       expect(events[0].args.paymentMethod).to.equal(subjectPaymentMethods[0]);
       expect(events[0].args.currency).to.equal(subjectCurrencies[0][0].code);
-      expect(events[0].args.conversionRate).to.equal(subjectCurrencies[0][0].minConversionRate);
+      expect(events[0].args.minConversionRate).to.equal(subjectCurrencies[0][0].minConversionRate);
 
       // Second event  
       expect(events[1].args.depositId).to.equal(0);
       expect(events[1].args.paymentMethod).to.equal(subjectPaymentMethods[0]);
       expect(events[1].args.currency).to.equal(subjectCurrencies[0][1].code);
-      expect(events[1].args.conversionRate).to.equal(subjectCurrencies[0][1].minConversionRate);
+      expect(events[1].args.minConversionRate).to.equal(subjectCurrencies[0][1].minConversionRate);
     });
 
     describe("when there are multiple payment methods", async () => {


### PR DESCRIPTION
`minConversionRate` is the correct name for that variable in v2.1 

### Todo
- [ ] Update the event definition in @zkp2p-indexer