### PR TITLE
feat: MultiAttestationVerifier

### DIFF
--- a/contracts/unifiedVerifier/MultiAttestationVerifier.sol
+++ b/contracts/unifiedVerifier/MultiAttestationVerifier.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import { IAttestationVerifier } from "../interfaces/IAttestationVerifier.sol";
+import { ThresholdSigVerifierUtils } from "../lib/ThresholdSigVerifierUtils.sol";
+
+/**
+ * @title MultiAttestationVerifier
+ * @notice Verifies attestations from one of N authorized witness addresses
+ * @dev Drop-in replacement for SimpleAttestationVerifier that supports a dynamic
+ *      witness set with a configurable signature threshold. Threshold defaults to 1
+ *      so the contract behaves as "any witness can sign" unless an owner raises it.
+ */
+contract MultiAttestationVerifier is IAttestationVerifier, Ownable {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    /* ============ Events ============ */
+
+    event WitnessAdded(address indexed witness);
+    event WitnessRemoved(address indexed witness);
+    event RequiredSignaturesUpdated(uint256 oldThreshold, uint256 newThreshold);
+
+    /* ============ State Variables ============ */
+
+    EnumerableSet.AddressSet private witnessesSet;
+    uint256 public requiredSignatures;
+
+    /* ============ Constructor ============ */
+
+    /**
+     * @notice Initializes the attestation verifier with an initial witness set and threshold
+     * @param _initialWitnesses Initial witness addresses
+     * @param _initialThreshold Initial required signature threshold
+     */
+    constructor(address[] memory _initialWitnesses, uint256 _initialThreshold) Ownable() {
+        require(_initialThreshold > 0, "MAV: threshold must be > 0");
+        require(_initialThreshold <= _initialWitnesses.length, "MAV: threshold exceeds count");
+
+        for (uint256 witnessIndex = 0; witnessIndex < _initialWitnesses.length; witnessIndex++) {
+            address witnessAddress = _initialWitnesses[witnessIndex];
+
+            require(witnessAddress != address(0), "MAV: zero witness");
+            require(witnessesSet.add(witnessAddress), "MAV: duplicate witness");
+
+            emit WitnessAdded(witnessAddress);
+        }
+
+        requiredSignatures = _initialThreshold;
+
+        emit RequiredSignaturesUpdated(0, _initialThreshold);
+    }
+
+    /* ============ External Functions ============ */
+
+    /**
+     * @notice Verifies attestation signatures against the current witness set
+     * @param _digest The message digest to verify
+     * @param _sigs Array of signatures from witnesses
+     * @return isValid True if the witness threshold is met
+     */
+    function verify(
+        bytes32 _digest,
+        bytes[] calldata _sigs,
+        bytes calldata
+    ) external view override returns (bool isValid) {
+        isValid = ThresholdSigVerifierUtils.verifyWitnessSignatures(
+            _digest,
+            _sigs,
+            witnessesSet.values(),
+            requiredSignatures
+        );
+
+        return isValid;
+    }
+
+    /* ============ Governance Functions ============ */
+
+    /**
+     * @notice Adds a new witness to the authorized witness set
+     * @param _witness New witness address
+     */
+    function addWitness(address _witness) external onlyOwner {
+        require(_witness != address(0), "MAV: zero witness");
+        require(witnessesSet.add(_witness), "MAV: already a witness");
+
+        emit WitnessAdded(_witness);
+    }
+
+    /**
+     * @notice Removes a witness from the authorized witness set
+     * @param _witness Witness address to remove
+     */
+    function removeWitness(address _witness) external onlyOwner {
+        require(witnessesSet.remove(_witness), "MAV: not a witness");
+        require(witnessesSet.length() >= requiredSignatures, "MAV: below threshold");
+
+        emit WitnessRemoved(_witness);
+    }
+
+    /**
+     * @notice Updates the required witness signature threshold
+     * @param _requiredSignatures New threshold
+     */
+    function setRequiredSignatures(uint256 _requiredSignatures) external onlyOwner {
+        require(_requiredSignatures > 0, "MAV: threshold must be > 0");
+        require(_requiredSignatures <= witnessesSet.length(), "MAV: exceeds witness count");
+
+        emit RequiredSignaturesUpdated(requiredSignatures, _requiredSignatures);
+
+        requiredSignatures = _requiredSignatures;
+    }
+
+    /* ============ View Functions ============ */
+
+    /**
+     * @notice Returns the current witness set
+     * @return The authorized witness addresses
+     */
+    function witnesses() external view returns (address[] memory) {
+        return witnessesSet.values();
+    }
+
+    /**
+     * @notice Returns whether an address is an authorized witness
+     * @param _witness Address to check
+     * @return True if the address is an authorized witness
+     */
+    function isWitness(address _witness) external view returns (bool) {
+        return witnessesSet.contains(_witness);
+    }
+
+    /**
+     * @notice Returns the current number of authorized witnesses
+     * @return The witness count
+     */
+    function witnessCount() external view returns (uint256) {
+        return witnessesSet.length();
+    }
+}

