### PR TITLE
Add tranche-aware RateManagerV2

### DIFF
--- a/contracts/RateManagerV2.sol
+++ b/contracts/RateManagerV2.sol
@@ -1,0 +1,594 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
+import { IEscrow } from "./interfaces/IEscrow.sol";
+import { IEscrowRegistry } from "./interfaces/IEscrowRegistry.sol";
+import { IRateManager } from "./interfaces/IRateManager.sol";
+import { IRateManagerV1Migratable } from "./interfaces/IRateManagerV1Migratable.sol";
+
+/**
+ * @title RateManagerV2
+ * @notice Delegated rate registry that keeps the V1 fixed-rate surface and adds liquidity tranches.
+ * @dev Tranche rates are resolved against the delegated deposit's current total liquidity
+ *      (`remainingDeposits + outstandingIntentAmount`). The first tranche whose `maxLiquidity`
+ *      covers that liquidity is considered active. When tranches exist for a tuple, they replace
+ *      the flat manager rate for that tuple.
+ */
+contract RateManagerV2 is Ownable, IRateManager {
+    /* ============ Constants ============ */
+
+    uint256 public constant GLOBAL_MAX_MANAGER_FEE = 5e16; // 5%
+
+    /* ============ Structs ============ */
+
+    struct RateManagerConfig {
+        address manager;
+        address feeRecipient;
+        uint256 maxFee;
+        uint256 fee;
+        uint256 minLiquidity;
+        string name;
+        string uri;
+    }
+
+    struct TrancheRate {
+        uint256 maxLiquidity;
+        uint256 rate;
+    }
+
+    struct LegacySource {
+        address rateManager;
+        bytes32 rateManagerId;
+    }
+
+    /* ============ Custom Errors ============ */
+
+    error ZeroAddress();
+    error ZeroValue();
+    error UnauthorizedCaller(address caller, address authorized);
+    error ArrayLengthMismatch(uint256 length1, uint256 length2);
+    error RateManagerNotFound(bytes32 rateManagerId);
+    error RateManagerAlreadyExists(bytes32 rateManagerId);
+    error FeeExceedsMaximum(uint256 fee, uint256 maximum);
+    error BelowMinLiquidity(uint256 totalLiquidity, uint256 required);
+    error UnauthorizedEscrow(address escrow);
+    error InvalidLegacyRateManager(address legacyRateManager);
+    error InvalidTrancheOrder(uint256 previousMaxLiquidity, uint256 nextMaxLiquidity);
+
+    /* ============ Events ============ */
+
+    event RateManagerCreated(
+        bytes32 indexed rateManagerId,
+        address indexed manager,
+        address indexed feeRecipient,
+        uint256 maxFee,
+        uint256 fee,
+        string name,
+        string uri
+    );
+
+    event RateManagerConfigUpdated(
+        bytes32 indexed rateManagerId,
+        address indexed manager,
+        address indexed feeRecipient,
+        string name,
+        string uri
+    );
+
+    event RateManagerFeeUpdated(bytes32 indexed rateManagerId, uint256 fee);
+    event RateManagerRateUpdated(bytes32 indexed rateManagerId, bytes32 indexed paymentMethod, bytes32 indexed currencyCode, uint256 rate);
+    event RateManagerRatesBatchUpdated(bytes32 indexed rateManagerId, uint256 totalUpdated);
+    event RateManagerImported(
+        bytes32 indexed rateManagerId,
+        address indexed legacyRateManager,
+        bytes32 indexed legacyRateManagerId,
+        uint256 totalCopied
+    );
+    event RateManagerTrancheRateUpdated(
+        bytes32 indexed rateManagerId,
+        bytes32 indexed paymentMethod,
+        bytes32 indexed currencyCode,
+        uint256 maxLiquidity,
+        uint256 rate
+    );
+    event RateManagerTrancheRatesUpdated(
+        bytes32 indexed rateManagerId,
+        bytes32 indexed paymentMethod,
+        bytes32 indexed currencyCode,
+        uint256 totalUpdated
+    );
+    event RateManagerTrancheRatesCleared(
+        bytes32 indexed rateManagerId,
+        bytes32 indexed paymentMethod,
+        bytes32 indexed currencyCode
+    );
+    event MinLiquidityUpdated(bytes32 indexed rateManagerId, uint256 minLiquidity);
+    event EscrowRegistryUpdated(address indexed escrowRegistry);
+
+    /* ============ State Variables ============ */
+
+    IEscrowRegistry public escrowRegistry;
+    uint256 internal nextRateManagerId = 1;
+
+    mapping(bytes32 => RateManagerConfig) internal rateManagers;
+    mapping(bytes32 => LegacySource) internal legacySources;
+    mapping(bytes32 => mapping(bytes32 => mapping(bytes32 => uint256))) internal rates;
+    mapping(bytes32 => mapping(bytes32 => mapping(bytes32 => bool))) internal hasRateOverride;
+    mapping(bytes32 => mapping(bytes32 => mapping(bytes32 => TrancheRate[]))) internal trancheRates;
+
+    /* ============ Constructor ============ */
+
+    constructor(address _escrowRegistry) Ownable() {
+        if (_escrowRegistry == address(0)) revert ZeroAddress();
+        escrowRegistry = IEscrowRegistry(_escrowRegistry);
+    }
+
+    /* ============ Modifiers ============ */
+
+    modifier onlyManager(bytes32 _rateManagerId) {
+        address manager = rateManagers[_rateManagerId].manager;
+        if (manager == address(0)) revert RateManagerNotFound(_rateManagerId);
+        if (msg.sender != manager) revert UnauthorizedCaller(msg.sender, manager);
+        _;
+    }
+
+    /* ============ External Functions ============ */
+
+    /**
+     * @notice Creates a new V2 manager while preserving the V1 config shape.
+     * @param _config Mutable manager configuration.
+     * @return rateManagerId Newly created manager id.
+     */
+    function createRateManager(RateManagerConfig calldata _config) external returns (bytes32 rateManagerId) {
+        _validateConfig(_config);
+
+        rateManagerId = keccak256(abi.encodePacked(address(this), nextRateManagerId++));
+        rateManagers[rateManagerId] = _config;
+
+        _emitRateManagerCreated(rateManagerId, _config);
+    }
+
+    /**
+     * @notice Copies an existing V1 manager config into V2 and optionally copies flat tuple rates.
+     * @dev The imported V2 manager intentionally reuses the legacy `rateManagerId` so downstream
+     *      systems can keep referring to the same logical manager identity after the contract switch.
+     * @param _legacyRateManager Source RateManagerV1 contract.
+     * @param _legacyRateManagerId Source manager id on the legacy contract.
+     * @param _paymentMethods Payment methods to copy from the legacy manager.
+     * @param _currencyCodes Currency lists aligned with `_paymentMethods`.
+     * @return rateManagerId Imported manager id. Equal to `_legacyRateManagerId`.
+     */
+    function importRateManager(
+        address _legacyRateManager,
+        bytes32 _legacyRateManagerId,
+        bytes32[] calldata _paymentMethods,
+        bytes32[][] calldata _currencyCodes
+    )
+        external
+        returns (bytes32 rateManagerId)
+    {
+        if (_legacyRateManager == address(0)) revert ZeroAddress();
+        if (_legacyRateManager.code.length == 0) revert InvalidLegacyRateManager(_legacyRateManager);
+        if (_paymentMethods.length != _currencyCodes.length) {
+            revert ArrayLengthMismatch(_paymentMethods.length, _currencyCodes.length);
+        }
+
+        IRateManagerV1Migratable legacyRateManager = IRateManagerV1Migratable(_legacyRateManager);
+        if (!legacyRateManager.isRateManager(_legacyRateManagerId)) revert RateManagerNotFound(_legacyRateManagerId);
+
+        rateManagerId = _legacyRateManagerId;
+        if (isRateManager(rateManagerId)) revert RateManagerAlreadyExists(rateManagerId);
+
+        IRateManagerV1Migratable.RateManagerConfig memory legacyConfig = legacyRateManager.getRateManager(_legacyRateManagerId);
+        RateManagerConfig memory importedConfig = RateManagerConfig({
+            manager: legacyConfig.manager,
+            feeRecipient: legacyConfig.feeRecipient,
+            maxFee: legacyConfig.maxFee,
+            fee: legacyConfig.fee,
+            minLiquidity: legacyConfig.minLiquidity,
+            name: legacyConfig.name,
+            uri: legacyConfig.uri
+        });
+        _validateConfig(importedConfig);
+
+        rateManagers[rateManagerId] = importedConfig;
+        legacySources[rateManagerId] = LegacySource({
+            rateManager: _legacyRateManager,
+            rateManagerId: _legacyRateManagerId
+        });
+
+        _emitRateManagerCreated(rateManagerId, importedConfig);
+
+        uint256 totalCopied;
+        for (uint256 i = 0; i < _paymentMethods.length; i++) {
+            bytes32 paymentMethod = _paymentMethods[i];
+            if (paymentMethod == bytes32(0)) revert ZeroValue();
+
+            for (uint256 j = 0; j < _currencyCodes[i].length; j++) {
+                bytes32 currencyCode = _currencyCodes[i][j];
+                if (currencyCode == bytes32(0)) revert ZeroValue();
+
+                uint256 rate = legacyRateManager.getManagerRate(_legacyRateManagerId, paymentMethod, currencyCode);
+                _setFlatRate(rateManagerId, paymentMethod, currencyCode, rate);
+                totalCopied++;
+            }
+        }
+
+        emit RateManagerRatesBatchUpdated(rateManagerId, totalCopied);
+        emit RateManagerImported(rateManagerId, _legacyRateManager, _legacyRateManagerId, totalCopied);
+    }
+
+    /**
+     * @notice Updates mutable manager config fields.
+     * @dev `maxFee` remains immutable once the manager id exists.
+     */
+    function setRateManagerConfig(
+        bytes32 _rateManagerId,
+        address _manager,
+        address _feeRecipient,
+        string calldata _name,
+        string calldata _uri
+    )
+        external
+        onlyManager(_rateManagerId)
+    {
+        if (_manager == address(0)) revert ZeroAddress();
+
+        RateManagerConfig storage config = rateManagers[_rateManagerId];
+        if (config.fee > 0 && _feeRecipient == address(0)) revert ZeroAddress();
+
+        config.manager = _manager;
+        config.feeRecipient = _feeRecipient;
+        config.name = _name;
+        config.uri = _uri;
+
+        emit RateManagerConfigUpdated(_rateManagerId, _manager, _feeRecipient, _name, _uri);
+    }
+
+    /**
+     * @notice Updates the delegated manager fee.
+     */
+    function setFee(bytes32 _rateManagerId, uint256 _fee) external onlyManager(_rateManagerId) {
+        RateManagerConfig storage config = rateManagers[_rateManagerId];
+        if (_fee > config.maxFee) revert FeeExceedsMaximum(_fee, config.maxFee);
+        if (_fee > 0 && config.feeRecipient == address(0)) revert ZeroAddress();
+
+        config.fee = _fee;
+        emit RateManagerFeeUpdated(_rateManagerId, _fee);
+    }
+
+    /**
+     * @notice Updates the minimum liquidity requirement enforced when a deposit opts in.
+     */
+    function setMinLiquidity(bytes32 _rateManagerId, uint256 _minLiquidity) external onlyManager(_rateManagerId) {
+        rateManagers[_rateManagerId].minLiquidity = _minLiquidity;
+        emit MinLiquidityUpdated(_rateManagerId, _minLiquidity);
+    }
+
+    /**
+     * @notice Updates the escrow registry used to authenticate `onDepositOptIn`.
+     */
+    function setEscrowRegistry(address _escrowRegistry) external onlyOwner {
+        if (_escrowRegistry == address(0)) revert ZeroAddress();
+        escrowRegistry = IEscrowRegistry(_escrowRegistry);
+        emit EscrowRegistryUpdated(_escrowRegistry);
+    }
+
+    /**
+     * @notice Sets a flat manager rate for a payment method / currency pair.
+     * @dev Flat rates remain useful for backwards compatibility and for tuples that do not need tranches.
+     */
+    function setRate(
+        bytes32 _rateManagerId,
+        bytes32 _paymentMethod,
+        bytes32 _currencyCode,
+        uint256 _rate
+    )
+        external
+        onlyManager(_rateManagerId)
+    {
+        if (_paymentMethod == bytes32(0) || _currencyCode == bytes32(0)) revert ZeroValue();
+        _setFlatRate(_rateManagerId, _paymentMethod, _currencyCode, _rate);
+    }
+
+    /**
+     * @notice Batch sets flat manager rates.
+     */
+    function setRateBatch(
+        bytes32 _rateManagerId,
+        bytes32[] calldata _paymentMethods,
+        bytes32[][] calldata _currencyCodes,
+        uint256[][] calldata _rates
+    )
+        external
+        onlyManager(_rateManagerId)
+    {
+        if (_paymentMethods.length != _currencyCodes.length) {
+            revert ArrayLengthMismatch(_paymentMethods.length, _currencyCodes.length);
+        }
+        if (_paymentMethods.length != _rates.length) {
+            revert ArrayLengthMismatch(_paymentMethods.length, _rates.length);
+        }
+
+        uint256 totalUpdated;
+        for (uint256 i = 0; i < _paymentMethods.length; i++) {
+            if (_currencyCodes[i].length != _rates[i].length) {
+                revert ArrayLengthMismatch(_currencyCodes[i].length, _rates[i].length);
+            }
+
+            bytes32 paymentMethod = _paymentMethods[i];
+            if (paymentMethod == bytes32(0)) revert ZeroValue();
+
+            for (uint256 j = 0; j < _currencyCodes[i].length; j++) {
+                bytes32 currencyCode = _currencyCodes[i][j];
+                if (currencyCode == bytes32(0)) revert ZeroValue();
+
+                _setFlatRate(_rateManagerId, paymentMethod, currencyCode, _rates[i][j]);
+                totalUpdated++;
+            }
+        }
+
+        emit RateManagerRatesBatchUpdated(_rateManagerId, totalUpdated);
+    }
+
+    /**
+     * @notice Replaces the full tranche schedule for a manager tuple.
+     * @dev Tranches are stored in ascending `maxLiquidity` order. The active tranche is the first
+     *      entry whose `maxLiquidity` is greater than or equal to current liquidity.
+     */
+    function setTrancheRates(
+        bytes32 _rateManagerId,
+        bytes32 _paymentMethod,
+        bytes32 _currencyCode,
+        TrancheRate[] calldata _tranches
+    )
+        external
+        onlyManager(_rateManagerId)
+    {
+        if (_paymentMethod == bytes32(0) || _currencyCode == bytes32(0)) revert ZeroValue();
+
+        delete trancheRates[_rateManagerId][_paymentMethod][_currencyCode];
+
+        if (_tranches.length == 0) {
+            emit RateManagerTrancheRatesCleared(_rateManagerId, _paymentMethod, _currencyCode);
+            return;
+        }
+
+        uint256 previousMaxLiquidity;
+        TrancheRate[] storage storedTranches = trancheRates[_rateManagerId][_paymentMethod][_currencyCode];
+        for (uint256 i = 0; i < _tranches.length; i++) {
+            TrancheRate calldata tranche = _tranches[i];
+            if (tranche.maxLiquidity == 0) revert ZeroValue();
+            if (tranche.maxLiquidity <= previousMaxLiquidity) {
+                revert InvalidTrancheOrder(previousMaxLiquidity, tranche.maxLiquidity);
+            }
+
+            storedTranches.push(TrancheRate({
+                maxLiquidity: tranche.maxLiquidity,
+                rate: tranche.rate
+            }));
+            emit RateManagerTrancheRateUpdated(
+                _rateManagerId,
+                _paymentMethod,
+                _currencyCode,
+                tranche.maxLiquidity,
+                tranche.rate
+            );
+
+            previousMaxLiquidity = tranche.maxLiquidity;
+        }
+
+        emit RateManagerTrancheRatesUpdated(_rateManagerId, _paymentMethod, _currencyCode, _tranches.length);
+    }
+
+    /**
+     * @notice Removes all tranche rates for a tuple and falls back to the flat rate, if any.
+     */
+    function clearTrancheRates(
+        bytes32 _rateManagerId,
+        bytes32 _paymentMethod,
+        bytes32 _currencyCode
+    )
+        external
+        onlyManager(_rateManagerId)
+    {
+        if (_paymentMethod == bytes32(0) || _currencyCode == bytes32(0)) revert ZeroValue();
+
+        delete trancheRates[_rateManagerId][_paymentMethod][_currencyCode];
+        emit RateManagerTrancheRatesCleared(_rateManagerId, _paymentMethod, _currencyCode);
+    }
+
+    /**
+     * @notice Callback invoked by EscrowV2 when a deposit opts into this manager.
+     */
+    function onDepositOptIn(
+        uint256 _depositId,
+        bytes32 _rateManagerId
+    )
+        external
+        view
+        override
+    {
+        address callingEscrow = msg.sender;
+        if (!escrowRegistry.isWhitelistedEscrow(callingEscrow) && !escrowRegistry.isAcceptingAllEscrows()) {
+            revert UnauthorizedEscrow(callingEscrow);
+        }
+
+        if (!isRateManager(_rateManagerId)) revert RateManagerNotFound(_rateManagerId);
+
+        uint256 required = rateManagers[_rateManagerId].minLiquidity;
+        if (required > 0) {
+            IEscrow.Deposit memory deposit = IEscrow(callingEscrow).getDeposit(_depositId);
+            uint256 totalLiquidity = deposit.remainingDeposits + deposit.outstandingIntentAmount;
+            if (totalLiquidity < required) {
+                revert BelowMinLiquidity(totalLiquidity, required);
+            }
+        }
+    }
+
+    /* ============ External View Functions ============ */
+
+    /**
+     * @notice Returns the effective manager-side rate for a delegated deposit.
+     * @dev Tranche schedules are resolved against the deposit's current total liquidity.
+     *      If no tranches are configured for the tuple, the flat V1-compatible rate is returned.
+     */
+    function getRate(
+        bytes32 _rateManagerId,
+        address _escrow,
+        uint256 _depositId,
+        bytes32 _paymentMethod,
+        bytes32 _currencyCode
+    )
+        external
+        view
+        override
+        returns (uint256 rate)
+    {
+        TrancheRate[] storage storedTranches = trancheRates[_rateManagerId][_paymentMethod][_currencyCode];
+        if (storedTranches.length == 0) {
+            if (!hasRateOverride[_rateManagerId][_paymentMethod][_currencyCode]) return 0;
+            return rates[_rateManagerId][_paymentMethod][_currencyCode];
+        }
+
+        if (_escrow == address(0) || _escrow.code.length == 0) return 0;
+
+        try IEscrow(_escrow).getDeposit(_depositId) returns (IEscrow.Deposit memory deposit) {
+            uint256 totalLiquidity = deposit.remainingDeposits + deposit.outstandingIntentAmount;
+            return getRateForLiquidity(_rateManagerId, _paymentMethod, _currencyCode, totalLiquidity);
+        } catch {
+            return 0;
+        }
+    }
+
+    /**
+     * @notice Returns the active tranche rate for an explicit liquidity amount.
+     * @dev This is useful off-chain when previewing how a deposit will reprice as liquidity changes.
+     */
+    function getRateForLiquidity(
+        bytes32 _rateManagerId,
+        bytes32 _paymentMethod,
+        bytes32 _currencyCode,
+        uint256 _liquidity
+    )
+        public
+        view
+        returns (uint256 rate)
+    {
+        TrancheRate[] storage storedTranches = trancheRates[_rateManagerId][_paymentMethod][_currencyCode];
+        for (uint256 i = 0; i < storedTranches.length; i++) {
+            if (_liquidity <= storedTranches[i].maxLiquidity) {
+                return storedTranches[i].rate;
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * @notice Returns fee recipient and fee for a manager id.
+     */
+    function getFee(bytes32 _rateManagerId) external view override returns (address recipient, uint256 fee) {
+        RateManagerConfig storage config = rateManagers[_rateManagerId];
+        return (config.feeRecipient, config.fee);
+    }
+
+    /**
+     * @notice Returns whether a manager id exists.
+     */
+    function isRateManager(bytes32 _rateManagerId) public view override returns (bool exists) {
+        return rateManagers[_rateManagerId].manager != address(0);
+    }
+
+    /**
+     * @notice Returns manager config for a manager id.
+     */
+    function getRateManager(bytes32 _rateManagerId) external view returns (RateManagerConfig memory config) {
+        return rateManagers[_rateManagerId];
+    }
+
+    /**
+     * @notice Returns the V1-compatible flat manager rate override for a tuple.
+     * @dev This getter does not resolve tranches. Use `getRate` or `getRateForLiquidity` for active pricing.
+     */
+    function getManagerRate(
+        bytes32 _rateManagerId,
+        bytes32 _paymentMethod,
+        bytes32 _currencyCode
+    )
+        external
+        view
+        returns (uint256 rate)
+    {
+        return rates[_rateManagerId][_paymentMethod][_currencyCode];
+    }
+
+    /**
+     * @notice Returns the copied V1 source for an imported manager id, if any.
+     */
+    function getLegacySource(bytes32 _rateManagerId) external view returns (address legacyRateManager, bytes32 legacyRateManagerId) {
+        LegacySource storage source = legacySources[_rateManagerId];
+        return (source.rateManager, source.rateManagerId);
+    }
+
+    /**
+     * @notice Returns the full ordered tranche schedule for a tuple.
+     */
+    function getTrancheRates(
+        bytes32 _rateManagerId,
+        bytes32 _paymentMethod,
+        bytes32 _currencyCode
+    )
+        external
+        view
+        returns (TrancheRate[] memory configuredTranches)
+    {
+        TrancheRate[] storage storedTranches = trancheRates[_rateManagerId][_paymentMethod][_currencyCode];
+        configuredTranches = new TrancheRate[](storedTranches.length);
+        for (uint256 i = 0; i < storedTranches.length; i++) {
+            configuredTranches[i] = storedTranches[i];
+        }
+    }
+
+    /* ============ Internal Helpers ============ */
+
+    function _setFlatRate(
+        bytes32 _rateManagerId,
+        bytes32 _paymentMethod,
+        bytes32 _currencyCode,
+        uint256 _rate
+    ) internal {
+        hasRateOverride[_rateManagerId][_paymentMethod][_currencyCode] = true;
+        rates[_rateManagerId][_paymentMethod][_currencyCode] = _rate;
+
+        emit RateManagerRateUpdated(_rateManagerId, _paymentMethod, _currencyCode, _rate);
+    }
+
+    function _validateConfig(RateManagerConfig memory _config) internal pure {
+        if (_config.manager == address(0)) revert ZeroAddress();
+        if (_config.fee > 0 && _config.feeRecipient == address(0)) revert ZeroAddress();
+        if (_config.maxFee > GLOBAL_MAX_MANAGER_FEE) {
+            revert FeeExceedsMaximum(_config.maxFee, GLOBAL_MAX_MANAGER_FEE);
+        }
+        if (_config.fee > _config.maxFee) revert FeeExceedsMaximum(_config.fee, _config.maxFee);
+    }
+
+    function _emitRateManagerCreated(bytes32 _rateManagerId, RateManagerConfig memory _config) internal {
+        emit RateManagerCreated(
+            _rateManagerId,
+            _config.manager,
+            _config.feeRecipient,
+            _config.maxFee,
+            _config.fee,
+            _config.name,
+            _config.uri
+        );
+
+        if (_config.minLiquidity > 0) {
+            emit MinLiquidityUpdated(_rateManagerId, _config.minLiquidity);
+        }
+    }
+}

--- a/contracts/interfaces/IRateManagerV1Migratable.sol
+++ b/contracts/interfaces/IRateManagerV1Migratable.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+/**
+ * @title IRateManagerV1Migratable
+ * @notice Minimal read surface required to copy existing RateManagerV1 configs into RateManagerV2.
+ */
+interface IRateManagerV1Migratable {
+    struct RateManagerConfig {
+        address manager;
+        address feeRecipient;
+        uint256 maxFee;
+        uint256 fee;
+        uint256 minLiquidity;
+        string name;
+        string uri;
+    }
+
+    function isRateManager(bytes32 _rateManagerId) external view returns (bool exists);
+
+    function getRateManager(bytes32 _rateManagerId) external view returns (RateManagerConfig memory config);
+
+    function getManagerRate(
+        bytes32 _rateManagerId,
+        bytes32 _paymentMethod,
+        bytes32 _currencyCode
+    ) external view returns (uint256 rate);
+}

--- a/test/rateManager/rateManagerV2.spec.ts
+++ b/test/rateManager/rateManagerV2.spec.ts
@@ -1,0 +1,1105 @@
+import "module-alias/register";
+
+import { ethers } from "hardhat";
+import { BigNumber, BytesLike } from "ethers";
+
+import DeployHelper from "@utils/deploys";
+import { ether, usdc } from "@utils/common";
+import { ADDRESS_ZERO, EMPTY_ORACLE_RATE_CONFIG, ONE, ZERO } from "@utils/constants";
+import { Currency } from "@utils/protocolUtils";
+import { getAccounts, getWaffleExpect } from "@utils/test";
+import {
+  EscrowRegistry,
+  EscrowV2,
+  OrchestratorRegistry,
+  PaymentVerifierMock,
+  PaymentVerifierRegistry,
+  RateManagerV1,
+  RateManagerV2,
+  USDCMock,
+} from "@utils/contracts";
+
+const expect = getWaffleExpect();
+
+describe("RateManagerV2", () => {
+  let owner: any;
+  let manager: any;
+  let depositor: any;
+  let feeRecipient: any;
+  let other: any;
+
+  let deployer: DeployHelper;
+
+  let rateManagerV1: RateManagerV1;
+  let rateManagerV2: RateManagerV2;
+  let usdcToken: USDCMock;
+  let escrow: EscrowV2;
+  let escrowRegistry: EscrowRegistry;
+  let orchestratorRegistry: OrchestratorRegistry;
+  let paymentVerifierRegistry: PaymentVerifierRegistry;
+  let verifier: PaymentVerifierMock;
+
+  let paymentMethod: BytesLike;
+  let payeeDetails: BytesLike;
+  let rateManagerId: string;
+
+  async function createRateManagerAndGetId(minLiquidity = ZERO): Promise<string> {
+    const tx = await rateManagerV2.createRateManager({
+      manager: manager.address,
+      feeRecipient: feeRecipient.address,
+      maxFee: ether(0.05),
+      fee: ether(0.01),
+      minLiquidity,
+      name: "PeerTwo",
+      uri: "ipfs://peertwo",
+    });
+    const receipt = await tx.wait();
+    const createdEvent = receipt.events?.find((event: any) => event.event === "RateManagerCreated");
+    return createdEvent?.args?.rateManagerId;
+  }
+
+  async function createLegacyRateManagerAndGetId(minLiquidity = ZERO): Promise<string> {
+    const tx = await rateManagerV1.createRateManager({
+      manager: manager.address,
+      feeRecipient: feeRecipient.address,
+      maxFee: ether(0.05),
+      fee: ether(0.01),
+      minLiquidity,
+      name: "LegacyPeer",
+      uri: "ipfs://legacy-peer",
+    });
+    const receipt = await tx.wait();
+    const createdEvent = receipt.events?.find((event: any) => event.event === "RateManagerCreated");
+    return createdEvent?.args?.rateManagerId;
+  }
+
+  async function setStandardTranches(subjectRateManagerId: BytesLike) {
+    await rateManagerV2.connect(manager.wallet).setTrancheRates(subjectRateManagerId, paymentMethod, Currency.USD, [
+      {
+        maxLiquidity: usdc(100),
+        rate: ether(1.05),
+      },
+      {
+        maxLiquidity: usdc(500),
+        rate: ether(1.02),
+      },
+    ]);
+  }
+
+  beforeEach(async () => {
+    [owner, manager, depositor, feeRecipient, other] = await getAccounts();
+    deployer = new DeployHelper(owner.wallet);
+
+    escrowRegistry = await deployer.deployEscrowRegistry();
+    rateManagerV1 = await deployer.deployRateManagerV1(escrowRegistry.address);
+    rateManagerV2 = await deployer.deployRateManagerV2(escrowRegistry.address);
+
+    usdcToken = await deployer.deployUSDCMock(usdc(1_000_000_000), "USDC", "USDC");
+    await usdcToken.transfer(depositor.address, usdc(100_000));
+
+    paymentVerifierRegistry = await deployer.deployPaymentVerifierRegistry();
+    orchestratorRegistry = await deployer.deployOrchestratorRegistry();
+    verifier = await deployer.deployPaymentVerifierMock();
+
+    paymentMethod = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("venmo"));
+    payeeDetails = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("payee"));
+
+    await paymentVerifierRegistry
+      .connect(owner.wallet)
+      .addPaymentMethod(paymentMethod, verifier.address, [Currency.USD]);
+
+    escrow = await deployer.deployEscrowV2(
+      owner.address,
+      ONE,
+      orchestratorRegistry.address,
+      paymentVerifierRegistry.address,
+      owner.address,
+      ZERO,
+      BigNumber.from(20),
+      BigNumber.from(60 * 60)
+    );
+
+    await escrowRegistry.addEscrow(escrow.address);
+
+    await usdcToken.connect(depositor.wallet).approve(escrow.address, usdc(100_000));
+    await escrow.connect(depositor.wallet).createDeposit({
+      token: usdcToken.address,
+      amount: usdc(500),
+      intentAmountRange: { min: usdc(10), max: usdc(200) },
+      paymentMethods: [paymentMethod],
+      paymentMethodData: [
+        {
+          intentGatingService: ADDRESS_ZERO,
+          payeeDetails,
+          data: "0x",
+        },
+      ],
+      currencies: [[{ code: Currency.USD, minConversionRate: ether(1), oracleRateConfig: EMPTY_ORACLE_RATE_CONFIG }]],
+      delegate: ADDRESS_ZERO,
+      intentGuardian: ADDRESS_ZERO,
+      retainOnEmpty: false,
+    });
+
+    rateManagerId = await createRateManagerAndGetId();
+  });
+
+  describe("#createRateManager", () => {
+    let subjectManager: string;
+    let subjectFeeRecipient: string;
+    let subjectMaxFee: BigNumber;
+    let subjectFee: BigNumber;
+
+    async function subject() {
+      return rateManagerV2.createRateManager({
+        manager: subjectManager,
+        feeRecipient: subjectFeeRecipient,
+        maxFee: subjectMaxFee,
+        fee: subjectFee,
+        minLiquidity: ZERO,
+        name: "RM",
+        uri: "ipfs://rm",
+      });
+    }
+
+    beforeEach(async () => {
+      subjectManager = manager.address;
+      subjectFeeRecipient = feeRecipient.address;
+      subjectMaxFee = ether(0.05);
+      subjectFee = ether(0.01);
+    });
+
+    it("creates a manager and emits RateManagerCreated", async () => {
+      await expect(subject()).to.emit(rateManagerV2, "RateManagerCreated");
+    });
+
+    it("emits MinLiquidityUpdated when minLiquidity is non-zero", async () => {
+      const tx = await rateManagerV2.createRateManager({
+        manager: subjectManager,
+        feeRecipient: subjectFeeRecipient,
+        maxFee: subjectMaxFee,
+        fee: subjectFee,
+        minLiquidity: usdc(50),
+        name: "RM",
+        uri: "ipfs://rm",
+      });
+
+      await expect(tx).to.emit(rateManagerV2, "RateManagerCreated");
+      await expect(tx).to.emit(rateManagerV2, "MinLiquidityUpdated");
+    });
+
+    describe("when maxFee exceeds the global cap", () => {
+      beforeEach(async () => {
+        subjectMaxFee = ether(0.06);
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "FeeExceedsMaximum");
+      });
+    });
+
+    describe("when manager is zero address", () => {
+      beforeEach(async () => {
+        subjectManager = ADDRESS_ZERO;
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "ZeroAddress");
+      });
+    });
+
+    describe("when fee recipient is zero and fee is non-zero", () => {
+      beforeEach(async () => {
+        subjectFeeRecipient = ADDRESS_ZERO;
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "ZeroAddress");
+      });
+    });
+
+    describe("when fee exceeds maxFee", () => {
+      beforeEach(async () => {
+        subjectFee = ether(0.02);
+        subjectMaxFee = ether(0.01);
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "FeeExceedsMaximum");
+      });
+    });
+  });
+
+  describe("constructor", () => {
+    it("reverts when escrow registry is zero address", async () => {
+      const factory = await ethers.getContractFactory("RateManagerV2", owner.wallet);
+
+      await expect(factory.deploy(ADDRESS_ZERO)).to.be.revertedWithCustomError(rateManagerV2, "ZeroAddress");
+    });
+  });
+
+  describe("#importRateManager", () => {
+    let legacyRateManagerId: string;
+
+    beforeEach(async () => {
+      legacyRateManagerId = await createLegacyRateManagerAndGetId(usdc(25));
+      await rateManagerV1.connect(manager.wallet).setRate(legacyRateManagerId, paymentMethod, Currency.USD, ether(1.11));
+    });
+
+    it("copies the legacy config, keeps the legacy id, and copies requested flat rates", async () => {
+      const tx = await rateManagerV2.importRateManager(rateManagerV1.address, legacyRateManagerId, [paymentMethod], [[Currency.USD]]);
+      await expect(tx)
+        .to.emit(rateManagerV2, "RateManagerImported")
+        .withArgs(legacyRateManagerId, rateManagerV1.address, legacyRateManagerId, 1);
+
+      const importedConfig = await rateManagerV2.getRateManager(legacyRateManagerId);
+      expect(importedConfig.manager).to.eq(manager.address);
+      expect(importedConfig.feeRecipient).to.eq(feeRecipient.address);
+      expect(importedConfig.minLiquidity).to.eq(usdc(25));
+      expect(await rateManagerV2.getManagerRate(legacyRateManagerId, paymentMethod, Currency.USD)).to.eq(ether(1.11));
+
+      const legacySource = await rateManagerV2.getLegacySource(legacyRateManagerId);
+      expect(legacySource.legacyRateManager).to.eq(rateManagerV1.address);
+      expect(legacySource.legacyRateManagerId).to.eq(legacyRateManagerId);
+    });
+
+    it("supports importing only the manager metadata", async () => {
+      await rateManagerV2.importRateManager(rateManagerV1.address, legacyRateManagerId, [], []);
+
+      expect(await rateManagerV2.getManagerRate(legacyRateManagerId, paymentMethod, Currency.USD)).to.eq(ZERO);
+    });
+
+    describe("when the legacy manager address is zero", () => {
+      it("reverts", async () => {
+        await expect(
+          rateManagerV2.importRateManager(ADDRESS_ZERO, legacyRateManagerId, [paymentMethod], [[Currency.USD]])
+        ).to.be.revertedWithCustomError(rateManagerV2, "ZeroAddress");
+      });
+    });
+
+    describe("when the legacy manager address has no code", () => {
+      it("reverts", async () => {
+        await expect(
+          rateManagerV2.importRateManager(other.address, legacyRateManagerId, [paymentMethod], [[Currency.USD]])
+        ).to.be.revertedWithCustomError(rateManagerV2, "InvalidLegacyRateManager");
+      });
+    });
+
+    describe("when the payment method and currency array lengths do not match", () => {
+      it("reverts", async () => {
+        await expect(
+          rateManagerV2.importRateManager(rateManagerV1.address, legacyRateManagerId, [paymentMethod], [])
+        ).to.be.revertedWithCustomError(rateManagerV2, "ArrayLengthMismatch");
+      });
+    });
+
+    describe("when the legacy manager id does not exist", () => {
+      it("reverts", async () => {
+        await expect(
+          rateManagerV2.importRateManager(
+            rateManagerV1.address,
+            ethers.utils.formatBytes32String("missing"),
+            [paymentMethod],
+            [[Currency.USD]]
+          )
+        ).to.be.revertedWithCustomError(rateManagerV2, "RateManagerNotFound");
+      });
+    });
+
+    describe("when the imported id already exists in V2", () => {
+      beforeEach(async () => {
+        await rateManagerV2.importRateManager(rateManagerV1.address, legacyRateManagerId, [], []);
+      });
+
+      it("reverts", async () => {
+        await expect(
+          rateManagerV2.importRateManager(rateManagerV1.address, legacyRateManagerId, [], [])
+        ).to.be.revertedWithCustomError(rateManagerV2, "RateManagerAlreadyExists");
+      });
+    });
+
+    describe("when a copied payment method is zero", () => {
+      it("reverts", async () => {
+        await expect(
+          rateManagerV2.importRateManager(rateManagerV1.address, legacyRateManagerId, [ethers.constants.HashZero], [[Currency.USD]])
+        ).to.be.revertedWithCustomError(rateManagerV2, "ZeroValue");
+      });
+    });
+
+    describe("when a copied currency is zero", () => {
+      it("reverts", async () => {
+        await expect(
+          rateManagerV2.importRateManager(rateManagerV1.address, legacyRateManagerId, [paymentMethod], [[ethers.constants.HashZero]])
+        ).to.be.revertedWithCustomError(rateManagerV2, "ZeroValue");
+      });
+    });
+  });
+
+  describe("#setRate", () => {
+    let subjectCaller: any;
+    let subjectRateManagerId: BytesLike;
+    let subjectPaymentMethod: BytesLike;
+    let subjectCurrencyCode: BytesLike;
+    let subjectRate: BigNumber;
+
+    async function subject() {
+      return rateManagerV2
+        .connect(subjectCaller.wallet)
+        .setRate(subjectRateManagerId, subjectPaymentMethod, subjectCurrencyCode, subjectRate);
+    }
+
+    beforeEach(async () => {
+      subjectCaller = manager;
+      subjectRateManagerId = rateManagerId;
+      subjectPaymentMethod = paymentMethod;
+      subjectCurrencyCode = Currency.USD;
+      subjectRate = ether(1.1);
+    });
+
+    it("sets the flat manager rate", async () => {
+      await expect(subject())
+        .to.emit(rateManagerV2, "RateManagerRateUpdated")
+        .withArgs(rateManagerId, paymentMethod, Currency.USD, subjectRate);
+
+      expect(await rateManagerV2.getManagerRate(rateManagerId, paymentMethod, Currency.USD)).to.eq(subjectRate);
+    });
+
+    describe("when caller is not the manager", () => {
+      beforeEach(async () => {
+        subjectCaller = other;
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "UnauthorizedCaller");
+      });
+    });
+
+    describe("when the manager id does not exist", () => {
+      beforeEach(async () => {
+        subjectRateManagerId = ethers.utils.formatBytes32String("missing-manager");
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "RateManagerNotFound");
+      });
+    });
+
+    describe("when payment method is zero", () => {
+      beforeEach(async () => {
+        subjectPaymentMethod = ethers.constants.HashZero;
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "ZeroValue");
+      });
+    });
+
+    describe("when currency code is zero", () => {
+      beforeEach(async () => {
+        subjectCurrencyCode = ethers.constants.HashZero;
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "ZeroValue");
+      });
+    });
+  });
+
+  describe("#setRateBatch", () => {
+    let subjectCaller: any;
+    let subjectRateManagerId: BytesLike;
+    let subjectPaymentMethods: BytesLike[];
+    let subjectCurrencyCodes: BytesLike[][];
+    let subjectRates: BigNumber[][];
+
+    async function subject() {
+      return rateManagerV2
+        .connect(subjectCaller.wallet)
+        .setRateBatch(subjectRateManagerId, subjectPaymentMethods, subjectCurrencyCodes, subjectRates);
+    }
+
+    beforeEach(async () => {
+      subjectCaller = manager;
+      subjectRateManagerId = rateManagerId;
+      subjectPaymentMethods = [paymentMethod];
+      subjectCurrencyCodes = [[Currency.USD]];
+      subjectRates = [[ether(1.15)]];
+    });
+
+    it("sets flat manager rates in batch", async () => {
+      await expect(subject())
+        .to.emit(rateManagerV2, "RateManagerRatesBatchUpdated")
+        .withArgs(rateManagerId, 1);
+
+      expect(await rateManagerV2.getManagerRate(rateManagerId, paymentMethod, Currency.USD)).to.eq(ether(1.15));
+    });
+
+    describe("when payment methods length does not match currencies length", () => {
+      beforeEach(async () => {
+        subjectCurrencyCodes = [];
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "ArrayLengthMismatch");
+      });
+    });
+
+    describe("when payment methods length does not match rates length", () => {
+      beforeEach(async () => {
+        subjectRates = [];
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "ArrayLengthMismatch");
+      });
+    });
+
+    describe("when currency codes length does not match rates length for an index", () => {
+      beforeEach(async () => {
+        subjectCurrencyCodes = [[Currency.USD, ethers.constants.HashZero]];
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "ArrayLengthMismatch");
+      });
+    });
+
+    describe("when payment method is zero", () => {
+      beforeEach(async () => {
+        subjectPaymentMethods = [ethers.constants.HashZero];
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "ZeroValue");
+      });
+    });
+
+    describe("when currency code is zero", () => {
+      beforeEach(async () => {
+        subjectCurrencyCodes = [[ethers.constants.HashZero]];
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "ZeroValue");
+      });
+    });
+
+    describe("when caller is not the manager", () => {
+      beforeEach(async () => {
+        subjectCaller = other;
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "UnauthorizedCaller");
+      });
+    });
+
+    describe("when rate manager id does not exist", () => {
+      beforeEach(async () => {
+        subjectRateManagerId = ethers.utils.formatBytes32String("missing-manager");
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "RateManagerNotFound");
+      });
+    });
+  });
+
+  describe("#setTrancheRates", () => {
+    let subjectCaller: any;
+    let subjectRateManagerId: BytesLike;
+    let subjectPaymentMethod: BytesLike;
+    let subjectCurrencyCode: BytesLike;
+    let subjectTranches: { maxLiquidity: BigNumber; rate: BigNumber }[];
+
+    async function subject() {
+      return rateManagerV2
+        .connect(subjectCaller.wallet)
+        .setTrancheRates(subjectRateManagerId, subjectPaymentMethod, subjectCurrencyCode, subjectTranches);
+    }
+
+    beforeEach(async () => {
+      subjectCaller = manager;
+      subjectRateManagerId = rateManagerId;
+      subjectPaymentMethod = paymentMethod;
+      subjectCurrencyCode = Currency.USD;
+      subjectTranches = [
+        { maxLiquidity: usdc(100), rate: ether(1.05) },
+        { maxLiquidity: usdc(500), rate: ether(1.02) },
+      ];
+    });
+
+    it("stores an ordered tranche schedule", async () => {
+      await expect(subject())
+        .to.emit(rateManagerV2, "RateManagerTrancheRatesUpdated")
+        .withArgs(rateManagerId, paymentMethod, Currency.USD, 2);
+
+      const tranches = await rateManagerV2.getTrancheRates(rateManagerId, paymentMethod, Currency.USD);
+      expect(tranches.length).to.eq(2);
+      expect(tranches[0].maxLiquidity).to.eq(usdc(100));
+      expect(tranches[0].rate).to.eq(ether(1.05));
+      expect(tranches[1].maxLiquidity).to.eq(usdc(500));
+      expect(tranches[1].rate).to.eq(ether(1.02));
+      expect(await rateManagerV2.getRateForLiquidity(rateManagerId, paymentMethod, Currency.USD, usdc(80))).to.eq(ether(1.05));
+      expect(await rateManagerV2.getRateForLiquidity(rateManagerId, paymentMethod, Currency.USD, usdc(300))).to.eq(ether(1.02));
+    });
+
+    it("replaces the previous tranche schedule", async () => {
+      await subject();
+      subjectTranches = [{ maxLiquidity: usdc(250), rate: ether(1.08) }];
+
+      await subject();
+
+      const tranches = await rateManagerV2.getTrancheRates(rateManagerId, paymentMethod, Currency.USD);
+      expect(tranches.length).to.eq(1);
+      expect(tranches[0].maxLiquidity).to.eq(usdc(250));
+      expect(tranches[0].rate).to.eq(ether(1.08));
+    });
+
+    it("clears tranches when called with an empty schedule", async () => {
+      await subject();
+      subjectTranches = [];
+
+      await expect(subject())
+        .to.emit(rateManagerV2, "RateManagerTrancheRatesCleared")
+        .withArgs(rateManagerId, paymentMethod, Currency.USD);
+
+      const tranches = await rateManagerV2.getTrancheRates(rateManagerId, paymentMethod, Currency.USD);
+      expect(tranches.length).to.eq(0);
+    });
+
+    describe("when payment method is zero", () => {
+      beforeEach(async () => {
+        subjectPaymentMethod = ethers.constants.HashZero;
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "ZeroValue");
+      });
+    });
+
+    describe("when currency code is zero", () => {
+      beforeEach(async () => {
+        subjectCurrencyCode = ethers.constants.HashZero;
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "ZeroValue");
+      });
+    });
+
+    describe("when a tranche max liquidity is zero", () => {
+      beforeEach(async () => {
+        subjectTranches = [{ maxLiquidity: ZERO, rate: ether(1.05) }];
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "ZeroValue");
+      });
+    });
+
+    describe("when tranche upper bounds are not strictly increasing", () => {
+      beforeEach(async () => {
+        subjectTranches = [
+          { maxLiquidity: usdc(100), rate: ether(1.05) },
+          { maxLiquidity: usdc(100), rate: ether(1.02) },
+        ];
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "InvalidTrancheOrder");
+      });
+    });
+
+    describe("when caller is not the manager", () => {
+      beforeEach(async () => {
+        subjectCaller = other;
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "UnauthorizedCaller");
+      });
+    });
+
+    describe("when rate manager id does not exist", () => {
+      beforeEach(async () => {
+        subjectRateManagerId = ethers.utils.formatBytes32String("missing-manager");
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "RateManagerNotFound");
+      });
+    });
+  });
+
+  describe("#clearTrancheRates", () => {
+    let subjectCaller: any;
+    let subjectRateManagerId: BytesLike;
+    let subjectPaymentMethod: BytesLike;
+    let subjectCurrencyCode: BytesLike;
+
+    async function subject() {
+      return rateManagerV2
+        .connect(subjectCaller.wallet)
+        .clearTrancheRates(subjectRateManagerId, subjectPaymentMethod, subjectCurrencyCode);
+    }
+
+    beforeEach(async () => {
+      subjectCaller = manager;
+      subjectRateManagerId = rateManagerId;
+      subjectPaymentMethod = paymentMethod;
+      subjectCurrencyCode = Currency.USD;
+      await rateManagerV2.connect(manager.wallet).setRate(rateManagerId, paymentMethod, Currency.USD, ether(1.09));
+      await setStandardTranches(rateManagerId);
+    });
+
+    it("clears tranches and falls back to the flat rate", async () => {
+      await expect(subject())
+        .to.emit(rateManagerV2, "RateManagerTrancheRatesCleared")
+        .withArgs(rateManagerId, paymentMethod, Currency.USD);
+
+      expect(await rateManagerV2.getTrancheRates(rateManagerId, paymentMethod, Currency.USD)).to.deep.eq([]);
+      expect(await rateManagerV2.getRate(rateManagerId, escrow.address, ZERO, paymentMethod, Currency.USD)).to.eq(ether(1.09));
+    });
+
+    describe("when payment method is zero", () => {
+      beforeEach(async () => {
+        subjectPaymentMethod = ethers.constants.HashZero;
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "ZeroValue");
+      });
+    });
+
+    describe("when currency code is zero", () => {
+      beforeEach(async () => {
+        subjectCurrencyCode = ethers.constants.HashZero;
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "ZeroValue");
+      });
+    });
+
+    describe("when caller is not the manager", () => {
+      beforeEach(async () => {
+        subjectCaller = other;
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "UnauthorizedCaller");
+      });
+    });
+
+    describe("when rate manager id does not exist", () => {
+      beforeEach(async () => {
+        subjectRateManagerId = ethers.utils.formatBytes32String("missing-manager");
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "RateManagerNotFound");
+      });
+    });
+  });
+
+  describe("#getRate", () => {
+    it("returns the flat manager rate when no tranches are set", async () => {
+      await rateManagerV2.connect(manager.wallet).setRate(rateManagerId, paymentMethod, Currency.USD, ether(1.1));
+
+      const rate = await rateManagerV2.getRate(rateManagerId, escrow.address, ZERO, paymentMethod, Currency.USD);
+      expect(rate).to.eq(ether(1.1));
+    });
+
+    it("returns 0 when the flat rate has not been set", async () => {
+      const rate = await rateManagerV2.getRate(rateManagerId, escrow.address, ZERO, paymentMethod, Currency.USD);
+      expect(rate).to.eq(ZERO);
+    });
+
+    it("returns the active tranche rate for the deposit's current liquidity", async () => {
+      await setStandardTranches(rateManagerId);
+
+      const rate = await rateManagerV2.getRate(rateManagerId, escrow.address, ZERO, paymentMethod, Currency.USD);
+      expect(rate).to.eq(ether(1.02));
+    });
+
+    it("uses tranches ahead of the flat override when both are configured", async () => {
+      await rateManagerV2.connect(manager.wallet).setRate(rateManagerId, paymentMethod, Currency.USD, ether(1.3));
+      await setStandardTranches(rateManagerId);
+
+      const rate = await rateManagerV2.getRate(rateManagerId, escrow.address, ZERO, paymentMethod, Currency.USD);
+      expect(rate).to.eq(ether(1.02));
+    });
+
+    it("moves into a tighter tranche after deposit liquidity shrinks", async () => {
+      await setStandardTranches(rateManagerId);
+      await escrow.connect(depositor.wallet).removeFunds(ZERO, usdc(420));
+
+      const rate = await rateManagerV2.getRate(rateManagerId, escrow.address, ZERO, paymentMethod, Currency.USD);
+      expect(rate).to.eq(ether(1.05));
+    });
+
+    it("returns 0 when liquidity is above the highest configured tranche", async () => {
+      await setStandardTranches(rateManagerId);
+      await usdcToken.connect(depositor.wallet).approve(escrow.address, usdc(200));
+      await escrow.connect(depositor.wallet).addFunds(ZERO, usdc(200));
+
+      const rate = await rateManagerV2.getRate(rateManagerId, escrow.address, ZERO, paymentMethod, Currency.USD);
+      expect(rate).to.eq(ZERO);
+    });
+
+    it("returns 0 for a missing manager", async () => {
+      const rate = await rateManagerV2.getRate(
+        ethers.utils.formatBytes32String("missing-manager"),
+        escrow.address,
+        ZERO,
+        paymentMethod,
+        Currency.USD
+      );
+      expect(rate).to.eq(ZERO);
+    });
+
+    it("returns 0 when tranches are configured and escrow is zero address", async () => {
+      await setStandardTranches(rateManagerId);
+
+      const rate = await rateManagerV2.getRate(rateManagerId, ADDRESS_ZERO, ZERO, paymentMethod, Currency.USD);
+      expect(rate).to.eq(ZERO);
+    });
+
+    it("returns 0 when tranche resolution points at an address with no code", async () => {
+      await setStandardTranches(rateManagerId);
+
+      const rate = await rateManagerV2.getRate(rateManagerId, other.address, ZERO, paymentMethod, Currency.USD);
+      expect(rate).to.eq(ZERO);
+    });
+
+    it("returns 0 when tranche resolution calls a contract that does not implement getDeposit", async () => {
+      await setStandardTranches(rateManagerId);
+
+      const rate = await rateManagerV2.getRate(rateManagerId, rateManagerV1.address, ZERO, paymentMethod, Currency.USD);
+      expect(rate).to.eq(ZERO);
+    });
+  });
+
+  describe("view getters", () => {
+    it("returns manager config via getRateManager", async () => {
+      const config = await rateManagerV2.getRateManager(rateManagerId);
+      expect(config.manager).to.eq(manager.address);
+      expect(config.feeRecipient).to.eq(feeRecipient.address);
+    });
+
+    it("returns fee config via getFee", async () => {
+      const feeConfig = await rateManagerV2.getFee(rateManagerId);
+      expect(feeConfig.recipient).to.eq(feeRecipient.address);
+      expect(feeConfig.fee).to.eq(ether(0.01));
+    });
+
+    it("returns zeroed legacy source for managers created natively in V2", async () => {
+      const source = await rateManagerV2.getLegacySource(rateManagerId);
+      expect(source.legacyRateManager).to.eq(ADDRESS_ZERO);
+      expect(source.legacyRateManagerId).to.eq(ethers.constants.HashZero);
+    });
+  });
+
+  describe("#setFee", () => {
+    let subjectCaller: any;
+    let subjectRateManagerId: BytesLike;
+    let subjectFee: BigNumber;
+
+    async function subject() {
+      return rateManagerV2.connect(subjectCaller.wallet).setFee(subjectRateManagerId, subjectFee);
+    }
+
+    beforeEach(async () => {
+      subjectCaller = manager;
+      subjectRateManagerId = rateManagerId;
+      subjectFee = ether(0.02);
+    });
+
+    it("updates the manager fee", async () => {
+      await expect(subject()).to.emit(rateManagerV2, "RateManagerFeeUpdated").withArgs(rateManagerId, subjectFee);
+
+      const feeConfig = await rateManagerV2.getFee(rateManagerId);
+      expect(feeConfig.recipient).to.eq(feeRecipient.address);
+      expect(feeConfig.fee).to.eq(subjectFee);
+    });
+
+    describe("when fee exceeds maxFee", () => {
+      beforeEach(async () => {
+        subjectFee = ether(0.06);
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "FeeExceedsMaximum");
+      });
+    });
+
+    describe("when caller is not the manager", () => {
+      beforeEach(async () => {
+        subjectCaller = other;
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "UnauthorizedCaller");
+      });
+    });
+
+    describe("when rate manager id does not exist", () => {
+      beforeEach(async () => {
+        subjectRateManagerId = ethers.utils.formatBytes32String("missing-manager");
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "RateManagerNotFound");
+      });
+    });
+
+    describe("when fee recipient is zero and fee is set above zero", () => {
+      beforeEach(async () => {
+        await rateManagerV2.connect(manager.wallet).setFee(rateManagerId, ZERO);
+        await rateManagerV2
+          .connect(manager.wallet)
+          .setRateManagerConfig(rateManagerId, manager.address, ADDRESS_ZERO, "RM", "ipfs://rm");
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "ZeroAddress");
+      });
+    });
+  });
+
+  describe("#setRateManagerConfig", () => {
+    let subjectCaller: any;
+    let subjectRateManagerId: BytesLike;
+    let subjectManager: string;
+    let subjectFeeRecipient: string;
+    let subjectName: string;
+    let subjectUri: string;
+
+    async function subject() {
+      return rateManagerV2
+        .connect(subjectCaller.wallet)
+        .setRateManagerConfig(subjectRateManagerId, subjectManager, subjectFeeRecipient, subjectName, subjectUri);
+    }
+
+    beforeEach(async () => {
+      subjectCaller = manager;
+      subjectRateManagerId = rateManagerId;
+      subjectManager = other.address;
+      subjectFeeRecipient = other.address;
+      subjectName = "Updated RM";
+      subjectUri = "ipfs://updated";
+    });
+
+    it("updates rate manager config fields", async () => {
+      await expect(subject())
+        .to.emit(rateManagerV2, "RateManagerConfigUpdated")
+        .withArgs(rateManagerId, subjectManager, subjectFeeRecipient, subjectName, subjectUri);
+
+      const updatedConfig = await rateManagerV2.getRateManager(rateManagerId);
+      expect(updatedConfig.manager).to.eq(subjectManager);
+      expect(updatedConfig.feeRecipient).to.eq(subjectFeeRecipient);
+      expect(updatedConfig.name).to.eq(subjectName);
+      expect(updatedConfig.uri).to.eq(subjectUri);
+    });
+
+    describe("when manager is zero address", () => {
+      beforeEach(async () => {
+        subjectManager = ADDRESS_ZERO;
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "ZeroAddress");
+      });
+    });
+
+    describe("when current fee is non-zero and fee recipient is zero address", () => {
+      beforeEach(async () => {
+        subjectFeeRecipient = ADDRESS_ZERO;
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "ZeroAddress");
+      });
+    });
+
+    describe("when current fee is zero and fee recipient is zero address", () => {
+      beforeEach(async () => {
+        await rateManagerV2.connect(manager.wallet).setFee(rateManagerId, ZERO);
+        subjectFeeRecipient = ADDRESS_ZERO;
+      });
+
+      it("updates the config", async () => {
+        await subject();
+        const updatedConfig = await rateManagerV2.getRateManager(rateManagerId);
+        expect(updatedConfig.feeRecipient).to.eq(ADDRESS_ZERO);
+      });
+    });
+
+    describe("when caller is not the manager", () => {
+      beforeEach(async () => {
+        subjectCaller = other;
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "UnauthorizedCaller");
+      });
+    });
+
+    describe("when rate manager id does not exist", () => {
+      beforeEach(async () => {
+        subjectRateManagerId = ethers.utils.formatBytes32String("missing-manager");
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "RateManagerNotFound");
+      });
+    });
+  });
+
+  describe("#setMinLiquidity", () => {
+    let subjectCaller: any;
+    let subjectRateManagerId: BytesLike;
+    let subjectMinLiquidity: BigNumber;
+
+    async function subject() {
+      return rateManagerV2.connect(subjectCaller.wallet).setMinLiquidity(subjectRateManagerId, subjectMinLiquidity);
+    }
+
+    beforeEach(async () => {
+      subjectCaller = manager;
+      subjectRateManagerId = rateManagerId;
+      subjectMinLiquidity = usdc(100);
+    });
+
+    it("sets min liquidity and emits MinLiquidityUpdated", async () => {
+      await expect(subject())
+        .to.emit(rateManagerV2, "MinLiquidityUpdated")
+        .withArgs(rateManagerId, subjectMinLiquidity);
+
+      expect((await rateManagerV2.getRateManager(rateManagerId)).minLiquidity).to.eq(subjectMinLiquidity);
+    });
+
+    describe("when clearing back to zero", () => {
+      beforeEach(async () => {
+        await rateManagerV2.connect(manager.wallet).setMinLiquidity(rateManagerId, usdc(100));
+        subjectMinLiquidity = ZERO;
+      });
+
+      it("clears the min liquidity", async () => {
+        await subject();
+        expect((await rateManagerV2.getRateManager(rateManagerId)).minLiquidity).to.eq(ZERO);
+      });
+    });
+
+    describe("when caller is not the manager", () => {
+      beforeEach(async () => {
+        subjectCaller = other;
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "UnauthorizedCaller");
+      });
+    });
+
+    describe("when rate manager id does not exist", () => {
+      beforeEach(async () => {
+        subjectRateManagerId = ethers.utils.formatBytes32String("missing-manager");
+      });
+
+      it("reverts", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(rateManagerV2, "RateManagerNotFound");
+      });
+    });
+  });
+
+  describe("#onDepositOptIn", () => {
+    let escrowSigner: any;
+
+    beforeEach(async () => {
+      await ethers.provider.send("hardhat_impersonateAccount", [escrow.address]);
+      escrowSigner = await ethers.getSigner(escrow.address);
+      await ethers.provider.send("hardhat_setBalance", [escrow.address, "0xDE0B6B3A7640000"]);
+    });
+
+    afterEach(async () => {
+      await ethers.provider.send("hardhat_stopImpersonatingAccount", [escrow.address]);
+    });
+
+    it("passes when no min liquidity is set", async () => {
+      await expect(rateManagerV2.connect(escrowSigner).onDepositOptIn(ZERO, rateManagerId)).to.not.be.reverted;
+    });
+
+    it("passes when the deposit liquidity meets the threshold", async () => {
+      await rateManagerV2.connect(manager.wallet).setMinLiquidity(rateManagerId, usdc(100));
+
+      await expect(rateManagerV2.connect(escrowSigner).onDepositOptIn(ZERO, rateManagerId)).to.not.be.reverted;
+    });
+
+    it("reverts when the deposit liquidity is below the threshold", async () => {
+      await rateManagerV2.connect(manager.wallet).setMinLiquidity(rateManagerId, usdc(1000));
+
+      await expect(
+        rateManagerV2.connect(escrowSigner).onDepositOptIn(ZERO, rateManagerId)
+      ).to.be.revertedWithCustomError(rateManagerV2, "BelowMinLiquidity");
+    });
+
+    it("passes when min liquidity is set and then cleared", async () => {
+      await rateManagerV2.connect(manager.wallet).setMinLiquidity(rateManagerId, usdc(1000));
+      await rateManagerV2.connect(manager.wallet).setMinLiquidity(rateManagerId, ZERO);
+
+      await expect(rateManagerV2.connect(escrowSigner).onDepositOptIn(ZERO, rateManagerId)).to.not.be.reverted;
+    });
+
+    it("reverts when caller is not a whitelisted escrow", async () => {
+      await expect(
+        rateManagerV2.connect(other.wallet).onDepositOptIn(ZERO, rateManagerId)
+      ).to.be.revertedWithCustomError(rateManagerV2, "UnauthorizedEscrow");
+    });
+
+    it("passes when caller is a whitelisted escrow", async () => {
+      await escrowRegistry.addEscrow(owner.address);
+
+      await expect(rateManagerV2.onDepositOptIn(ZERO, rateManagerId)).to.not.be.reverted;
+    });
+
+    it("passes when acceptAllEscrows is enabled", async () => {
+      await escrowRegistry.setAcceptAllEscrows(true);
+
+      await expect(rateManagerV2.connect(other.wallet).onDepositOptIn(ZERO, rateManagerId)).to.not.be.reverted;
+    });
+
+    it("reverts when the manager id does not exist", async () => {
+      await escrowRegistry.setAcceptAllEscrows(true);
+
+      await expect(
+        rateManagerV2.connect(other.wallet).onDepositOptIn(ZERO, ethers.utils.formatBytes32String("missing-manager"))
+      ).to.be.reverted;
+    });
+  });
+
+  describe("#setEscrowRegistry", () => {
+    it("updates the escrow registry", async () => {
+      const newRegistry = await deployer.deployEscrowRegistry();
+      await rateManagerV2.setEscrowRegistry(newRegistry.address);
+      expect(await rateManagerV2.escrowRegistry()).to.eq(newRegistry.address);
+    });
+
+    it("emits EscrowRegistryUpdated", async () => {
+      const newRegistry = await deployer.deployEscrowRegistry();
+      await expect(rateManagerV2.setEscrowRegistry(newRegistry.address))
+        .to.emit(rateManagerV2, "EscrowRegistryUpdated")
+        .withArgs(newRegistry.address);
+    });
+
+    it("reverts when called by a non-owner", async () => {
+      const newRegistry = await deployer.deployEscrowRegistry();
+      await expect(
+        rateManagerV2.connect(other.wallet).setEscrowRegistry(newRegistry.address)
+      ).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+
+    it("reverts when the new registry is zero address", async () => {
+      await expect(rateManagerV2.setEscrowRegistry(ADDRESS_ZERO)).to.be.revertedWithCustomError(rateManagerV2, "ZeroAddress");
+    });
+  });
+});

