### PR TITLE
feat: use depositor attestation witness config

### DIFF
--- a/contracts/interfaces/IAttestationVerifier.sol
+++ b/contracts/interfaces/IAttestationVerifier.sol
@@ -10,7 +10,7 @@ interface IAttestationVerifier {
      * @notice Verifies attestations for a given digest
      * @param _digest The message digest to verify (EIP-712 formatted)
      * @param _sigs Array of signatures from attestors
-     * @param _data Verification data containing attestor identities or hints
+     * @param _data Verification data containing attestor identities and threshold requirements
      * @return isValid Returns true if the attestation is valid, false otherwise
      */
     function verify(

--- a/contracts/unifiedVerifier/MultiAttestationVerifier.sol
+++ b/contracts/unifiedVerifier/MultiAttestationVerifier.sol
@@ -1,141 +1,63 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
-import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import { IAttestationVerifier } from "../interfaces/IAttestationVerifier.sol";
 import { ThresholdSigVerifierUtils } from "../lib/ThresholdSigVerifierUtils.sol";
 
 /**
  * @title MultiAttestationVerifier
- * @notice Verifies attestations from one of N authorized witness addresses
- * @dev Drop-in replacement for SimpleAttestationVerifier that supports a dynamic
- *      witness set with a configurable signature threshold. Threshold defaults to 1
- *      so the contract behaves as "any witness can sign" unless an owner raises it.
+ * @notice Verifies attestations against depositor-selected witness configuration.
+ * @dev The caller supplies witness configuration in `_data` as
+ *      `abi.encode(address[] witnesses, uint256 requiredSignatures)`.
  */
-contract MultiAttestationVerifier is IAttestationVerifier, Ownable {
-    using EnumerableSet for EnumerableSet.AddressSet;
-
-    /* ============ Events ============ */
-
-    event WitnessAdded(address indexed witness);
-    event WitnessRemoved(address indexed witness);
-    event RequiredSignaturesUpdated(uint256 oldThreshold, uint256 newThreshold);
-
-    /* ============ State Variables ============ */
-
-    EnumerableSet.AddressSet private witnessesSet;
-    uint256 public requiredSignatures;
-
-    /* ============ Constructor ============ */
-
-    /**
-     * @notice Initializes the attestation verifier with an initial witness set and threshold
-     * @param _initialWitnesses Initial witness addresses
-     * @param _initialThreshold Initial required signature threshold
-     */
-    constructor(address[] memory _initialWitnesses, uint256 _initialThreshold) Ownable() {
-        require(_initialThreshold > 0, "MAV: threshold must be > 0");
-        require(_initialThreshold <= _initialWitnesses.length, "MAV: threshold exceeds count");
-
-        for (uint256 witnessIndex = 0; witnessIndex < _initialWitnesses.length; witnessIndex++) {
-            address witnessAddress = _initialWitnesses[witnessIndex];
-
-            require(witnessAddress != address(0), "MAV: zero witness");
-            require(witnessesSet.add(witnessAddress), "MAV: duplicate witness");
-
-            emit WitnessAdded(witnessAddress);
-        }
-
-        requiredSignatures = _initialThreshold;
-
-        emit RequiredSignaturesUpdated(0, _initialThreshold);
-    }
-
+contract MultiAttestationVerifier is IAttestationVerifier {
     /* ============ External Functions ============ */
 
     /**
-     * @notice Verifies attestation signatures against the current witness set
+     * @notice Verifies attestation signatures against depositor-selected witnesses.
      * @param _digest The message digest to verify
      * @param _sigs Array of signatures from witnesses
+     * @param _data ABI-encoded witness config: `abi.encode(address[] witnesses, uint256 requiredSignatures)`
      * @return isValid True if the witness threshold is met
      */
     function verify(
         bytes32 _digest,
         bytes[] calldata _sigs,
-        bytes calldata
+        bytes calldata _data
     ) external view override returns (bool isValid) {
+        (address[] memory witnesses, uint256 requiredSignatures) = _decodeWitnessConfig(_data);
+
         isValid = ThresholdSigVerifierUtils.verifyWitnessSignatures(
             _digest,
             _sigs,
-            witnessesSet.values(),
+            witnesses,
             requiredSignatures
         );
 
         return isValid;
     }
 
-    /* ============ Governance Functions ============ */
+    /* ============ Internal Functions ============ */
 
-    /**
-     * @notice Adds a new witness to the authorized witness set
-     * @param _witness New witness address
-     */
-    function addWitness(address _witness) external onlyOwner {
-        require(_witness != address(0), "MAV: zero witness");
-        require(witnessesSet.add(_witness), "MAV: already a witness");
+    function _decodeWitnessConfig(bytes calldata _data)
+        internal
+        pure
+        returns (address[] memory witnesses, uint256 requiredSignatures)
+    {
+        require(_data.length > 0, "MAV: witness config required");
 
-        emit WitnessAdded(_witness);
-    }
+        (witnesses, requiredSignatures) = abi.decode(_data, (address[], uint256));
 
-    /**
-     * @notice Removes a witness from the authorized witness set
-     * @param _witness Witness address to remove
-     */
-    function removeWitness(address _witness) external onlyOwner {
-        require(witnessesSet.remove(_witness), "MAV: not a witness");
-        require(witnessesSet.length() >= requiredSignatures, "MAV: below threshold");
+        require(witnesses.length > 0, "MAV: empty witnesses");
+        require(requiredSignatures > 0, "MAV: threshold must be > 0");
+        require(requiredSignatures <= witnesses.length, "MAV: threshold exceeds count");
 
-        emit WitnessRemoved(_witness);
-    }
+        for (uint256 i = 0; i < witnesses.length; i++) {
+            require(witnesses[i] != address(0), "MAV: zero witness");
 
-    /**
-     * @notice Updates the required witness signature threshold
-     * @param _requiredSignatures New threshold
-     */
-    function setRequiredSignatures(uint256 _requiredSignatures) external onlyOwner {
-        require(_requiredSignatures > 0, "MAV: threshold must be > 0");
-        require(_requiredSignatures <= witnessesSet.length(), "MAV: exceeds witness count");
-
-        emit RequiredSignaturesUpdated(requiredSignatures, _requiredSignatures);
-
-        requiredSignatures = _requiredSignatures;
-    }
-
-    /* ============ View Functions ============ */
-
-    /**
-     * @notice Returns the current witness set
-     * @return The authorized witness addresses
-     */
-    function witnesses() external view returns (address[] memory) {
-        return witnessesSet.values();
-    }
-
-    /**
-     * @notice Returns whether an address is an authorized witness
-     * @param _witness Address to check
-     * @return True if the address is an authorized witness
-     */
-    function isWitness(address _witness) external view returns (bool) {
-        return witnessesSet.contains(_witness);
-    }
-
-    /**
-     * @notice Returns the current number of authorized witnesses
-     * @return The witness count
-     */
-    function witnessCount() external view returns (uint256) {
-        return witnessesSet.length();
+            for (uint256 j = 0; j < i; j++) {
+                require(witnesses[i] != witnesses[j], "MAV: duplicate witness");
+            }
+        }
     }
 }

--- a/contracts/unifiedVerifier/UnifiedPaymentVerifier.sol
+++ b/contracts/unifiedVerifier/UnifiedPaymentVerifier.sol
@@ -146,9 +146,12 @@ contract UnifiedPaymentVerifier is IPaymentVerifier, BaseUnifiedPaymentVerifier 
         ) = _decodeAttestationPayload(attestation.data);
         require(isPaymentMethod[paymentDetails.method], "UPV: Invalid payment method");
         
-        _validateIntentSnapshot(_verifyPaymentData.intentHash, intentSnapshot);
+        bytes memory attestationVerifierData = _validateIntentSnapshot(
+            _verifyPaymentData.intentHash,
+            intentSnapshot
+        );
 
-        bool isValid = _verifyAttestation(attestation);
+        bool isValid = _verifyAttestation(attestation, attestationVerifierData);
         require(isValid, "UPV: Invalid attestation");
                 
         // Nullify the payment to prevent double-spending
@@ -185,7 +188,10 @@ contract UnifiedPaymentVerifier is IPaymentVerifier, BaseUnifiedPaymentVerifier 
      * Verifies the EIP-712 attestation using the attestation verifier. Also verifies the integrity of the 
      * verify payment data using the data hash attached to the attestation.
      */
-    function _verifyAttestation(PaymentAttestation memory attestation) internal view returns (bool) {
+    function _verifyAttestation(
+        PaymentAttestation memory attestation,
+        bytes memory attestationVerifierData
+    ) internal view returns (bool) {
         bytes32 structHash = keccak256(
             abi.encode(
                 PAYMENT_ATTESTATION_TYPEHASH,
@@ -212,7 +218,7 @@ contract UnifiedPaymentVerifier is IPaymentVerifier, BaseUnifiedPaymentVerifier 
         bool isValid = attestationVerifier.verify(
             digest, 
             attestation.signatures,
-            attestation.data
+            attestationVerifierData
         );
 
         return isValid;
@@ -225,8 +231,12 @@ contract UnifiedPaymentVerifier is IPaymentVerifier, BaseUnifiedPaymentVerifier 
     function _validateIntentSnapshot(
         bytes32 intentHash,
         IntentSnapshot memory snapshot
-    ) internal view {
+    ) internal view returns (bytes memory attestationVerifierData) {
         require(snapshot.intentHash == intentHash, "UPV: Snapshot hash mismatch");
+
+        address escrow;
+        uint256 depositId;
+        bytes32 paymentMethod;
 
         if (_isV2Orchestrator(msg.sender)) {
             IOrchestratorV2.Intent memory intentV2 = IOrchestratorV2(msg.sender).getIntent(intentHash);
@@ -239,6 +249,10 @@ contract UnifiedPaymentVerifier is IPaymentVerifier, BaseUnifiedPaymentVerifier 
                 intentV2.conversionRate,
                 intentV2.timestamp
             );
+
+            escrow = intentV2.escrow;
+            depositId = intentV2.depositId;
+            paymentMethod = intentV2.paymentMethod;
         } else {
             IOrchestrator.Intent memory intent = IOrchestrator(msg.sender).getIntent(intentHash);
             _validateSnapshotAgainstIntent(
@@ -250,9 +264,30 @@ contract UnifiedPaymentVerifier is IPaymentVerifier, BaseUnifiedPaymentVerifier 
                 intent.conversionRate,
                 intent.timestamp
             );
+
+            escrow = intent.escrow;
+            depositId = intent.depositId;
+            paymentMethod = intent.paymentMethod;
         }
 
         require(snapshot.timestampBuffer <= MAX_TIMESTAMP_BUFFER, "UPV: Snapshot timestamp buffer exceeds maximum");
+
+        attestationVerifierData = _getDepositAttestationVerifierData(
+            escrow,
+            depositId,
+            paymentMethod
+        );
+    }
+
+    function _getDepositAttestationVerifierData(
+        address escrow,
+        uint256 depositId,
+        bytes32 paymentMethod
+    ) internal view returns (bytes memory) {
+        IEscrow.DepositPaymentMethodData memory paymentMethodData =
+            IEscrow(escrow).getDepositPaymentMethodData(depositId, paymentMethod);
+
+        return paymentMethodData.data;
     }
 
     function _validateSnapshotAgainstIntent(

--- a/deploy/24_deploy_multi_attestation_verifier.ts
+++ b/deploy/24_deploy_multi_attestation_verifier.ts
@@ -5,14 +5,8 @@ import { DeployFunction } from "hardhat-deploy/types";
 import { ethers } from "hardhat";
 
 import {
-  MULTI_SIG,
-  MULTI_WITNESS_ADDRESSES,
-  MULTI_WITNESS_THRESHOLD,
-} from "../deployments/parameters";
-import {
   getDeployedContractAddress,
   setAttestationVerifier,
-  setNewOwner,
 } from "../deployments/helpers";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
@@ -20,23 +14,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const network = hre.deployments.getNetworkName();
 
   const [deployer] = await hre.getUnnamedAccounts();
-  const multiSig = MULTI_SIG[network] ? MULTI_SIG[network] : deployer;
-
-  const initialWitnesses = MULTI_WITNESS_ADDRESSES[network];
-  const initialThreshold = MULTI_WITNESS_THRESHOLD[network];
-
-  if (!initialWitnesses || initialWitnesses.length === 0) {
-    throw new Error(`No MultiAttestationVerifier witnesses configured for ${network}`);
-  }
-
-  if (!initialThreshold) {
-    throw new Error(`No MultiAttestationVerifier threshold configured for ${network}`);
-  }
 
   // 1. Deploy MultiAttestationVerifier.
   const multiAttestationVerifier = await deploy("MultiAttestationVerifier", {
     from: deployer,
-    args: [initialWitnesses, initialThreshold],
+    args: [],
   });
   console.log("MultiAttestationVerifier deployed at", multiAttestationVerifier.address);
 
@@ -51,15 +33,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const upvV2Address = getDeployedContractAddress(network, "UnifiedPaymentVerifierV2");
   const upvV2 = await ethers.getContractAt("UnifiedPaymentVerifier", upvV2Address);
   await setAttestationVerifier(hre, upvV2, multiAttestationVerifier.address);
-
-  // 3. Transfer MultiAttestationVerifier ownership to the multisig. On networks where the
-  //    multisig is the deployer (localhost, base_staging, base_sepolia) this is a no-op.
-  const multiAttestationVerifierContract = await ethers.getContractAt(
-    "MultiAttestationVerifier",
-    multiAttestationVerifier.address
-  );
-  await setNewOwner(hre, multiAttestationVerifierContract, multiSig);
-  console.log("MultiAttestationVerifier ownership transferred to", multiSig);
 };
 
 func.tags = ["MultiAttestationVerifier"];

--- a/deployments/parameters.ts
+++ b/deployments/parameters.ts
@@ -58,23 +58,6 @@ export const WITNESS_ADDRESS: any = {
   "base_sepolia": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
 };
 
-export const MULTI_WITNESS_ADDRESSES: Record<string, string[]> = {
-  base: ["0xDB4Ed7FAF170F0f6493E3adaaCaaFaF47092c754"], // current AWS KMS signer
-  base_staging: [
-    "0x66649F896521b0fb487fE2077b4FBDA283d7f19a", // current AWS Nitro TEE signer
-    "0x4ab950AE1e3326578Bf7e643a2031E858aBa2927", // current Railway staging signer (SIGNER_MODE=local)
-  ],
-  base_sepolia: ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"],
-  localhost: ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"],
-};
-
-export const MULTI_WITNESS_THRESHOLD: Record<string, number> = {
-  base: 1,
-  base_staging: 1,
-  base_sepolia: 1,
-  localhost: 1,
-};
-
 export const USDC: any = {
   "base": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
   "base_staging": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"

--- a/test-foundry/fuzz/MultiAttestationVerifierFuzz.t.sol
+++ b/test-foundry/fuzz/MultiAttestationVerifierFuzz.t.sol
@@ -8,38 +8,10 @@ import { MultiAttestationVerifier } from "../../contracts/unifiedVerifier/MultiA
 contract MultiAttestationVerifierFuzz is Test {
     uint256 internal constant MAX_WITNESSES = 5;
 
-    address public owner;
+    MultiAttestationVerifier public verifier;
 
     function setUp() public {
-        owner = makeAddr("owner");
-    }
-
-    function testFuzz_addRemoveAddRoundTripPreservesWitnessCount(uint256 newWitnessPrivateKey) public {
-        address[] memory initialWitnesses = new address[](2);
-        initialWitnesses[0] = vm.addr(1);
-        initialWitnesses[1] = vm.addr(2);
-
-        MultiAttestationVerifier verifier = _deployVerifier(initialWitnesses, 1);
-
-        newWitnessPrivateKey = bound(newWitnessPrivateKey, 3, type(uint128).max);
-        address newWitness = vm.addr(newWitnessPrivateKey);
-
-        uint256 initialCount = verifier.witnessCount();
-
-        vm.prank(owner);
-        verifier.addWitness(newWitness);
-        uint256 countAfterFirstAdd = verifier.witnessCount();
-
-        vm.prank(owner);
-        verifier.removeWitness(newWitness);
-        uint256 countAfterRemove = verifier.witnessCount();
-
-        vm.prank(owner);
-        verifier.addWitness(newWitness);
-
-        assertEq(countAfterFirstAdd, initialCount + 1);
-        assertEq(countAfterRemove, initialCount);
-        assertEq(verifier.witnessCount(), countAfterFirstAdd);
+        verifier = new MultiAttestationVerifier();
     }
 
     function testFuzz_verifyMatchesRandomSubset(
@@ -52,7 +24,7 @@ contract MultiAttestationVerifierFuzz is Test {
         uint256 requiredSignatures = bound(uint256(thresholdSeed), 1, witnessCount);
 
         (address[] memory witnesses, uint256[] memory privateKeys) = _buildWitnessSet(witnessCount);
-        MultiAttestationVerifier verifier = _deployVerifier(witnesses, requiredSignatures);
+        bytes memory witnessConfig = abi.encode(witnesses, requiredSignatures);
 
         bytes32 messageHash = keccak256(
             abi.encodePacked("multi-attestation-verifier-fuzz", messageSeed, witnessCount, requiredSignatures)
@@ -78,20 +50,12 @@ contract MultiAttestationVerifierFuzz is Test {
         bool shouldVerify = selectedCount >= requiredSignatures;
 
         if (shouldVerify) {
-            bool isValid = verifier.verify(digest, signatures, "");
+            bool isValid = verifier.verify(digest, signatures, witnessConfig);
             assertTrue(isValid);
         } else {
             vm.expectRevert();
-            verifier.verify(digest, signatures, "");
+            verifier.verify(digest, signatures, witnessConfig);
         }
-    }
-
-    function _deployVerifier(
-        address[] memory initialWitnesses,
-        uint256 initialThreshold
-    ) internal returns (MultiAttestationVerifier deployedVerifier) {
-        vm.prank(owner);
-        deployedVerifier = new MultiAttestationVerifier(initialWitnesses, initialThreshold);
     }
 
     function _buildWitnessSet(

--- a/test-foundry/unit/MultiAttestationVerifierUnit.t.sol
+++ b/test-foundry/unit/MultiAttestationVerifierUnit.t.sol
@@ -8,126 +8,73 @@ import { MultiAttestationVerifier } from "../../contracts/unifiedVerifier/MultiA
 contract MultiAttestationVerifierUnit is Test {
     MultiAttestationVerifier public verifier;
 
-    address public owner;
-    address public nonOwner;
     address public witnessA;
     address public witnessB;
-    address public witnessC;
 
     function setUp() public {
-        owner = makeAddr("owner");
-        nonOwner = makeAddr("nonOwner");
         witnessA = makeAddr("witnessA");
         witnessB = makeAddr("witnessB");
-        witnessC = makeAddr("witnessC");
 
-        verifier = _deployVerifier(_twoWitnesses(), 1);
+        verifier = new MultiAttestationVerifier();
     }
 
-    function test_constructor_revertsOnZeroWitness() public {
-        address[] memory initialWitnesses = new address[](2);
-        initialWitnesses[0] = witnessA;
-        initialWitnesses[1] = address(0);
+    function test_verify_reachesSignatureThresholdValidationWithValidConfig() public {
+        address[] memory witnesses = _twoWitnesses();
+        bytes memory data = abi.encode(witnesses, uint256(2));
+        bytes[] memory signatures = new bytes[](0);
 
-        vm.prank(owner);
-        vm.expectRevert("MAV: zero witness");
-        new MultiAttestationVerifier(initialWitnesses, 1);
+        vm.expectRevert("ThresholdSigVerifierUtils: req threshold exceeds signatures");
+        verifier.verify(bytes32(0), signatures, data);
     }
 
-    function test_constructor_revertsOnDuplicateWitness() public {
-        address[] memory initialWitnesses = new address[](2);
-        initialWitnesses[0] = witnessA;
-        initialWitnesses[1] = witnessA;
-
-        vm.prank(owner);
-        vm.expectRevert("MAV: duplicate witness");
-        new MultiAttestationVerifier(initialWitnesses, 2);
+    function test_verify_revertsOnEmptyData() public {
+        vm.expectRevert("MAV: witness config required");
+        verifier.verify(bytes32(0), new bytes[](0), "");
     }
 
-    function test_constructor_revertsOnZeroThreshold() public {
-        vm.prank(owner);
+    function test_verify_revertsOnEmptyWitnesses() public {
+        address[] memory witnesses = new address[](0);
+
+        vm.expectRevert("MAV: empty witnesses");
+        verifier.verify(bytes32(0), new bytes[](0), abi.encode(witnesses, uint256(1)));
+    }
+
+    function test_verify_revertsOnZeroThreshold() public {
         vm.expectRevert("MAV: threshold must be > 0");
-        new MultiAttestationVerifier(_singleWitness(witnessA), 0);
+        verifier.verify(bytes32(0), new bytes[](0), abi.encode(_singleWitness(witnessA), uint256(0)));
     }
 
-    function test_constructor_revertsWhenThresholdExceedsWitnessCount() public {
-        vm.prank(owner);
+    function test_verify_revertsWhenThresholdExceedsWitnessCount() public {
         vm.expectRevert("MAV: threshold exceeds count");
-        new MultiAttestationVerifier(_singleWitness(witnessA), 2);
+        verifier.verify(bytes32(0), new bytes[](0), abi.encode(_singleWitness(witnessA), uint256(2)));
     }
 
-    function test_addWitness_revertsWhenCallerNotOwner() public {
-        vm.prank(nonOwner);
-        vm.expectRevert("Ownable: caller is not the owner");
-        verifier.addWitness(witnessC);
-    }
+    function test_verify_revertsOnZeroWitness() public {
+        address[] memory witnesses = new address[](2);
+        witnesses[0] = witnessA;
+        witnesses[1] = address(0);
 
-    function test_addWitness_revertsOnZeroWitness() public {
-        vm.prank(owner);
         vm.expectRevert("MAV: zero witness");
-        verifier.addWitness(address(0));
+        verifier.verify(bytes32(0), new bytes[](0), abi.encode(witnesses, uint256(1)));
     }
 
-    function test_addWitness_revertsOnDuplicateWitness() public {
-        vm.prank(owner);
-        vm.expectRevert("MAV: already a witness");
-        verifier.addWitness(witnessA);
+    function test_verify_revertsOnDuplicateWitness() public {
+        address[] memory witnesses = new address[](2);
+        witnesses[0] = witnessA;
+        witnesses[1] = witnessA;
+
+        vm.expectRevert("MAV: duplicate witness");
+        verifier.verify(bytes32(0), new bytes[](0), abi.encode(witnesses, uint256(1)));
     }
 
-    function test_removeWitness_revertsWhenCallerNotOwner() public {
-        vm.prank(nonOwner);
-        vm.expectRevert("Ownable: caller is not the owner");
-        verifier.removeWitness(witnessB);
+    function _singleWitness(address witnessAddress) internal pure returns (address[] memory witnesses) {
+        witnesses = new address[](1);
+        witnesses[0] = witnessAddress;
     }
 
-    function test_removeWitness_revertsWhenWitnessDoesNotExist() public {
-        vm.prank(owner);
-        vm.expectRevert("MAV: not a witness");
-        verifier.removeWitness(witnessC);
-    }
-
-    function test_removeWitness_revertsWhenRemovalFallsBelowThreshold() public {
-        MultiAttestationVerifier singleWitnessVerifier = _deployVerifier(_singleWitness(witnessA), 1);
-
-        vm.prank(owner);
-        vm.expectRevert("MAV: below threshold");
-        singleWitnessVerifier.removeWitness(witnessA);
-    }
-
-    function test_setRequiredSignatures_revertsWhenCallerNotOwner() public {
-        vm.prank(nonOwner);
-        vm.expectRevert("Ownable: caller is not the owner");
-        verifier.setRequiredSignatures(2);
-    }
-
-    function test_setRequiredSignatures_revertsOnZeroThreshold() public {
-        vm.prank(owner);
-        vm.expectRevert("MAV: threshold must be > 0");
-        verifier.setRequiredSignatures(0);
-    }
-
-    function test_setRequiredSignatures_revertsWhenThresholdExceedsWitnessCount() public {
-        vm.prank(owner);
-        vm.expectRevert("MAV: exceeds witness count");
-        verifier.setRequiredSignatures(3);
-    }
-
-    function _deployVerifier(
-        address[] memory initialWitnesses,
-        uint256 initialThreshold
-    ) internal returns (MultiAttestationVerifier deployedVerifier) {
-        vm.prank(owner);
-        deployedVerifier = new MultiAttestationVerifier(initialWitnesses, initialThreshold);
-    }
-
-    function _singleWitness(address witnessAddress) internal pure returns (address[] memory initialWitnesses) {
-        initialWitnesses = new address[](1);
-        initialWitnesses[0] = witnessAddress;
-    }
-
-    function _twoWitnesses() internal view returns (address[] memory initialWitnesses) {
-        initialWitnesses = new address[](2);
-        initialWitnesses[0] = witnessA;
-        initialWitnesses[1] = witnessB;
+    function _twoWitnesses() internal view returns (address[] memory witnesses) {
+        witnesses = new address[](2);
+        witnesses[0] = witnessA;
+        witnesses[1] = witnessB;
     }
 }

--- a/test/deploy/24_multiAttestationVerifier.spec.ts
+++ b/test/deploy/24_multiAttestationVerifier.spec.ts
@@ -1,13 +1,11 @@
 import "module-alias/register";
 
-import { deployments } from "hardhat";
+import { deployments, ethers } from "hardhat";
 
 import {
   UnifiedPaymentVerifier,
 } from "../../utils/contracts";
 import {
-  MultiAttestationVerifier,
-  MultiAttestationVerifier__factory,
   UnifiedPaymentVerifier__factory,
 } from "../../typechain";
 
@@ -18,34 +16,22 @@ import {
 import {
   Account
 } from "../../utils/test/types";
-import {
-  Address
-} from "../../utils/types";
-
-import {
-  MULTI_SIG,
-  MULTI_WITNESS_ADDRESSES,
-  MULTI_WITNESS_THRESHOLD,
-} from "../../deployments/parameters";
 import { getDeployedContractAddress } from "../../deployments/helpers";
 
 const expect = getWaffleExpect();
 
 describe("MultiAttestationVerifier Deployment", () => {
   let deployer: Account;
-  let multiSig: Address;
 
-  let multiAttestationVerifier: MultiAttestationVerifier;
+  let multiAttestationVerifierAddress: string;
   let unifiedPaymentVerifierV2: UnifiedPaymentVerifier;
 
   const network: string = deployments.getNetworkName();
 
   before(async () => {
     [deployer] = await getAccounts();
-    multiSig = MULTI_SIG[network] ? MULTI_SIG[network] : deployer.address;
 
-    const multiAttestationVerifierAddress = getDeployedContractAddress(network, "MultiAttestationVerifier");
-    multiAttestationVerifier = new MultiAttestationVerifier__factory(deployer.wallet).attach(multiAttestationVerifierAddress);
+    multiAttestationVerifierAddress = getDeployedContractAddress(network, "MultiAttestationVerifier");
 
     // UnifiedPaymentVerifierV2 shares the base verifier ABI with UnifiedPaymentVerifier,
     // so we attach the V1 typechain factory — same pattern used by test/deploy/14_v2System.spec.ts.
@@ -53,43 +39,18 @@ describe("MultiAttestationVerifier Deployment", () => {
     unifiedPaymentVerifierV2 = new UnifiedPaymentVerifier__factory(deployer.wallet).attach(upvV2Address);
   });
 
-  describe("MultiAttestationVerifier Constructor", async () => {
-    it("should have the configured initial witness set", async () => {
-      const actualWitnesses = (await multiAttestationVerifier.witnesses()).map((w) => w.toLowerCase());
-      const expectedWitnesses = MULTI_WITNESS_ADDRESSES[network].map((w) => w.toLowerCase());
-      expect(actualWitnesses).to.have.members(expectedWitnesses);
-      expect(actualWitnesses.length).to.eq(expectedWitnesses.length);
-    });
+  describe("MultiAttestationVerifier", async () => {
+    it("should be deployed", async () => {
+      const deployedCode = await ethers.provider.getCode(multiAttestationVerifierAddress);
 
-    it("should have the configured threshold", async () => {
-      const actualThreshold = (await multiAttestationVerifier.requiredSignatures()).toNumber();
-      const expectedThreshold = MULTI_WITNESS_THRESHOLD[network];
-      expect(actualThreshold).to.eq(expectedThreshold);
-    });
-
-    it("should have every configured witness in the allowlist", async () => {
-      for (const witness of MULTI_WITNESS_ADDRESSES[network]) {
-        expect(await multiAttestationVerifier.isWitness(witness)).to.be.true;
-      }
-    });
-
-    it("should report the configured witness count", async () => {
-      const count = (await multiAttestationVerifier.witnessCount()).toNumber();
-      expect(count).to.eq(MULTI_WITNESS_ADDRESSES[network].length);
-    });
-  });
-
-  describe("MultiAttestationVerifier Ownership", async () => {
-    it("should have ownership transferred to the multisig", async () => {
-      const actualOwner = await multiAttestationVerifier.owner();
-      expect(actualOwner).to.eq(multiSig);
+      expect(deployedCode).to.not.eq("0x");
     });
   });
 
   describe("UnifiedPaymentVerifierV2 Wiring", async () => {
     it("should have UnifiedPaymentVerifierV2.attestationVerifier set to MultiAttestationVerifier", async () => {
       const actualAttestationVerifier = await unifiedPaymentVerifierV2.attestationVerifier();
-      expect(actualAttestationVerifier).to.eq(multiAttestationVerifier.address);
+      expect(actualAttestationVerifier).to.eq(multiAttestationVerifierAddress);
     });
   });
 });

--- a/test/unifiedVerifier/MultiAttestationVerifier.spec.ts
+++ b/test/unifiedVerifier/MultiAttestationVerifier.spec.ts
@@ -14,14 +14,11 @@ import { MultiAttestationVerifier } from "../../typechain";
 const expect = getWaffleExpect();
 
 describe("MultiAttestationVerifier", () => {
-  let owner: Account;
-  let nonOwner: Account;
   let witnessA: Account;
   let witnessB: Account;
   let witnessC: Account;
   let otherAccount: Account;
 
-  let baseMultiAttestationVerifier: MultiAttestationVerifier;
   let multiAttestationVerifier: MultiAttestationVerifier;
 
   let messageHash: string;
@@ -29,8 +26,8 @@ describe("MultiAttestationVerifier", () => {
 
   before(async () => {
     [
-      owner,
-      nonOwner,
+      ,
+      ,
       witnessA,
       witnessB,
       witnessC,
@@ -47,25 +44,30 @@ describe("MultiAttestationVerifier", () => {
       ])
     );
 
-    baseMultiAttestationVerifier = await deployVerifier([witnessA.address], 1);
-    multiAttestationVerifier = baseMultiAttestationVerifier;
+    multiAttestationVerifier = await deployVerifier();
   });
 
   addSnapshotBeforeRestoreAfterEach();
 
-  async function deployVerifier(
-    initialWitnesses: string[],
-    initialThreshold: number
-  ): Promise<MultiAttestationVerifier> {
+  async function deployVerifier(): Promise<MultiAttestationVerifier> {
     const verifierFactory = await ethers.getContractFactory(
-      "MultiAttestationVerifier",
-      owner.wallet
+      "MultiAttestationVerifier"
     );
 
-    const verifier = await verifierFactory.deploy(initialWitnesses, initialThreshold);
+    const verifier = await verifierFactory.deploy();
     await verifier.deployed();
 
     return verifier as MultiAttestationVerifier;
+  }
+
+  function encodeWitnessConfig(
+    witnesses: string[],
+    requiredSignatures: number
+  ): string {
+    return ethers.utils.defaultAbiCoder.encode(
+      ["address[]", "uint256"],
+      [witnesses, requiredSignatures]
+    );
   }
 
   async function signWitness(
@@ -85,7 +87,7 @@ describe("MultiAttestationVerifier", () => {
     beforeEach(() => {
       subjectDigest = digest;
       subjectSignatures = [];
-      subjectData = "0x";
+      subjectData = encodeWitnessConfig([witnessA.address], 1);
     });
 
     async function subject(): Promise<boolean> {
@@ -96,174 +98,134 @@ describe("MultiAttestationVerifier", () => {
       );
     }
 
-    describe("when deployed with one witness and threshold 1", () => {
+    describe("when the configured witness signs and threshold is one", () => {
       beforeEach(async () => {
-        multiAttestationVerifier = baseMultiAttestationVerifier;
         subjectSignatures = [await signWitness(witnessA)];
       });
 
-      it("should return true with a valid signature from that witness", async () => {
+      it("should return true", async () => {
         const result = await subject();
 
         expect(result).to.equal(true);
       });
     });
 
-    describe("when deployed with two witnesses and threshold 1", () => {
+    describe("when one of several configured witnesses signs and threshold is one", () => {
       beforeEach(async () => {
-        multiAttestationVerifier = await deployVerifier(
+        subjectData = encodeWitnessConfig(
           [witnessA.address, witnessB.address],
           1
         );
+        subjectSignatures = [await signWitness(witnessB)];
       });
 
-      describe("when witness A signs the digest", () => {
-        beforeEach(async () => {
-          subjectSignatures = [await signWitness(witnessA)];
-        });
+      it("should return true", async () => {
+        const result = await subject();
 
-        it("should return true", async () => {
-          const result = await subject();
-
-          expect(result).to.equal(true);
-        });
-      });
-
-      describe("when witness B signs the digest", () => {
-        beforeEach(async () => {
-          subjectSignatures = [await signWitness(witnessB)];
-        });
-
-        it("should return true", async () => {
-          const result = await subject();
-
-          expect(result).to.equal(true);
-        });
-      });
-
-      describe("when a non-witness signs the digest", () => {
-        beforeEach(async () => {
-          subjectSignatures = [await signWitness(otherAccount)];
-        });
-
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith(
-            "ThresholdSigVerifierUtils: Not enough valid witness signatures"
-          );
-        });
-      });
-
-      describe("when the same witness signature is passed twice", () => {
-        beforeEach(async () => {
-          const duplicateSignature = await signWitness(witnessA);
-          subjectSignatures = [duplicateSignature, duplicateSignature];
-        });
-
-        it("should return true because the unique signer threshold is still met", async () => {
-          const result = await subject();
-
-          expect(result).to.equal(true);
-        });
+        expect(result).to.equal(true);
       });
     });
 
-    describe("when deployed with two witnesses and threshold 2", () => {
+    describe("when threshold is two and two configured witnesses sign", () => {
       beforeEach(async () => {
-        multiAttestationVerifier = await deployVerifier(
-          [witnessA.address, witnessB.address],
+        subjectData = encodeWitnessConfig(
+          [witnessA.address, witnessB.address, witnessC.address],
           2
         );
-      });
-
-      describe("when witness A and witness B sign the digest", () => {
-        beforeEach(async () => {
-          subjectSignatures = [
-            await signWitness(witnessA),
-            await signWitness(witnessB),
-          ];
-        });
-
-        it("should return true", async () => {
-          const result = await subject();
-
-          expect(result).to.equal(true);
-        });
-      });
-
-      describe("when the same witness signs twice", () => {
-        beforeEach(async () => {
-          const duplicateSignature = await signWitness(witnessA);
-          subjectSignatures = [duplicateSignature, duplicateSignature];
-        });
-
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith(
-            "ThresholdSigVerifierUtils: Not enough valid witness signatures"
-          );
-        });
-      });
-    });
-
-    describe("when deployed with three witnesses and threshold 3", () => {
-      beforeEach(async () => {
-        multiAttestationVerifier = await deployVerifier(
-          [witnessA.address, witnessB.address, witnessC.address],
-          3
-        );
-
-        const duplicateSignature = await signWitness(witnessA);
         subjectSignatures = [
-          duplicateSignature,
-          duplicateSignature,
-          duplicateSignature,
+          await signWitness(witnessA),
+          await signWitness(witnessC),
         ];
       });
 
-      it("should revert when the same signature bytes are replayed three times", async () => {
+      it("should return true", async () => {
+        const result = await subject();
+
+        expect(result).to.equal(true);
+      });
+    });
+
+    describe("when a non-configured witness signs", () => {
+      beforeEach(async () => {
+        subjectData = encodeWitnessConfig([witnessA.address, witnessB.address], 1);
+        subjectSignatures = [await signWitness(otherAccount)];
+      });
+
+      it("should revert", async () => {
         await expect(subject()).to.be.revertedWith(
           "ThresholdSigVerifierUtils: Not enough valid witness signatures"
         );
       });
     });
+
+    describe("when the same configured witness signs twice for threshold two", () => {
+      beforeEach(async () => {
+        const duplicateSignature = await signWitness(witnessA);
+        subjectData = encodeWitnessConfig([witnessA.address, witnessB.address], 2);
+        subjectSignatures = [duplicateSignature, duplicateSignature];
+      });
+
+      it("should revert because duplicate signatures only count once", async () => {
+        await expect(subject()).to.be.revertedWith(
+          "ThresholdSigVerifierUtils: Not enough valid witness signatures"
+        );
+      });
+    });
+
+    describe("when there are fewer signatures than the required threshold", () => {
+      beforeEach(async () => {
+        subjectData = encodeWitnessConfig([witnessA.address, witnessB.address], 2);
+        subjectSignatures = [await signWitness(witnessA)];
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith(
+          "ThresholdSigVerifierUtils: req threshold exceeds signatures"
+        );
+      });
+    });
   });
 
-  describe("#constructor", () => {
-    let subjectWitnesses: string[];
-    let subjectThreshold: number;
+  describe("witness config validation", () => {
+    let subjectData: string;
 
     beforeEach(() => {
-      subjectWitnesses = [witnessA.address];
-      subjectThreshold = 1;
+      subjectData = encodeWitnessConfig([witnessA.address], 1);
     });
 
-    async function subject(): Promise<MultiAttestationVerifier> {
-      return deployVerifier(subjectWitnesses, subjectThreshold);
+    async function subject(): Promise<boolean> {
+      return multiAttestationVerifier.verify(digest, [], subjectData);
     }
 
-    describe("when the initial witness set contains the zero address", () => {
+    it("should reach signature threshold validation when witness config is valid", async () => {
+      await expect(subject()).to.be.revertedWith(
+        "ThresholdSigVerifierUtils: req threshold exceeds signatures"
+      );
+    });
+
+    describe("when data is empty", () => {
       beforeEach(() => {
-        subjectWitnesses = [witnessA.address, ADDRESS_ZERO];
+        subjectData = "0x";
       });
 
       it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("MAV: zero witness");
+        await expect(subject()).to.be.revertedWith("MAV: witness config required");
       });
     });
 
-    describe("when the initial witness set contains a duplicate", () => {
+    describe("when witnesses are empty", () => {
       beforeEach(() => {
-        subjectWitnesses = [witnessA.address, witnessA.address];
-        subjectThreshold = 2;
+        subjectData = encodeWitnessConfig([], 1);
       });
 
       it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("MAV: duplicate witness");
+        await expect(subject()).to.be.revertedWith("MAV: empty witnesses");
       });
     });
 
-    describe("when the initial threshold is zero", () => {
+    describe("when threshold is zero", () => {
       beforeEach(() => {
-        subjectThreshold = 0;
+        subjectData = encodeWitnessConfig([witnessA.address], 0);
       });
 
       it("should revert", async () => {
@@ -271,61 +233,19 @@ describe("MultiAttestationVerifier", () => {
       });
     });
 
-    describe("when the initial threshold exceeds the witness count", () => {
+    describe("when threshold exceeds witness count", () => {
       beforeEach(() => {
-        subjectWitnesses = [witnessA.address];
-        subjectThreshold = 2;
+        subjectData = encodeWitnessConfig([witnessA.address], 2);
       });
 
       it("should revert", async () => {
         await expect(subject()).to.be.revertedWith("MAV: threshold exceeds count");
       });
     });
-  });
 
-  describe("#addWitness", () => {
-    let subjectWitness: string;
-    let subjectCaller: Account;
-
-    beforeEach(async () => {
-      multiAttestationVerifier = await deployVerifier([witnessA.address], 1);
-      subjectWitness = witnessB.address;
-      subjectCaller = owner;
-    });
-
-    async function subject(): Promise<any> {
-      return multiAttestationVerifier
-        .connect(subjectCaller.wallet)
-        .addWitness(subjectWitness);
-    }
-
-    describe("when called by the owner with a new witness", () => {
-      it("should emit WitnessAdded and increase the witness count", async () => {
-        const transaction = await subject();
-
-        await expect(transaction)
-          .to.emit(multiAttestationVerifier, "WitnessAdded")
-          .withArgs(subjectWitness);
-
-        expect(await multiAttestationVerifier.witnessCount()).to.equal(2);
-      });
-    });
-
-    describe("when called by a non-owner", () => {
+    describe("when a witness is the zero address", () => {
       beforeEach(() => {
-        subjectCaller = nonOwner;
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith(
-          "Ownable: caller is not the owner"
-        );
-      });
-    });
-
-    describe("when the new witness is the zero address", () => {
-      beforeEach(() => {
-        subjectWitness = ADDRESS_ZERO;
+        subjectData = encodeWitnessConfig([witnessA.address, ADDRESS_ZERO], 1);
       });
 
       it("should revert", async () => {
@@ -333,155 +253,13 @@ describe("MultiAttestationVerifier", () => {
       });
     });
 
-    describe("when the witness already exists", () => {
+    describe("when the witness config contains duplicates", () => {
       beforeEach(() => {
-        subjectWitness = witnessA.address;
+        subjectData = encodeWitnessConfig([witnessA.address, witnessA.address], 1);
       });
 
       it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("MAV: already a witness");
-      });
-    });
-  });
-
-  describe("#removeWitness", () => {
-    let subjectWitness: string;
-    let subjectCaller: Account;
-
-    beforeEach(async () => {
-      multiAttestationVerifier = await deployVerifier(
-        [witnessA.address, witnessB.address],
-        1
-      );
-      subjectWitness = witnessB.address;
-      subjectCaller = owner;
-    });
-
-    async function subject(): Promise<any> {
-      return multiAttestationVerifier
-        .connect(subjectCaller.wallet)
-        .removeWitness(subjectWitness);
-    }
-
-    describe("when called by the owner for an existing witness", () => {
-      it("should emit WitnessRemoved and decrease the witness count", async () => {
-        const transaction = await subject();
-
-        await expect(transaction)
-          .to.emit(multiAttestationVerifier, "WitnessRemoved")
-          .withArgs(subjectWitness);
-
-        expect(await multiAttestationVerifier.witnessCount()).to.equal(1);
-      });
-    });
-
-    describe("when the removal would drop the set below the threshold", () => {
-      beforeEach(async () => {
-        multiAttestationVerifier = await deployVerifier([witnessA.address], 1);
-        subjectWitness = witnessA.address;
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("MAV: below threshold");
-      });
-    });
-
-    describe("when the witness is not in the set", () => {
-      beforeEach(() => {
-        subjectWitness = witnessC.address;
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("MAV: not a witness");
-      });
-    });
-  });
-
-  describe("#setRequiredSignatures", () => {
-    let subjectRequiredSignatures: number;
-    let subjectCaller: Account;
-
-    beforeEach(async () => {
-      multiAttestationVerifier = await deployVerifier(
-        [witnessA.address, witnessB.address],
-        1
-      );
-      subjectRequiredSignatures = 2;
-      subjectCaller = owner;
-    });
-
-    async function subject(): Promise<any> {
-      return multiAttestationVerifier
-        .connect(subjectCaller.wallet)
-        .setRequiredSignatures(subjectRequiredSignatures);
-    }
-
-    describe("when called by the owner with a valid threshold", () => {
-      it("should emit RequiredSignaturesUpdated and update the threshold", async () => {
-        const transaction = await subject();
-
-        await expect(transaction)
-          .to.emit(multiAttestationVerifier, "RequiredSignaturesUpdated")
-          .withArgs(1, subjectRequiredSignatures);
-
-        expect(await multiAttestationVerifier.requiredSignatures()).to.equal(
-          subjectRequiredSignatures
-        );
-      });
-    });
-
-    describe("when the new threshold is zero", () => {
-      beforeEach(() => {
-        subjectRequiredSignatures = 0;
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("MAV: threshold must be > 0");
-      });
-    });
-
-    describe("when the new threshold exceeds the witness count", () => {
-      beforeEach(() => {
-        subjectRequiredSignatures = 3;
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("MAV: exceeds witness count");
-      });
-    });
-  });
-
-  describe("view helpers", () => {
-    describe("#witnesses", () => {
-      beforeEach(async () => {
-        multiAttestationVerifier = await deployVerifier(
-          [witnessA.address, witnessB.address],
-          1
-        );
-
-        await multiAttestationVerifier.connect(owner.wallet).addWitness(witnessC.address);
-        await multiAttestationVerifier.connect(owner.wallet).removeWitness(witnessA.address);
-      });
-
-      it("should return the current witness set", async () => {
-        expect(await multiAttestationVerifier.witnesses()).to.have.deep.members([
-          witnessB.address,
-          witnessC.address,
-        ]);
-      });
-    });
-
-    describe("#isWitness", () => {
-      beforeEach(async () => {
-        multiAttestationVerifier = await deployVerifier(
-          [witnessA.address, witnessB.address],
-          1
-        );
-      });
-
-      it("should return the correct boolean", async () => {
-        expect(await multiAttestationVerifier.isWitness(witnessA.address)).to.equal(true);
-        expect(await multiAttestationVerifier.isWitness(witnessC.address)).to.equal(false);
+        await expect(subject()).to.be.revertedWith("MAV: duplicate witness");
       });
     });
   });

--- a/test/unifiedVerifier/unifiedPaymentVerifierV2.spec.ts
+++ b/test/unifiedVerifier/unifiedPaymentVerifierV2.spec.ts
@@ -14,13 +14,13 @@ import {
   OrchestratorV2,
   PaymentVerifierRegistry,
   RelayerRegistry,
-  SimpleAttestationVerifier,
   UnifiedPaymentVerifier,
   USDCMock,
 } from "@utils/contracts";
 import { buildUnifiedPaymentProof } from "@utils/unifiedVerifierUtils";
 import { Currency } from "@utils/protocolUtils";
 import { ADDRESS_ZERO, EMPTY_ORACLE_RATE_CONFIG, ONE, ZERO } from "@utils/constants";
+import { MultiAttestationVerifier } from "../../typechain";
 
 const expect = getWaffleExpect();
 const ZERO_BYTES = "0x";
@@ -42,7 +42,7 @@ describe("UnifiedPaymentVerifierV2 Compatibility", () => {
   let nullifierRegistry: NullifierRegistry;
   let escrow: EscrowV2;
   let orchestrator: OrchestratorV2;
-  let attestationVerifier: SimpleAttestationVerifier;
+  let attestationVerifier: MultiAttestationVerifier;
   let verifier: UnifiedPaymentVerifier;
 
   let chainId: number;
@@ -52,6 +52,7 @@ describe("UnifiedPaymentVerifierV2 Compatibility", () => {
   let intentAmount: BigNumber;
   let conversionRate: BigNumber;
   let currency: BytesLike;
+  let witnessConfig: string;
 
   beforeEach(async () => {
     [owner, attacker, maker, taker, witness] = await getAccounts();
@@ -87,7 +88,7 @@ describe("UnifiedPaymentVerifierV2 Compatibility", () => {
       owner.address,
     );
 
-    attestationVerifier = await deployer.deploySimpleAttestationVerifier(witness.address);
+    attestationVerifier = await deployMultiAttestationVerifier();
     verifier = await deployer.deployUnifiedPaymentVerifier(
       orchestratorRegistry.address,
       nullifierRegistry.address,
@@ -103,6 +104,7 @@ describe("UnifiedPaymentVerifierV2 Compatibility", () => {
     payeeId = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("payee-v2"));
     conversionRate = ethers.utils.parseEther("1");
     intentAmount = ethers.utils.parseUnits("50", 6);
+    witnessConfig = encodeWitnessConfig([witness.address], 1);
 
     await verifier.addPaymentMethod(paymentMethod);
     await paymentVerifierRegistry.addPaymentMethod(paymentMethod, verifier.address, [currency]);
@@ -118,7 +120,7 @@ describe("UnifiedPaymentVerifierV2 Compatibility", () => {
       paymentMethodData: [{
         intentGatingService: ADDRESS_ZERO,
         payeeDetails: payeeId,
-        data: ZERO_BYTES,
+        data: witnessConfig,
       }],
       currencies: [[{ code: currency, minConversionRate: conversionRate, oracleRateConfig: EMPTY_ORACLE_RATE_CONFIG }]],
       delegate: ADDRESS_ZERO,
@@ -126,11 +128,18 @@ describe("UnifiedPaymentVerifierV2 Compatibility", () => {
       retainOnEmpty: false,
     });
 
-    const signalTx = await orchestrator.connect(taker.wallet).signalIntent({
+    intentHash = await signalIntent(ZERO);
+  });
+
+  async function signalIntent(
+    depositId: BigNumber,
+    intentOwner: Account = taker
+  ): Promise<BytesLike> {
+    const signalTx = await orchestrator.connect(intentOwner.wallet).signalIntent({
       escrow: escrow.address,
-      depositId: ZERO,
+      depositId,
       amount: intentAmount,
-      to: taker.address,
+      to: intentOwner.address,
       paymentMethod,
       fiatCurrency: currency,
       conversionRate,
@@ -144,17 +153,41 @@ describe("UnifiedPaymentVerifierV2 Compatibility", () => {
 
     const signalReceipt = await signalTx.wait();
     const intentSignaledEvent = signalReceipt.events?.find((event: any) => event.event === "IntentSignaled");
-    intentHash = intentSignaledEvent?.args?.intentHash;
-  });
+    return intentSignaledEvent?.args?.intentHash;
+  }
 
-  it("fulfills a V2 intent using UnifiedPaymentVerifier", async () => {
-    const intent = await orchestrator.getIntent(intentHash);
+  async function deployMultiAttestationVerifier(): Promise<MultiAttestationVerifier> {
+    const verifierFactory = await ethers.getContractFactory(
+      "MultiAttestationVerifier",
+      owner.wallet
+    );
+
+    const deployedVerifier = await verifierFactory.deploy();
+    await deployedVerifier.deployed();
+
+    return deployedVerifier as MultiAttestationVerifier;
+  }
+
+  function encodeWitnessConfig(witnesses: string[], requiredSignatures: number): string {
+    return ethers.utils.defaultAbiCoder.encode(
+      ["address[]", "uint256"],
+      [witnesses, requiredSignatures],
+    );
+  }
+
+  async function buildProofForIntent(
+    targetIntentHash: BytesLike,
+    paymentIdLabel: string,
+    attestationSigner: Account = witness
+  ) {
+    const intent = await orchestrator.getIntent(targetIntentHash);
     const paymentTimestamp = BigNumber.from((await ethers.provider.getBlock("latest")).timestamp).mul(1000);
-    const paymentId = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("payment-v2"));
+    const paymentId = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(paymentIdLabel));
 
-    const builtProof = await buildUnifiedPaymentProof({
+    return buildUnifiedPaymentProof({
       verifier: verifier.address,
       witness,
+      attestationSigner,
       chainId,
       paymentPaymentMethod: paymentMethod,
       paymentPayeeId: payeeId,
@@ -162,9 +195,9 @@ describe("UnifiedPaymentVerifierV2 Compatibility", () => {
       paymentCurrency: currency,
       paymentTimestamp,
       paymentPaymentId: paymentId,
-      attestationIntentHash: intentHash,
+      attestationIntentHash: targetIntentHash,
       attestationReleaseAmount: intent.amount,
-      snapshotIntentHash: intentHash,
+      snapshotIntentHash: targetIntentHash,
       snapshotIntentAmount: intent.amount,
       snapshotIntentPaymentMethod: paymentMethod,
       snapshotIntentFiatCurrency: currency,
@@ -172,10 +205,14 @@ describe("UnifiedPaymentVerifierV2 Compatibility", () => {
       snapshotIntentConversionRate: intent.conversionRate,
       snapshotIntentSignalTimestamp: intent.timestamp,
       snapshotIntentTimestampBuffer: ZERO,
-      intentDepositId: ZERO,
-      intentEscrow: escrow.address,
-      intentTo: taker.address,
+      intentDepositId: intent.depositId,
+      intentEscrow: intent.escrow,
+      intentTo: intent.to,
     });
+  }
+
+  it("fulfills a V2 intent using UnifiedPaymentVerifier", async () => {
+    const builtProof = await buildProofForIntent(intentHash, "payment-v2");
 
     const takerBalanceBefore = await usdcToken.balanceOf(taker.address);
 
@@ -183,7 +220,7 @@ describe("UnifiedPaymentVerifierV2 Compatibility", () => {
       orchestrator.connect(attacker.wallet).fulfillIntent({
         paymentProof: builtProof.paymentProof,
         intentHash,
-        verificationData: ZERO_BYTES,
+        verificationData: encodeWitnessConfig([attacker.address], 1),
         postIntentHookData: ZERO_BYTES,
       }),
     )
@@ -200,5 +237,68 @@ describe("UnifiedPaymentVerifierV2 Compatibility", () => {
 
     const takerBalanceAfter = await usdcToken.balanceOf(taker.address);
     expect(takerBalanceAfter.sub(takerBalanceBefore)).to.eq(intentAmount);
+  });
+
+  it("rejects signatures outside the depositor-selected witness config even when verificationData is tampered", async () => {
+    const builtProof = await buildProofForIntent(
+      intentHash,
+      "tampered-witness-payment-v2",
+      attacker
+    );
+
+    await expect(
+      orchestrator.connect(attacker.wallet).fulfillIntent({
+        paymentProof: builtProof.paymentProof,
+        intentHash,
+        verificationData: encodeWitnessConfig([attacker.address], 1),
+        postIntentHookData: ZERO_BYTES,
+      }),
+    ).to.be.revertedWith(
+      "ThresholdSigVerifierUtils: Not enough valid witness signatures"
+    );
+  });
+
+  it("uses the witness config from each deposit for the same payment method", async () => {
+    await escrow.connect(maker.wallet).createDeposit({
+      token: usdcToken.address,
+      amount: ethers.utils.parseUnits("100", 6),
+      intentAmountRange: { min: ethers.utils.parseUnits("10", 6), max: ethers.utils.parseUnits("200", 6) },
+      paymentMethods: [paymentMethod],
+      paymentMethodData: [{
+        intentGatingService: ADDRESS_ZERO,
+        payeeDetails: payeeId,
+        data: encodeWitnessConfig([attacker.address], 1),
+      }],
+      currencies: [[{ code: currency, minConversionRate: conversionRate, oracleRateConfig: EMPTY_ORACLE_RATE_CONFIG }]],
+      delegate: ADDRESS_ZERO,
+      intentGuardian: ADDRESS_ZERO,
+      retainOnEmpty: false,
+    });
+
+    const secondIntentHash = await signalIntent(ONE, attacker);
+    const builtProof = await buildProofForIntent(
+      secondIntentHash,
+      "second-deposit-witness-payment-v2",
+      attacker
+    );
+
+    await expect(
+      orchestrator.connect(witness.wallet).fulfillIntent({
+        paymentProof: builtProof.paymentProof,
+        intentHash: secondIntentHash,
+        verificationData: encodeWitnessConfig([witness.address], 1),
+        postIntentHookData: ZERO_BYTES,
+      }),
+    )
+      .to.emit(verifier, "PaymentVerified")
+      .withArgs(
+        secondIntentHash,
+        paymentMethod,
+        currency,
+        builtProof.paymentDetails.amount,
+        builtProof.paymentDetails.timestamp,
+        builtProof.paymentDetails.paymentId,
+        builtProof.paymentDetails.payeeId,
+      );
   });
 });


### PR DESCRIPTION
## Summary
- make `MultiAttestationVerifier` stateless and decode depositor-selected witness config from verifier data as `abi.encode(address[] witnesses, uint256 requiredSignatures)`
- update `UnifiedPaymentVerifier` to load attestation verifier data from the intent's deposit/payment method instead of trusting taker-supplied `verificationData`
- remove protocol-owned multi-witness deployment parameters and constructor/ownership wiring
- update Hardhat and Foundry coverage for deposit-scoped witness configs, invalid configs, and same-method deposits with different witness sets

## Validation
- `git diff --check`
- `yarn build`
- `npx hardhat test test/unifiedVerifier/*.ts`
- `forge test --match-contract MultiAttestationVerifier`

## Notes
- Hard cutover: existing deposits encoded as only `address[]` will not verify through `MultiAttestationVerifier`; new deposits must encode `(address[], uint256)`.
- Client changes are intentionally not included in this PR. A separate Notion handoff will track the web/sdk follow-up.