--- a/deploy/23_deploy_multi_attestation_verifier.ts
+++ b/deploy/23_deploy_multi_attestation_verifier.ts
@@ -1,0 +1,38 @@
+import "module-alias/register";
+
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+import {
+  MULTI_WITNESS_ADDRESSES,
+  MULTI_WITNESS_THRESHOLD,
+} from "../deployments/parameters";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deploy } = await hre.deployments;
+  const network = hre.deployments.getNetworkName();
+
+  const [deployer] = await hre.getUnnamedAccounts();
+
+  const initialWitnesses = MULTI_WITNESS_ADDRESSES[network];
+  const initialThreshold = MULTI_WITNESS_THRESHOLD[network];
+
+  if (!initialWitnesses || initialWitnesses.length === 0) {
+    throw new Error(`No MultiAttestationVerifier witnesses configured for ${network}`);
+  }
+
+  if (!initialThreshold) {
+    throw new Error(`No MultiAttestationVerifier threshold configured for ${network}`);
+  }
+
+  const multiAttestationVerifier = await deploy("MultiAttestationVerifier", {
+    from: deployer,
+    args: [initialWitnesses, initialThreshold],
+  });
+
+  console.log("MultiAttestationVerifier deployed at", multiAttestationVerifier.address);
+};
+
+func.tags = ["MultiAttestationVerifier"];
+
+export default func;

--- a/deployments/parameters.ts
+++ b/deployments/parameters.ts
@@ -58,6 +58,20 @@ export const WITNESS_ADDRESS: any = {
   "base_sepolia": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
 };
 
