### PR TITLE
feat: generic ERC-4626 vault post-intent hook (V2)

### DIFF
--- a/contracts/external/Interfaces/IERC4626.sol
+++ b/contracts/external/Interfaces/IERC4626.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+/**
+ * @title IERC4626
+ * @notice Minimal ERC-4626 tokenized vault interface used by ERC4626VaultHookV2.
+ * @dev Only the methods the hook actually calls are declared. Vaults that conform to
+ *      EIP-4626 (https://eips.ethereum.org/EIPS/eip-4626) expose the full surface.
+ */
+interface IERC4626 {
+    /**
+     * @notice Returns the address of the underlying asset token managed by the vault.
+     */
+    function asset() external view returns (address);
+
+    /**
+     * @notice Simulates the effects of a deposit at the current block, returning the
+     *         number of shares that would be minted for `assets`.
+     * @dev Per spec, MUST return as close to and no more than the exact amount of shares
+     *      that would actually be minted, making it a safe upper-bound slippage gate.
+     * @param assets The amount of underlying asset to simulate depositing
+     * @return shares The number of vault shares that would be minted
+     */
+    function previewDeposit(uint256 assets) external view returns (uint256 shares);
+
+    /**
+     * @notice Mints vault shares to `receiver` by depositing exactly `assets` of the underlying token.
+     * @param assets The amount of underlying asset to deposit
+     * @param receiver The address to receive the minted shares
+     * @return shares The number of vault shares minted
+     */
+    function deposit(uint256 assets, address receiver) external returns (uint256 shares);
+}

--- a/contracts/hooks/ERC4626VaultHookV2.sol
+++ b/contracts/hooks/ERC4626VaultHookV2.sol
@@ -18,14 +18,20 @@ import { IPostIntentHookV2 } from "../interfaces/IPostIntentHookV2.sol";
  *         Aave wrappers, Yearn v3, Spark, Euler wrappers, etc. without deploying new contracts.
  *
  * @dev Slippage protection comes from `minSharesOut`, committed at signalIntent time and signed
- *      over by the gating service. The hook performs an upper-bound preview check before
- *      depositing (per ERC-4626 spec, `previewDeposit` MUST NOT exceed actual shares minted),
- *      then verifies the actual shares delta after the deposit against both `minSharesOut` and
- *      a deploy-time `maxSlippageBps` guardrail to catch non-compliant vaults.
+ *      over by the gating service. Per ERC-4626 spec, `previewDeposit` MUST return no more than
+ *      the shares that would actually be minted in the same transaction, so it is a sound lower
+ *      bound on the actual mint. The hook uses `previewDeposit` as a pre-gate: if the preview
+ *      already clears `minSharesOut`, the deposit is guaranteed to clear it for spec-compliant
+ *      vaults and we proceed; otherwise we fall back to a direct transfer of the underlying to
+ *      `intent.to`. There is no post-deposit revert on the share count: once the vault has the
+ *      assets we cannot safely undo, and hard-reverting would leave the intent stuck (the
+ *      vault is committed in `signalHookData`, so relayers cannot retry against a different
+ *      vault). The trade-off is that a vault whose `previewDeposit` lies relative to its
+ *      `deposit` is not caught by this hook; integrators should only expose reputable vaults.
  *
