### PR TITLE
chore: add automated CLAUDE.md update workflow

### DIFF
--- a/.github/prompts/update-docs.md
+++ b/.github/prompts/update-docs.md
@@ -1,0 +1,36 @@
+# Update CLAUDE.md for zkp2p-v2-contracts
+
+You are updating the CLAUDE.md file for a Solidity smart contracts repository that uses Foundry and Hardhat. This is a ZKP2P v2 protocol for trustless peer-to-peer fiat-to-crypto exchanges.
+
+## Steps
+
+1. **Read the current CLAUDE.md** at the repo root.
+
+2. **Analyze recent changes** by reviewing git commits since the last CLAUDE.md modification:
+   - Run `git log --oneline --since="$(git log -1 --format=%ci CLAUDE.md 2>/dev/null || echo '30 days ago')" -- . ':!CLAUDE.md'` to see recent commits.
+   - Focus on changes to: `contracts/`, `test/`, `test-foundry/`, `deploy/`, `hardhat.config.ts`, `foundry.toml`, `package.json`, and `deployments/`.
+
+3. **Identify what needs updating** in CLAUDE.md:
+   - New Solidity contracts or modules added
+   - Changed contract interfaces or function signatures
+   - New or modified deploy scripts
+   - Updated test commands, build steps, or Foundry/Hardhat configuration
+   - New registries, verifiers, or protocol components
+   - Updated network deployments or addresses
+   - New utility functions or testing patterns
+
+4. **Update CLAUDE.md** to reflect the current state:
+   - Keep the file under 200 lines (token-efficient for AI context)
+   - Maintain the existing structure and section ordering
+   - Update build/test commands if package.json scripts changed
+   - Update architecture diagrams if contract relationships changed
+   - Update code organization if directory structure changed
+   - Add new patterns or conventions discovered in recent commits
+
+## Rules
+
+- ONLY modify CLAUDE.md - do NOT touch any code files
+- Do NOT add information you cannot verify from the codebase
+- Do NOT remove sections that are still accurate
+- Preserve the existing markdown formatting style
+- If nothing meaningful has changed, make no edits

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,85 @@
+name: Update CLAUDE.md
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # Daily at 2am UTC
+  workflow_dispatch:
+  repository_dispatch:
+    types: [update-docs]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run Claude to update CLAUDE.md
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          claude -p "$(cat .github/prompts/update-docs.md)" \
+            --allowedTools "Read,Glob,Grep,Write,Edit" \
+            --model claude-sonnet-4-6 \
+            --max-turns 15
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if [ -n "$(git diff -- CLAUDE.md)" ] || [ -n "$(git ls-files --others --exclude-standard -- CLAUDE.md)" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="auto-docs/update-$(date +%Y-%m-%d)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add CLAUDE.md
+          git commit -m "docs: daily CLAUDE.md update"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "docs: daily doc update" \
+            --body "Automated daily update of CLAUDE.md to reflect recent codebase changes." \
+            --label "auto-docs"
+          gh pr merge --squash --delete-branch
+
+  notify-internal-docs:
+    needs: update-docs
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if docs PR was merged
+        id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="auto-docs/update-$(date +%Y-%m-%d)"
+          PR=$(gh pr list --repo ${{ github.repository }} --head "$BRANCH" --state merged --json number -q '.[0].number' 2>/dev/null || true)
+          if [ -n "$PR" ]; then
+            echo "merged=true" >> $GITHUB_OUTPUT
+          fi
+        continue-on-error: true
+
+      - name: Notify internal-docs repo
+        if: steps.check.outputs.merged == 'true'
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/zkp2p/zkp2p-internal-docs/dispatches \
+            -f event_type=repo-docs-updated \
+            -f client_payload[repo]=${{ github.repository }}

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   update-docs:
     runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.create-pr.outputs.branch }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -40,11 +42,13 @@ jobs:
           fi
 
       - name: Create Pull Request
+        id: create-pr
         if: steps.changes.outputs.has_changes == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BRANCH="auto-docs/update-$(date +%Y-%m-%d)"
+          BRANCH="auto-docs/update-$(date +%Y-%m-%d)-${{ github.run_id }}"
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
@@ -55,7 +59,7 @@ jobs:
             --title "docs: daily doc update" \
             --body "Automated daily update of CLAUDE.md to reflect recent codebase changes." \
             --label "auto-docs"
-          gh pr merge --squash --delete-branch
+          gh pr merge --auto --squash --delete-branch
 
   notify-internal-docs:
     needs: update-docs
@@ -67,7 +71,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BRANCH="auto-docs/update-$(date +%Y-%m-%d)"
+          BRANCH="${{ needs.update-docs.outputs.branch }}"
+          if [ -z "$BRANCH" ]; then
+            echo "No branch output from update-docs job, skipping"
+            exit 0
+          fi
           PR=$(gh pr list --repo ${{ github.repository }} --head "$BRANCH" --state merged --json number -q '.[0].number' 2>/dev/null || true)
           if [ -n "$PR" ]; then
             echo "merged=true" >> $GITHUB_OUTPUT
@@ -78,7 +86,7 @@ jobs:
         if: steps.check.outputs.merged == 'true'
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.INTERNAL_DOCS_PAT }}
         run: |
           gh api repos/zkp2p/zkp2p-internal-docs/dispatches \
             -f event_type=repo-docs-updated \

--- a/.gitignore
+++ b/.gitignore
@@ -15,19 +15,14 @@ yarn-error.log
 
 .yarn/install-state.gz
 
-*CLAUDE.md
-
-CLAUDE.md
-*/CLAUDE.md
-*/*/CLAUDE.md
-*/*/*/CLAUDE.md
 docs/ai-context/
 
 out/
 cache_forge/
 
-AGENTS.md
-
-
 docs/
 ./scripts
+
+# AI agent local overrides
+CLAUDE.local.md
+AGENTS.override.md


### PR DESCRIPTION
## Summary
- Adds a daily GitHub Actions workflow (2am UTC) that uses Claude CLI in headless mode to keep `CLAUDE.md` fresh
- Includes a repo-specific prompt (`.github/prompts/update-docs.md`) tailored for Solidity/Foundry
- Auto-creates and merges PRs when docs change
- Scoped `git add CLAUDE.md` (not `-A`) to prevent unintended file staging
- Dispatch to `zkp2p-internal-docs` only fires after confirmed PR merge
- Removes `CLAUDE.md` / `AGENTS.md` from `.gitignore` so they can be tracked
- Adds `CLAUDE.local.md` and `AGENTS.override.md` to `.gitignore`

## Setup required after merge
1. Add `ANTHROPIC_API_KEY` to repo secrets (Settings > Secrets > Actions)
2. Enable auto-merge in repo settings (Settings > General > Allow auto-merge)
3. Optionally create an `auto-docs` label

## Test plan
- [ ] Trigger manually via `gh workflow run update-docs.yml` after adding API key
- [ ] Verify PR is created with CLAUDE.md updates
- [ ] Verify merge completes and dispatch fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zkp2p/zkp2p-contracts/pull/128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