+export const MULTI_WITNESS_ADDRESSES: Record<string, string[]> = {
+  base: ["0x5106A86819ED6Bb82c77CcBfC151250E1d369DbA"],
+  base_staging: ["0x4ab950AE1e3326578Bf7e643a2031E858aBa2927"],
+  base_sepolia: ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"],
+  localhost: ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"],
+};
+
+export const MULTI_WITNESS_THRESHOLD: Record<string, number> = {
+  base: 1,
+  base_staging: 1,
+  base_sepolia: 1,
+  localhost: 1,
+};
+
 export const USDC: any = {
   "base": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
   "base_staging": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"

--- a/test-foundry/fuzz/MultiAttestationVerifierFuzz.t.sol
+++ b/test-foundry/fuzz/MultiAttestationVerifierFuzz.t.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import { Test } from "forge-std/Test.sol";
+
+import { MultiAttestationVerifier } from "../../contracts/unifiedVerifier/MultiAttestationVerifier.sol";
+
+contract MultiAttestationVerifierFuzz is Test {
+    uint256 internal constant MAX_WITNESSES = 5;
+
+    address public owner;
+
+    function setUp() public {
+        owner = makeAddr("owner");
+    }
+
+    function testFuzz_addRemoveAddRoundTripPreservesWitnessCount(uint256 newWitnessPrivateKey) public {
+        address[] memory initialWitnesses = new address[](2);
+        initialWitnesses[0] = vm.addr(1);
+        initialWitnesses[1] = vm.addr(2);
+
+        MultiAttestationVerifier verifier = _deployVerifier(initialWitnesses, 1);
+
+        newWitnessPrivateKey = bound(newWitnessPrivateKey, 3, type(uint128).max);
+        address newWitness = vm.addr(newWitnessPrivateKey);
+
+        uint256 initialCount = verifier.witnessCount();
+
+        vm.prank(owner);
+        verifier.addWitness(newWitness);
+        uint256 countAfterFirstAdd = verifier.witnessCount();
+
+        vm.prank(owner);
+        verifier.removeWitness(newWitness);
+        uint256 countAfterRemove = verifier.witnessCount();
+
+        vm.prank(owner);
+        verifier.addWitness(newWitness);
+
+        assertEq(countAfterFirstAdd, initialCount + 1);
+        assertEq(countAfterRemove, initialCount);
+        assertEq(verifier.witnessCount(), countAfterFirstAdd);
+    }
+
+    function testFuzz_verifyMatchesRandomSubset(
+        uint8 witnessCountSeed,
+        uint8 thresholdSeed,
+        uint256 signatureMaskSeed,
+        uint256 messageSeed
+    ) public {
+        uint256 witnessCount = bound(uint256(witnessCountSeed), 1, MAX_WITNESSES);
+        uint256 requiredSignatures = bound(uint256(thresholdSeed), 1, witnessCount);
+
+        (address[] memory witnesses, uint256[] memory privateKeys) = _buildWitnessSet(witnessCount);
+        MultiAttestationVerifier verifier = _deployVerifier(witnesses, requiredSignatures);
+
+        bytes32 messageHash = keccak256(
+            abi.encodePacked("multi-attestation-verifier-fuzz", messageSeed, witnessCount, requiredSignatures)
+        );
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash)
+        );
+
+        uint256 selectionSpace = uint256(1) << witnessCount;
+        uint256 signatureMask = signatureMaskSeed % selectionSpace;
+        uint256 selectedCount = _countSelectedWitnesses(signatureMask, witnessCount);
+
+        bytes[] memory signatures = new bytes[](selectedCount);
+        uint256 signatureIndex = 0;
+
+        for (uint256 witnessIndex = 0; witnessIndex < witnessCount; witnessIndex++) {
+            if ((signatureMask & (uint256(1) << witnessIndex)) != 0) {
+                signatures[signatureIndex] = _signDigest(privateKeys[witnessIndex], digest);
+                signatureIndex++;
+            }
+        }
+
+        bool shouldVerify = selectedCount >= requiredSignatures;
+
+        if (shouldVerify) {
+            bool isValid = verifier.verify(digest, signatures, "");
+            assertTrue(isValid);
+        } else {
+            vm.expectRevert();
+            verifier.verify(digest, signatures, "");
+        }
+    }
+
+    function _deployVerifier(
+        address[] memory initialWitnesses,
+        uint256 initialThreshold
+    ) internal returns (MultiAttestationVerifier deployedVerifier) {
+        vm.prank(owner);
+        deployedVerifier = new MultiAttestationVerifier(initialWitnesses, initialThreshold);
+    }
+
+    function _buildWitnessSet(
+        uint256 witnessCount
+    ) internal pure returns (address[] memory witnesses, uint256[] memory privateKeys) {
+        witnesses = new address[](witnessCount);
+        privateKeys = new uint256[](witnessCount);
+
+        for (uint256 witnessIndex = 0; witnessIndex < witnessCount; witnessIndex++) {
+            uint256 privateKey = uint256(
+                keccak256(abi.encodePacked("multi-attestation-fuzz-witness", witnessCount, witnessIndex))
+            );
+
+            if (privateKey == 0) {
+                privateKey = witnessIndex + 1;
+            }
+
+            privateKeys[witnessIndex] = privateKey;
+            witnesses[witnessIndex] = vm.addr(privateKey);
+        }
+    }
+
+    function _countSelectedWitnesses(
+        uint256 signatureMask,
+        uint256 witnessCount
+    ) internal pure returns (uint256 selectedCount) {
+        for (uint256 witnessIndex = 0; witnessIndex < witnessCount; witnessIndex++) {
+            if ((signatureMask & (uint256(1) << witnessIndex)) != 0) {
+                selectedCount++;
+            }
+        }
+    }
+
+    function _signDigest(uint256 privateKey, bytes32 digest) internal pure returns (bytes memory signature) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        signature = abi.encodePacked(r, s, v);
+    }
+}