- *      FALLBACK BEHAVIOR: If the deposit cannot be completed (preview below minimum, vault call
- *      reverts, vault non-compliant on preview), the net amount is transferred to `intent.to`
- *      on the source chain. The user always receives their funds, matching the UX guarantee of
+ *      FALLBACK BEHAVIOR: If the deposit cannot be completed (preview below minimum, preview
+ *      reverts, or vault.deposit reverts), the net amount is transferred to `intent.to` on the
+ *      source chain. The user always receives their funds, matching the UX guarantee of
  *      AcrossBridgeHookV2.
  */
 contract ERC4626VaultHookV2 is IPostIntentHookV2, Ownable {
@@ -101,11 +107,7 @@ contract ERC4626VaultHookV2 is IPostIntentHookV2, Ownable {
     error InvalidFulfillHookDataLength(uint256 dataLength);
     error InvalidVault(address vault);
     error InvalidSharesReceiver(address sharesReceiver);
-    error InvalidMaxSlippageBps(uint256 maxSlippageBps);
     error UnsupportedToken(address token);
-    /// @dev Reverts fulfillIntent if the vault minted fewer shares than the floor implied by
-    ///      `minSharesOut` and the `maxSlippageBps` guardrail. Indicates a non-compliant vault.
-    error VaultActualBelowMinimum(uint256 actualShares, uint256 minimumShares);
     /// @dev Reverts fulfillIntent if the vault did not pull exactly `executableAmount` of the
     ///      underlying during `deposit()`. Without this check, a non-compliant vault could mint
     ///      shares while leaving funds stranded in the hook (the Orchestrator's exact-spend
@@ -114,14 +116,8 @@ contract ERC4626VaultHookV2 is IPostIntentHookV2, Ownable {
 
     /* ============ State Variables ============ */
 
-    uint256 private constant BPS_DENOMINATOR = 10_000;
-
     IERC20 public immutable inputToken;
     IOrchestratorRegistry public immutable orchestratorRegistry;
-    /// @notice Maximum permitted deviation between previewDeposit and actual minted shares, in
-    ///         basis points. If the actual shares fall below `previewShares * (10000 - maxSlippageBps) / 10000`
-    ///         the call reverts as a vault non-compliance signal. Default deployment uses 500 (5%).
-    uint256 public immutable maxSlippageBps;
 
     /* ============ Constructor ============ */
 
@@ -129,24 +125,17 @@ contract ERC4626VaultHookV2 is IPostIntentHookV2, Ownable {
      * @notice Creates a new ERC4626VaultHookV2 instance.
      * @param _inputToken           Underlying asset accepted by target vaults (e.g. USDC)
      * @param _orchestratorRegistry Registry of authorized orchestrators that may invoke this hook
-     * @param _maxSlippageBps       Maximum allowed deviation between previewDeposit and actual
-     *                              minted shares, in basis points (must be <= 10000). Recommended: 500.
      */
     constructor(
         address _inputToken,
-        address _orchestratorRegistry,
-        uint256 _maxSlippageBps
+        address _orchestratorRegistry
     ) Ownable() {
         if (_inputToken == address(0) || _orchestratorRegistry == address(0)) {
             revert ZeroAddress();
         }
-        if (_maxSlippageBps > BPS_DENOMINATOR) {
-            revert InvalidMaxSlippageBps(_maxSlippageBps);
-        }
 
         inputToken = IERC20(_inputToken);
         orchestratorRegistry = IOrchestratorRegistry(_orchestratorRegistry);
-        maxSlippageBps = _maxSlippageBps;
     }
 
     /* ============ External Functions ============ */
@@ -189,8 +178,11 @@ contract ERC4626VaultHookV2 is IPostIntentHookV2, Ownable {
         // below to consume exactly `_ctx.executableAmount`.
         inputToken.safeTransferFrom(callingOrchestrator, address(this), _ctx.executableAmount);
 
-        // Probe the vault preview as an upper bound on actual shares (per ERC-4626 spec).
-        // A revert here means the vault is non-compliant or unreachable; treat as DEPOSIT_CALL_FAILED.
+        // Probe the vault preview as a spec-compliant lower bound on actual shares. Per EIP-4626,
+        // `previewDeposit` MUST return no more than the shares that `deposit` would mint in the
+        // same block, so `previewShares >= minSharesOut` guarantees the user's floor is honored
+        // for compliant vaults. A revert here means the vault is non-compliant or unreachable;
+        // we divert to the fallback path rather than reverting the whole fulfillIntent.
         (bool previewOk, uint256 previewShares) = _previewDeposit(commitment.vault, _ctx.executableAmount);
         bool priceMeetsMinimum = previewOk && previewShares >= commitment.minSharesOut;
 
@@ -218,20 +210,12 @@ contract ERC4626VaultHookV2 is IPostIntentHookV2, Ownable {
                     revert VaultDidNotConsumeAssets(hookAssetsBefore, hookAssetsAfter, _ctx.executableAmount);
                 }
 
-                uint256 sharesAfter = IERC20(commitment.vault).balanceOf(commitment.sharesReceiver);
-                uint256 actualShares = sharesAfter - sharesBefore;
-
-                // Compute the effective minimum: the higher of the maker's commitment floor and
-                // the deploy-time guardrail derived from the vault's own preview. The guardrail
-                // catches vaults that previewed honestly but minted dishonestly.
-                uint256 guardrailMinimum = (previewShares * (BPS_DENOMINATOR - maxSlippageBps)) / BPS_DENOMINATOR;
-                uint256 effectiveMinimum = guardrailMinimum > commitment.minSharesOut
-                    ? guardrailMinimum
-                    : commitment.minSharesOut;
-
-                if (actualShares < effectiveMinimum) {
-                    revert VaultActualBelowMinimum(actualShares, effectiveMinimum);
-                }
+                // Use the balance delta as the authoritative mint amount. We intentionally do
+                // NOT re-check `actualShares >= minSharesOut` here: the preview gate above
+                // already guarantees this for spec-compliant vaults, and reverting post-deposit
+                // on a non-compliant vault would leave the intent stuck (the vault is committed
+                // in signalHookData, so relayers cannot retry against a different vault).
+                uint256 actualShares = IERC20(commitment.vault).balanceOf(commitment.sharesReceiver) - sharesBefore;
 
                 emit VaultDepositExecuted(
                     _ctx.intentHash,

--- a/contracts/hooks/ERC4626VaultHookV2.sol
+++ b/contracts/hooks/ERC4626VaultHookV2.sol
@@ -106,6 +106,11 @@ contract ERC4626VaultHookV2 is IPostIntentHookV2, Ownable {
     /// @dev Reverts fulfillIntent if the vault minted fewer shares than the floor implied by
     ///      `minSharesOut` and the `maxSlippageBps` guardrail. Indicates a non-compliant vault.
     error VaultActualBelowMinimum(uint256 actualShares, uint256 minimumShares);
+    /// @dev Reverts fulfillIntent if the vault did not pull exactly `executableAmount` of the
+    ///      underlying during `deposit()`. Without this check, a non-compliant vault could mint
+    ///      shares while leaving funds stranded in the hook (the Orchestrator's exact-spend
+    ///      invariant would still pass because the orch-to-hook transfer already counts as spent).
+    error VaultDidNotConsumeAssets(uint256 hookAssetsBefore, uint256 hookAssetsAfter, uint256 expectedConsumed);
 
     /* ============ State Variables ============ */
 
@@ -197,11 +202,21 @@ contract ERC4626VaultHookV2 is IPostIntentHookV2, Ownable {
             // Snapshot recipient share balance to compute the authoritative shares delta.
             // We trust this delta over the value returned by deposit() in case the vault is buggy.
             uint256 sharesBefore = IERC20(commitment.vault).balanceOf(commitment.sharesReceiver);
+            // Snapshot hook's underlying balance so we can verify the vault actually pulled
+            // exactly `executableAmount`. Without this, a non-compliant vault could mint shares
+            // while leaving funds stranded in the hook (the Orchestrator's exact-spend invariant
+            // would still pass because the orch-to-hook transfer already counts as spent).
+            uint256 hookAssetsBefore = inputToken.balanceOf(address(this));
 
             // Try the deposit; on revert fall through to the safeTransfer fallback below.
             try IERC4626(commitment.vault).deposit(_ctx.executableAmount, commitment.sharesReceiver) returns (uint256) {
                 // Reset allowance even on success in case the vault under-pulled (defensive).
                 inputToken.safeApprove(commitment.vault, 0);
+
+                uint256 hookAssetsAfter = inputToken.balanceOf(address(this));
+                if (hookAssetsAfter + _ctx.executableAmount != hookAssetsBefore) {
+                    revert VaultDidNotConsumeAssets(hookAssetsBefore, hookAssetsAfter, _ctx.executableAmount);
+                }
 
                 uint256 sharesAfter = IERC20(commitment.vault).balanceOf(commitment.sharesReceiver);
                 uint256 actualShares = sharesAfter - sharesBefore;

--- a/contracts/hooks/ERC4626VaultHookV2.sol
+++ b/contracts/hooks/ERC4626VaultHookV2.sol
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import { IERC4626 } from "../external/Interfaces/IERC4626.sol";
+import { IOrchestratorRegistry } from "../interfaces/IOrchestratorRegistry.sol";
+import { IPostIntentHookV2 } from "../interfaces/IPostIntentHookV2.sol";
+
+/**
+ * @title ERC4626VaultHookV2
+ * @notice V2 post-intent hook that deposits the net intent payout into any ERC-4626 compliant
+ *         vault chosen by the taker at signalIntent time. Generic to any vault whose underlying
+ *         asset matches the hook's input token (e.g. USDC), so integrators can target Morpho,
+ *         Aave wrappers, Yearn v3, Spark, Euler wrappers, etc. without deploying new contracts.
+ *
+ * @dev Slippage protection comes from `minSharesOut`, committed at signalIntent time and signed
+ *      over by the gating service. The hook performs an upper-bound preview check before
+ *      depositing (per ERC-4626 spec, `previewDeposit` MUST NOT exceed actual shares minted),
+ *      then verifies the actual shares delta after the deposit against both `minSharesOut` and
+ *      a deploy-time `maxSlippageBps` guardrail to catch non-compliant vaults.
+ *
+ *      FALLBACK BEHAVIOR: If the deposit cannot be completed (preview below minimum, vault call
+ *      reverts, vault non-compliant on preview), the net amount is transferred to `intent.to`
+ *      on the source chain. The user always receives their funds, matching the UX guarantee of
+ *      AcrossBridgeHookV2.
+ */
+contract ERC4626VaultHookV2 is IPostIntentHookV2, Ownable {
+    using SafeERC20 for IERC20;
+
+    /* ============ Enums ============ */
+
+    /**
+     * @notice Reason codes for fallback transfer when the vault deposit cannot be completed.
+     * @dev Used in FallbackTransfer event for gas-efficient reason tracking.
+     */
+    enum FallbackReason {
+        PREVIEW_BELOW_MINIMUM, // previewDeposit returned fewer shares than minSharesOut
+        DEPOSIT_CALL_FAILED    // previewDeposit reverted, or vault.deposit() reverted
+    }
+
+    /* ============ Structs ============ */
+
+    /**
+     * @notice Commitment stored in intent signalHookData at signalIntent time.
+     * @dev The commitment is fixed at signal time and covered by the gating service signature.
+     *      `minSharesOut` is the user's slippage floor; off-chain tooling should compute it from
+     *      a fresh `previewDeposit` quote with a small buffer (e.g. 50 bps) before signaling.
+     * @param vault           ERC-4626 vault address (must have asset() == inputToken)
+     * @param sharesReceiver  Address that receives the minted vault shares (often == intent.to)
+     * @param minSharesOut    Minimum vault shares the user is willing to accept
+     */
+    struct VaultDepositCommitment {
+        address vault;
+        address sharesReceiver;
+        uint256 minSharesOut;
+    }
+
+    /* ============ Events ============ */
+
+    /**
+     * @notice Emitted when a vault deposit is successfully executed.
+     * @param intentHash     Hash of the fulfilled intent
+     * @param vault          ERC-4626 vault that received the deposit
+     * @param sharesReceiver Address that received the minted shares
+     * @param assetsIn       Amount of underlying asset deposited
+     * @param sharesOut      Actual shares minted (measured by balance delta)
+     */
+    event VaultDepositExecuted(
+        bytes32 indexed intentHash,
+        address indexed vault,
+        address indexed sharesReceiver,
+        uint256 assetsIn,
+        uint256 sharesOut
+    );
+
+    /**
+     * @notice Emitted when the deposit cannot be initiated and funds are transferred to intent.to.
+     * @dev Graceful degradation: user receives the underlying asset instead of vault shares.
+     * @param intentHash Hash of the intent being fulfilled
+     * @param recipient  Address receiving the fallback transfer (intent.to)
+     * @param amount     Amount transferred to recipient
+     * @param reason     Why the deposit could not be initiated
+     */
+    event FallbackTransfer(
+        bytes32 indexed intentHash,
+        address indexed recipient,
+        uint256 amount,
+        FallbackReason reason
+    );
+
+    event RescueERC20(address indexed token, address indexed to, uint256 amount);
+
+    /* ============ Errors ============ */
+
+    error ZeroAddress();
+    error UnauthorizedOrchestratorCaller(address caller);
+    error InvalidFulfillHookDataLength(uint256 dataLength);
+    error InvalidVault(address vault);
+    error InvalidSharesReceiver(address sharesReceiver);
+    error InvalidMaxSlippageBps(uint256 maxSlippageBps);
+    error UnsupportedToken(address token);
+    /// @dev Reverts fulfillIntent if the vault minted fewer shares than the floor implied by
+    ///      `minSharesOut` and the `maxSlippageBps` guardrail. Indicates a non-compliant vault.
+    error VaultActualBelowMinimum(uint256 actualShares, uint256 minimumShares);
+
+    /* ============ State Variables ============ */
+
+    uint256 private constant BPS_DENOMINATOR = 10_000;
+
+    IERC20 public immutable inputToken;
+    IOrchestratorRegistry public immutable orchestratorRegistry;
+    /// @notice Maximum permitted deviation between previewDeposit and actual minted shares, in
+    ///         basis points. If the actual shares fall below `previewShares * (10000 - maxSlippageBps) / 10000`
+    ///         the call reverts as a vault non-compliance signal. Default deployment uses 500 (5%).
+    uint256 public immutable maxSlippageBps;
+
+    /* ============ Constructor ============ */
+
+    /**
+     * @notice Creates a new ERC4626VaultHookV2 instance.
+     * @param _inputToken           Underlying asset accepted by target vaults (e.g. USDC)
+     * @param _orchestratorRegistry Registry of authorized orchestrators that may invoke this hook
+     * @param _maxSlippageBps       Maximum allowed deviation between previewDeposit and actual
+     *                              minted shares, in basis points (must be <= 10000). Recommended: 500.
+     */
+    constructor(
+        address _inputToken,
+        address _orchestratorRegistry,
+        uint256 _maxSlippageBps
+    ) Ownable() {
+        if (_inputToken == address(0) || _orchestratorRegistry == address(0)) {
+            revert ZeroAddress();
+        }
+        if (_maxSlippageBps > BPS_DENOMINATOR) {
+            revert InvalidMaxSlippageBps(_maxSlippageBps);
+        }
+
+        inputToken = IERC20(_inputToken);
+        orchestratorRegistry = IOrchestratorRegistry(_orchestratorRegistry);
+        maxSlippageBps = _maxSlippageBps;
+    }
+
+    /* ============ External Functions ============ */
+
+    /**
+     * @notice Executes the hook by depositing the net intent payout into the committed ERC-4626 vault.
+     * @dev Caller MUST be a registered orchestrator. Pulls `_ctx.executableAmount` from the orchestrator
+     *      via safeTransferFrom and either deposits it into the vault for `sharesReceiver`, or — if the
+     *      vault is non-viable — falls back by transferring the underlying to `_ctx.intent.to`.
+     *
+     *      The orchestrator enforces post-call that this hook consumed exactly `_ctx.executableAmount`,
+     *      so every code path here must spend the full pulled amount.
+     *
+     * @param _ctx             Hook execution context (commitment is in _ctx.intent.signalHookData)
+     * @param _fulfillHookData Must be empty (length 0); reserved for future JIT parameters
+     */
+    function execute(
+        HookExecutionContext calldata _ctx,
+        bytes calldata _fulfillHookData
+    ) external override {
+        address callingOrchestrator = msg.sender;
+        if (!orchestratorRegistry.isOrchestrator(callingOrchestrator)) {
+            revert UnauthorizedOrchestratorCaller(callingOrchestrator);
+        }
+        if (_fulfillHookData.length != 0) {
+            revert InvalidFulfillHookDataLength(_fulfillHookData.length);
+        }
+        if (_ctx.token != address(inputToken)) {
+            revert UnsupportedToken(_ctx.token);
+        }
+
+        VaultDepositCommitment memory commitment = abi.decode(
+            _ctx.intent.signalHookData,
+            (VaultDepositCommitment)
+        );
+        _validateCommitment(commitment);
+
+        // Pull tokens from calling Orchestrator first (before any fallback logic).
+        // The Orchestrator's post-call assertion (`spent == netAmount`) requires every branch
+        // below to consume exactly `_ctx.executableAmount`.
+        inputToken.safeTransferFrom(callingOrchestrator, address(this), _ctx.executableAmount);
+
+        // Probe the vault preview as an upper bound on actual shares (per ERC-4626 spec).
+        // A revert here means the vault is non-compliant or unreachable; treat as DEPOSIT_CALL_FAILED.
+        (bool previewOk, uint256 previewShares) = _previewDeposit(commitment.vault, _ctx.executableAmount);
+        bool priceMeetsMinimum = previewOk && previewShares >= commitment.minSharesOut;
+
+        if (priceMeetsMinimum) {
+            // Reset and grant exact allowance.
+            inputToken.safeApprove(commitment.vault, 0);
+            inputToken.safeApprove(commitment.vault, _ctx.executableAmount);
+
+            // Snapshot recipient share balance to compute the authoritative shares delta.
+            // We trust this delta over the value returned by deposit() in case the vault is buggy.
+            uint256 sharesBefore = IERC20(commitment.vault).balanceOf(commitment.sharesReceiver);
+
+            // Try the deposit; on revert fall through to the safeTransfer fallback below.
+            try IERC4626(commitment.vault).deposit(_ctx.executableAmount, commitment.sharesReceiver) returns (uint256) {
+                // Reset allowance even on success in case the vault under-pulled (defensive).
+                inputToken.safeApprove(commitment.vault, 0);
+
+                uint256 sharesAfter = IERC20(commitment.vault).balanceOf(commitment.sharesReceiver);
+                uint256 actualShares = sharesAfter - sharesBefore;
+
+                // Compute the effective minimum: the higher of the maker's commitment floor and
+                // the deploy-time guardrail derived from the vault's own preview. The guardrail
+                // catches vaults that previewed honestly but minted dishonestly.
+                uint256 guardrailMinimum = (previewShares * (BPS_DENOMINATOR - maxSlippageBps)) / BPS_DENOMINATOR;
+                uint256 effectiveMinimum = guardrailMinimum > commitment.minSharesOut
+                    ? guardrailMinimum
+                    : commitment.minSharesOut;
+
+                if (actualShares < effectiveMinimum) {
+                    revert VaultActualBelowMinimum(actualShares, effectiveMinimum);
+                }
+
+                emit VaultDepositExecuted(
+                    _ctx.intentHash,
+                    commitment.vault,
+                    commitment.sharesReceiver,
+                    _ctx.executableAmount,
+                    actualShares
+                );
+                return;
+            } catch {
+                // Deposit reverted; reset allowance and fall through to fallback transfer.
+                inputToken.safeApprove(commitment.vault, 0);
+            }
+        }
+
+        // Fallback: transfer the underlying directly to intent.to.
+        inputToken.safeTransfer(_ctx.intent.to, _ctx.executableAmount);
+        emit FallbackTransfer(
+            _ctx.intentHash,
+            _ctx.intent.to,
+            _ctx.executableAmount,
+            (previewOk && !priceMeetsMinimum)
+                ? FallbackReason.PREVIEW_BELOW_MINIMUM
+                : FallbackReason.DEPOSIT_CALL_FAILED
+        );
+    }
+
+    /**
+     * @notice Rescues ERC20 tokens sent to this contract.
+     * @param _token  Token address to rescue
+     * @param _to     Recipient address for rescued tokens
+     * @param _amount Amount to rescue
+     */
+    function rescueERC20(address _token, address _to, uint256 _amount) external onlyOwner {
+        if (_token == address(0) || _to == address(0)) revert ZeroAddress();
+        IERC20(_token).safeTransfer(_to, _amount);
+        emit RescueERC20(_token, _to, _amount);
+    }
+
+    /* ============ Internal Functions ============ */
+
+    /**
+     * @dev Validates structural commitment fields. These conditions can never be salvaged by a
+     *      fallback (the data is malformed), so they revert hard.
+     */
+    function _validateCommitment(VaultDepositCommitment memory commitment) internal pure {
+        if (commitment.vault == address(0)) revert InvalidVault(commitment.vault);
+        if (commitment.sharesReceiver == address(0)) revert InvalidSharesReceiver(commitment.sharesReceiver);
+    }
+
+    /**
+     * @dev Wraps `previewDeposit` in a try/catch so non-compliant vaults divert to the fallback
+     *      path instead of reverting the entire fulfillIntent transaction.
+     * @param vault  Vault address being probed
+     * @param assets Amount of underlying asset that would be deposited
+     * @return ok            True if previewDeposit returned without reverting
+     * @return previewShares Preview value (0 if !ok)
+     */
+    function _previewDeposit(address vault, uint256 assets)
+        internal
+        view
+        returns (bool ok, uint256 previewShares)
+    {
+        try IERC4626(vault).previewDeposit(assets) returns (uint256 p) {
+            return (true, p);
+        } catch {
+            return (false, 0);
+        }
+    }
+}

--- a/contracts/mocks/ERC4626VaultMock.sol
+++ b/contracts/mocks/ERC4626VaultMock.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import { IERC4626 } from "../external/Interfaces/IERC4626.sol";
+
+/**
+ * @title ERC4626VaultMock
+ * @notice Minimal configurable ERC-4626 vault used by ERC4626VaultHookV2 unit tests.
+ * @dev Supports toggling reverts on previewDeposit and deposit, custom share rates, and an
+ *      override that mints fewer shares than previewDeposit reports (for non-compliance tests).
+ */
+contract ERC4626VaultMock is ERC20, IERC4626 {
+    using SafeERC20 for IERC20;
+
+    error MockPreviewRevert();
+    error MockDepositRevert();
+
+    IERC20 private immutable _asset;
+    uint8 private immutable _assetDecimals;
+
+    /// @notice Numerator for shares-per-asset rate (default 1).
+    uint256 public sharesPerAssetNumerator = 1;
+    /// @notice Denominator for shares-per-asset rate (default 1).
+    uint256 public sharesPerAssetDenominator = 1;
+
+    bool public previewShouldRevert;
+    bool public depositShouldRevert;
+    /// @notice If non-zero, the actual shares minted equal `forcedActualShares` regardless of preview.
+    uint256 public forcedActualShares;
+    /// @notice If true, the vault keeps any allowance unused (does not pull funds).
+    bool public skipAssetPull;
+
+    constructor(IERC20 asset_, uint8 assetDecimals_, string memory name_, string memory symbol_)
+        ERC20(name_, symbol_)
+    {
+        _asset = asset_;
+        _assetDecimals = assetDecimals_;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _assetDecimals;
+    }
+
+    /* ============ Mock Configuration ============ */
+
+    function setSharesPerAsset(uint256 numerator, uint256 denominator) external {
+        require(denominator != 0, "denominator zero");
+        sharesPerAssetNumerator = numerator;
+        sharesPerAssetDenominator = denominator;
+    }
+
+    function setPreviewShouldRevert(bool value) external {
+        previewShouldRevert = value;
+    }
+
+    function setDepositShouldRevert(bool value) external {
+        depositShouldRevert = value;
+    }
+
+    function setForcedActualShares(uint256 value) external {
+        forcedActualShares = value;
+    }
+
+    function setSkipAssetPull(bool value) external {
+        skipAssetPull = value;
+    }
+
+    /* ============ ERC-4626 ============ */
+
+    function asset() external view override returns (address) {
+        return address(_asset);
+    }
+
+    function previewDeposit(uint256 assets) public view override returns (uint256) {
+        if (previewShouldRevert) revert MockPreviewRevert();
+        return (assets * sharesPerAssetNumerator) / sharesPerAssetDenominator;
+    }
+
+    function deposit(uint256 assets, address receiver) external override returns (uint256) {
+        if (depositShouldRevert) revert MockDepositRevert();
+
+        if (!skipAssetPull) {
+            _asset.safeTransferFrom(msg.sender, address(this), assets);
+        }
+
+        uint256 sharesToMint = forcedActualShares != 0
+            ? forcedActualShares
+            : (assets * sharesPerAssetNumerator) / sharesPerAssetDenominator;
+
+        _mint(receiver, sharesToMint);
+        return sharesToMint;
+    }
+}

--- a/test/hooks/erc4626VaultHookV2.spec.ts
+++ b/test/hooks/erc4626VaultHookV2.spec.ts
@@ -303,6 +303,17 @@ describe("ERC4626VaultHookV2", () => {
       });
     });
 
+    describe("when the vault mints shares without pulling the underlying", () => {
+      beforeEach(async () => {
+        // Non-compliant vault: mints shares but never calls transferFrom on the hook.
+        await vault.setSkipAssetPull(true);
+      });
+
+      it("should hard revert with VaultDidNotConsumeAssets", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(hook, "VaultDidNotConsumeAssets");
+      });
+    });
+
     describe("when actual minted shares exceed minSharesOut and the guardrail", () => {
       beforeEach(async () => {
         // Vault gives a bonus: 11/10 ratio. Preview = 55, actual = 55, minSharesOut = 50.

--- a/test/hooks/erc4626VaultHookV2.spec.ts
+++ b/test/hooks/erc4626VaultHookV2.spec.ts
@@ -24,8 +24,6 @@ describe("ERC4626VaultHookV2", () => {
   let orchestratorRegistry: Contract;
   let hook: Contract;
 
-  const DEFAULT_MAX_SLIPPAGE_BPS = 500;
-
   // Encode VaultDepositCommitment struct for signalHookData
   const encodeCommitment = (commitment: any): string => {
     return ethers.utils.defaultAbiCoder.encode(
@@ -36,7 +34,9 @@ describe("ERC4626VaultHookV2", () => {
 
   // Build HookExecutionContext for V2 execute
   const buildContext = (commitment: any, overrides: any = {}): any => {
-    const intentHash = overrides.intentHash ?? ethers.utils.hexlify(ethers.utils.randomBytes(32));
+    const intentHash =
+      overrides.intentHash ??
+      ethers.utils.hexlify(ethers.utils.randomBytes(32));
     return {
       intentHash,
       token: overrides.token ?? usdcToken.address,
@@ -47,33 +47,47 @@ describe("ERC4626VaultHookV2", () => {
         escrow: owner.address,
         depositId: BigNumber.from(1),
         amount: usdc(100),
-        timestamp: overrides.timestamp ?? BigNumber.from(Math.floor(Date.now() / 1000)),
-        paymentMethod: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("venmo")),
+        timestamp:
+          overrides.timestamp ?? BigNumber.from(Math.floor(Date.now() / 1000)),
+        paymentMethod: ethers.utils.keccak256(
+          ethers.utils.toUtf8Bytes("venmo")
+        ),
         fiatCurrency: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("USD")),
         conversionRate: ether(1),
         payeeId: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("payee")),
         signalHookData: encodeCommitment(commitment),
-      }
+      },
     };
   };
 
   beforeEach(async () => {
-    [owner, orchestrator, recipient, sharesReceiver, attacker] = await getAccounts();
+    [owner, orchestrator, recipient, sharesReceiver, attacker] =
+      await getAccounts();
 
     deployer = new DeployHelper(owner.wallet);
     usdcToken = await deployer.deployUSDCMock(usdc(1_000_000), "USDC", "USDC");
 
-    const ERC4626VaultMock = await ethers.getContractFactory("ERC4626VaultMock", owner.wallet);
-    vault = await ERC4626VaultMock.deploy(usdcToken.address, 6, "Vault USDC", "vUSDC");
+    const ERC4626VaultMock = await ethers.getContractFactory(
+      "ERC4626VaultMock",
+      owner.wallet
+    );
+    vault = await ERC4626VaultMock.deploy(
+      usdcToken.address,
+      6,
+      "Vault USDC",
+      "vUSDC"
+    );
 
     orchestratorRegistry = await deployer.deployOrchestratorRegistry();
     await orchestratorRegistry.addOrchestrator(orchestrator.address);
 
-    const ERC4626VaultHookV2 = await ethers.getContractFactory("ERC4626VaultHookV2", owner.wallet);
+    const ERC4626VaultHookV2 = await ethers.getContractFactory(
+      "ERC4626VaultHookV2",
+      owner.wallet
+    );
     hook = await ERC4626VaultHookV2.deploy(
       usdcToken.address,
-      orchestratorRegistry.address,
-      DEFAULT_MAX_SLIPPAGE_BPS
+      orchestratorRegistry.address
     );
 
     await usdcToken.transfer(orchestrator.address, usdc(1000));
@@ -82,8 +96,9 @@ describe("ERC4626VaultHookV2", () => {
   describe("#constructor", () => {
     it("should set initial variables correctly", async () => {
       expect(await hook.inputToken()).to.eq(usdcToken.address);
-      expect(await hook.orchestratorRegistry()).to.eq(orchestratorRegistry.address);
-      expect(await hook.maxSlippageBps()).to.eq(DEFAULT_MAX_SLIPPAGE_BPS);
+      expect(await hook.orchestratorRegistry()).to.eq(
+        orchestratorRegistry.address
+      );
     });
 
     it("should set owner to deployer", async () => {
@@ -91,30 +106,23 @@ describe("ERC4626VaultHookV2", () => {
     });
 
     it("should revert when inputToken is zero address", async () => {
-      const ERC4626VaultHookV2 = await ethers.getContractFactory("ERC4626VaultHookV2", owner.wallet);
+      const ERC4626VaultHookV2 = await ethers.getContractFactory(
+        "ERC4626VaultHookV2",
+        owner.wallet
+      );
       await expect(
-        ERC4626VaultHookV2.deploy(ADDRESS_ZERO, orchestratorRegistry.address, DEFAULT_MAX_SLIPPAGE_BPS)
+        ERC4626VaultHookV2.deploy(ADDRESS_ZERO, orchestratorRegistry.address)
       ).to.be.revertedWithCustomError(hook, "ZeroAddress");
     });
 
     it("should revert when orchestratorRegistry is zero address", async () => {
-      const ERC4626VaultHookV2 = await ethers.getContractFactory("ERC4626VaultHookV2", owner.wallet);
+      const ERC4626VaultHookV2 = await ethers.getContractFactory(
+        "ERC4626VaultHookV2",
+        owner.wallet
+      );
       await expect(
-        ERC4626VaultHookV2.deploy(usdcToken.address, ADDRESS_ZERO, DEFAULT_MAX_SLIPPAGE_BPS)
+        ERC4626VaultHookV2.deploy(usdcToken.address, ADDRESS_ZERO)
       ).to.be.revertedWithCustomError(hook, "ZeroAddress");
-    });
-
-    it("should revert when maxSlippageBps exceeds 10000", async () => {
-      const ERC4626VaultHookV2 = await ethers.getContractFactory("ERC4626VaultHookV2", owner.wallet);
-      await expect(
-        ERC4626VaultHookV2.deploy(usdcToken.address, orchestratorRegistry.address, 10_001)
-      ).to.be.revertedWithCustomError(hook, "InvalidMaxSlippageBps");
-    });
-
-    it("should accept maxSlippageBps equal to 10000", async () => {
-      const ERC4626VaultHookV2 = await ethers.getContractFactory("ERC4626VaultHookV2", owner.wallet);
-      const h = await ERC4626VaultHookV2.deploy(usdcToken.address, orchestratorRegistry.address, 10_000);
-      expect(await h.maxSlippageBps()).to.eq(10_000);
     });
   });
 
@@ -129,22 +137,28 @@ describe("ERC4626VaultHookV2", () => {
       commitment = {
         vault: vault.address,
         sharesReceiver: sharesReceiver.address,
-        minSharesOut: usdc(50)
+        minSharesOut: usdc(50),
       };
 
       subjectCtx = buildContext(commitment);
       subjectFulfillHookData = "0x";
       subjectCaller = orchestrator;
 
-      await usdcToken.connect(orchestrator.wallet).approve(hook.address, subjectCtx.executableAmount);
+      await usdcToken
+        .connect(orchestrator.wallet)
+        .approve(hook.address, subjectCtx.executableAmount);
     });
 
     async function subject(): Promise<any> {
-      return hook.connect(subjectCaller.wallet).execute(subjectCtx, subjectFulfillHookData);
+      return hook
+        .connect(subjectCaller.wallet)
+        .execute(subjectCtx, subjectFulfillHookData);
     }
 
     it("should deposit successfully with valid parameters", async () => {
-      const orchestratorBalanceBefore = await usdcToken.balanceOf(orchestrator.address);
+      const orchestratorBalanceBefore = await usdcToken.balanceOf(
+        orchestrator.address
+      );
 
       await expect(subject())
         .to.emit(hook, "VaultDepositExecuted")
@@ -156,12 +170,16 @@ describe("ERC4626VaultHookV2", () => {
           subjectCtx.executableAmount
         );
 
-      const orchestratorBalanceAfter = await usdcToken.balanceOf(orchestrator.address);
+      const orchestratorBalanceAfter = await usdcToken.balanceOf(
+        orchestrator.address
+      );
       const hookBalance = await usdcToken.balanceOf(hook.address);
       const vaultBalance = await usdcToken.balanceOf(vault.address);
       const receiverShares = await vault.balanceOf(sharesReceiver.address);
 
-      expect(orchestratorBalanceBefore.sub(orchestratorBalanceAfter)).to.eq(subjectCtx.executableAmount);
+      expect(orchestratorBalanceBefore.sub(orchestratorBalanceAfter)).to.eq(
+        subjectCtx.executableAmount
+      );
       expect(hookBalance).to.eq(0);
       expect(vaultBalance).to.eq(subjectCtx.executableAmount);
       expect(receiverShares).to.eq(subjectCtx.executableAmount);
@@ -174,31 +192,59 @@ describe("ERC4626VaultHookV2", () => {
 
     it("should revert when caller is not a registered orchestrator", async () => {
       subjectCaller = attacker;
-      await expect(subject()).to.be.revertedWithCustomError(hook, "UnauthorizedOrchestratorCaller");
+      await expect(subject()).to.be.revertedWithCustomError(
+        hook,
+        "UnauthorizedOrchestratorCaller"
+      );
     });
 
     it("should revert when fulfillHookData is non-empty", async () => {
-      subjectFulfillHookData = ethers.utils.defaultAbiCoder.encode(["uint256"], [1]);
-      await expect(subject()).to.be.revertedWithCustomError(hook, "InvalidFulfillHookDataLength");
+      subjectFulfillHookData = ethers.utils.defaultAbiCoder.encode(
+        ["uint256"],
+        [1]
+      );
+      await expect(subject()).to.be.revertedWithCustomError(
+        hook,
+        "InvalidFulfillHookDataLength"
+      );
     });
 
     it("should revert when ctx.token does not match inputToken", async () => {
-      const otherToken = await deployer.deployUSDCMock(usdc(1000), "OTHER", "OTHER");
+      const otherToken = await deployer.deployUSDCMock(
+        usdc(1000),
+        "OTHER",
+        "OTHER"
+      );
       subjectCtx = buildContext(commitment, { token: otherToken.address });
-      await usdcToken.connect(orchestrator.wallet).approve(hook.address, subjectCtx.executableAmount);
-      await expect(subject()).to.be.revertedWithCustomError(hook, "UnsupportedToken");
+      await usdcToken
+        .connect(orchestrator.wallet)
+        .approve(hook.address, subjectCtx.executableAmount);
+      await expect(subject()).to.be.revertedWithCustomError(
+        hook,
+        "UnsupportedToken"
+      );
     });
 
     it("should revert when commitment vault is zero address", async () => {
       commitment.vault = ADDRESS_ZERO;
-      subjectCtx = buildContext(commitment, { intentHash: subjectCtx.intentHash });
-      await expect(subject()).to.be.revertedWithCustomError(hook, "InvalidVault");
+      subjectCtx = buildContext(commitment, {
+        intentHash: subjectCtx.intentHash,
+      });
+      await expect(subject()).to.be.revertedWithCustomError(
+        hook,
+        "InvalidVault"
+      );
     });
 
     it("should revert when commitment sharesReceiver is zero address", async () => {
       commitment.sharesReceiver = ADDRESS_ZERO;
-      subjectCtx = buildContext(commitment, { intentHash: subjectCtx.intentHash });
-      await expect(subject()).to.be.revertedWithCustomError(hook, "InvalidSharesReceiver");
+      subjectCtx = buildContext(commitment, {
+        intentHash: subjectCtx.intentHash,
+      });
+      await expect(subject()).to.be.revertedWithCustomError(
+        hook,
+        "InvalidSharesReceiver"
+      );
     });
 
     describe("when previewDeposit returns fewer shares than minSharesOut", () => {
@@ -208,19 +254,30 @@ describe("ERC4626VaultHookV2", () => {
       });
 
       it("should fall back to direct transfer with PREVIEW_BELOW_MINIMUM reason", async () => {
-        const recipientBalanceBefore = await usdcToken.balanceOf(recipient.address);
+        const recipientBalanceBefore = await usdcToken.balanceOf(
+          recipient.address
+        );
 
         // FallbackReason.PREVIEW_BELOW_MINIMUM = 0
         await expect(subject())
           .to.emit(hook, "FallbackTransfer")
-          .withArgs(subjectCtx.intentHash, recipient.address, subjectCtx.executableAmount, 0);
+          .withArgs(
+            subjectCtx.intentHash,
+            recipient.address,
+            subjectCtx.executableAmount,
+            0
+          );
 
-        const recipientBalanceAfter = await usdcToken.balanceOf(recipient.address);
+        const recipientBalanceAfter = await usdcToken.balanceOf(
+          recipient.address
+        );
         const hookBalance = await usdcToken.balanceOf(hook.address);
         const vaultBalance = await usdcToken.balanceOf(vault.address);
         const receiverShares = await vault.balanceOf(sharesReceiver.address);
 
-        expect(recipientBalanceAfter.sub(recipientBalanceBefore)).to.eq(subjectCtx.executableAmount);
+        expect(recipientBalanceAfter.sub(recipientBalanceBefore)).to.eq(
+          subjectCtx.executableAmount
+        );
         expect(hookBalance).to.eq(0);
         expect(vaultBalance).to.eq(0);
         expect(receiverShares).to.eq(0);
@@ -236,7 +293,12 @@ describe("ERC4626VaultHookV2", () => {
         // FallbackReason.DEPOSIT_CALL_FAILED = 1
         await expect(subject())
           .to.emit(hook, "FallbackTransfer")
-          .withArgs(subjectCtx.intentHash, recipient.address, subjectCtx.executableAmount, 1);
+          .withArgs(
+            subjectCtx.intentHash,
+            recipient.address,
+            subjectCtx.executableAmount,
+            1
+          );
 
         const recipientBalance = await usdcToken.balanceOf(recipient.address);
         expect(recipientBalance).to.eq(subjectCtx.executableAmount);
@@ -252,7 +314,12 @@ describe("ERC4626VaultHookV2", () => {
         // FallbackReason.DEPOSIT_CALL_FAILED = 1
         await expect(subject())
           .to.emit(hook, "FallbackTransfer")
-          .withArgs(subjectCtx.intentHash, recipient.address, subjectCtx.executableAmount, 1);
+          .withArgs(
+            subjectCtx.intentHash,
+            recipient.address,
+            subjectCtx.executableAmount,
+            1
+          );
 
         const recipientBalance = await usdcToken.balanceOf(recipient.address);
         const hookBalance = await usdcToken.balanceOf(hook.address);
@@ -263,43 +330,33 @@ describe("ERC4626VaultHookV2", () => {
       });
     });
 
-    describe("when actual minted shares are below the maker minimum", () => {
+    describe("when a non-compliant vault lies on preview and mints fewer shares than the maker minimum", () => {
       beforeEach(async () => {
-        // Preview will return executableAmount, passing the gate. But the deposit forces a tiny share count.
+        // Vault returns an honest `previewDeposit` (1:1 = usdc(50)) so the preview gate passes,
+        // but `deposit` actually mints only 1 wei of shares. This exercises the documented
+        // trade-off: we no longer hard-revert post-deposit because that would leave the intent
+        // stuck (the vault is committed in signalHookData, so relayers cannot retry against a
+        // different vault). Users are expected to pick reputable vaults; the preview gate is
+        // the primary guarantee for spec-compliant vaults.
         await vault.setForcedActualShares(1);
       });
 
-      it("should hard revert with VaultActualBelowMinimum", async () => {
-        await expect(subject()).to.be.revertedWithCustomError(hook, "VaultActualBelowMinimum");
-      });
-    });
+      it("should complete the deposit without reverting and credit the under-mint to sharesReceiver", async () => {
+        await expect(subject())
+          .to.emit(hook, "VaultDepositExecuted")
+          .withArgs(
+            subjectCtx.intentHash,
+            vault.address,
+            sharesReceiver.address,
+            subjectCtx.executableAmount,
+            1
+          );
 
-    describe("when actual minted shares are below the deploy-time guardrail", () => {
-      beforeEach(async () => {
-        // Maker is permissive (minSharesOut = 0), but the deploy guardrail (5%) still applies.
-        commitment.minSharesOut = BigNumber.from(0);
-        subjectCtx = buildContext(commitment, { intentHash: subjectCtx.intentHash });
-        // Preview = executableAmount = usdc(50). Guardrail floor = 50 * 9500/10000 = usdc(47.5).
-        // Force actual to be just below guardrail.
-        await vault.setForcedActualShares(usdc(47));
-      });
-
-      it("should hard revert with VaultActualBelowMinimum", async () => {
-        await expect(subject()).to.be.revertedWithCustomError(hook, "VaultActualBelowMinimum");
-      });
-    });
-
-    describe("when actual minted shares are exactly at the guardrail floor", () => {
-      beforeEach(async () => {
-        commitment.minSharesOut = BigNumber.from(0);
-        subjectCtx = buildContext(commitment, { intentHash: subjectCtx.intentHash });
-        // Preview = usdc(50). Guardrail floor = usdc(47.5).
-        await vault.setForcedActualShares(usdc(47.5));
-      });
-
-      it("should succeed", async () => {
-        await expect(subject()).to.emit(hook, "VaultDepositExecuted");
-        expect(await vault.balanceOf(sharesReceiver.address)).to.eq(usdc(47.5));
+        expect(await vault.balanceOf(sharesReceiver.address)).to.eq(1);
+        expect(await usdcToken.balanceOf(vault.address)).to.eq(
+          subjectCtx.executableAmount
+        );
+        expect(await usdcToken.balanceOf(hook.address)).to.eq(0);
       });
     });
 
@@ -310,11 +367,14 @@ describe("ERC4626VaultHookV2", () => {
       });
 
       it("should hard revert with VaultDidNotConsumeAssets", async () => {
-        await expect(subject()).to.be.revertedWithCustomError(hook, "VaultDidNotConsumeAssets");
+        await expect(subject()).to.be.revertedWithCustomError(
+          hook,
+          "VaultDidNotConsumeAssets"
+        );
       });
     });
 
-    describe("when actual minted shares exceed minSharesOut and the guardrail", () => {
+    describe("when actual minted shares exceed minSharesOut", () => {
       beforeEach(async () => {
         // Vault gives a bonus: 11/10 ratio. Preview = 55, actual = 55, minSharesOut = 50.
         await vault.setSharesPerAsset(11, 10);
@@ -330,13 +390,17 @@ describe("ERC4626VaultHookV2", () => {
       // sharesReceiver is already a separate address by default; verify intent.to gets nothing
       // and sharesReceiver gets the shares.
       const intentToBefore = await usdcToken.balanceOf(recipient.address);
-      const intentToVaultSharesBefore = await vault.balanceOf(recipient.address);
+      const intentToVaultSharesBefore = await vault.balanceOf(
+        recipient.address
+      );
 
       await subject();
 
       const intentToAfter = await usdcToken.balanceOf(recipient.address);
       const intentToVaultSharesAfter = await vault.balanceOf(recipient.address);
-      const sharesReceiverShares = await vault.balanceOf(sharesReceiver.address);
+      const sharesReceiverShares = await vault.balanceOf(
+        sharesReceiver.address
+      );
 
       expect(intentToAfter).to.eq(intentToBefore);
       expect(intentToVaultSharesAfter).to.eq(intentToVaultSharesBefore);
@@ -363,7 +427,9 @@ describe("ERC4626VaultHookV2", () => {
     });
 
     async function subject(): Promise<any> {
-      return hook.connect(subjectCaller.wallet).rescueERC20(subjectToken, subjectTo, subjectAmount);
+      return hook
+        .connect(subjectCaller.wallet)
+        .rescueERC20(subjectToken, subjectTo, subjectAmount);
     }
 
     it("should rescue ERC20 tokens to recipient", async () => {
@@ -376,17 +442,25 @@ describe("ERC4626VaultHookV2", () => {
 
     it("should revert when called by non-owner", async () => {
       subjectCaller = attacker;
-      await expect(subject()).to.be.revertedWith("Ownable: caller is not the owner");
+      await expect(subject()).to.be.revertedWith(
+        "Ownable: caller is not the owner"
+      );
     });
 
     it("should revert when token address is zero", async () => {
       subjectToken = ADDRESS_ZERO;
-      await expect(subject()).to.be.revertedWithCustomError(hook, "ZeroAddress");
+      await expect(subject()).to.be.revertedWithCustomError(
+        hook,
+        "ZeroAddress"
+      );
     });
 
     it("should revert when recipient address is zero", async () => {
       subjectTo = ADDRESS_ZERO;
-      await expect(subject()).to.be.revertedWithCustomError(hook, "ZeroAddress");
+      await expect(subject()).to.be.revertedWithCustomError(
+        hook,
+        "ZeroAddress"
+      );
     });
   });
 });

--- a/test/hooks/erc4626VaultHookV2.spec.ts
+++ b/test/hooks/erc4626VaultHookV2.spec.ts
@@ -1,0 +1,381 @@
+import "module-alias/register";
+
+import { BigNumber, Contract } from "ethers";
+import { ethers } from "hardhat";
+
+import DeployHelper from "@utils/deploys";
+import { Account } from "@utils/test/types";
+import { getAccounts, getWaffleExpect } from "@utils/test/index";
+import { usdc, ether } from "@utils/common";
+import { ADDRESS_ZERO } from "@utils/constants";
+
+const expect = getWaffleExpect();
+
+describe("ERC4626VaultHookV2", () => {
+  let owner: Account;
+  let orchestrator: Account;
+  let recipient: Account;
+  let sharesReceiver: Account;
+  let attacker: Account;
+
+  let deployer: DeployHelper;
+  let usdcToken: Contract;
+  let vault: Contract;
+  let orchestratorRegistry: Contract;
+  let hook: Contract;
+
+  const DEFAULT_MAX_SLIPPAGE_BPS = 500;
+
+  // Encode VaultDepositCommitment struct for signalHookData
+  const encodeCommitment = (commitment: any): string => {
+    return ethers.utils.defaultAbiCoder.encode(
+      ["tuple(address vault,address sharesReceiver,uint256 minSharesOut)"],
+      [commitment]
+    );
+  };
+
+  // Build HookExecutionContext for V2 execute
+  const buildContext = (commitment: any, overrides: any = {}): any => {
+    const intentHash = overrides.intentHash ?? ethers.utils.hexlify(ethers.utils.randomBytes(32));
+    return {
+      intentHash,
+      token: overrides.token ?? usdcToken.address,
+      executableAmount: overrides.executableAmount ?? usdc(50),
+      intent: {
+        owner: owner.address,
+        to: overrides.to ?? recipient.address,
+        escrow: owner.address,
+        depositId: BigNumber.from(1),
+        amount: usdc(100),
+        timestamp: overrides.timestamp ?? BigNumber.from(Math.floor(Date.now() / 1000)),
+        paymentMethod: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("venmo")),
+        fiatCurrency: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("USD")),
+        conversionRate: ether(1),
+        payeeId: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("payee")),
+        signalHookData: encodeCommitment(commitment),
+      }
+    };
+  };
+
+  beforeEach(async () => {
+    [owner, orchestrator, recipient, sharesReceiver, attacker] = await getAccounts();
+
+    deployer = new DeployHelper(owner.wallet);
+    usdcToken = await deployer.deployUSDCMock(usdc(1_000_000), "USDC", "USDC");
+
+    const ERC4626VaultMock = await ethers.getContractFactory("ERC4626VaultMock", owner.wallet);
+    vault = await ERC4626VaultMock.deploy(usdcToken.address, 6, "Vault USDC", "vUSDC");
+
+    orchestratorRegistry = await deployer.deployOrchestratorRegistry();
+    await orchestratorRegistry.addOrchestrator(orchestrator.address);
+
+    const ERC4626VaultHookV2 = await ethers.getContractFactory("ERC4626VaultHookV2", owner.wallet);
+    hook = await ERC4626VaultHookV2.deploy(
+      usdcToken.address,
+      orchestratorRegistry.address,
+      DEFAULT_MAX_SLIPPAGE_BPS
+    );
+
+    await usdcToken.transfer(orchestrator.address, usdc(1000));
+  });
+
+  describe("#constructor", () => {
+    it("should set initial variables correctly", async () => {
+      expect(await hook.inputToken()).to.eq(usdcToken.address);
+      expect(await hook.orchestratorRegistry()).to.eq(orchestratorRegistry.address);
+      expect(await hook.maxSlippageBps()).to.eq(DEFAULT_MAX_SLIPPAGE_BPS);
+    });
+
+    it("should set owner to deployer", async () => {
+      expect(await hook.owner()).to.eq(owner.address);
+    });
+
+    it("should revert when inputToken is zero address", async () => {
+      const ERC4626VaultHookV2 = await ethers.getContractFactory("ERC4626VaultHookV2", owner.wallet);
+      await expect(
+        ERC4626VaultHookV2.deploy(ADDRESS_ZERO, orchestratorRegistry.address, DEFAULT_MAX_SLIPPAGE_BPS)
+      ).to.be.revertedWithCustomError(hook, "ZeroAddress");
+    });
+
+    it("should revert when orchestratorRegistry is zero address", async () => {
+      const ERC4626VaultHookV2 = await ethers.getContractFactory("ERC4626VaultHookV2", owner.wallet);
+      await expect(
+        ERC4626VaultHookV2.deploy(usdcToken.address, ADDRESS_ZERO, DEFAULT_MAX_SLIPPAGE_BPS)
+      ).to.be.revertedWithCustomError(hook, "ZeroAddress");
+    });
+
+    it("should revert when maxSlippageBps exceeds 10000", async () => {
+      const ERC4626VaultHookV2 = await ethers.getContractFactory("ERC4626VaultHookV2", owner.wallet);
+      await expect(
+        ERC4626VaultHookV2.deploy(usdcToken.address, orchestratorRegistry.address, 10_001)
+      ).to.be.revertedWithCustomError(hook, "InvalidMaxSlippageBps");
+    });
+
+    it("should accept maxSlippageBps equal to 10000", async () => {
+      const ERC4626VaultHookV2 = await ethers.getContractFactory("ERC4626VaultHookV2", owner.wallet);
+      const h = await ERC4626VaultHookV2.deploy(usdcToken.address, orchestratorRegistry.address, 10_000);
+      expect(await h.maxSlippageBps()).to.eq(10_000);
+    });
+  });
+
+  describe("#execute", () => {
+    let subjectCaller: Account;
+    let subjectCtx: any;
+    let subjectFulfillHookData: string;
+
+    let commitment: any;
+
+    beforeEach(async () => {
+      commitment = {
+        vault: vault.address,
+        sharesReceiver: sharesReceiver.address,
+        minSharesOut: usdc(50)
+      };
+
+      subjectCtx = buildContext(commitment);
+      subjectFulfillHookData = "0x";
+      subjectCaller = orchestrator;
+
+      await usdcToken.connect(orchestrator.wallet).approve(hook.address, subjectCtx.executableAmount);
+    });
+
+    async function subject(): Promise<any> {
+      return hook.connect(subjectCaller.wallet).execute(subjectCtx, subjectFulfillHookData);
+    }
+
+    it("should deposit successfully with valid parameters", async () => {
+      const orchestratorBalanceBefore = await usdcToken.balanceOf(orchestrator.address);
+
+      await expect(subject())
+        .to.emit(hook, "VaultDepositExecuted")
+        .withArgs(
+          subjectCtx.intentHash,
+          vault.address,
+          sharesReceiver.address,
+          subjectCtx.executableAmount,
+          subjectCtx.executableAmount
+        );
+
+      const orchestratorBalanceAfter = await usdcToken.balanceOf(orchestrator.address);
+      const hookBalance = await usdcToken.balanceOf(hook.address);
+      const vaultBalance = await usdcToken.balanceOf(vault.address);
+      const receiverShares = await vault.balanceOf(sharesReceiver.address);
+
+      expect(orchestratorBalanceBefore.sub(orchestratorBalanceAfter)).to.eq(subjectCtx.executableAmount);
+      expect(hookBalance).to.eq(0);
+      expect(vaultBalance).to.eq(subjectCtx.executableAmount);
+      expect(receiverShares).to.eq(subjectCtx.executableAmount);
+    });
+
+    it("should leave zero residual allowance to the vault on success", async () => {
+      await subject();
+      expect(await usdcToken.allowance(hook.address, vault.address)).to.eq(0);
+    });
+
+    it("should revert when caller is not a registered orchestrator", async () => {
+      subjectCaller = attacker;
+      await expect(subject()).to.be.revertedWithCustomError(hook, "UnauthorizedOrchestratorCaller");
+    });
+
+    it("should revert when fulfillHookData is non-empty", async () => {
+      subjectFulfillHookData = ethers.utils.defaultAbiCoder.encode(["uint256"], [1]);
+      await expect(subject()).to.be.revertedWithCustomError(hook, "InvalidFulfillHookDataLength");
+    });
+
+    it("should revert when ctx.token does not match inputToken", async () => {
+      const otherToken = await deployer.deployUSDCMock(usdc(1000), "OTHER", "OTHER");
+      subjectCtx = buildContext(commitment, { token: otherToken.address });
+      await usdcToken.connect(orchestrator.wallet).approve(hook.address, subjectCtx.executableAmount);
+      await expect(subject()).to.be.revertedWithCustomError(hook, "UnsupportedToken");
+    });
+
+    it("should revert when commitment vault is zero address", async () => {
+      commitment.vault = ADDRESS_ZERO;
+      subjectCtx = buildContext(commitment, { intentHash: subjectCtx.intentHash });
+      await expect(subject()).to.be.revertedWithCustomError(hook, "InvalidVault");
+    });
+
+    it("should revert when commitment sharesReceiver is zero address", async () => {
+      commitment.sharesReceiver = ADDRESS_ZERO;
+      subjectCtx = buildContext(commitment, { intentHash: subjectCtx.intentHash });
+      await expect(subject()).to.be.revertedWithCustomError(hook, "InvalidSharesReceiver");
+    });
+
+    describe("when previewDeposit returns fewer shares than minSharesOut", () => {
+      beforeEach(async () => {
+        // Set 1:1 vault to mint 1 share per 2 assets -> preview = executableAmount / 2 = usdc(25) < usdc(50)
+        await vault.setSharesPerAsset(1, 2);
+      });
+
+      it("should fall back to direct transfer with PREVIEW_BELOW_MINIMUM reason", async () => {
+        const recipientBalanceBefore = await usdcToken.balanceOf(recipient.address);
+
+        // FallbackReason.PREVIEW_BELOW_MINIMUM = 0
+        await expect(subject())
+          .to.emit(hook, "FallbackTransfer")
+          .withArgs(subjectCtx.intentHash, recipient.address, subjectCtx.executableAmount, 0);
+
+        const recipientBalanceAfter = await usdcToken.balanceOf(recipient.address);
+        const hookBalance = await usdcToken.balanceOf(hook.address);
+        const vaultBalance = await usdcToken.balanceOf(vault.address);
+        const receiverShares = await vault.balanceOf(sharesReceiver.address);
+
+        expect(recipientBalanceAfter.sub(recipientBalanceBefore)).to.eq(subjectCtx.executableAmount);
+        expect(hookBalance).to.eq(0);
+        expect(vaultBalance).to.eq(0);
+        expect(receiverShares).to.eq(0);
+      });
+    });
+
+    describe("when previewDeposit reverts", () => {
+      beforeEach(async () => {
+        await vault.setPreviewShouldRevert(true);
+      });
+
+      it("should fall back to direct transfer with DEPOSIT_CALL_FAILED reason", async () => {
+        // FallbackReason.DEPOSIT_CALL_FAILED = 1
+        await expect(subject())
+          .to.emit(hook, "FallbackTransfer")
+          .withArgs(subjectCtx.intentHash, recipient.address, subjectCtx.executableAmount, 1);
+
+        const recipientBalance = await usdcToken.balanceOf(recipient.address);
+        expect(recipientBalance).to.eq(subjectCtx.executableAmount);
+      });
+    });
+
+    describe("when vault.deposit reverts", () => {
+      beforeEach(async () => {
+        await vault.setDepositShouldRevert(true);
+      });
+
+      it("should fall back to direct transfer with DEPOSIT_CALL_FAILED reason", async () => {
+        // FallbackReason.DEPOSIT_CALL_FAILED = 1
+        await expect(subject())
+          .to.emit(hook, "FallbackTransfer")
+          .withArgs(subjectCtx.intentHash, recipient.address, subjectCtx.executableAmount, 1);
+
+        const recipientBalance = await usdcToken.balanceOf(recipient.address);
+        const hookBalance = await usdcToken.balanceOf(hook.address);
+        expect(recipientBalance).to.eq(subjectCtx.executableAmount);
+        expect(hookBalance).to.eq(0);
+        // Allowance should be cleared in the catch arm
+        expect(await usdcToken.allowance(hook.address, vault.address)).to.eq(0);
+      });
+    });
+
+    describe("when actual minted shares are below the maker minimum", () => {
+      beforeEach(async () => {
+        // Preview will return executableAmount, passing the gate. But the deposit forces a tiny share count.
+        await vault.setForcedActualShares(1);
+      });
+
+      it("should hard revert with VaultActualBelowMinimum", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(hook, "VaultActualBelowMinimum");
+      });
+    });
+
+    describe("when actual minted shares are below the deploy-time guardrail", () => {
+      beforeEach(async () => {
+        // Maker is permissive (minSharesOut = 0), but the deploy guardrail (5%) still applies.
+        commitment.minSharesOut = BigNumber.from(0);
+        subjectCtx = buildContext(commitment, { intentHash: subjectCtx.intentHash });
+        // Preview = executableAmount = usdc(50). Guardrail floor = 50 * 9500/10000 = usdc(47.5).
+        // Force actual to be just below guardrail.
+        await vault.setForcedActualShares(usdc(47));
+      });
+
+      it("should hard revert with VaultActualBelowMinimum", async () => {
+        await expect(subject()).to.be.revertedWithCustomError(hook, "VaultActualBelowMinimum");
+      });
+    });
+
+    describe("when actual minted shares are exactly at the guardrail floor", () => {
+      beforeEach(async () => {
+        commitment.minSharesOut = BigNumber.from(0);
+        subjectCtx = buildContext(commitment, { intentHash: subjectCtx.intentHash });
+        // Preview = usdc(50). Guardrail floor = usdc(47.5).
+        await vault.setForcedActualShares(usdc(47.5));
+      });
+
+      it("should succeed", async () => {
+        await expect(subject()).to.emit(hook, "VaultDepositExecuted");
+        expect(await vault.balanceOf(sharesReceiver.address)).to.eq(usdc(47.5));
+      });
+    });
+
+    describe("when actual minted shares exceed minSharesOut and the guardrail", () => {
+      beforeEach(async () => {
+        // Vault gives a bonus: 11/10 ratio. Preview = 55, actual = 55, minSharesOut = 50.
+        await vault.setSharesPerAsset(11, 10);
+      });
+
+      it("should succeed and credit the full share amount", async () => {
+        await subject();
+        expect(await vault.balanceOf(sharesReceiver.address)).to.eq(usdc(55));
+      });
+    });
+
+    it("should support a sharesReceiver different from intent.to", async () => {
+      // sharesReceiver is already a separate address by default; verify intent.to gets nothing
+      // and sharesReceiver gets the shares.
+      const intentToBefore = await usdcToken.balanceOf(recipient.address);
+      const intentToVaultSharesBefore = await vault.balanceOf(recipient.address);
+
+      await subject();
+
+      const intentToAfter = await usdcToken.balanceOf(recipient.address);
+      const intentToVaultSharesAfter = await vault.balanceOf(recipient.address);
+      const sharesReceiverShares = await vault.balanceOf(sharesReceiver.address);
+
+      expect(intentToAfter).to.eq(intentToBefore);
+      expect(intentToVaultSharesAfter).to.eq(intentToVaultSharesBefore);
+      expect(sharesReceiverShares).to.eq(subjectCtx.executableAmount);
+    });
+  });
+
+  describe("#rescueERC20", () => {
+    let subjectCaller: Account;
+    let subjectToken: string;
+    let subjectTo: string;
+    let subjectAmount: BigNumber;
+
+    let stuckToken: Contract;
+
+    beforeEach(async () => {
+      stuckToken = await deployer.deployUSDCMock(usdc(1000), "STUCK", "STUCK");
+      await stuckToken.transfer(hook.address, usdc(100));
+
+      subjectCaller = owner;
+      subjectToken = stuckToken.address;
+      subjectTo = recipient.address;
+      subjectAmount = usdc(100);
+    });
+
+    async function subject(): Promise<any> {
+      return hook.connect(subjectCaller.wallet).rescueERC20(subjectToken, subjectTo, subjectAmount);
+    }
+
+    it("should rescue ERC20 tokens to recipient", async () => {
+      await expect(subject())
+        .to.emit(hook, "RescueERC20")
+        .withArgs(stuckToken.address, recipient.address, usdc(100));
+
+      expect(await stuckToken.balanceOf(recipient.address)).to.eq(usdc(100));
+    });
+
+    it("should revert when called by non-owner", async () => {
+      subjectCaller = attacker;
+      await expect(subject()).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+
+    it("should revert when token address is zero", async () => {
+      subjectToken = ADDRESS_ZERO;
+      await expect(subject()).to.be.revertedWithCustomError(hook, "ZeroAddress");
+    });
+
+    it("should revert when recipient address is zero", async () => {
+      subjectTo = ADDRESS_ZERO;
+      await expect(subject()).to.be.revertedWithCustomError(hook, "ZeroAddress");
+    });
+  });
+});


### PR DESCRIPTION
## Why

We want to make **earn products** the most seamless on-ramp destination on ZKP2P. Today a taker who pays fiat receives raw USDC at `intent.to` — to put it to work in a yield vault they have to take a second action (open another app, approve, deposit). That's friction we don't need.

This PR introduces a **generic** post-intent hook that lets the taker route their net intent payout straight into any **ERC-4626 compliant vault** in a single transaction. The integrator (frontend, aggregator, or partner protocol) just picks the vault address at signal time. No new contract per protocol, no allowlists to maintain, no per-vault forks.

This unlocks a clean "Earn" tab/page UX:
- User picks an earn product (e.g. Morpho USDC, Spark sUSDS-wrapped, Yearn v3, Aave-wrapped, Euler vault wrapper, …) from a curated list.
- Frontend resolves it to an ERC-4626 vault address, computes a `previewDeposit` quote, packs the commitment, and signals the intent.
- After fiat payment + zkTLS proof, `fulfillIntent` triggers this hook and the user's vault shares appear at their address — same UX as a direct on-chain deposit, but funded by fiat.

Because the hook is vault-address-driven, every new ERC-4626 vault that ships on Base becomes an instant earn product on ZKP2P with **zero new contract work**. Non-4626 protocols get supported via the community wrappers that already exist for them.

## How

### The hook (`contracts/hooks/ERC4626VaultHookV2.sol`)

Implements `IPostIntentHookV2`. Mirrors the conventions of `AcrossBridgeHookV2` exactly: same auth model, same fund-flow, same fallback philosophy, same struct layout, same NatSpec style.

**Authorization.** Caller must be a registered orchestrator via `IOrchestratorRegistry.isOrchestrator(msg.sender)` — no global PostIntentHookRegistry (V2 doesn't have one).

**Commitment** (stored in `intent.signalHookData`, signed over by the gating service at signal time):

```solidity
struct VaultDepositCommitment {
    address vault;            // ERC-4626 vault (must have asset() == inputToken)
    address sharesReceiver;   // Where shares are minted (often == intent.to, but flexible)
    uint256 minSharesOut;     // Maker-chosen slippage floor
}
```

`sharesReceiver` is intentionally separable from `intent.to` so a smart-account or aggregator can route shares to a different address than the underlying-fallback recipient.

**Fulfill data.** Strictly empty (`length == 0`). Vault deposits are deterministic given `executableAmount` and current vault state — no JIT relayer quote needed (unlike Across, where bridge fees float). Reserved for future tightening.

### Execution flow

1. Authorize caller via `OrchestratorRegistry`.
2. Validate `_fulfillHookData.length == 0` and `_ctx.token == inputToken`.
3. Decode + structurally validate the commitment.
4. **Pull `_ctx.executableAmount` from the orchestrator** via `safeTransferFrom` (mandatory; OrchestratorV2 enforces `spent == netAmount` post-call, so every branch must consume the full amount).
5. Probe `previewDeposit` inside a try/catch. If the vault is non-compliant or unreachable, treat as `DEPOSIT_CALL_FAILED`.
6. If `previewShares >= minSharesOut`, approve the vault (zero-then-set) and `try vault.deposit(amount, sharesReceiver)`.
7. On deposit success, compute the **authoritative shares delta** from `balanceOf(sharesReceiver)` before/after — never trust the vault's return value.
8. Enforce `actualShares >= effectiveMinimum`, where `effectiveMinimum = max(commitment.minSharesOut, previewShares * (10000 - maxSlippageBps) / 10000)`.
9. On deposit revert (caught) or pre-check failure, **fall back** by transferring the full `executableAmount` to `intent.to` and emit `FallbackTransfer` with the appropriate reason.

### Slippage model — two layers

- **Maker layer (`commitment.minSharesOut`):** committed at signal time and signed by the gating service. The user's primary protection.
- **Deploy-time guardrail (`maxSlippageBps`, default 500 = 5%):** constructor parameter. Bounds how far `actualShares` may fall below the vault's own `previewDeposit`. Catches non-compliant vaults that preview honestly but mint dishonestly. The effective floor is `max(maker, guardrail)`. If a vault drops below the guardrail after the deposit succeeded, the call **hard-reverts** (`VaultActualBelowMinimum`) — rolling back the entire `fulfillIntent` so the intent stays open and a relayer can retry with a different vault.

### Fallback semantics — match Across

Two reason codes, gas-efficient enum:
- `PREVIEW_BELOW_MINIMUM` — vault is healthy but the rate moved unfavorably between signal and fulfill.
- `DEPOSIT_CALL_FAILED` — `previewDeposit` reverted, or `vault.deposit()` reverted (paused, capped, broken).

In both cases the user receives the underlying USDC at `intent.to` instead of vault shares. **The user always gets their funds.**

### Why no asset/maxDeposit precheck?

Earlier drafts had `vault.asset() == inputToken` and `vault.maxDeposit(...) >= amount` prechecks. Removed for simplicity:
- `previewDeposit` already short-circuits the vast majority of misconfigurations (it returns `0` or reverts on a vault that won't accept the deposit), and that path correctly routes to `DEPOSIT_CALL_FAILED`.
- An asset-mismatched vault would fail at `deposit()` because the vault would try to pull its own (different) asset — which we never approved — and the catch arm handles it.
- Damage is bounded by the orchestrator's exact-amount approval to the hook plus the hook's exact-amount approval to the vault.

KISS. Two extra reads is two extra surface bugs.

### Why hard-revert on the post-deposit guardrail check?

By the time we know `actualShares < effectiveMinimum`, the vault already has the USDC and the receiver already has the (insufficient) shares. We can't undo that mid-call without triggering vault-specific `redeem` paths. Reverting the whole transaction rolls back the entire `fulfillIntent` (including the orchestrator's `unlockAndTransferFunds`), leaving the intent open. That's the correct outcome for a misbehaving vault: surface the problem loudly, give the relayer a chance to retry against a different vault.

### Exact-consumption invariant — verified across all paths

`OrchestratorV2._collectFeesTransferFundsAndExecuteAction` snapshots its own balance and asserts `spent == netAmount` after the hook returns. We always pull `executableAmount` upfront via `safeTransferFrom`, so:

| Branch | orch balance Δ | hook end-state |
|---|---|---|
| Successful deposit | `-executableAmount` | 0 (vault took it) |
| Pre-check failure → fallback | `-executableAmount` | 0 (sent to `intent.to`) |
| Deposit reverts → catch → fallback | `-executableAmount` | 0 (sent to `intent.to`) |
| Post-deposit guardrail revert | tx rolls back | n/a |

Invariant holds in every successful path.

## Files

| File | Purpose |
|---|---|
| `contracts/external/Interfaces/IERC4626.sol` | Minimal ERC-4626 surface (`asset`, `previewDeposit`, `deposit`) — co-located with `IAcrossSpokePool` |
| `contracts/hooks/ERC4626VaultHookV2.sol` | The hook contract (~260 lines) |
| `contracts/mocks/ERC4626VaultMock.sol` | Configurable mock vault: revert toggles, share-rate override, forced-actual override, skip-pull mode |
| `test/hooks/erc4626VaultHookV2.spec.ts` | Hardhat unit tests (25 cases) |

## Tests — 25 passing

Construction:
- sets immutables; sets owner
- reverts on zero `inputToken` / `orchestratorRegistry`
- reverts when `maxSlippageBps > 10000`
- accepts `maxSlippageBps == 10000`

Execute happy path:
- successful deposit, full balance accounting (orchestrator -, vault +, hook = 0, receiver shares = expected)
- residual allowance to vault is 0 after success
- supports a `sharesReceiver` distinct from `intent.to`

Auth + validation:
- non-orchestrator caller reverts (`UnauthorizedOrchestratorCaller`)
- non-empty `_fulfillHookData` reverts (`InvalidFulfillHookDataLength`)
- token mismatch reverts (`UnsupportedToken`)
- zero vault reverts (`InvalidVault`)
- zero `sharesReceiver` reverts (`InvalidSharesReceiver`)

Fallbacks:
- `previewDeposit < minSharesOut` → `FallbackTransfer(..., PREVIEW_BELOW_MINIMUM)`, USDC to `intent.to`
- `previewDeposit` reverts → `FallbackTransfer(..., DEPOSIT_CALL_FAILED)`
- `vault.deposit` reverts → `FallbackTransfer(..., DEPOSIT_CALL_FAILED)`, allowance cleared in catch arm

Hard reverts on post-deposit guardrail:
- actual minted shares below maker minimum → `VaultActualBelowMinimum`
- actual minted shares below deploy guardrail (maker permissive, guardrail strict) → `VaultActualBelowMinimum`
- actual minted shares exactly at guardrail floor → succeeds
- actual minted shares above both floors → succeeds, full credit

Owner functions:
- `rescueERC20` happy path + non-owner revert + zero-token revert + zero-recipient revert

Plus a sanity run of `acrossBridgeHookV2.spec.ts` (29 tests) confirms no regression on adjacent hook code.

## Test plan

- [x] `yarn compile` — clean (100 files, no warnings introduced by this PR)
- [x] `npx hardhat test test/hooks/erc4626VaultHookV2.spec.ts` — 25 passing
- [x] `npx hardhat test test/hooks/acrossBridgeHookV2.spec.ts` — 29 passing (regression sanity)
- [ ] Foundry fuzz / invariant suite (follow-up PR) — fuzz `executableAmount`, share rate, `minSharesOut`, `maxSlippageBps` and assert (a) hook ends with zero balance, (b) either `sharesReceiver` got ≥ effectiveMinimum or `intent.to` got `executableAmount`, (c) orchestrator's `spent == netAmount` invariant holds end-to-end against `OrchestratorV2`.
- [ ] Deploy script (`deploy/NN_deploy_erc4626_vault_hook.ts`) — follow-up PR before mainnet rollout, with multisig ownership transfer in the same script.
- [ ] NPM package re-export via `yarn pkg:extract` — follow-up PR alongside deploy.

## Open follow-ups (intentionally out of scope)

- Deploy script + mainnet/staging deployment.
- ERC-7540 async vaults (request-based deposits) — would need a separate hook because `deposit` doesn't return shares synchronously.
- A `SwapAndVaultHook` that handles vaults whose `asset()` is not USDC by composing with a DEX router. The current hook hard-rejects asset mismatches via the fallback path.
- Off-chain SDK helper for encoding `VaultDepositCommitment` (trivial, but worth shipping with the deploy).