--- a/utils/contracts.ts
+++ b/utils/contracts.ts
@@ -16,6 +16,7 @@ export {
   Orchestrator,
   OrchestratorV2,
   RateManagerV1,
+  RateManagerV2,
   OrchestratorRegistry,
   RateManagerMock,
   PaymentVerifierRegistry,

--- a/utils/deploys.ts
+++ b/utils/deploys.ts
@@ -12,6 +12,7 @@ import {
   Orchestrator,
   OrchestratorV2,
   RateManagerV1,
+  RateManagerV2,
   OrchestratorRegistry,
   PaymentVerifierMock,
   PreIntentHookMock,
@@ -75,6 +76,7 @@ import { ProtocolViewer__factory } from "../typechain/factories/contracts/index"
 import { Orchestrator__factory } from "../typechain/factories/contracts/index";
 import { OrchestratorV2__factory } from "../typechain/factories/contracts/OrchestratorV2__factory";
 import { RateManagerV1__factory } from "../typechain/factories/contracts/RateManagerV1__factory";
+import { RateManagerV2__factory } from "../typechain/factories/contracts/RateManagerV2__factory";
 import { UnifiedPaymentVerifier__factory } from "../typechain/factories/contracts/unifiedVerifier";
 import { SimpleAttestationVerifier__factory } from "../typechain/factories/contracts/unifiedVerifier";
 import { SignatureGatingPreIntentHook__factory } from "../typechain/factories/contracts/hooks/SignatureGatingPreIntentHook__factory";
@@ -253,6 +255,10 @@ export default class DeployHelper {
 
   public async deployRateManagerV1(escrowRegistry: Address): Promise<RateManagerV1> {
     return await new RateManagerV1__factory(this._deployerSigner).deploy(escrowRegistry);
+  }
+
+  public async deployRateManagerV2(escrowRegistry: Address): Promise<RateManagerV2> {
+    return await new RateManagerV2__factory(this._deployerSigner).deploy(escrowRegistry);
   }
 
   public async deployRateManagerMock(): Promise<RateManagerMock> {


### PR DESCRIPTION
## Summary
- add a backwards-compatible `RateManagerV2` that keeps the V1 flat-rate surface and adds tranche schedules per payment-method/currency pair
- support importing V1 manager configs and flat-rate tuples into V2 for downstream continuity
- add deployment exports and a dedicated `RateManagerV2` test suite with targeted 100% coverage on the new contract

## Testing
- `yarn build`
- `npx hardhat test test/rateManager/rateManagerV2.spec.ts`
- `npx hardhat coverage --testfiles 'test/rateManager/rateManagerV2.spec.ts'`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zkp2p/zkp2p-contracts/pull/151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
