### PR TITLE
feat(MAV): add deposit attestor configs

### DIFF
--- a/contracts/unifiedVerifier/MultiAttestationVerifier.sol
+++ b/contracts/unifiedVerifier/MultiAttestationVerifier.sol
@@ -8,10 +8,22 @@ import { ThresholdSigVerifierUtils } from "../lib/ThresholdSigVerifierUtils.sol"
 
 /**
  * @title MultiAttestationVerifier
- * @notice Verifies attestations from one of N authorized witness addresses
+ * @notice Verifies attestations against the witness set or a deposit-specific attestor set
  * @dev Drop-in replacement for SimpleAttestationVerifier that supports a dynamic
  *      witness set with a configurable signature threshold. Threshold defaults to 1
  *      so the contract behaves as "any witness can sign" unless an owner raises it.
+ *
+ *      Depositors can add their own attestors by storing tagged deposit attestor data
+ *      in the deposit's payment method verification data
+ *      (DepositPaymentMethodData.data), encoded as:
+ *
+ *          abi.encode(DEPOSIT_ATTESTORS_TAG, address[] attestors, uint256 threshold)
+ *
+ *      The UnifiedPaymentVerifier forwards that data as the `_data` param of verify().
+ *      Tagged data appends the depositor's attestors to the witness set and verifies
+ *      against that combined set. Empty data falls back to the witness set for legacy
+ *      deposits. Non-empty untagged data reverts so malformed depositor configuration
+ *      cannot silently fall back to a different policy.
  */
 contract MultiAttestationVerifier is IAttestationVerifier, Ownable {
     using EnumerableSet for EnumerableSet.AddressSet;
@@ -21,6 +33,14 @@ contract MultiAttestationVerifier is IAttestationVerifier, Ownable {
     event WitnessAdded(address indexed witness);
     event WitnessRemoved(address indexed witness);
     event RequiredSignaturesUpdated(uint256 oldThreshold, uint256 newThreshold);
+
+    /* ============ Constants ============ */
+
+    // First 32 bytes of deposit verification data that opts a deposit into additional attestors
+    bytes32 public constant DEPOSIT_ATTESTORS_TAG = keccak256("zkp2p.depositAttestors.v1");
+
+    // Caps additional deposit-specific attestors so fulfillment remains bounded for takers
+    uint256 public constant MAX_DEPOSIT_ATTESTORS = 3;
 
     /* ============ State Variables ============ */
 
@@ -55,21 +75,25 @@ contract MultiAttestationVerifier is IAttestationVerifier, Ownable {
     /* ============ External Functions ============ */
 
     /**
-     * @notice Verifies attestation signatures against the current witness set
+     * @notice Verifies attestation signatures against the attestor set resolved from `_data`
      * @param _digest The message digest to verify
-     * @param _sigs Array of signatures from witnesses
-     * @return isValid True if the witness threshold is met
+     * @param _sigs Array of signatures from attestors
+     * @param _data Deposit verification data; empty data resolves to the witness set,
+     * and tagged data appends the depositor's attestors to the witness set
+     * @return isValid True if the resolved attestor threshold is met
      */
     function verify(
         bytes32 _digest,
         bytes[] calldata _sigs,
-        bytes calldata
+        bytes calldata _data
     ) external view override returns (bool isValid) {
+        (address[] memory attestors, uint256 threshold) = resolveAttestors(_data);
+
         isValid = ThresholdSigVerifierUtils.verifyWitnessSignatures(
             _digest,
             _sigs,
-            witnessesSet.values(),
-            requiredSignatures
+            attestors,
+            threshold
         );
 
         return isValid;
@@ -113,6 +137,65 @@ contract MultiAttestationVerifier is IAttestationVerifier, Ownable {
     }
 
     /* ============ View Functions ============ */
+
+    /**
+     * @notice Resolves the attestor set and threshold that apply to a deposit's verification data
+     * @dev Data tagged with DEPOSIT_ATTESTORS_TAG must decode as (bytes32, address[], uint256) and
+     * is validated strictly; malformed deposit attestor data reverts so a depositor's custom trust
+     * policy can never silently fall back to a different policy. Attestors can be EOAs or ERC-1271
+     * contracts. Empty data resolves to the witness set for legacy deposits. Tagged data appends
+     * deposit attestors to the witness set. Any non-empty untagged data reverts so invalid custom
+     * configuration fails closed.
+     * @param _data Deposit verification data (DepositPaymentMethodData.data)
+     * @return attestors The attestor addresses signatures are verified against
+     * @return threshold The minimum number of distinct attestor signatures required
+     */
+    function resolveAttestors(bytes calldata _data)
+        public
+        view
+        returns (address[] memory attestors, uint256 threshold)
+    {
+        if (_data.length == 0) {
+            return (witnessesSet.values(), requiredSignatures);
+        }
+
+        require(_data.length >= 32, "MAV: invalid deposit attestors tag");
+        require(bytes32(_data[0:32]) == DEPOSIT_ATTESTORS_TAG, "MAV: invalid deposit attestors tag");
+
+        address[] memory defaultWitnesses = witnessesSet.values();
+        address[] memory depositAttestors;
+        (, depositAttestors, threshold) = abi.decode(_data, (bytes32, address[], uint256));
+
+        require(depositAttestors.length > 0, "MAV: empty deposit attestors");
+        require(depositAttestors.length <= MAX_DEPOSIT_ATTESTORS, "MAV: too many deposit attestors");
+        require(threshold > 0, "MAV: deposit threshold must be > 0");
+        require(threshold >= requiredSignatures, "MAV: deposit threshold below default");
+        require(threshold <= defaultWitnesses.length + depositAttestors.length, "MAV: deposit threshold exceeds count");
+
+        attestors = new address[](defaultWitnesses.length + depositAttestors.length);
+        for (uint256 witnessIndex = 0; witnessIndex < defaultWitnesses.length; witnessIndex++) {
+            attestors[witnessIndex] = defaultWitnesses[witnessIndex];
+        }
+
+        for (uint256 i = 0; i < depositAttestors.length; i++) {
+            address depositAttestor = depositAttestors[i];
+            require(depositAttestor != address(0), "MAV: zero deposit attestor");
+
+            for (uint256 witnessIndex = 0; witnessIndex < defaultWitnesses.length; witnessIndex++) {
+                // IMPORTANT: deployment/client flows must keep deposit attestors disjoint from
+                // default witnesses. If that invariant changes, deduplicate the combined set
+                // instead of reverting on default/deposit overlap, and only reject duplicates
+                // within the user-provided list if needed.
+                require(depositAttestor != defaultWitnesses[witnessIndex], "MAV: duplicate deposit attestor");
+            }
+
+            for (uint256 j = i + 1; j < depositAttestors.length; j++) {
+                require(depositAttestor != depositAttestors[j], "MAV: duplicate deposit attestor");
+            }
+
+            attestors[defaultWitnesses.length + i] = depositAttestor;
+        }
+    }
 
     /**
      * @notice Returns the current witness set

--- a/contracts/unifiedVerifier/UnifiedPaymentVerifier.sol
+++ b/contracts/unifiedVerifier/UnifiedPaymentVerifier.sol
@@ -141,14 +141,14 @@ contract UnifiedPaymentVerifier is IPaymentVerifier, BaseUnifiedPaymentVerifier 
         PaymentAttestation memory attestation = _decodeAttestation(_verifyPaymentData.paymentProof);
         
         (
-            PaymentDetails memory paymentDetails, 
+            PaymentDetails memory paymentDetails,
             IntentSnapshot memory intentSnapshot
         ) = _decodeAttestationPayload(attestation.data);
         require(isPaymentMethod[paymentDetails.method], "UPV: Invalid payment method");
-        
-        _validateIntentSnapshot(_verifyPaymentData.intentHash, intentSnapshot);
 
-        bool isValid = _verifyAttestation(attestation);
+        bytes memory depositData = _validateIntentSnapshotAndGetDepositData(_verifyPaymentData.intentHash, intentSnapshot);
+
+        bool isValid = _verifyAttestation(attestation, depositData);
         require(isValid, "UPV: Invalid attestation");
                 
         // Nullify the payment to prevent double-spending
@@ -182,10 +182,15 @@ contract UnifiedPaymentVerifier is IPaymentVerifier, BaseUnifiedPaymentVerifier 
     }
 
     /**
-     * Verifies the EIP-712 attestation using the attestation verifier. Also verifies the integrity of the 
-     * verify payment data using the data hash attached to the attestation.
+     * Verifies the EIP-712 attestation using the attestation verifier. Also verifies the integrity of the
+     * verify payment data using the data hash attached to the attestation. The deposit's verification data
+     * is forwarded to the attestation verifier so it can resolve the attestor set the depositor trusts
+     * (e.g. deposit attestors on MultiAttestationVerifier).
      */
-    function _verifyAttestation(PaymentAttestation memory attestation) internal view returns (bool) {
+    function _verifyAttestation(
+        PaymentAttestation memory attestation,
+        bytes memory depositData
+    ) internal view returns (bool) {
         bytes32 structHash = keccak256(
             abi.encode(
                 PAYMENT_ATTESTATION_TYPEHASH,
@@ -210,23 +215,29 @@ contract UnifiedPaymentVerifier is IPaymentVerifier, BaseUnifiedPaymentVerifier 
         );
 
         bool isValid = attestationVerifier.verify(
-            digest, 
+            digest,
             attestation.signatures,
-            attestation.data
+            depositData
         );
 
         return isValid;
     }
 
     /**
-     * Reads intent data from the Orchestrator and checks them against the intent data provided by the 
-     * attestation verifier.
+     * Reads intent data from the Orchestrator and checks them against the intent data provided by the
+     * attestation verifier. Returns the deposit's payment method verification data, read from the escrow
+     * the intent points to, so the attestation can be verified against the attestor set the depositor
+     * trusts. Reverts if the escrow doesn't expose the deposit data rather than falling back, so a
+     * depositor's custom trust policy can never be silently downgraded to the witness set.
      */
-    function _validateIntentSnapshot(
+    function _validateIntentSnapshotAndGetDepositData(
         bytes32 intentHash,
         IntentSnapshot memory snapshot
-    ) internal view {
+    ) internal view returns (bytes memory depositData) {
         require(snapshot.intentHash == intentHash, "UPV: Snapshot hash mismatch");
+
+        address escrow;
+        uint256 depositId;
 
         if (_isV2Orchestrator(msg.sender)) {
             IOrchestratorV2.Intent memory intentV2 = IOrchestratorV2(msg.sender).getIntent(intentHash);
@@ -239,6 +250,8 @@ contract UnifiedPaymentVerifier is IPaymentVerifier, BaseUnifiedPaymentVerifier 
                 intentV2.conversionRate,
                 intentV2.timestamp
             );
+            escrow = intentV2.escrow;
+            depositId = intentV2.depositId;
         } else {
             IOrchestrator.Intent memory intent = IOrchestrator(msg.sender).getIntent(intentHash);
             _validateSnapshotAgainstIntent(
@@ -250,9 +263,13 @@ contract UnifiedPaymentVerifier is IPaymentVerifier, BaseUnifiedPaymentVerifier 
                 intent.conversionRate,
                 intent.timestamp
             );
+            escrow = intent.escrow;
+            depositId = intent.depositId;
         }
 
         require(snapshot.timestampBuffer <= MAX_TIMESTAMP_BUFFER, "UPV: Snapshot timestamp buffer exceeds maximum");
+
+        depositData = IEscrow(escrow).getDepositPaymentMethodData(depositId, snapshot.paymentMethod).data;
     }
 
     function _validateSnapshotAgainstIntent(

--- a/deploy/24_deploy_multi_attestation_verifier.ts
+++ b/deploy/24_deploy_multi_attestation_verifier.ts
@@ -5,9 +5,9 @@ import { DeployFunction } from "hardhat-deploy/types";
 import { ethers } from "hardhat";
 
 import {
-  MULTI_SIG,
   MULTI_WITNESS_ADDRESSES,
   MULTI_WITNESS_THRESHOLD,
+  MULTI_SIG,
 } from "../deployments/parameters";
 import {
   getDeployedContractAddress,
@@ -60,6 +60,18 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   );
   await setNewOwner(hre, multiAttestationVerifierContract, multiSig);
   console.log("MultiAttestationVerifier ownership transferred to", multiSig);
+};
+
+// Skip on live networks once the MultiAttestationVerifier has been deployed; later
+// redeployments (e.g. script 25 for deposit attestor data) manage their own
+// rollout. Localhost always runs to bootstrap a fresh chain.
+func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> => {
+  const network = hre.network.name;
+  if (network != "localhost") {
+    try { getDeployedContractAddress(network, "MultiAttestationVerifier"); } catch (e) { return false; }
+    return true;
+  }
+  return false;
 };
 
 func.tags = ["MultiAttestationVerifier"];

--- a/deploy/25_redeploy_upv_mav_deposit_attestors.ts
+++ b/deploy/25_redeploy_upv_mav_deposit_attestors.ts
@@ -1,0 +1,301 @@
+import "module-alias/register";
+
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { ethers } from "hardhat";
+
+import {
+  getDeployedContractAddress,
+  addWritePermission,
+  removeWritePermission,
+  addPaymentMethodToUnifiedVerifier,
+  addPaymentMethodToRegistry,
+  removePaymentMethodFromRegistry,
+  savePaymentMethodSnapshot,
+  setNewOwner,
+  waitForDeploymentDelay,
+} from "../deployments/helpers";
+import {
+  MULTI_WITNESS_ADDRESSES,
+  MULTI_WITNESS_THRESHOLD,
+  MULTI_SIG,
+} from "../deployments/parameters";
+import { safeBatchCollector } from "../deployments/safeBatchCollector";
+import { VENMO_PROVIDER_CONFIG } from "../deployments/verifiers/venmo";
+import { REVOLUT_PROVIDER_CONFIG } from "../deployments/verifiers/revolut";
+import { CASHAPP_PROVIDER_CONFIG } from "../deployments/verifiers/cashapp";
+import { WISE_PROVIDER_CONFIG } from "../deployments/verifiers/wise";
+import { MERCADOPAGO_PROVIDER_CONFIG } from "../deployments/verifiers/mercadopago";
+import {
+  ZELLE_CITI_PROVIDER_CONFIG,
+  ZELLE_CHASE_PROVIDER_CONFIG,
+  ZELLE_BOFA_PROVIDER_CONFIG,
+} from "../deployments/verifiers/zelle";
+import { PAYPAL_PROVIDER_CONFIG } from "../deployments/verifiers/paypal";
+import { MONZO_PROVIDER_CONFIG } from "../deployments/verifiers/monzo";
+import { N26_PROVIDER_CONFIG } from "../deployments/verifiers/n26";
+import { ALIPAY_PROVIDER_CONFIG } from "../deployments/verifiers/alipay";
+import { CHIME_PROVIDER_CONFIG } from "../deployments/verifiers/chime";
+import { LUXON_PROVIDER_CONFIG } from "../deployments/verifiers/luxon";
+
+// Old addresses being replaced (deployed by scripts 22 and 24, before deposit attestor data).
+// The new UnifiedPaymentVerifierV2 forwards deposit verification data to the attestation verifier and
+// the new MultiAttestationVerifier resolves tagged deposit attestors from it.
+const OLD_UPV_V2: any = {
+  "base_staging": "0x7750f8Cc276f21B7Db1477FA044Bf3FD4951Bf20",
+  "base": "0x46A58Dc65587D4D7B8198C6A25eEdf5b2535Da94",
+};
+
+const ALL_PAYMENT_METHODS = [
+  { key: "venmo", config: VENMO_PROVIDER_CONFIG },
+  { key: "revolut", config: REVOLUT_PROVIDER_CONFIG },
+  { key: "cashapp", config: CASHAPP_PROVIDER_CONFIG },
+  { key: "wise", config: WISE_PROVIDER_CONFIG },
+  { key: "mercadopago", config: MERCADOPAGO_PROVIDER_CONFIG },
+  { key: "zelle-citi", config: ZELLE_CITI_PROVIDER_CONFIG },
+  { key: "zelle-chase", config: ZELLE_CHASE_PROVIDER_CONFIG },
+  { key: "zelle-bofa", config: ZELLE_BOFA_PROVIDER_CONFIG },
+  { key: "paypal", config: PAYPAL_PROVIDER_CONFIG },
+  { key: "monzo", config: MONZO_PROVIDER_CONFIG },
+  { key: "n26", config: N26_PROVIDER_CONFIG },
+  { key: "alipay", config: ALIPAY_PROVIDER_CONFIG },
+  { key: "chime", config: CHIME_PROVIDER_CONFIG },
+  { key: "luxon", config: LUXON_PROVIDER_CONFIG },
+];
+
+const PAYMENT_METHOD_LABELS = new Map(
+  ALL_PAYMENT_METHODS.map(({ key, config }) => [config.paymentMethodHash.toLowerCase(), key])
+);
+const DEPRECATED_PAYMENT_METHODS = new Set([
+  N26_PROVIDER_CONFIG.paymentMethodHash.toLowerCase(),
+  LUXON_PROVIDER_CONFIG.paymentMethodHash.toLowerCase(),
+]);
+
+type PaymentMethodMigration = {
+  key: string;
+  paymentMethodHash: string;
+  currencies: string[];
+};
+
+function getPaymentMethodLabel(paymentMethodHash: string): string {
+  return PAYMENT_METHOD_LABELS.get(paymentMethodHash.toLowerCase()) ?? `unknown-${paymentMethodHash.slice(0, 10)}`;
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deploy } = await hre.deployments;
+  const network = hre.deployments.getNetworkName();
+
+  const [deployer] = await hre.getUnnamedAccounts();
+  const multiSig = MULTI_SIG[network] ? MULTI_SIG[network] : deployer;
+
+  const oldUpvV2 = OLD_UPV_V2[network];
+  if (!oldUpvV2) {
+    throw new Error(`No old UPV V2 address configured for network ${network}`);
+  }
+
+  const initialWitnesses = MULTI_WITNESS_ADDRESSES[network];
+  const initialThreshold = MULTI_WITNESS_THRESHOLD[network];
+  if (!initialWitnesses || initialWitnesses.length === 0) {
+    throw new Error(`No MultiAttestationVerifier witnesses configured for ${network}`);
+  }
+  if (!initialThreshold) {
+    throw new Error(`No MultiAttestationVerifier threshold configured for ${network}`);
+  }
+
+  // Resolve existing infrastructure
+  const orchestratorRegistryAddress = getDeployedContractAddress(network, "OrchestratorRegistry");
+  const nullifierRegistryAddress = getDeployedContractAddress(network, "NullifierRegistry");
+  const paymentVerifierRegistryAddress = getDeployedContractAddress(network, "PaymentVerifierRegistry");
+
+  console.log("=== Redeploying UPV V2 + MultiAttestationVerifier (deposit attestors) ===");
+  console.log("Old UPV V2:", oldUpvV2);
+
+  // 1. Deploy new MultiAttestationVerifier with the same witness set and threshold
+  //    (overwrites deployment artifact)
+  const multiAttestationVerifier = await deploy("MultiAttestationVerifier", {
+    from: deployer,
+    args: [initialWitnesses, initialThreshold],
+  });
+  console.log("New MultiAttestationVerifier deployed at", multiAttestationVerifier.address);
+  await waitForDeploymentDelay(hre);
+
+  // 2. Deploy new UnifiedPaymentVerifier wired to the new MultiAttestationVerifier
+  //    (overwrites deployment artifact)
+  const upv = await deploy("UnifiedPaymentVerifierV2", {
+    contract: "UnifiedPaymentVerifier",
+    from: deployer,
+    args: [
+      orchestratorRegistryAddress,
+      nullifierRegistryAddress,
+      multiAttestationVerifier.address,
+    ],
+  });
+  console.log("New UnifiedPaymentVerifierV2 deployed at", upv.address);
+  await waitForDeploymentDelay(hre);
+
+  // 3. Build migration plan from live registry state before mutating permissions.
+  const paymentVerifierRegistryContract = await ethers.getContractAt("PaymentVerifierRegistry", paymentVerifierRegistryAddress);
+  const v2VerifierContract = await ethers.getContractAt("UnifiedPaymentVerifier", upv.address);
+  const livePaymentMethods = await paymentVerifierRegistryContract.getPaymentMethods();
+  const migrationPlan: PaymentMethodMigration[] = [];
+  const deprecatedPlan: PaymentMethodMigration[] = [];
+
+  for (const paymentMethodHash of livePaymentMethods) {
+    const currencies = await paymentVerifierRegistryContract.getCurrencies(paymentMethodHash);
+    if (currencies.length === 0) {
+      throw new Error(`Payment method ${paymentMethodHash} has no currencies configured`);
+    }
+
+    if (DEPRECATED_PAYMENT_METHODS.has(paymentMethodHash.toLowerCase())) {
+      deprecatedPlan.push({
+        key: getPaymentMethodLabel(paymentMethodHash),
+        paymentMethodHash,
+        currencies,
+      });
+      continue;
+    }
+
+    const currentVerifier = await paymentVerifierRegistryContract.getVerifier(paymentMethodHash);
+    if (currentVerifier.toLowerCase() !== oldUpvV2.toLowerCase()) {
+      continue;
+    }
+
+    migrationPlan.push({
+      key: getPaymentMethodLabel(paymentMethodHash),
+      paymentMethodHash,
+      currencies,
+    });
+  }
+
+  if (migrationPlan.length === 0 && deprecatedPlan.length === 0) {
+    throw new Error(`No payment methods found for migration or deprecation`);
+  }
+
+  console.log(`Migration plan includes ${migrationPlan.length} payment methods:`);
+  for (const { key, paymentMethodHash, currencies } of migrationPlan) {
+    console.log(`- ${key}: ${paymentMethodHash} (${currencies.length} currencies)`);
+  }
+  console.log(`Deprecation plan includes ${deprecatedPlan.length} payment methods:`);
+  for (const { key, paymentMethodHash } of deprecatedPlan) {
+    console.log(`- ${key}: ${paymentMethodHash}`);
+  }
+
+  // 4. Grant NullifierRegistry write permission to new UPV
+  const nullifierRegistryContract = await ethers.getContractAt("NullifierRegistry", nullifierRegistryAddress);
+  await addWritePermission(hre, nullifierRegistryContract, upv.address);
+  console.log("NullifierRegistry write permission granted to new UPV");
+
+  // 5. Configure payment methods on new UPV and update PaymentVerifierRegistry
+  // Detect whether deployer can execute registry transactions directly
+  const registryOwner = await paymentVerifierRegistryContract.owner();
+  const deployerIsRegistryOwner = (await hre.getUnnamedAccounts()).includes(registryOwner);
+
+  for (const { key, paymentMethodHash, currencies } of migrationPlan) {
+    console.log(`\nConfiguring payment method: ${key}`);
+
+    // Add payment method to new UPV (deployer owns new UPV, always direct)
+    await addPaymentMethodToUnifiedVerifier(hre, v2VerifierContract, paymentMethodHash);
+
+    const isPaymentMethod = await paymentVerifierRegistryContract.isPaymentMethod(paymentMethodHash);
+
+    // Remove from registry (currently points to old UPV)
+    await removePaymentMethodFromRegistry(hre, paymentVerifierRegistryContract, paymentMethodHash);
+
+    // Re-add with new UPV address
+    // On production (deployer != registry owner), the removal above only logged Safe
+    // batch calldata without executing, so isPaymentMethod() still returns true.
+    // addPaymentMethodToRegistry would skip due to its idempotency check. Bypass it
+    // by encoding the calldata directly into the Safe batch.
+    if (!deployerIsRegistryOwner && isPaymentMethod) {
+      const addCalldata = paymentVerifierRegistryContract.interface.encodeFunctionData("addPaymentMethod", [
+        paymentMethodHash,
+        upv.address,
+        currencies,
+      ]);
+      safeBatchCollector.add(
+        paymentVerifierRegistryContract.address,
+        addCalldata,
+        `PaymentVerifierRegistry.addPaymentMethod(${key}, ${upv.address})`
+      );
+    } else {
+      await addPaymentMethodToRegistry(
+        hre,
+        paymentVerifierRegistryContract,
+        paymentMethodHash,
+        upv.address,
+        currencies
+      );
+    }
+    console.log(`${key} wired to new UPV in PaymentVerifierRegistry`);
+
+    // Save snapshot
+    savePaymentMethodSnapshot(network, key, {
+      paymentMethodHash,
+      currencies,
+    });
+  }
+
+  for (const { key, paymentMethodHash } of deprecatedPlan) {
+    console.log(`\nRemoving deprecated payment method: ${key}`);
+    await removePaymentMethodFromRegistry(hre, paymentVerifierRegistryContract, paymentMethodHash);
+  }
+
+  if (deployerIsRegistryOwner) {
+    for (const { paymentMethodHash } of migrationPlan) {
+      const verifier = await paymentVerifierRegistryContract.getVerifier(paymentMethodHash);
+      if (verifier.toLowerCase() !== upv.address.toLowerCase()) {
+        throw new Error(`Payment method ${paymentMethodHash} was not migrated to new UPV V2`);
+      }
+    }
+    for (const { paymentMethodHash } of deprecatedPlan) {
+      if (await paymentVerifierRegistryContract.isPaymentMethod(paymentMethodHash)) {
+        throw new Error(`Deprecated payment method ${paymentMethodHash} was not removed`);
+      }
+    }
+  } else {
+    console.log("Registry ownership is multisig controlled; migration transactions were appended to the Safe batch");
+  }
+
+  // 6. Remove old UPV write permission from NullifierRegistry after registry migration steps
+  await removeWritePermission(hre, nullifierRegistryContract, oldUpvV2);
+  console.log("Old UPV V2 write permission removal queued/executed after registry rewiring");
+
+  // 7. Transfer ownership of both new contracts
+  await setNewOwner(hre, v2VerifierContract, multiSig);
+  console.log("UnifiedPaymentVerifierV2 ownership transferred to", multiSig);
+
+  const multiAttestationVerifierContract = await ethers.getContractAt(
+    "MultiAttestationVerifier",
+    multiAttestationVerifier.address
+  );
+  await setNewOwner(hre, multiAttestationVerifierContract, multiSig);
+  console.log("MultiAttestationVerifier ownership transferred to", multiSig);
+
+  // 8. Write Safe batch file if any multisig transactions were collected
+  const chainId = (await ethers.provider.getNetwork()).chainId;
+  const batchCount = safeBatchCollector.count();
+  if (batchCount > 0) {
+    const batchFile = safeBatchCollector.writeBatchFile(network, String(chainId), multiSig);
+    console.log(`\nSafe batch file written with ${batchCount} transactions: ${batchFile}`);
+  }
+
+  console.log("=== UPV V2 + MultiAttestationVerifier redeployment finished ===");
+  await waitForDeploymentDelay(hre);
+};
+
+func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> => {
+  const network = hre.network.name;
+  const oldAddress = OLD_UPV_V2[network];
+  if (!oldAddress) return true; // Skip networks without old addresses (localhost gets current code from script 14)
+  try {
+    const currentAddress = getDeployedContractAddress(network, "UnifiedPaymentVerifierV2");
+    return currentAddress !== oldAddress; // Skip if already replaced
+  } catch (e) {
+    return false;
+  }
+};
+
+func.tags = ["25_redeploy_upv_mav_deposit_attestors"];
+func.dependencies = ["MultiAttestationVerifier"];
+
+export default func;

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -31,7 +31,7 @@ import { baseSepolia as paymentMethods } from "@zkp2p/contracts-v2/paymentMethod
 import type { Escrow, Orchestrator } from "@zkp2p/contracts-v2/types"
 
 // Import utility functions
-import { getKeccak256Hash, calculateIntentHash } from "@zkp2p/contracts-v2/utils/protocolUtils"
+import { getKeccak256Hash, calculateIntentHash, encodeDepositAttestors } from "@zkp2p/contracts-v2/utils/protocolUtils"
 
 // Example: Create contract instance with ethers
 import { ethers } from 'ethers';
@@ -124,17 +124,16 @@ Protocol utility functions:
 
 ```typescript
 // Import protocol utilities
-import { getKeccak256Hash, calculateIntentHash, getCurrencyInfo } from "@zkp2p/contracts-v2/utils/protocolUtils"
-import { Currency } from "@zkp2p/contracts-v2/utils/types"
+import { getKeccak256Hash, calculateIntentHash, encodeDepositAttestors } from "@zkp2p/contracts-v2/utils/protocolUtils"
 
 // Use utility functions
 const paymentMethodHash = getKeccak256Hash("venmo");
 const intentHash = calculateIntentHash(depositor, depositId, signalIntentParams);
 
-// Get currency information
-const usdInfo = getCurrencyInfo(Currency.USD);
-console.log('Currency code:', usdInfo.code);
-console.log('Decimals:', usdInfo.decimals);
+// Encode additional deposit attestors for DepositPaymentMethodData.data.
+// MultiAttestationVerifier appends these to the default witness set, so either
+// defaults or added attestors can satisfy the combined threshold.
+const verificationData = encodeDepositAttestors([attestorAddress], 1);
 ```
 
 

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -118,11 +118,17 @@
     },
     "./utils": {
       "types": "./utils/index.d.ts",
-      "default": "./utils/index.ts"
+      "import": "./_esm/utils/index.js",
+      "react-native": "./_esm/utils/index.js",
+      "require": "./_cjs/utils/index.js",
+      "default": "./_esm/utils/index.js"
     },
     "./utils/protocolUtils": {
       "types": "./utils/protocolUtils.d.ts",
-      "default": "./utils/protocolUtils.ts"
+      "import": "./_esm/utils/protocolUtils.js",
+      "react-native": "./_esm/utils/protocolUtils.js",
+      "require": "./_cjs/utils/protocolUtils.js",
+      "default": "./_esm/utils/protocolUtils.js"
     },
     "./abis/base": {
       "types": "./abis/base.d.ts",

--- a/packages/contracts/scripts/build-modules.ts
+++ b/packages/contracts/scripts/build-modules.ts
@@ -24,6 +24,26 @@ function createJsonModule(content: string, format: 'esm' | 'cjs'): string {
   return `const data = ${serialized};\nmodule.exports = data;\nmodule.exports.default = data;\n`;
 }
 
+function rewriteEsmSpecifier(specifier: string): string {
+  if (specifier.endsWith('.json')) {
+    return specifier.replace(/\.json$/, '.js');
+  }
+  if (/\.(js|mjs|cjs)$/.test(specifier)) {
+    return specifier;
+  }
+  return `${specifier}.js`;
+}
+
+function rewriteEsmRelativeImports(source: string): string {
+  return source
+    .replace(/(from\s+["'])(\.{1,2}\/[^"']+)(["'])/g, (_match, prefix, specifier, suffix) => {
+      return `${prefix}${rewriteEsmSpecifier(specifier)}${suffix}`;
+    })
+    .replace(/(import\s+["'])(\.{1,2}\/[^"']+)(["'])/g, (_match, prefix, specifier, suffix) => {
+      return `${prefix}${rewriteEsmSpecifier(specifier)}${suffix}`;
+    });
+}
+
 function compileModule(moduleName: string, format: 'esm' | 'cjs') {
   const inputDir = path.join(PKG_ROOT, moduleName);
   const outputDir = path.join(PKG_ROOT, format === 'esm' ? '_esm' : '_cjs', moduleName);
@@ -53,24 +73,19 @@ function compileModule(moduleName: string, format: 'esm' | 'cjs') {
         // Compile TypeScript files
         const source = fs.readFileSync(inputPath, 'utf8');
 
-        // Simple transformation for imports/exports
-        let transformed = source;
+        let transformed = ts.transpileModule(source, {
+          compilerOptions: {
+            esModuleInterop: true,
+            module: format === 'esm' ? ts.ModuleKind.ES2020 : ts.ModuleKind.CommonJS,
+            moduleResolution: ts.ModuleResolutionKind.NodeJs,
+            resolveJsonModule: true,
+            target: ts.ScriptTarget.ES2020,
+          },
+          fileName: inputPath,
+        }).outputText;
 
-        if (format === 'cjs') {
-          // Convert ES modules to CommonJS
-          transformed = transformed
-            .replace(/export \{ default as (\w+) \} from '\.\/(.+)\.json'/g, 
-                    "exports.$1 = require('./$2.json')")
-            .replace(/export \* as (\w+) from '\.\/(.+)'/g, 
-                    "exports.$1 = require('./$2')")
-            .replace(/export \{([^}]+)\} from '\.\/(.+)'/g, 
-                    "Object.assign(exports, require('./$2'))")
-            .replace(/import type \{([^}]+)\} from '\.\/(.+)'/g, '')
-            .replace(/export type \{([^}]+)\}/g, '');
-        } else {
-          transformed = transformed
-            .replace(/from "\.\/(.+)\.json"/g, "from './$1.js'")
-            .replace(/from '\.\/(.+)\.json'/g, "from './$1.js'");
+        if (format === 'esm') {
+          transformed = rewriteEsmRelativeImports(transformed);
         }
 
         // Write the output file with .js extension
@@ -92,13 +107,16 @@ function compileModule(moduleName: string, format: 'esm' | 'cjs') {
 }
 
 function buildMainIndex() {
+  const packageJson = JSON.parse(fs.readFileSync(path.join(PKG_ROOT, 'package.json'), 'utf8'));
+  const version = JSON.stringify(packageJson.version);
+
   // Build simple main index files
   const esmIndex = `// Auto-generated main entry point
-export const version = require('../package.json').version;
+export const version = ${version};
 `;
   
   const cjsIndex = `// Auto-generated main entry point
-exports.version = require('../package.json').version;
+exports.version = ${version};
 `;
   
   ensureDir(path.join(PKG_ROOT, '_esm'));

--- a/packages/contracts/scripts/extractors/constants.ts
+++ b/packages/contracts/scripts/extractors/constants.ts
@@ -76,6 +76,14 @@ export async function extractConstants(): Promise<void> {
       networkConstants.WITNESS_ADDRESS = params.WITNESS_ADDRESS[network];
     }
 
+    if (params.MULTI_WITNESS_ADDRESSES?.[network] !== undefined) {
+      networkConstants.MULTI_WITNESS_ADDRESSES = params.MULTI_WITNESS_ADDRESSES[network];
+    }
+
+    if (params.MULTI_WITNESS_THRESHOLD?.[network] !== undefined) {
+      networkConstants.MULTI_WITNESS_THRESHOLD = params.MULTI_WITNESS_THRESHOLD[network];
+    }
+
     if (params.ZKTLS_ATTESTOR_ADDRESS?.[network] !== undefined) {
       networkConstants.ZKTLS_ATTESTOR_ADDRESS = params.ZKTLS_ATTESTOR_ADDRESS[network];
     }

--- a/packages/contracts/scripts/extractors/utils.ts
+++ b/packages/contracts/scripts/extractors/utils.ts
@@ -33,10 +33,13 @@ export * from './protocolUtils';
 
 // Re-export commonly used items for convenience
 export { 
+  DEPOSIT_ATTESTORS_TAG,
+  MAX_DEPOSIT_ATTESTORS,
   Currency, 
   getKeccak256Hash, 
   getCurrencyCodeFromHash,
-  calculateIntentHash
+  calculateIntentHash,
+  encodeDepositAttestors
 } from './protocolUtils';
 `;
   

--- a/packages/contracts/scripts/generate-types.ts
+++ b/packages/contracts/scripts/generate-types.ts
@@ -4,8 +4,9 @@ import * as ts from 'typescript';
 import * as fs from 'fs';
 import * as path from 'path';
 
-// Generate declarations inside the built package directory
-const PACKAGE_ROOT = path.resolve(__dirname, '..', 'dist');
+// Generate declarations beside the extracted package source files so build-modules
+// can copy them into _types.
+const PACKAGE_ROOT = path.resolve(__dirname, '..');
 
 // Directories to process
 const DIRECTORIES_TO_PROCESS = [

--- a/test-foundry/fuzz/MultiAttestationVerifierFuzz.t.sol
+++ b/test-foundry/fuzz/MultiAttestationVerifierFuzz.t.sol
@@ -6,7 +6,7 @@ import { Test } from "forge-std/Test.sol";
 import { MultiAttestationVerifier } from "../../contracts/unifiedVerifier/MultiAttestationVerifier.sol";
 
 contract MultiAttestationVerifierFuzz is Test {
-    uint256 internal constant MAX_WITNESSES = 5;
+    uint256 internal constant MAX_SIGNERS = 5;
 
     address public owner;
 
@@ -48,10 +48,10 @@ contract MultiAttestationVerifierFuzz is Test {
         uint256 signatureMaskSeed,
         uint256 messageSeed
     ) public {
-        uint256 witnessCount = bound(uint256(witnessCountSeed), 1, MAX_WITNESSES);
+        uint256 witnessCount = bound(uint256(witnessCountSeed), 1, MAX_SIGNERS);
         uint256 requiredSignatures = bound(uint256(thresholdSeed), 1, witnessCount);
 
-        (address[] memory witnesses, uint256[] memory privateKeys) = _buildWitnessSet(witnessCount);
+        (address[] memory witnesses, uint256[] memory privateKeys) = _buildSignerSet(witnessCount);
         MultiAttestationVerifier verifier = _deployVerifier(witnesses, requiredSignatures);
 
         bytes32 messageHash = keccak256(
@@ -63,7 +63,7 @@ contract MultiAttestationVerifierFuzz is Test {
 
         uint256 selectionSpace = uint256(1) << witnessCount;
         uint256 signatureMask = signatureMaskSeed % selectionSpace;
-        uint256 selectedCount = _countSelectedWitnesses(signatureMask, witnessCount);
+        uint256 selectedCount = _countSelectedSigners(signatureMask, witnessCount);
 
         bytes[] memory signatures = new bytes[](selectedCount);
         uint256 signatureIndex = 0;
@@ -86,6 +86,93 @@ contract MultiAttestationVerifierFuzz is Test {
         }
     }
 
+    function testFuzz_depositAttestorsVerifyMatchesRandomSubset(
+        uint8 attestorCountSeed,
+        uint8 thresholdSeed,
+        uint256 signatureMaskSeed,
+        uint256 messageSeed
+    ) public {
+        // Deposit attestors are appended to the witness set by construction
+        address[] memory witnesses = new address[](2);
+        witnesses[0] = vm.addr(1);
+        witnesses[1] = vm.addr(2);
+
+        MultiAttestationVerifier verifier = _deployVerifier(witnesses, 1);
+
+        uint256 attestorCount = bound(uint256(attestorCountSeed), 1, verifier.MAX_DEPOSIT_ATTESTORS());
+        uint256 combinedCount = witnesses.length + attestorCount;
+        uint256 depositThreshold = bound(uint256(thresholdSeed), 1, combinedCount);
+
+        (address[] memory attestors, uint256[] memory privateKeys) = _buildSignerSet(attestorCount);
+        bytes memory depositAttestorsData = abi.encode(verifier.DEPOSIT_ATTESTORS_TAG(), attestors, depositThreshold);
+
+        uint256[] memory combinedPrivateKeys = new uint256[](combinedCount);
+        combinedPrivateKeys[0] = 1;
+        combinedPrivateKeys[1] = 2;
+        for (uint256 attestorIndex = 0; attestorIndex < attestorCount; attestorIndex++) {
+            combinedPrivateKeys[witnesses.length + attestorIndex] = privateKeys[attestorIndex];
+        }
+
+        bytes32 digest = keccak256(
+            abi.encodePacked("deposit-attestors-fuzz", messageSeed, attestorCount, depositThreshold)
+        );
+
+        uint256 selectionSpace = uint256(1) << combinedCount;
+        uint256 signatureMask = signatureMaskSeed % selectionSpace;
+        uint256 selectedCount = _countSelectedSigners(signatureMask, combinedCount);
+
+        bytes[] memory signatures = new bytes[](selectedCount);
+        uint256 signatureIndex = 0;
+
+        for (uint256 signerIndex = 0; signerIndex < combinedCount; signerIndex++) {
+            if ((signatureMask & (uint256(1) << signerIndex)) != 0) {
+                signatures[signatureIndex] = _signDigest(combinedPrivateKeys[signerIndex], digest);
+                signatureIndex++;
+            }
+        }
+
+        bool shouldVerify = selectedCount >= depositThreshold;
+
+        if (shouldVerify) {
+            assertTrue(verifier.verify(digest, signatures, depositAttestorsData));
+        } else {
+            vm.expectRevert();
+            verifier.verify(digest, signatures, depositAttestorsData);
+        }
+
+        // A witness signature alone still satisfies appended deposit attestors when the
+        // threshold is one; higher thresholds reject the undersized signature array first.
+        bytes[] memory witnessSignatures = new bytes[](1);
+        witnessSignatures[0] = _signDigest(1, digest);
+
+        if (depositThreshold > 1) {
+            vm.expectRevert("ThresholdSigVerifierUtils: req threshold exceeds signatures");
+            verifier.verify(digest, witnessSignatures, depositAttestorsData);
+        } else {
+            assertTrue(verifier.verify(digest, witnessSignatures, depositAttestorsData));
+        }
+    }
+
+    function testFuzz_nonEmptyUntaggedDataReverts(bytes memory data) public {
+        address[] memory witnesses = new address[](2);
+        witnesses[0] = vm.addr(1);
+        witnesses[1] = vm.addr(2);
+
+        MultiAttestationVerifier verifier = _deployVerifier(witnesses, 2);
+
+        vm.assume(data.length > 0);
+        if (data.length >= 32) {
+            bytes32 firstWord;
+            assembly {
+                firstWord := mload(add(data, 32))
+            }
+            vm.assume(firstWord != verifier.DEPOSIT_ATTESTORS_TAG());
+        }
+
+        vm.expectRevert("MAV: invalid deposit attestors tag");
+        verifier.resolveAttestors(data);
+    }
+
     function _deployVerifier(
         address[] memory initialWitnesses,
         uint256 initialThreshold
@@ -94,32 +181,32 @@ contract MultiAttestationVerifierFuzz is Test {
         deployedVerifier = new MultiAttestationVerifier(initialWitnesses, initialThreshold);
     }
 
-    function _buildWitnessSet(
-        uint256 witnessCount
-    ) internal pure returns (address[] memory witnesses, uint256[] memory privateKeys) {
-        witnesses = new address[](witnessCount);
-        privateKeys = new uint256[](witnessCount);
+    function _buildSignerSet(
+        uint256 signerCount
+    ) internal pure returns (address[] memory signers, uint256[] memory privateKeys) {
+        signers = new address[](signerCount);
+        privateKeys = new uint256[](signerCount);
 
-        for (uint256 witnessIndex = 0; witnessIndex < witnessCount; witnessIndex++) {
+        for (uint256 signerIndex = 0; signerIndex < signerCount; signerIndex++) {
             uint256 privateKey = uint256(
-                keccak256(abi.encodePacked("multi-attestation-fuzz-witness", witnessCount, witnessIndex))
+                keccak256(abi.encodePacked("multi-attestation-fuzz-signer", signerCount, signerIndex))
             );
 
             if (privateKey == 0) {
-                privateKey = witnessIndex + 1;
+                privateKey = signerIndex + 1;
             }
 
-            privateKeys[witnessIndex] = privateKey;
-            witnesses[witnessIndex] = vm.addr(privateKey);
+            privateKeys[signerIndex] = privateKey;
+            signers[signerIndex] = vm.addr(privateKey);
         }
     }
 
-    function _countSelectedWitnesses(
+    function _countSelectedSigners(
         uint256 signatureMask,
-        uint256 witnessCount
+        uint256 signerCount
     ) internal pure returns (uint256 selectedCount) {
-        for (uint256 witnessIndex = 0; witnessIndex < witnessCount; witnessIndex++) {
-            if ((signatureMask & (uint256(1) << witnessIndex)) != 0) {
+        for (uint256 signerIndex = 0; signerIndex < signerCount; signerIndex++) {
+            if ((signatureMask & (uint256(1) << signerIndex)) != 0) {
                 selectedCount++;
             }
         }

--- a/test-foundry/unit/MultiAttestationVerifierUnit.t.sol
+++ b/test-foundry/unit/MultiAttestationVerifierUnit.t.sol
@@ -112,6 +112,181 @@ contract MultiAttestationVerifierUnit is Test {
         verifier.setRequiredSignatures(3);
     }
 
+    /* ============ resolveAttestors ============ */
+
+    function test_resolveAttestors_emptyDataReturnsWitnessSet() public view {
+        (address[] memory attestors, uint256 threshold) = verifier.resolveAttestors("");
+
+        assertEq(attestors.length, 2);
+        assertEq(attestors[0], witnessA);
+        assertEq(attestors[1], witnessB);
+        assertEq(threshold, 1);
+    }
+
+    function test_resolveAttestors_revertsOnNonEmptyUntaggedData() public {
+        // Legacy non-empty deposit data format: bare abi-encoded address array
+        bytes memory legacyData = abi.encode(_singleWitness(witnessC));
+
+        vm.expectRevert("MAV: invalid deposit attestors tag");
+        verifier.resolveAttestors(legacyData);
+    }
+
+    function test_resolveAttestors_revertsOnShortNonEmptyData() public {
+        vm.expectRevert("MAV: invalid deposit attestors tag");
+        verifier.resolveAttestors(hex"1234");
+    }
+
+    function test_resolveAttestors_taggedDataReturnsWitnessesPlusDepositSet() public {
+        address customAttestor = makeAddr("customAttestor");
+        bytes memory depositAttestorsData = _encodeDepositAttestors(_singleAttestor(customAttestor), 1);
+
+        (address[] memory attestors, uint256 threshold) = verifier.resolveAttestors(depositAttestorsData);
+
+        assertEq(attestors.length, 3);
+        assertEq(attestors[0], witnessA);
+        assertEq(attestors[1], witnessB);
+        assertEq(attestors[2], customAttestor);
+        assertEq(threshold, 1);
+    }
+
+    function test_resolveAttestors_revertsOnEmptyDepositAttestors() public {
+        bytes memory depositAttestorsData = _encodeDepositAttestors(new address[](0), 1);
+
+        vm.expectRevert("MAV: empty deposit attestors");
+        verifier.resolveAttestors(depositAttestorsData);
+    }
+
+    function test_resolveAttestors_revertsWhenDepositDataExceedsMaxAttestors() public {
+        uint256 attestorCount = verifier.MAX_DEPOSIT_ATTESTORS() + 1;
+        address[] memory attestors = new address[](attestorCount);
+        for (uint256 i = 0; i < attestorCount; i++) {
+            attestors[i] = vm.addr(i + 1);
+        }
+        bytes memory depositAttestorsData = _encodeDepositAttestors(attestors, 1);
+
+        vm.expectRevert("MAV: too many deposit attestors");
+        verifier.resolveAttestors(depositAttestorsData);
+    }
+
+    function test_resolveAttestors_revertsOnZeroDepositThreshold() public {
+        bytes memory depositAttestorsData = _encodeDepositAttestors(_singleAttestor(witnessC), 0);
+
+        vm.expectRevert("MAV: deposit threshold must be > 0");
+        verifier.resolveAttestors(depositAttestorsData);
+    }
+
+    function test_resolveAttestors_revertsWhenDepositThresholdExceedsCount() public {
+        bytes memory depositAttestorsData = _encodeDepositAttestors(_singleAttestor(witnessC), 4);
+
+        vm.expectRevert("MAV: deposit threshold exceeds count");
+        verifier.resolveAttestors(depositAttestorsData);
+    }
+
+    function test_resolveAttestors_revertsWhenDepositThresholdBelowDefault() public {
+        MultiAttestationVerifier thresholdTwoVerifier = _deployVerifier(_twoWitnesses(), 2);
+        bytes memory depositAttestorsData = _encodeDepositAttestors(_singleAttestor(witnessC), 1);
+
+        vm.expectRevert("MAV: deposit threshold below default");
+        thresholdTwoVerifier.resolveAttestors(depositAttestorsData);
+    }
+
+    function test_resolveAttestors_revertsOnZeroDepositAttestor() public {
+        address[] memory attestors = new address[](2);
+        attestors[0] = witnessC;
+        attestors[1] = address(0);
+        bytes memory depositAttestorsData = _encodeDepositAttestors(attestors, 1);
+
+        vm.expectRevert("MAV: zero deposit attestor");
+        verifier.resolveAttestors(depositAttestorsData);
+    }
+
+    function test_resolveAttestors_revertsOnDuplicateDepositAttestor() public {
+        address[] memory attestors = new address[](2);
+        attestors[0] = witnessC;
+        attestors[1] = witnessC;
+        bytes memory depositAttestorsData = _encodeDepositAttestors(attestors, 1);
+
+        vm.expectRevert("MAV: duplicate deposit attestor");
+        verifier.resolveAttestors(depositAttestorsData);
+    }
+
+    function test_resolveAttestors_revertsWhenDepositAttestorDuplicatesWitness() public {
+        bytes memory depositAttestorsData = _encodeDepositAttestors(_singleAttestor(witnessA), 1);
+
+        vm.expectRevert("MAV: duplicate deposit attestor");
+        verifier.resolveAttestors(depositAttestorsData);
+    }
+
+    function test_resolveAttestors_revertsOnTaggedButMalformedData() public {
+        bytes memory malformedData = abi.encodePacked(verifier.DEPOSIT_ATTESTORS_TAG());
+
+        vm.expectRevert();
+        verifier.resolveAttestors(malformedData);
+    }
+
+    /* ============ verify with deposit attestors ============ */
+
+    function test_verify_depositAttestorsAcceptCustomAttestorSignature() public {
+        (address customAttestor, uint256 customAttestorKey) = makeAddrAndKey("customAttestor");
+        bytes32 digest = keccak256("attestation digest");
+
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = _signDigest(customAttestorKey, digest);
+
+        bool isValid = verifier.verify(digest, signatures, _encodeDepositAttestors(_singleAttestor(customAttestor), 1));
+
+        assertTrue(isValid);
+    }
+
+    function test_verify_depositAttestorsAcceptWitnessAndCustomAttestorSignature() public {
+        (address witness, uint256 witnessKey) = makeAddrAndKey("witness");
+        (address customAttestor, uint256 customAttestorKey) = makeAddrAndKey("customAttestor");
+
+        MultiAttestationVerifier signingVerifier = _deployVerifier(_singleWitness(witness), 1);
+
+        bytes32 digest = keccak256("attestation digest");
+        bytes[] memory signatures = new bytes[](2);
+        signatures[0] = _signDigest(witnessKey, digest);
+        signatures[1] = _signDigest(customAttestorKey, digest);
+
+        bool isValid = signingVerifier.verify(
+            digest,
+            signatures,
+            _encodeDepositAttestors(_singleAttestor(customAttestor), 2)
+        );
+
+        assertTrue(isValid);
+    }
+
+    function test_verify_depositAttestorsAcceptWitnessSignature() public {
+        (address witness, uint256 witnessKey) = makeAddrAndKey("witness");
+        address customAttestor = makeAddr("customAttestor");
+
+        MultiAttestationVerifier signingVerifier = _deployVerifier(_singleWitness(witness), 1);
+
+        bytes32 digest = keccak256("attestation digest");
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = _signDigest(witnessKey, digest);
+        bytes memory depositAttestorsData = _encodeDepositAttestors(_singleAttestor(customAttestor), 1);
+
+        // Sanity: the witness signature verifies without deposit attestors
+        assertTrue(signingVerifier.verify(digest, signatures, ""));
+
+        assertTrue(signingVerifier.verify(digest, signatures, depositAttestorsData));
+    }
+
+    function _encodeDepositAttestors(
+        address[] memory attestors,
+        uint256 threshold
+    ) internal view returns (bytes memory depositAttestorsData) {
+        depositAttestorsData = abi.encode(verifier.DEPOSIT_ATTESTORS_TAG(), attestors, threshold);
+    }
+
+    function _signDigest(uint256 privateKey, bytes32 digest) internal pure returns (bytes memory signature) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        signature = abi.encodePacked(r, s, v);
+    }
+
     function _deployVerifier(
         address[] memory initialWitnesses,
         uint256 initialThreshold
@@ -123,6 +298,11 @@ contract MultiAttestationVerifierUnit is Test {
     function _singleWitness(address witnessAddress) internal pure returns (address[] memory initialWitnesses) {
         initialWitnesses = new address[](1);
         initialWitnesses[0] = witnessAddress;
+    }
+
+    function _singleAttestor(address attestor) internal pure returns (address[] memory attestors) {
+        attestors = new address[](1);
+        attestors[0] = attestor;
     }
 
     function _twoWitnesses() internal view returns (address[] memory initialWitnesses) {

--- a/test/deploy/25_depositAttestorsRedeploy.spec.ts
+++ b/test/deploy/25_depositAttestorsRedeploy.spec.ts
@@ -1,0 +1,143 @@
+import "module-alias/register";
+
+import { deployments } from "hardhat";
+
+import {
+  MultiAttestationVerifier,
+  MultiAttestationVerifier__factory,
+  NullifierRegistry,
+  NullifierRegistry__factory,
+  PaymentVerifierRegistry,
+  PaymentVerifierRegistry__factory,
+  UnifiedPaymentVerifier,
+  UnifiedPaymentVerifier__factory,
+} from "../../typechain";
+
+import {
+  getAccounts,
+  getWaffleExpect,
+} from "../../utils/test";
+import {
+  Account
+} from "../../utils/test/types";
+import {
+  Address
+} from "../../utils/types";
+import {
+  DEPOSIT_ATTESTORS_TAG,
+  encodeDepositAttestors,
+} from "../../utils/unifiedVerifierUtils";
+
+import {
+  MULTI_SIG,
+  MULTI_WITNESS_ADDRESSES,
+  MULTI_WITNESS_THRESHOLD,
+} from "../../deployments/parameters";
+import { getDeployedContractAddress } from "../../deployments/helpers";
+import { N26_PROVIDER_CONFIG } from "../../deployments/verifiers/n26";
+import { LUXON_PROVIDER_CONFIG } from "../../deployments/verifiers/luxon";
+
+const expect = getWaffleExpect();
+
+describe("Deposit Attestor Wiring", () => {
+  let deployer: Account;
+  let additionalAttestor: Account;
+  let multiSig: Address;
+
+  let multiAttestationVerifier: MultiAttestationVerifier;
+  let unifiedPaymentVerifierV2: UnifiedPaymentVerifier;
+  let nullifierRegistry: NullifierRegistry;
+  let paymentVerifierRegistry: PaymentVerifierRegistry;
+
+  const network: string = deployments.getNetworkName();
+
+  before(async () => {
+    [deployer, additionalAttestor] = await getAccounts();
+    multiSig = MULTI_SIG[network] ? MULTI_SIG[network] : deployer.address;
+
+    const multiAttestationVerifierAddress = getDeployedContractAddress(network, "MultiAttestationVerifier");
+    multiAttestationVerifier = new MultiAttestationVerifier__factory(deployer.wallet).attach(multiAttestationVerifierAddress);
+
+    // UnifiedPaymentVerifierV2 shares the base verifier ABI with UnifiedPaymentVerifier,
+    // so we attach the V1 typechain factory — same pattern used by test/deploy/14_v2System.spec.ts.
+    const upvV2Address = getDeployedContractAddress(network, "UnifiedPaymentVerifierV2");
+    unifiedPaymentVerifierV2 = new UnifiedPaymentVerifier__factory(deployer.wallet).attach(upvV2Address);
+
+    const nullifierRegistryAddress = getDeployedContractAddress(network, "NullifierRegistry");
+    nullifierRegistry = new NullifierRegistry__factory(deployer.wallet).attach(nullifierRegistryAddress);
+
+    const paymentVerifierRegistryAddress = getDeployedContractAddress(network, "PaymentVerifierRegistry");
+    paymentVerifierRegistry = new PaymentVerifierRegistry__factory(deployer.wallet).attach(paymentVerifierRegistryAddress);
+  });
+
+  describe("MultiAttestationVerifier deposit attestors", async () => {
+    it("should expose the deposit attestors tag used by clients", async () => {
+      const actualTag = await multiAttestationVerifier.DEPOSIT_ATTESTORS_TAG();
+      expect(actualTag).to.eq(DEPOSIT_ATTESTORS_TAG);
+    });
+
+    it("should resolve empty deposit data to the configured witness set", async () => {
+      const [attestors, threshold] = await multiAttestationVerifier.resolveAttestors("0x");
+
+      const expectedWitnesses = MULTI_WITNESS_ADDRESSES[network].map((w) => w.toLowerCase());
+      expect(attestors.map((a) => a.toLowerCase())).to.have.members(expectedWitnesses);
+      expect(threshold.toNumber()).to.eq(MULTI_WITNESS_THRESHOLD[network]);
+    });
+
+    it("should resolve tagged deposit data to the witness set plus depositor attestors", async () => {
+      const depositAttestorsData = encodeDepositAttestors(
+        [additionalAttestor.address],
+        MULTI_WITNESS_THRESHOLD[network]
+      );
+
+      const [attestors, threshold] = await multiAttestationVerifier.resolveAttestors(depositAttestorsData);
+
+      const expectedAttestors = [
+        ...MULTI_WITNESS_ADDRESSES[network],
+        additionalAttestor.address,
+      ].map((attestor) => attestor.toLowerCase());
+      expect(attestors.map((attestor) => attestor.toLowerCase())).to.deep.eq(expectedAttestors);
+      expect(threshold.toNumber()).to.eq(MULTI_WITNESS_THRESHOLD[network]);
+    });
+  });
+
+  describe("UnifiedPaymentVerifierV2 wiring", async () => {
+    it("should point at the MultiAttestationVerifier", async () => {
+      const actualAttestationVerifier = await unifiedPaymentVerifierV2.attestationVerifier();
+      expect(actualAttestationVerifier).to.eq(multiAttestationVerifier.address);
+    });
+
+    it("should have write permission on the NullifierRegistry", async () => {
+      expect(await nullifierRegistry.isWriter(unifiedPaymentVerifierV2.address)).to.be.true;
+    });
+
+    it("should be the registered verifier for every payment method", async () => {
+      const paymentMethods = await paymentVerifierRegistry.getPaymentMethods();
+      expect(paymentMethods.length).to.be.gt(0);
+
+      for (const paymentMethod of paymentMethods) {
+        const actualVerifier = await paymentVerifierRegistry.getVerifier(paymentMethod);
+        expect(actualVerifier).to.eq(unifiedPaymentVerifierV2.address);
+      }
+    });
+
+    it("should configure the new verifier for every registered payment method", async () => {
+      const registryPaymentMethods = await paymentVerifierRegistry.getPaymentMethods();
+      const verifierPaymentMethods = await unifiedPaymentVerifierV2.getPaymentMethods();
+
+      expect(verifierPaymentMethods.map((m) => m.toLowerCase())).to.include.members(
+        registryPaymentMethods.map((m) => m.toLowerCase())
+      );
+    });
+
+    it("should remove deprecated payment methods from the registry", async () => {
+      expect(await paymentVerifierRegistry.isPaymentMethod(N26_PROVIDER_CONFIG.paymentMethodHash)).to.be.false;
+      expect(await paymentVerifierRegistry.isPaymentMethod(LUXON_PROVIDER_CONFIG.paymentMethodHash)).to.be.false;
+    });
+
+    it("should have ownership transferred to the multisig", async () => {
+      const actualOwner = await unifiedPaymentVerifierV2.owner();
+      expect(actualOwner).to.eq(multiSig);
+    });
+  });
+});

--- a/test/unifiedVerifier/MultiAttestationVerifier.spec.ts
+++ b/test/unifiedVerifier/MultiAttestationVerifier.spec.ts
@@ -9,6 +9,7 @@ import {
 } from "@utils/test";
 import { ADDRESS_ZERO } from "@utils/constants";
 import { Account } from "@utils/test/types";
+import { DEPOSIT_ATTESTORS_TAG, encodeDepositAttestors } from "@utils/unifiedVerifierUtils";
 import { MultiAttestationVerifier } from "../../typechain";
 
 const expect = getWaffleExpect();
@@ -68,7 +69,7 @@ describe("MultiAttestationVerifier", () => {
     return verifier as MultiAttestationVerifier;
   }
 
-  async function signWitness(
+  async function signAttestor(
     signer: Account,
     hashToSign?: string
   ): Promise<string> {
@@ -99,7 +100,7 @@ describe("MultiAttestationVerifier", () => {
     describe("when deployed with one witness and threshold 1", () => {
       beforeEach(async () => {
         multiAttestationVerifier = baseMultiAttestationVerifier;
-        subjectSignatures = [await signWitness(witnessA)];
+        subjectSignatures = [await signAttestor(witnessA)];
       });
 
       it("should return true with a valid signature from that witness", async () => {
@@ -119,7 +120,7 @@ describe("MultiAttestationVerifier", () => {
 
       describe("when witness A signs the digest", () => {
         beforeEach(async () => {
-          subjectSignatures = [await signWitness(witnessA)];
+          subjectSignatures = [await signAttestor(witnessA)];
         });
 
         it("should return true", async () => {
@@ -131,7 +132,7 @@ describe("MultiAttestationVerifier", () => {
 
       describe("when witness B signs the digest", () => {
         beforeEach(async () => {
-          subjectSignatures = [await signWitness(witnessB)];
+          subjectSignatures = [await signAttestor(witnessB)];
         });
 
         it("should return true", async () => {
@@ -143,7 +144,7 @@ describe("MultiAttestationVerifier", () => {
 
       describe("when a non-witness signs the digest", () => {
         beforeEach(async () => {
-          subjectSignatures = [await signWitness(otherAccount)];
+          subjectSignatures = [await signAttestor(otherAccount)];
         });
 
         it("should revert", async () => {
@@ -153,9 +154,9 @@ describe("MultiAttestationVerifier", () => {
         });
       });
 
-      describe("when the same witness signature is passed twice", () => {
+      describe("when the witness signature is passed twice", () => {
         beforeEach(async () => {
-          const duplicateSignature = await signWitness(witnessA);
+          const duplicateSignature = await signAttestor(witnessA);
           subjectSignatures = [duplicateSignature, duplicateSignature];
         });
 
@@ -178,8 +179,8 @@ describe("MultiAttestationVerifier", () => {
       describe("when witness A and witness B sign the digest", () => {
         beforeEach(async () => {
           subjectSignatures = [
-            await signWitness(witnessA),
-            await signWitness(witnessB),
+            await signAttestor(witnessA),
+            await signAttestor(witnessB),
           ];
         });
 
@@ -190,9 +191,9 @@ describe("MultiAttestationVerifier", () => {
         });
       });
 
-      describe("when the same witness signs twice", () => {
+      describe("when the witness signs twice", () => {
         beforeEach(async () => {
-          const duplicateSignature = await signWitness(witnessA);
+          const duplicateSignature = await signAttestor(witnessA);
           subjectSignatures = [duplicateSignature, duplicateSignature];
         });
 
@@ -211,7 +212,7 @@ describe("MultiAttestationVerifier", () => {
           3
         );
 
-        const duplicateSignature = await signWitness(witnessA);
+        const duplicateSignature = await signAttestor(witnessA);
         subjectSignatures = [
           duplicateSignature,
           duplicateSignature,
@@ -223,6 +224,308 @@ describe("MultiAttestationVerifier", () => {
         await expect(subject()).to.be.revertedWith(
           "ThresholdSigVerifierUtils: Not enough valid witness signatures"
         );
+      });
+    });
+
+    describe("when the data carries deposit attestors", () => {
+      let customAttestorA: Account;
+      let customAttestorB: Account;
+
+      beforeEach(async () => {
+        customAttestorA = otherAccount;
+        customAttestorB = nonOwner;
+
+        multiAttestationVerifier = await deployVerifier(
+          [witnessA.address, witnessB.address],
+          1
+        );
+        subjectData = encodeDepositAttestors([customAttestorA.address], 1);
+      });
+
+      describe("when the custom attestor signs the digest", () => {
+        beforeEach(async () => {
+          subjectSignatures = [await signAttestor(customAttestorA)];
+        });
+
+        it("should return true even though the signer is not a witness", async () => {
+          const result = await subject();
+
+          expect(result).to.equal(true);
+        });
+      });
+
+      describe("when only a witness signs the digest", () => {
+        beforeEach(async () => {
+          subjectSignatures = [await signAttestor(witnessA)];
+        });
+
+        it("should return true because deposit attestors append to the witness set", async () => {
+          const result = await subject();
+
+          expect(result).to.equal(true);
+        });
+      });
+
+      describe("when deposit data requires 2-of-4 combined attestors", () => {
+        beforeEach(() => {
+          subjectData = encodeDepositAttestors(
+            [customAttestorA.address, customAttestorB.address],
+            2
+          );
+        });
+
+        describe("when both custom attestors sign", () => {
+          beforeEach(async () => {
+            subjectSignatures = [
+              await signAttestor(customAttestorA),
+              await signAttestor(customAttestorB),
+            ];
+          });
+
+          it("should return true", async () => {
+            const result = await subject();
+
+            expect(result).to.equal(true);
+          });
+        });
+
+        describe("when a witness and one custom attestor sign", () => {
+          beforeEach(async () => {
+            subjectSignatures = [
+              await signAttestor(customAttestorA),
+              await signAttestor(witnessA),
+            ];
+          });
+
+          it("should return true", async () => {
+            const result = await subject();
+
+            expect(result).to.equal(true);
+          });
+        });
+
+        describe("when only one custom attestor signs", () => {
+          beforeEach(async () => {
+            subjectSignatures = [await signAttestor(customAttestorA)];
+          });
+
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith(
+              "ThresholdSigVerifierUtils: req threshold exceeds signatures"
+            );
+          });
+        });
+      });
+
+      describe("when deposit data includes a witness explicitly", () => {
+        beforeEach(async () => {
+          subjectData = encodeDepositAttestors(
+            [customAttestorA.address, witnessA.address],
+            1
+          );
+          subjectSignatures = [await signAttestor(witnessA)];
+        });
+
+        it("should revert because witnesses are already included by default", async () => {
+          await expect(subject()).to.be.revertedWith("MAV: duplicate deposit attestor");
+        });
+      });
+
+      describe("when deposit data has no attestors", () => {
+        beforeEach(async () => {
+          subjectData = encodeDepositAttestors([], 1);
+          subjectSignatures = [await signAttestor(witnessA)];
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("MAV: empty deposit attestors");
+        });
+      });
+
+      describe("when deposit data exceeds the max attestor count", () => {
+        beforeEach(async () => {
+          const maxDepositAttestors = await multiAttestationVerifier.MAX_DEPOSIT_ATTESTORS();
+          const attestors = Array.from({ length: maxDepositAttestors.toNumber() + 1 }, (_, index) =>
+            ethers.utils.getAddress(
+              ethers.utils.hexZeroPad(ethers.utils.hexlify(index + 1), 20)
+            )
+          );
+          subjectData = encodeDepositAttestors(attestors, 1);
+          subjectSignatures = [await signAttestor(customAttestorA)];
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("MAV: too many deposit attestors");
+        });
+      });
+
+      describe("when deposit data threshold is zero", () => {
+        beforeEach(async () => {
+          subjectData = encodeDepositAttestors([customAttestorA.address], 0);
+          subjectSignatures = [await signAttestor(customAttestorA)];
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("MAV: deposit threshold must be > 0");
+        });
+      });
+
+      describe("when deposit data threshold exceeds the attestor count", () => {
+        beforeEach(async () => {
+          subjectData = encodeDepositAttestors([customAttestorA.address], 4);
+          subjectSignatures = [await signAttestor(customAttestorA)];
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("MAV: deposit threshold exceeds count");
+        });
+      });
+
+      describe("when deposit data contains the zero address", () => {
+        beforeEach(async () => {
+          subjectData = encodeDepositAttestors([customAttestorA.address, ADDRESS_ZERO], 1);
+          subjectSignatures = [await signAttestor(customAttestorA)];
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("MAV: zero deposit attestor");
+        });
+      });
+
+      describe("when deposit data contains a duplicate attestor", () => {
+        beforeEach(async () => {
+          subjectData = encodeDepositAttestors(
+            [customAttestorA.address, customAttestorA.address],
+            1
+          );
+          subjectSignatures = [await signAttestor(customAttestorA)];
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("MAV: duplicate deposit attestor");
+        });
+      });
+
+      describe("when the data is tagged but malformed", () => {
+        beforeEach(async () => {
+          subjectData = DEPOSIT_ATTESTORS_TAG; // tag only, no attestor payload
+          subjectSignatures = [await signAttestor(witnessA)];
+        });
+
+        it("should revert instead of falling back to the witness set", async () => {
+          await expect(subject()).to.be.reverted;
+        });
+      });
+    });
+
+    describe("when the data is non-empty and untagged", () => {
+      beforeEach(async () => {
+        multiAttestationVerifier = await deployVerifier(
+          [witnessA.address, witnessB.address],
+          1
+        );
+        subjectSignatures = [await signAttestor(witnessA)];
+      });
+
+      describe("when the data is a legacy bare address array", () => {
+        beforeEach(() => {
+          subjectData = ethers.utils.defaultAbiCoder.encode(
+            ["address[]"],
+            [[otherAccount.address]]
+          );
+        });
+
+        it("should revert instead of falling back to the witness set", async () => {
+          await expect(subject()).to.be.revertedWith("MAV: invalid deposit attestors tag");
+        });
+      });
+
+      describe("when the data is shorter than 32 bytes", () => {
+        beforeEach(() => {
+          subjectData = "0x1234";
+        });
+
+        it("should revert instead of falling back to the witness set", async () => {
+          await expect(subject()).to.be.revertedWith("MAV: invalid deposit attestors tag");
+        });
+      });
+
+      describe("when the data is 32+ bytes of non-tag content", () => {
+        beforeEach(() => {
+          subjectData = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("unrelated"));
+        });
+
+        it("should revert instead of falling back to the witness set", async () => {
+          await expect(subject()).to.be.revertedWith("MAV: invalid deposit attestors tag");
+        });
+      });
+    });
+  });
+
+  describe("#resolveAttestors", () => {
+    let subjectData: string;
+
+    beforeEach(async () => {
+      multiAttestationVerifier = await deployVerifier(
+        [witnessA.address, witnessB.address],
+        2
+      );
+      subjectData = "0x";
+    });
+
+    async function subject(): Promise<[string[], any]> {
+      return multiAttestationVerifier.resolveAttestors(subjectData);
+    }
+
+    it("should expose the tag constant used by integrators", async () => {
+      expect(await multiAttestationVerifier.DEPOSIT_ATTESTORS_TAG()).to.equal(
+        DEPOSIT_ATTESTORS_TAG
+      );
+    });
+
+    describe("when the data is empty", () => {
+      it("should return the witness set and threshold", async () => {
+        const [attestors, threshold] = await subject();
+
+        expect(attestors).to.have.deep.members([witnessA.address, witnessB.address]);
+        expect(threshold).to.equal(2);
+      });
+    });
+
+    describe("when the data carries deposit attestors", () => {
+      beforeEach(() => {
+        subjectData = encodeDepositAttestors([otherAccount.address], 2);
+      });
+
+      it("should return the witness set plus deposit attestors and threshold", async () => {
+        const [attestors, threshold] = await subject();
+
+        expect(attestors).to.deep.equal([
+          witnessA.address,
+          witnessB.address,
+          otherAccount.address,
+        ]);
+        expect(threshold).to.equal(2);
+      });
+    });
+
+    describe("when the deposit threshold is below the default threshold", () => {
+      beforeEach(() => {
+        subjectData = encodeDepositAttestors([otherAccount.address], 1);
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("MAV: deposit threshold below default");
+      });
+    });
+
+    describe("when the data is non-empty and untagged", () => {
+      beforeEach(() => {
+        subjectData = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("unrelated"));
+      });
+
+      it("should revert instead of returning the witness set", async () => {
+        await expect(subject()).to.be.revertedWith("MAV: invalid deposit attestors tag");
       });
     });
   });

--- a/test/unifiedVerifier/unifiedPaymentVerifierV2.spec.ts
+++ b/test/unifiedVerifier/unifiedPaymentVerifierV2.spec.ts
@@ -18,7 +18,8 @@ import {
   UnifiedPaymentVerifier,
   USDCMock,
 } from "@utils/contracts";
-import { buildUnifiedPaymentProof } from "@utils/unifiedVerifierUtils";
+import { MultiAttestationVerifier } from "../../typechain";
+import { buildUnifiedPaymentProof, encodeDepositAttestors } from "@utils/unifiedVerifierUtils";
 import { Currency } from "@utils/protocolUtils";
 import { ADDRESS_ZERO, EMPTY_ORACLE_RATE_CONFIG, ONE, ZERO } from "@utils/constants";
 
@@ -31,6 +32,8 @@ describe("UnifiedPaymentVerifierV2 Compatibility", () => {
   let maker: Account;
   let taker: Account;
   let witness: Account;
+  let customAttestor: Account;
+  let taker2: Account;
 
   let deployer: DeployHelper;
 
@@ -54,7 +57,7 @@ describe("UnifiedPaymentVerifierV2 Compatibility", () => {
   let currency: BytesLike;
 
   beforeEach(async () => {
-    [owner, attacker, maker, taker, witness] = await getAccounts();
+    [owner, attacker, maker, taker, witness, customAttestor, taker2] = await getAccounts();
     deployer = new DeployHelper(owner.wallet);
 
     usdcToken = await deployer.deployUSDCMock(ethers.utils.parseUnits("1000000", 6), "USDC", "USDC");
@@ -200,5 +203,260 @@ describe("UnifiedPaymentVerifierV2 Compatibility", () => {
 
     const takerBalanceAfter = await usdcToken.balanceOf(taker.address);
     expect(takerBalanceAfter.sub(takerBalanceBefore)).to.eq(intentAmount);
+  });
+
+  describe("when the attestation verifier is MultiAttestationVerifier", () => {
+    let multiAttestationVerifier: MultiAttestationVerifier;
+
+    beforeEach(async () => {
+      const verifierFactory = await ethers.getContractFactory("MultiAttestationVerifier", owner.wallet);
+      multiAttestationVerifier = (await verifierFactory.deploy([witness.address], 1)) as MultiAttestationVerifier;
+      await multiAttestationVerifier.deployed();
+
+      await verifier.connect(owner.wallet).setAttestationVerifier(multiAttestationVerifier.address);
+    });
+
+    async function buildProofForIntent(
+      targetIntentHash: string,
+      signers: Account[],
+    ): Promise<string> {
+      const intent = await orchestrator.getIntent(targetIntentHash);
+      const paymentTimestamp = BigNumber.from((await ethers.provider.getBlock("latest")).timestamp).mul(1000);
+      const paymentId = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(`payment-${targetIntentHash}`));
+
+      const builtProof = await buildUnifiedPaymentProof({
+        verifier: verifier.address,
+        witness,
+        chainId,
+        attestationSigners: signers,
+        paymentPaymentMethod: paymentMethod,
+        paymentPayeeId: payeeId,
+        paymentAmount: intent.amount,
+        paymentCurrency: currency,
+        paymentTimestamp,
+        paymentPaymentId: paymentId,
+        attestationIntentHash: targetIntentHash,
+        attestationReleaseAmount: intent.amount,
+        snapshotIntentHash: targetIntentHash,
+        snapshotIntentAmount: intent.amount,
+        snapshotIntentPaymentMethod: paymentMethod,
+        snapshotIntentFiatCurrency: currency,
+        snapshotIntentPayeeDetails: payeeId,
+        snapshotIntentConversionRate: intent.conversionRate,
+        snapshotIntentSignalTimestamp: intent.timestamp,
+        snapshotIntentTimestampBuffer: ZERO,
+        intentDepositId: intent.depositId,
+        intentEscrow: escrow.address,
+        intentTo: taker.address,
+      });
+
+      return builtProof.paymentProof as string;
+    }
+
+    async function fulfill(targetIntentHash: string, paymentProof: string): Promise<any> {
+      return orchestrator.connect(attacker.wallet).fulfillIntent({
+        paymentProof,
+        intentHash: targetIntentHash,
+        verificationData: ZERO_BYTES,
+        postIntentHookData: ZERO_BYTES,
+      });
+    }
+
+    it("fulfills a deposit without deposit attestors using the witness", async () => {
+      const paymentProof = await buildProofForIntent(intentHash as string, [witness]);
+
+      const takerBalanceBefore = await usdcToken.balanceOf(taker.address);
+      await fulfill(intentHash as string, paymentProof);
+      const takerBalanceAfter = await usdcToken.balanceOf(taker.address);
+
+      expect(takerBalanceAfter.sub(takerBalanceBefore)).to.eq(intentAmount);
+    });
+
+    it("rejects non-empty untagged deposit verifier data instead of falling back", async () => {
+      await escrow.connect(maker.wallet).createDeposit({
+        token: usdcToken.address,
+        amount: ethers.utils.parseUnits("500", 6),
+        intentAmountRange: { min: ethers.utils.parseUnits("10", 6), max: ethers.utils.parseUnits("200", 6) },
+        paymentMethods: [paymentMethod],
+        paymentMethodData: [{
+          intentGatingService: ADDRESS_ZERO,
+          payeeDetails: payeeId,
+          data: "0x1234",
+        }],
+        currencies: [[{ code: currency, minConversionRate: conversionRate, oracleRateConfig: EMPTY_ORACLE_RATE_CONFIG }]],
+        delegate: ADDRESS_ZERO,
+        intentGuardian: ADDRESS_ZERO,
+        retainOnEmpty: false,
+      });
+
+      const signalTx = await orchestrator.connect(taker2.wallet).signalIntent({
+        escrow: escrow.address,
+        depositId: ONE,
+        amount: intentAmount,
+        to: taker2.address,
+        paymentMethod,
+        fiatCurrency: currency,
+        conversionRate,
+        referralFees: [],
+        gatingServiceSignature: ZERO_BYTES,
+        signatureExpiration: ZERO,
+        postIntentHook: ADDRESS_ZERO,
+        preIntentHookData: ZERO_BYTES,
+        data: ZERO_BYTES,
+      });
+      const signalReceipt = await signalTx.wait();
+      const intentSignaledEvent = signalReceipt.events?.find((event: any) => event.event === "IntentSignaled");
+      const untaggedIntentHash = intentSignaledEvent?.args?.intentHash;
+      const paymentProof = await buildProofForIntent(untaggedIntentHash, [witness]);
+
+      await expect(fulfill(untaggedIntentHash, paymentProof)).to.be.revertedWith(
+        "MAV: invalid deposit attestors tag"
+      );
+    });
+
+    describe("when the deposit specifies deposit attestors", () => {
+      let depositAttestorsIntentHash: string;
+
+      beforeEach(async () => {
+        await escrow.connect(maker.wallet).createDeposit({
+          token: usdcToken.address,
+          amount: ethers.utils.parseUnits("500", 6),
+          intentAmountRange: { min: ethers.utils.parseUnits("10", 6), max: ethers.utils.parseUnits("200", 6) },
+          paymentMethods: [paymentMethod],
+          paymentMethodData: [{
+            intentGatingService: ADDRESS_ZERO,
+            payeeDetails: payeeId,
+            data: encodeDepositAttestors([customAttestor.address], 1),
+          }],
+          currencies: [[{ code: currency, minConversionRate: conversionRate, oracleRateConfig: EMPTY_ORACLE_RATE_CONFIG }]],
+          delegate: ADDRESS_ZERO,
+          intentGuardian: ADDRESS_ZERO,
+          retainOnEmpty: false,
+        });
+
+        const signalTx = await orchestrator.connect(taker2.wallet).signalIntent({
+          escrow: escrow.address,
+          depositId: ONE,
+          amount: intentAmount,
+          to: taker2.address,
+          paymentMethod,
+          fiatCurrency: currency,
+          conversionRate,
+          referralFees: [],
+          gatingServiceSignature: ZERO_BYTES,
+          signatureExpiration: ZERO,
+          postIntentHook: ADDRESS_ZERO,
+          preIntentHookData: ZERO_BYTES,
+          data: ZERO_BYTES,
+        });
+
+        const signalReceipt = await signalTx.wait();
+        const intentSignaledEvent = signalReceipt.events?.find((event: any) => event.event === "IntentSignaled");
+        depositAttestorsIntentHash = intentSignaledEvent?.args?.intentHash;
+      });
+
+      it("fulfills with an attestation signed by the depositor's custom attestor", async () => {
+        const paymentProof = await buildProofForIntent(depositAttestorsIntentHash, [customAttestor]);
+
+        const takerBalanceBefore = await usdcToken.balanceOf(taker2.address);
+        await fulfill(depositAttestorsIntentHash, paymentProof);
+        const takerBalanceAfter = await usdcToken.balanceOf(taker2.address);
+
+        expect(takerBalanceAfter.sub(takerBalanceBefore)).to.eq(intentAmount);
+      });
+
+      it("fulfills with an attestation signed only by the witness", async () => {
+        const paymentProof = await buildProofForIntent(depositAttestorsIntentHash, [witness]);
+
+        const takerBalanceBefore = await usdcToken.balanceOf(taker2.address);
+        await fulfill(depositAttestorsIntentHash, paymentProof);
+        const takerBalanceAfter = await usdcToken.balanceOf(taker2.address);
+
+        expect(takerBalanceAfter.sub(takerBalanceBefore)).to.eq(intentAmount);
+      });
+
+      it("fulfills with an attestation signed by the witness and custom attestor", async () => {
+        const paymentProof = await buildProofForIntent(depositAttestorsIntentHash, [witness, customAttestor]);
+
+        const takerBalanceBefore = await usdcToken.balanceOf(taker2.address);
+        await fulfill(depositAttestorsIntentHash, paymentProof);
+        const takerBalanceAfter = await usdcToken.balanceOf(taker2.address);
+
+        expect(takerBalanceAfter.sub(takerBalanceBefore)).to.eq(intentAmount);
+      });
+
+      it("still fulfills the deposit without deposit attestors using the witness", async () => {
+        const paymentProof = await buildProofForIntent(intentHash as string, [witness]);
+
+        const takerBalanceBefore = await usdcToken.balanceOf(taker.address);
+        await fulfill(intentHash as string, paymentProof);
+        const takerBalanceAfter = await usdcToken.balanceOf(taker.address);
+
+        expect(takerBalanceAfter.sub(takerBalanceBefore)).to.eq(intentAmount);
+      });
+    });
+
+    describe("when the deposit requires 2-of-2 combined attestors", () => {
+      let thresholdIntentHash: string;
+
+      beforeEach(async () => {
+        await usdcToken.transfer(maker.address, ethers.utils.parseUnits("500", 6));
+        await usdcToken.connect(maker.wallet).approve(escrow.address, ethers.utils.parseUnits("500", 6));
+
+        await escrow.connect(maker.wallet).createDeposit({
+          token: usdcToken.address,
+          amount: ethers.utils.parseUnits("500", 6),
+          intentAmountRange: { min: ethers.utils.parseUnits("10", 6), max: ethers.utils.parseUnits("200", 6) },
+          paymentMethods: [paymentMethod],
+          paymentMethodData: [{
+            intentGatingService: ADDRESS_ZERO,
+            payeeDetails: payeeId,
+            data: encodeDepositAttestors([customAttestor.address], 2),
+          }],
+          currencies: [[{ code: currency, minConversionRate: conversionRate, oracleRateConfig: EMPTY_ORACLE_RATE_CONFIG }]],
+          delegate: ADDRESS_ZERO,
+          intentGuardian: ADDRESS_ZERO,
+          retainOnEmpty: false,
+        });
+
+        const signalTx = await orchestrator.connect(taker2.wallet).signalIntent({
+          escrow: escrow.address,
+          depositId: ONE,
+          amount: intentAmount,
+          to: taker2.address,
+          paymentMethod,
+          fiatCurrency: currency,
+          conversionRate,
+          referralFees: [],
+          gatingServiceSignature: ZERO_BYTES,
+          signatureExpiration: ZERO,
+          postIntentHook: ADDRESS_ZERO,
+          preIntentHookData: ZERO_BYTES,
+          data: ZERO_BYTES,
+        });
+
+        const signalReceipt = await signalTx.wait();
+        const intentSignaledEvent = signalReceipt.events?.find((event: any) => event.event === "IntentSignaled");
+        thresholdIntentHash = intentSignaledEvent?.args?.intentHash;
+      });
+
+      it("fulfills when the witness and custom attestor sign", async () => {
+        const paymentProof = await buildProofForIntent(thresholdIntentHash, [customAttestor, witness]);
+
+        const takerBalanceBefore = await usdcToken.balanceOf(taker2.address);
+        await fulfill(thresholdIntentHash, paymentProof);
+        const takerBalanceAfter = await usdcToken.balanceOf(taker2.address);
+
+        expect(takerBalanceAfter.sub(takerBalanceBefore)).to.eq(intentAmount);
+      });
+
+      it("rejects when only one attestor signs", async () => {
+        const paymentProof = await buildProofForIntent(thresholdIntentHash, [customAttestor]);
+
+        await expect(fulfill(thresholdIntentHash, paymentProof)).to.be.revertedWith(
+          "ThresholdSigVerifierUtils: req threshold exceeds signatures"
+        );
+      });
+    });
   });
 });

--- a/utils/protocolUtils.ts
+++ b/utils/protocolUtils.ts
@@ -11,6 +11,23 @@ export const getKeccak256Hash = (value: string): string => {
   return ethers.utils.keccak256(bytes);
 }
 
+export const DEPOSIT_ATTESTORS_TAG = ethers.utils.keccak256(
+  ethers.utils.toUtf8Bytes("zkp2p.depositAttestors.v1")
+);
+
+export const MAX_DEPOSIT_ATTESTORS = 3;
+
+// Encodes additional attestors appended to the default witness set.
+export const encodeDepositAttestors = (
+  attestors: string[],
+  threshold: BigNumber | number | string,
+): string => {
+  return ethers.utils.defaultAbiCoder.encode(
+    ["bytes32", "address[]", "uint256"],
+    [DEPOSIT_ATTESTORS_TAG, attestors, threshold]
+  );
+}
+
 export const Currency = {
   AED: getKeccak256Hash("AED"),
   ARS: getKeccak256Hash("ARS"),

--- a/utils/unifiedVerifierUtils.ts
+++ b/utils/unifiedVerifierUtils.ts
@@ -100,6 +100,28 @@ export async function createAttestation(
 }
 
 /* -------------------------------------------------------------------------- */
+/* Deposit attestor helpers                                                   */
+/* -------------------------------------------------------------------------- */
+
+// keccak256("zkp2p.depositAttestors.v1"); must match MultiAttestationVerifier.DEPOSIT_ATTESTORS_TAG
+export const DEPOSIT_ATTESTORS_TAG = ethers.utils.keccak256(
+  ethers.utils.toUtf8Bytes("zkp2p.depositAttestors.v1")
+);
+
+// Encodes additional attestors for DepositPaymentMethodData.data.
+// MultiAttestationVerifier appends these to the default witness set, so either
+// defaults or added attestors can satisfy the combined threshold.
+export function encodeDepositAttestors(
+  attestors: Address[],
+  threshold: BigNumber | number
+): string {
+  return ethers.utils.defaultAbiCoder.encode(
+    ["bytes32", "address[]", "uint256"],
+    [DEPOSIT_ATTESTORS_TAG, attestors, threshold]
+  );
+}
+
+/* -------------------------------------------------------------------------- */
 /* New Unified Payment Verifier helpers                                       */
 /* -------------------------------------------------------------------------- */
 
@@ -164,6 +186,7 @@ export interface BuildPaymentProofOverrides {
   attestationData?: BytesLike;
   attestationMetadata?: BytesLike;
   attestationSigner?: Account;
+  attestationSigners?: Account[];
   snapshotIntentHash?: BytesLike;
   snapshotIntentAmount?: BigNumber;
   snapshotIntentPaymentMethod?: BytesLike;
@@ -250,6 +273,7 @@ export async function buildUnifiedPaymentProof({
   paymentTimestamp,
   paymentPaymentId,
   attestationSigner,
+  attestationSigners,
   attestationIntentHash,
   attestationReleaseAmount,
   attestationDataHash,
@@ -299,17 +323,19 @@ export async function buildUnifiedPaymentProof({
   const attReleaseAmount = attestationReleaseAmount ?? paymentDetails.amount;
   const attDataHash = attestationDataHash ?? dataHash;
   const attMetadata = attestationMetadata ?? ZERO_BYTES;
-  const signerAccount = attestationSigner ?? witness;
+  const signerAccounts = attestationSigners ?? [attestationSigner ?? witness];
   const attData = attestationData ?? encodedPaymentDetails;
 
-  const signature = await signUnifiedPaymentAttestation(signerAccount, verifier, {
-    intentHash: attIntentHash,
-    releaseAmount: attReleaseAmount,
-    dataHash: attDataHash,
-    chainId,
-  });
-
-  const signatures = [signature];
+  const signatures = await Promise.all(
+    signerAccounts.map((signerAccount) =>
+      signUnifiedPaymentAttestation(signerAccount, verifier, {
+        intentHash: attIntentHash,
+        releaseAmount: attReleaseAmount,
+        dataHash: attDataHash,
+        chainId,
+      })
+    )
+  );
 
   const paymentProof = ethers.utils.defaultAbiCoder.encode(
     ["tuple(bytes32,uint256,bytes32,bytes[],bytes,bytes)"],


### PR DESCRIPTION
## Summary
- Add tagged per-deposit attestor configuration for `MultiAttestationVerifier` via `DEPOSIT_ATTESTORS_TAG` and `abi.encode(bytes32,address[],uint256)` data.
- Treat encoded deposit attestors as additional training-rails attestors: tagged data appends them to the default MAV witness set instead of replacing it.
- Cap additional per-deposit attestors at 3, so total resolved attestors are the default witness count plus up to 3 deposit-provided attestors.
- Apply the tagged deposit threshold to the combined default + deposit attestor set, so either defaults or additional attestors can satisfy the threshold.
- Require tagged deposit thresholds to be at least the MAV `requiredSignatures`, so the combined threshold cannot be lower than the default policy.
- Preserve the existing MAV witness governance/query API names for unchanged operations: `addWitness`, `removeWitness`, `setRequiredSignatures`, `witnesses`, `isWitness`, `witnessCount`, and `requiredSignatures`.
- Forward `Escrow` `DepositPaymentMethodData.data` from `UnifiedPaymentVerifier` into the attestation verifier so each deposit can opt into additional attestors.
- Keep empty deposit data temporarily compatible by falling back to the MAV witness set; fail closed for any non-empty untagged data.
- Export client helpers/constants for encoding deposit attestors and generated `MULTI_WITNESS_*` deployment constants.
- Add script 25 to redeploy UPV V2 + MAV and rewire live registry payment methods to the new verifier path.
- Intentionally deprecate N26 and Luxon in script 25: the new UPV migration removes them from `PaymentVerifierRegistry` instead of migrating them.
- Fix generated package ESM exports so `@zkp2p/contracts-v2/utils` and the package root import cleanly in Node ESM.

## Main Baseline / Cap Rationale
- `main` had no deposit-specific attestor data and therefore no per-deposit cap. MAV always verified against the contract-level `witnessesSet` and `requiredSignatures`; the third `verify` calldata argument was ignored.
- Current deployment params remain threshold 1: base is 1-of-1, staging is 1-of-2 with threshold 1. The new cap only bounds additional per-deposit opt-in attestors.
- During the training-rails phase, explicit deposit attestors are additive. A bad or unavailable additional attestor does not block fulfillment when the default witnesses can still meet the combined threshold, and a custom attestor can authorize fulfillment by itself when the configured combined threshold permits it.
- A temporary Foundry gas harness measured MAV-only `verify` after setup at roughly 8.9k gas for 1-of-1, 22.5k for 2-of-2, 41.5k for 3-of-3, 95.4k for 5-of-5, and 323.7k for 10-of-10. The harness was removed after measurement.

## Migration Plan
1. Preflight live registry state before execution: script 25 reads `PaymentVerifierRegistry.getPaymentMethods()`, migrates every non-deprecated method currently pointing at the old UPV V2, preserves each method current on-chain currencies from `getCurrencies()`, and builds a separate deprecation plan for N26/Luxon.
2. Before executing the migration, confirm there are no N26/Luxon obligations that must keep fulfilling. After this cutover, those methods are removed from the registry.
3. Deploy the new `MultiAttestationVerifier` with the current witness set and temporary default threshold, then deploy the new `UnifiedPaymentVerifierV2` pointing at that MAV.
4. Grant the new UPV V2 `NullifierRegistry` writer permission before any registry cutover.
5. Rewire active payment methods from old UPV V2 to new UPV V2. On multisig-owned registries, execute the generated Safe Transaction Builder batch as one atomic batch. Do not split or reorder the remove/add registry transactions.
6. Remove N26 and Luxon from `PaymentVerifierRegistry` in the same migration batch.
7. Remove old UPV V2 `NullifierRegistry` writer permission only after the registry rewire/removal transactions. Script 25 queues this removal last in the Safe batch.
8. After the batch executes, verify every migrated registry method points at the new UPV V2, verify N26/Luxon are absent from the registry, and verify the new UPV V2 has nullifier writer permission.
9. Only then update clients to encode additional deposit attestors with `encodeDepositAttestors([attestor], threshold)` for all new deposits. During this phase, clients should set `threshold` to the default MAV `requiredSignatures` unless they intentionally want a stricter combined-set policy.
10. Existing/open deposits and intents with empty payment method data continue to fulfill through the temporary MAV witness fallback, except deprecated N26/Luxon methods which are intentionally removed.
11. Monitor remaining empty-data deposits. Once that population no longer needs compatibility and clients are ready for attestor-only mode, ship a follow-up hard cut that removes the default witness append/fallback path and requires explicit deposit attestors only.

## Package Export Note
The package export map for `./utils` selects the runtime file by consumer type: `import` and `react-native` use `./_esm/utils/index.js`, `require` uses `./_cjs/utils/index.js`, and `default` is the fallback condition. The bug fixed here was that the advertised ESM entry existed but generated `./_esm/utils/index.js` imported `./protocolUtils` without the `.js` extension, which fails under Node ESM.

## Validation
- `yarn workspace @zkp2p/contracts-v2 build`
- `yarn transpile`
- `npx hardhat test test/unifiedVerifier/MultiAttestationVerifier.spec.ts test/unifiedVerifier/unifiedPaymentVerifierV2.spec.ts` - 54 passing (Node 23 warning)
- `forge test --match-contract MultiAttestationVerifier` - 33 passing (Foundry signature-cache warning after pass)
- `node --input-type=module -e "const u = await import('./packages/contracts/_esm/utils/index.js'); console.log(typeof u.encodeDepositAttestors)"`
- `node --input-type=module -e "const m = await import('./packages/contracts/_esm/index.js'); console.log(m.version)"`
- `node -e "const u = require('./packages/contracts/_cjs/utils/index.js'); console.log(typeof u.encodeDepositAttestors)"`
- `git diff --check`

## Notes
- Existing saved `deployments/base*` MAV artifacts are not refreshed in this PR; they should only change after a real deployment/export refresh.
- Previous deploy scripts/specs are intentionally left alone. N26/Luxon deprecation is scoped to the new script 25 migration.
- Do not enable client-side additional deposit attestor data before the registry cutover is confirmed on-chain, because the old UPV V2 does not honor the new deposit data path.