--- a/test-foundry/unit/MultiAttestationVerifierUnit.t.sol
+++ b/test-foundry/unit/MultiAttestationVerifierUnit.t.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import { Test } from "forge-std/Test.sol";
+
+import { MultiAttestationVerifier } from "../../contracts/unifiedVerifier/MultiAttestationVerifier.sol";
+
+contract MultiAttestationVerifierUnit is Test {
+    MultiAttestationVerifier public verifier;
+
+    address public owner;
+    address public nonOwner;
+    address public witnessA;
+    address public witnessB;
+    address public witnessC;
+
+    function setUp() public {
+        owner = makeAddr("owner");
+        nonOwner = makeAddr("nonOwner");
+        witnessA = makeAddr("witnessA");
+        witnessB = makeAddr("witnessB");
+        witnessC = makeAddr("witnessC");
+
+        verifier = _deployVerifier(_twoWitnesses(), 1);
+    }
+
+    function test_constructor_revertsOnZeroWitness() public {
+        address[] memory initialWitnesses = new address[](2);
+        initialWitnesses[0] = witnessA;
+        initialWitnesses[1] = address(0);
+
+        vm.prank(owner);
+        vm.expectRevert("MAV: zero witness");
+        new MultiAttestationVerifier(initialWitnesses, 1);
+    }
+
+    function test_constructor_revertsOnDuplicateWitness() public {
+        address[] memory initialWitnesses = new address[](2);
+        initialWitnesses[0] = witnessA;
+        initialWitnesses[1] = witnessA;
+
+        vm.prank(owner);
+        vm.expectRevert("MAV: duplicate witness");
+        new MultiAttestationVerifier(initialWitnesses, 2);
+    }
+
+    function test_constructor_revertsOnZeroThreshold() public {
+        vm.prank(owner);
+        vm.expectRevert("MAV: threshold must be > 0");
+        new MultiAttestationVerifier(_singleWitness(witnessA), 0);
+    }
+
+    function test_constructor_revertsWhenThresholdExceedsWitnessCount() public {
+        vm.prank(owner);
+        vm.expectRevert("MAV: threshold exceeds count");
+        new MultiAttestationVerifier(_singleWitness(witnessA), 2);
+    }
+
+    function test_addWitness_revertsWhenCallerNotOwner() public {
+        vm.prank(nonOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        verifier.addWitness(witnessC);
+    }
+
+    function test_addWitness_revertsOnZeroWitness() public {
+        vm.prank(owner);
+        vm.expectRevert("MAV: zero witness");
+        verifier.addWitness(address(0));
+    }
+
+    function test_addWitness_revertsOnDuplicateWitness() public {
+        vm.prank(owner);
+        vm.expectRevert("MAV: already a witness");
+        verifier.addWitness(witnessA);
+    }
+
+    function test_removeWitness_revertsWhenCallerNotOwner() public {
+        vm.prank(nonOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        verifier.removeWitness(witnessB);
+    }
+
+    function test_removeWitness_revertsWhenWitnessDoesNotExist() public {
+        vm.prank(owner);
+        vm.expectRevert("MAV: not a witness");
+        verifier.removeWitness(witnessC);
+    }
+
+    function test_removeWitness_revertsWhenRemovalFallsBelowThreshold() public {
+        MultiAttestationVerifier singleWitnessVerifier = _deployVerifier(_singleWitness(witnessA), 1);
+
+        vm.prank(owner);
+        vm.expectRevert("MAV: below threshold");
+        singleWitnessVerifier.removeWitness(witnessA);
+    }
+
+    function test_setRequiredSignatures_revertsWhenCallerNotOwner() public {
+        vm.prank(nonOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        verifier.setRequiredSignatures(2);
+    }
+
+    function test_setRequiredSignatures_revertsOnZeroThreshold() public {
+        vm.prank(owner);
+        vm.expectRevert("MAV: threshold must be > 0");
+        verifier.setRequiredSignatures(0);
+    }
+
+    function test_setRequiredSignatures_revertsWhenThresholdExceedsWitnessCount() public {
+        vm.prank(owner);
+        vm.expectRevert("MAV: exceeds witness count");
+        verifier.setRequiredSignatures(3);
+    }
+
+    function _deployVerifier(
+        address[] memory initialWitnesses,
+        uint256 initialThreshold
+    ) internal returns (MultiAttestationVerifier deployedVerifier) {
+        vm.prank(owner);
+        deployedVerifier = new MultiAttestationVerifier(initialWitnesses, initialThreshold);
+    }
+
+    function _singleWitness(address witnessAddress) internal pure returns (address[] memory initialWitnesses) {
+        initialWitnesses = new address[](1);
+        initialWitnesses[0] = witnessAddress;
+    }
+
+    function _twoWitnesses() internal view returns (address[] memory initialWitnesses) {
+        initialWitnesses = new address[](2);
+        initialWitnesses[0] = witnessA;
+        initialWitnesses[1] = witnessB;
+    }
+}

--- a/test/unifiedVerifier/MultiAttestationVerifier.spec.ts
+++ b/test/unifiedVerifier/MultiAttestationVerifier.spec.ts
@@ -1,0 +1,488 @@
+import "module-alias/register";
+
+import { ethers } from "hardhat";
+
+import {
+  addSnapshotBeforeRestoreAfterEach,
+  getAccounts,
+  getWaffleExpect,
+} from "@utils/test";
+import { ADDRESS_ZERO } from "@utils/constants";
+import { Account } from "@utils/test/types";
+import { MultiAttestationVerifier } from "../../typechain";
+
+const expect = getWaffleExpect();
+
+describe("MultiAttestationVerifier", () => {
+  let owner: Account;
+  let nonOwner: Account;
+  let witnessA: Account;
+  let witnessB: Account;
+  let witnessC: Account;
+  let otherAccount: Account;
+
+  let baseMultiAttestationVerifier: MultiAttestationVerifier;
+  let multiAttestationVerifier: MultiAttestationVerifier;
+
+  let messageHash: string;
+  let digest: string;
+
+  before(async () => {
+    [
+      owner,
+      nonOwner,
+      witnessA,
+      witnessB,
+      witnessC,
+      otherAccount,
+    ] = await getAccounts();
+
+    messageHash = ethers.utils.keccak256(
+      ethers.utils.toUtf8Bytes("Test attestation message")
+    );
+    digest = ethers.utils.keccak256(
+      ethers.utils.concat([
+        ethers.utils.toUtf8Bytes("\x19Ethereum Signed Message:\n32"),
+        messageHash,
+      ])
+    );
+
+    baseMultiAttestationVerifier = await deployVerifier([witnessA.address], 1);
+    multiAttestationVerifier = baseMultiAttestationVerifier;
+  });
+
+  addSnapshotBeforeRestoreAfterEach();
+
+  async function deployVerifier(
+    initialWitnesses: string[],
+    initialThreshold: number
+  ): Promise<MultiAttestationVerifier> {
+    const verifierFactory = await ethers.getContractFactory(
+      "MultiAttestationVerifier",
+      owner.wallet
+    );
+
+    const verifier = await verifierFactory.deploy(initialWitnesses, initialThreshold);
+    await verifier.deployed();
+
+    return verifier as MultiAttestationVerifier;
+  }
+
+  async function signWitness(
+    signer: Account,
+    hashToSign?: string
+  ): Promise<string> {
+    return signer.wallet.signMessage(
+      ethers.utils.arrayify(hashToSign ?? messageHash)
+    );
+  }
+
+  describe("#verify", () => {
+    let subjectDigest: string;
+    let subjectSignatures: string[];
+    let subjectData: string;
+
+    beforeEach(() => {
+      subjectDigest = digest;
+      subjectSignatures = [];
+      subjectData = "0x";
+    });
+
+    async function subject(): Promise<boolean> {
+      return multiAttestationVerifier.verify(
+        subjectDigest,
+        subjectSignatures,
+        subjectData
+      );
+    }
+
+    describe("when deployed with one witness and threshold 1", () => {
+      beforeEach(async () => {
+        multiAttestationVerifier = baseMultiAttestationVerifier;
+        subjectSignatures = [await signWitness(witnessA)];
+      });
+
+      it("should return true with a valid signature from that witness", async () => {
+        const result = await subject();
+
+        expect(result).to.equal(true);
+      });
+    });
+
+    describe("when deployed with two witnesses and threshold 1", () => {
+      beforeEach(async () => {
+        multiAttestationVerifier = await deployVerifier(
+          [witnessA.address, witnessB.address],
+          1
+        );
+      });
+
+      describe("when witness A signs the digest", () => {
+        beforeEach(async () => {
+          subjectSignatures = [await signWitness(witnessA)];
+        });
+
+        it("should return true", async () => {
+          const result = await subject();
+
+          expect(result).to.equal(true);
+        });
+      });
+
+      describe("when witness B signs the digest", () => {
+        beforeEach(async () => {
+          subjectSignatures = [await signWitness(witnessB)];
+        });
+
+        it("should return true", async () => {
+          const result = await subject();
+
+          expect(result).to.equal(true);
+        });
+      });
+
+      describe("when a non-witness signs the digest", () => {
+        beforeEach(async () => {
+          subjectSignatures = [await signWitness(otherAccount)];
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith(
+            "ThresholdSigVerifierUtils: Not enough valid witness signatures"
+          );
+        });
+      });
+
+      describe("when the same witness signature is passed twice", () => {
+        beforeEach(async () => {
+          const duplicateSignature = await signWitness(witnessA);
+          subjectSignatures = [duplicateSignature, duplicateSignature];
+        });
+
+        it("should return true because the unique signer threshold is still met", async () => {
+          const result = await subject();
+
+          expect(result).to.equal(true);
+        });
+      });
+    });
+
+    describe("when deployed with two witnesses and threshold 2", () => {
+      beforeEach(async () => {
+        multiAttestationVerifier = await deployVerifier(
+          [witnessA.address, witnessB.address],
+          2
+        );
+      });
+
+      describe("when witness A and witness B sign the digest", () => {
+        beforeEach(async () => {
+          subjectSignatures = [
+            await signWitness(witnessA),
+            await signWitness(witnessB),
+          ];
+        });
+
+        it("should return true", async () => {
+          const result = await subject();
+
+          expect(result).to.equal(true);
+        });
+      });
+
+      describe("when the same witness signs twice", () => {
+        beforeEach(async () => {
+          const duplicateSignature = await signWitness(witnessA);
+          subjectSignatures = [duplicateSignature, duplicateSignature];
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith(
+            "ThresholdSigVerifierUtils: Not enough valid witness signatures"
+          );
+        });
+      });
+    });
+
+    describe("when deployed with three witnesses and threshold 3", () => {
+      beforeEach(async () => {
+        multiAttestationVerifier = await deployVerifier(
+          [witnessA.address, witnessB.address, witnessC.address],
+          3
+        );
+
+        const duplicateSignature = await signWitness(witnessA);
+        subjectSignatures = [
+          duplicateSignature,
+          duplicateSignature,
+          duplicateSignature,
+        ];
+      });
+
+      it("should revert when the same signature bytes are replayed three times", async () => {
+        await expect(subject()).to.be.revertedWith(
+          "ThresholdSigVerifierUtils: Not enough valid witness signatures"
+        );
+      });
+    });
+  });
+
+  describe("#constructor", () => {
+    let subjectWitnesses: string[];
+    let subjectThreshold: number;
+
+    beforeEach(() => {
+      subjectWitnesses = [witnessA.address];
+      subjectThreshold = 1;
+    });
+
+    async function subject(): Promise<MultiAttestationVerifier> {
+      return deployVerifier(subjectWitnesses, subjectThreshold);
+    }
+
+    describe("when the initial witness set contains the zero address", () => {
+      beforeEach(() => {
+        subjectWitnesses = [witnessA.address, ADDRESS_ZERO];
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("MAV: zero witness");
+      });
+    });
+
+    describe("when the initial witness set contains a duplicate", () => {
+      beforeEach(() => {
+        subjectWitnesses = [witnessA.address, witnessA.address];
+        subjectThreshold = 2;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("MAV: duplicate witness");
+      });
+    });
+
+    describe("when the initial threshold is zero", () => {
+      beforeEach(() => {
+        subjectThreshold = 0;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("MAV: threshold must be > 0");
+      });
+    });
+
+    describe("when the initial threshold exceeds the witness count", () => {
+      beforeEach(() => {
+        subjectWitnesses = [witnessA.address];
+        subjectThreshold = 2;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("MAV: threshold exceeds count");
+      });
+    });
+  });
+
+  describe("#addWitness", () => {
+    let subjectWitness: string;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      multiAttestationVerifier = await deployVerifier([witnessA.address], 1);
+      subjectWitness = witnessB.address;
+      subjectCaller = owner;
+    });
+
+    async function subject(): Promise<any> {
+      return multiAttestationVerifier
+        .connect(subjectCaller.wallet)
+        .addWitness(subjectWitness);
+    }
+
+    describe("when called by the owner with a new witness", () => {
+      it("should emit WitnessAdded and increase the witness count", async () => {
+        const transaction = await subject();
+
+        await expect(transaction)
+          .to.emit(multiAttestationVerifier, "WitnessAdded")
+          .withArgs(subjectWitness);
+
+        expect(await multiAttestationVerifier.witnessCount()).to.equal(2);
+      });
+    });
+
+    describe("when called by a non-owner", () => {
+      beforeEach(() => {
+        subjectCaller = nonOwner;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith(
+          "Ownable: caller is not the owner"
+        );
+      });
+    });
+
+    describe("when the new witness is the zero address", () => {
+      beforeEach(() => {
+        subjectWitness = ADDRESS_ZERO;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("MAV: zero witness");
+      });
+    });
+
+    describe("when the witness already exists", () => {
+      beforeEach(() => {
+        subjectWitness = witnessA.address;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("MAV: already a witness");
+      });
+    });
+  });
+
+  describe("#removeWitness", () => {
+    let subjectWitness: string;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      multiAttestationVerifier = await deployVerifier(
+        [witnessA.address, witnessB.address],
+        1
+      );
+      subjectWitness = witnessB.address;
+      subjectCaller = owner;
+    });
+
+    async function subject(): Promise<any> {
+      return multiAttestationVerifier
+        .connect(subjectCaller.wallet)
+        .removeWitness(subjectWitness);
+    }
+
+    describe("when called by the owner for an existing witness", () => {
+      it("should emit WitnessRemoved and decrease the witness count", async () => {
+        const transaction = await subject();
+
+        await expect(transaction)
+          .to.emit(multiAttestationVerifier, "WitnessRemoved")
+          .withArgs(subjectWitness);
+
+        expect(await multiAttestationVerifier.witnessCount()).to.equal(1);
+      });
+    });
+
+    describe("when the removal would drop the set below the threshold", () => {
+      beforeEach(async () => {
+        multiAttestationVerifier = await deployVerifier([witnessA.address], 1);
+        subjectWitness = witnessA.address;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("MAV: below threshold");
+      });
+    });
+
+    describe("when the witness is not in the set", () => {
+      beforeEach(() => {
+        subjectWitness = witnessC.address;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("MAV: not a witness");
+      });
+    });
+  });
+
+  describe("#setRequiredSignatures", () => {
+    let subjectRequiredSignatures: number;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      multiAttestationVerifier = await deployVerifier(
+        [witnessA.address, witnessB.address],
+        1
+      );
+      subjectRequiredSignatures = 2;
+      subjectCaller = owner;
+    });
+
+    async function subject(): Promise<any> {
+      return multiAttestationVerifier
+        .connect(subjectCaller.wallet)
+        .setRequiredSignatures(subjectRequiredSignatures);
+    }
+
+    describe("when called by the owner with a valid threshold", () => {
+      it("should emit RequiredSignaturesUpdated and update the threshold", async () => {
+        const transaction = await subject();
+
+        await expect(transaction)
+          .to.emit(multiAttestationVerifier, "RequiredSignaturesUpdated")
+          .withArgs(1, subjectRequiredSignatures);
+
+        expect(await multiAttestationVerifier.requiredSignatures()).to.equal(
+          subjectRequiredSignatures
+        );
+      });
+    });
+
+    describe("when the new threshold is zero", () => {
+      beforeEach(() => {
+        subjectRequiredSignatures = 0;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("MAV: threshold must be > 0");
+      });
+    });
+
+    describe("when the new threshold exceeds the witness count", () => {
+      beforeEach(() => {
+        subjectRequiredSignatures = 3;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("MAV: exceeds witness count");
+      });
+    });
+  });
+
+  describe("view helpers", () => {
+    describe("#witnesses", () => {
+      beforeEach(async () => {
+        multiAttestationVerifier = await deployVerifier(
+          [witnessA.address, witnessB.address],
+          1
+        );
+
+        await multiAttestationVerifier.connect(owner.wallet).addWitness(witnessC.address);
+        await multiAttestationVerifier.connect(owner.wallet).removeWitness(witnessA.address);
+      });
+
+      it("should return the current witness set", async () => {
+        expect(await multiAttestationVerifier.witnesses()).to.have.deep.members([
+          witnessB.address,
+          witnessC.address,
+        ]);
+      });
+    });
+
+    describe("#isWitness", () => {
+      beforeEach(async () => {
+        multiAttestationVerifier = await deployVerifier(
+          [witnessA.address, witnessB.address],
+          1
+        );
+      });
+
+      it("should return the correct boolean", async () => {
+        expect(await multiAttestationVerifier.isWitness(witnessA.address)).to.equal(true);
+        expect(await multiAttestationVerifier.isWitness(witnessC.address)).to.equal(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- New `MultiAttestationVerifier` contract — a drop-in replacement for `SimpleAttestationVerifier` that supports a dynamic witness set with a configurable signature threshold (defaults to `1`).
- Adds Hardhat spec (24 cases) + Foundry unit (13) + Foundry fuzz (2 properties × 256 runs) test coverage.
- Adds `deploy/23_deploy_multi_attestation_verifier.ts` plus `MULTI_WITNESS_ADDRESSES` / `MULTI_WITNESS_THRESHOLD` network config in `deployments/parameters.ts`.

This unblocks running multiple attestation-service signers in parallel on-chain (e.g. Railway prod + a new TEE deploy). 

## Design

- Reuses the existing `ThresholdSigVerifierUtils.verifyWitnessSignatures(...)` library, which already handles N-witness dedupe and threshold-based acceptance.
- Uses OpenZeppelin `EnumerableSet.AddressSet` for witness storage — O(1) add/remove/contains, clean enumeration.
- Same file layout / section dividers / NatSpec style as `SimpleAttestationVerifier.sol`; short `"MAV: ..."` revert strings to match.
- Governance surface: `addWitness(addr)`, `removeWitness(addr)`, `setRequiredSignatures(n)` — all `onlyOwner`. Read helpers: `witnesses()`, `isWitness(addr)`, `witnessCount()`.
- Safety rails: `removeWitness` reverts if the remove would drop the set below `requiredSignatures`; `setRequiredSignatures(0)` and `> witnessCount()` revert; zero / duplicate initial witnesses revert in the constructor.

## Tests

- **Hardhat** — `test/unifiedVerifier/MultiAttestationVerifier.spec.ts`, 24/24 passing. Mirrors the subject pattern used in sibling specs; covers constructor reverts, `verify` with 1/2/3 witnesses at threshold 1/2/3, `addWitness` / `removeWitness` / `setRequiredSignatures` happy paths + reverts, and view helpers.
- **Foundry unit** — `test-foundry/unit/MultiAttestationVerifierUnit.t.sol`, 13/13 passing. Governance revert cases (zero address, duplicates, threshold out of range, below-threshold remove, non-owner).
- **Foundry fuzz** — `test-foundry/fuzz/MultiAttestationVerifierFuzz.t.sol`, 2/2 passing at 256 runs. `testFuzz_addRemoveAddRoundTripPreservesWitnessCount` (governance invariant) and `testFuzz_verifyMatchesRandomSubset` (arbitrary (witnessCount, threshold) with random-subset signatures).

## Gas

Per-verify gas delta vs `SimpleAttestationVerifier` is a few kgas (one `EnumerableSet.values()` copy to memory + library loop over N=1..few witnesses). Not material for settlement cost.

## Out of scope

- Does **not** wire the new verifier into `UnifiedPaymentVerifierV2`. `BaseUnifiedPaymentVerifier.setAttestationVerifier(address)` is `onlyOwner` — swap happens as a separate multisig tx on deploy day.
- Does **not** transfer ownership to a multisig; deploy script ships as-is for the deployer. Ownership handover is a follow-up Safe batch per the rollout runbook.
- Does **not** modify `SimpleAttestationVerifier.sol`, `UnifiedPaymentVerifier.sol`, `BaseUnifiedPaymentVerifier.sol`, or any existing deploy script.

## Test plan (reviewer)

- [x] `yarn compile` clean
- [x] `yarn test test/unifiedVerifier/MultiAttestationVerifier.spec.ts` → 24/24 green
- [x] `yarn test:forge --match-path "*MultiAttestationVerifier*"` → 15/15 green (13 unit + 2 fuzz × 256 runs)
- [x] `yarn test` full suite — not regressed (pre-existing `AcrossBridgeHookFork` fork tests fail on main independent of this branch)
- [x] Verify `deployments/parameters.ts` witness addresses match the current Railway prod signer (`0x5106A8…9DbA`) + staging enclave signer (`0x4ab950…2927`)
- [x] Confirm contract style matches `SimpleAttestationVerifier.sol` (section dividers, NatSpec, revert-string convention)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zkp2p/zkp2p-contracts/pull/154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
