### PR TITLE
feat(zelle): Add generic Zelle payment method

### DIFF
--- a/deploy/25_add_generic_zelle_payment_method.ts
+++ b/deploy/25_add_generic_zelle_payment_method.ts
@@ -1,0 +1,116 @@
+import "module-alias/register";
+
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { ethers } from "hardhat";
+
+import {
+  addPaymentMethodToRegistry,
+  addPaymentMethodToUnifiedVerifier,
+  getDeployedContractAddress,
+  removePaymentMethodFromRegistry,
+  removePaymentMethodFromUnifiedVerifier,
+  removePaymentMethodSnapshot,
+  savePaymentMethodSnapshot,
+  waitForDeploymentDelay,
+} from "../deployments/helpers";
+import { LUXON_PROVIDER_CONFIG } from "../deployments/verifiers/luxon";
+import { N26_PROVIDER_CONFIG } from "../deployments/verifiers/n26";
+import { ZELLE_PROVIDER_CONFIG } from "../deployments/verifiers/zelle";
+
+const REMOVED_PAYMENT_METHODS = [
+  { key: "n26", config: N26_PROVIDER_CONFIG },
+  { key: "luxon", config: LUXON_PROVIDER_CONFIG },
+];
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const network = hre.deployments.getNetworkName();
+
+  const legacyVerifierAddress = getDeployedContractAddress(network, "UnifiedPaymentVerifier");
+  const v2VerifierAddress = getDeployedContractAddress(network, "UnifiedPaymentVerifierV2");
+  const paymentVerifierRegistryAddress = getDeployedContractAddress(network, "PaymentVerifierRegistry");
+
+  const legacyVerifierContract = await ethers.getContractAt("UnifiedPaymentVerifier", legacyVerifierAddress);
+  const v2VerifierContract = await ethers.getContractAt("UnifiedPaymentVerifier", v2VerifierAddress);
+  const paymentVerifierRegistryContract = await ethers.getContractAt("PaymentVerifierRegistry", paymentVerifierRegistryAddress);
+
+  console.log("\nConfiguring generic Zelle payment method");
+
+  // New Zelle liquidity uses only the generic zelle hash. The legacy
+  // zelle-citi/chase/bofa hashes remain registered in earlier scripts for
+  // historical fulfillment and drain support only.
+  await addPaymentMethodToUnifiedVerifier(
+    hre,
+    v2VerifierContract,
+    ZELLE_PROVIDER_CONFIG.paymentMethodHash
+  );
+
+  await addPaymentMethodToRegistry(
+    hre,
+    paymentVerifierRegistryContract,
+    ZELLE_PROVIDER_CONFIG.paymentMethodHash,
+    v2VerifierAddress,
+    ZELLE_PROVIDER_CONFIG.currencies
+  );
+
+  savePaymentMethodSnapshot(network, "zelle", {
+    paymentMethodHash: ZELLE_PROVIDER_CONFIG.paymentMethodHash,
+    currencies: ZELLE_PROVIDER_CONFIG.currencies,
+  });
+
+  console.log("Generic Zelle added to PaymentVerifierRegistry with V2 verifier");
+
+  for (const { key, config } of REMOVED_PAYMENT_METHODS) {
+    console.log(`\nRemoving ${key} payment method from verifier surfaces`);
+    await removePaymentMethodFromUnifiedVerifier(hre, legacyVerifierContract, config.paymentMethodHash);
+    await removePaymentMethodFromUnifiedVerifier(hre, v2VerifierContract, config.paymentMethodHash);
+    await removePaymentMethodFromRegistry(hre, paymentVerifierRegistryContract, config.paymentMethodHash);
+    removePaymentMethodSnapshot(network, key);
+  }
+
+  await waitForDeploymentDelay(hre);
+};
+
+func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> => {
+  const network = hre.deployments.getNetworkName();
+
+  try {
+    const legacyVerifierAddress = getDeployedContractAddress(network, "UnifiedPaymentVerifier");
+    const v2VerifierAddress = getDeployedContractAddress(network, "UnifiedPaymentVerifierV2");
+    const paymentVerifierRegistryAddress = getDeployedContractAddress(network, "PaymentVerifierRegistry");
+
+    const legacyVerifierContract = await ethers.getContractAt("UnifiedPaymentVerifier", legacyVerifierAddress);
+    const v2VerifierContract = await ethers.getContractAt("UnifiedPaymentVerifier", v2VerifierAddress);
+    const paymentVerifierRegistryContract = await ethers.getContractAt("PaymentVerifierRegistry", paymentVerifierRegistryAddress);
+
+    const legacyPaymentMethods = await legacyVerifierContract.getPaymentMethods();
+    const paymentMethods = await v2VerifierContract.getPaymentMethods();
+    const inUnifiedVerifier = paymentMethods.includes(ZELLE_PROVIDER_CONFIG.paymentMethodHash);
+    const inRegistry = await paymentVerifierRegistryContract.isPaymentMethod(ZELLE_PROVIDER_CONFIG.paymentMethodHash);
+    const removedMethodsAbsent = await Promise.all(
+      REMOVED_PAYMENT_METHODS.map(async ({ config }) => {
+        const inLegacyUnifiedVerifier = legacyPaymentMethods.includes(config.paymentMethodHash);
+        const inUnifiedVerifier = paymentMethods.includes(config.paymentMethodHash);
+        const inRegistry = await paymentVerifierRegistryContract.isPaymentMethod(config.paymentMethodHash);
+        return !inLegacyUnifiedVerifier && !inUnifiedVerifier && !inRegistry;
+      })
+    );
+
+    if (!inUnifiedVerifier || !inRegistry) {
+      return false;
+    }
+
+    if (removedMethodsAbsent.some((isAbsent) => !isAbsent)) {
+      return false;
+    }
+
+    const verifier = await paymentVerifierRegistryContract.getVerifier(ZELLE_PROVIDER_CONFIG.paymentMethodHash);
+    return verifier.toLowerCase() === v2VerifierAddress.toLowerCase();
+  } catch (e) {
+    return false;
+  }
+};
+
+func.dependencies = ["16_configure_v2_payment_methods"];
+
+export default func;

--- a/deployments/helpers.ts
+++ b/deployments/helpers.ts
@@ -311,6 +311,40 @@ export async function addPaymentMethodToUnifiedVerifier(
   }
 }
 
+export async function removePaymentMethodFromUnifiedVerifier(
+  hre: HardhatRuntimeEnvironment,
+  unifiedVerifierContract: any,
+  paymentMethodHash: string
+): Promise<void> {
+  const currentOwner = await unifiedVerifierContract.owner();
+  const paymentMethods = await unifiedVerifierContract.getPaymentMethods();
+
+  if (paymentMethods.includes(paymentMethodHash)) {
+    if ((await hre.getUnnamedAccounts()).includes(currentOwner)) {
+      console.log(`Removing payment method ${paymentMethodHash} from unified verifier`);
+      const data = unifiedVerifierContract.interface.encodeFunctionData("removePaymentMethod", [
+        paymentMethodHash
+      ]);
+      await sendDeploymentTransaction(hre, {
+        from: currentOwner,
+        to: unifiedVerifierContract.address,
+        data,
+      });
+    } else {
+      const data = unifiedVerifierContract.interface.encodeFunctionData("removePaymentMethod", [
+        paymentMethodHash
+      ]);
+      safeBatchCollector.add(
+        unifiedVerifierContract.address,
+        data,
+        `UnifiedPaymentVerifier.removePaymentMethod(${paymentMethodHash.slice(0, 10)}...)`
+      );
+    }
+  } else {
+    console.log(`Payment method ${paymentMethodHash} not found in unified verifier`);
+  }
+}
+
 export async function addOrchestratorToRegistry(
   hre: HardhatRuntimeEnvironment,
   contract: any,
@@ -459,5 +493,26 @@ export function savePaymentMethodSnapshot(
 
     current.methods[methodKey] = snapshotData;
     fs.writeFileSync(filePath, JSON.stringify(current, null, 2));
+  }
+}
+
+export function removePaymentMethodSnapshot(
+  network: string,
+  methodKey: string
+): void {
+  const providersDir = path.join(__dirname, "outputs", "platforms");
+  const filePath = path.join(providersDir, `${network}.json`);
+
+  let current: any = { methods: {} };
+  try {
+    if (fs.existsSync(filePath)) {
+      current = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    }
+  } catch { }
+
+  if (current.methods?.[methodKey]) {
+    delete current.methods[methodKey];
+    fs.writeFileSync(filePath, JSON.stringify(current, null, 2));
+    console.log(`Removed payment method snapshot from: ${filePath}`);
   }
 }

--- a/deployments/outputs/platforms/base.json
+++ b/deployments/outputs/platforms/base.json
@@ -93,7 +93,7 @@
       "currencies": [
         "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
       ],
-      "updatedAt": "2026-06-22T00:31:56.103Z"
+      "updatedAt": "2026-06-22T02:11:08.890Z"
     },
     "zelle-citi": {
       "paymentMethodHash": "0x817260692b75e93c7fbc51c71637d4075a975e221e1ebc1abeddfabd731fd90d",

--- a/deployments/outputs/platforms/base.json
+++ b/deployments/outputs/platforms/base.json
@@ -88,6 +88,13 @@
       ],
       "updatedAt": "2026-03-16T12:46:01.355Z"
     },
+    "zelle": {
+      "paymentMethodHash": "0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3",
+      "currencies": [
+        "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
+      ],
+      "updatedAt": "2026-06-22T00:31:56.103Z"
+    },
     "zelle-citi": {
       "paymentMethodHash": "0x817260692b75e93c7fbc51c71637d4075a975e221e1ebc1abeddfabd731fd90d",
       "currencies": [
@@ -129,13 +136,6 @@
       ],
       "updatedAt": "2026-03-16T12:47:05.353Z"
     },
-    "n26": {
-      "paymentMethodHash": "0xd9ff4fd6b39a3e3dd43c41d05662a5547de4a878bc97a65bcb352ade493cdc6b",
-      "currencies": [
-        "0xfff16d60be267153303bbfa66e593fb8d06e24ea5ef24b6acca5224c2ca6b907"
-      ],
-      "updatedAt": "2026-03-16T12:47:17.300Z"
-    },
     "alipay": {
       "paymentMethodHash": "0xcac9daea62d7b89d75ac73af4ee14dcf25721012ae82b568c2ea5c808eaa04ff",
       "currencies": [
@@ -149,15 +149,6 @@
         "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
       ],
       "updatedAt": "2026-03-16T12:47:45.525Z"
-    },
-    "luxon": {
-      "paymentMethodHash": "0xaea63ef983458674f54ee50cdaa7b09d80a5c6c03ed505f51c90b0f2b54abb01",
-      "currencies": [
-        "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e",
-        "0xfff16d60be267153303bbfa66e593fb8d06e24ea5ef24b6acca5224c2ca6b907",
-        "0x90832e2dc3221e4d56977c1aa8f6a6706b9ad6542fbbdaac13097d0fa5e42e67"
-      ],
-      "updatedAt": "2026-03-16T12:48:02.216Z"
     }
   }
 }

--- a/deployments/outputs/platforms/base_sepolia.json
+++ b/deployments/outputs/platforms/base_sepolia.json
@@ -72,6 +72,13 @@
       ],
       "updatedAt": "2025-09-30T05:02:59.721Z"
     },
+    "zelle": {
+      "paymentMethodHash": "0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3",
+      "currencies": [
+        "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
+      ],
+      "updatedAt": "2026-06-22T00:31:56.103Z"
+    },
     "zelle-citi": {
       "paymentMethodHash": "0x817260692b75e93c7fbc51c71637d4075a975e221e1ebc1abeddfabd731fd90d",
       "currencies": [

--- a/deployments/outputs/platforms/base_staging.json
+++ b/deployments/outputs/platforms/base_staging.json
@@ -88,6 +88,13 @@
       ],
       "updatedAt": "2026-03-16T12:15:56.855Z"
     },
+    "zelle": {
+      "paymentMethodHash": "0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3",
+      "currencies": [
+        "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
+      ],
+      "updatedAt": "2026-06-22T00:41:48.697Z"
+    },
     "zelle-citi": {
       "paymentMethodHash": "0x817260692b75e93c7fbc51c71637d4075a975e221e1ebc1abeddfabd731fd90d",
       "currencies": [
@@ -129,13 +136,6 @@
       ],
       "updatedAt": "2026-03-16T12:20:37.332Z"
     },
-    "n26": {
-      "paymentMethodHash": "0xd9ff4fd6b39a3e3dd43c41d05662a5547de4a878bc97a65bcb352ade493cdc6b",
-      "currencies": [
-        "0xfff16d60be267153303bbfa66e593fb8d06e24ea5ef24b6acca5224c2ca6b907"
-      ],
-      "updatedAt": "2026-03-16T12:21:31.669Z"
-    },
     "alipay": {
       "paymentMethodHash": "0xcac9daea62d7b89d75ac73af4ee14dcf25721012ae82b568c2ea5c808eaa04ff",
       "currencies": [
@@ -149,15 +149,6 @@
         "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
       ],
       "updatedAt": "2026-03-16T12:23:24.348Z"
-    },
-    "luxon": {
-      "paymentMethodHash": "0xaea63ef983458674f54ee50cdaa7b09d80a5c6c03ed505f51c90b0f2b54abb01",
-      "currencies": [
-        "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e",
-        "0xfff16d60be267153303bbfa66e593fb8d06e24ea5ef24b6acca5224c2ca6b907",
-        "0x90832e2dc3221e4d56977c1aa8f6a6706b9ad6542fbbdaac13097d0fa5e42e67"
-      ],
-      "updatedAt": "2026-03-16T12:24:18.151Z"
     }
   }
 }

--- a/deployments/outputs/platforms/snapshots/base/zelle_2026-06-22T02-11-08.json
+++ b/deployments/outputs/platforms/snapshots/base/zelle_2026-06-22T02-11-08.json
@@ -1,0 +1,7 @@
+{
+  "paymentMethodHash": "0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3",
+  "currencies": [
+    "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
+  ],
+  "updatedAt": "2026-06-22T02:11:08.890Z"
+}

--- a/deployments/outputs/platforms/snapshots/base_staging/zelle_2026-06-22T00-41-48.json
+++ b/deployments/outputs/platforms/snapshots/base_staging/zelle_2026-06-22T00-41-48.json
@@ -1,0 +1,7 @@
+{
+  "paymentMethodHash": "0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3",
+  "currencies": [
+    "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
+  ],
+  "updatedAt": "2026-06-22T00:41:48.697Z"
+}

--- a/deployments/outputs/safe-batches/base_2026-06-22T02-11-17.json
+++ b/deployments/outputs/safe-batches/base_2026-06-22T02-11-17.json
@@ -1,0 +1,70 @@
+{
+  "version": "1.0",
+  "chainId": "8453",
+  "createdAt": 1782094277724,
+  "meta": {
+    "name": "ZKP2P V2 Deployment - base",
+    "description": "Registry wiring and payment method migration for V2 deployment on base",
+    "txBuilderVersion": "1.16.5",
+    "createdFromSafeAddress": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0x46A58Dc65587D4D7B8198C6A25eEdf5b2535Da94",
+      "value": "0",
+      "data": "0x3992eaf6f752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3",
+      "contractMethod": null,
+      "contractInputsValues": null
+    },
+    {
+      "to": "0x2b82D24437ff66Fb173eabDfD67ee2ACeb8bEb1e",
+      "value": "0",
+      "data": "0xdbcb3005f752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd300000000000000000000000046a58dc65587d4d7b8198c6a25eedf5b2535da9400000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000001c4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e",
+      "contractMethod": null,
+      "contractInputsValues": null
+    },
+    {
+      "to": "0x16b3e4a3CA36D3A4bCA281767f15C7ADeF4ab163",
+      "value": "0",
+      "data": "0x334c2ef3d9ff4fd6b39a3e3dd43c41d05662a5547de4a878bc97a65bcb352ade493cdc6b",
+      "contractMethod": null,
+      "contractInputsValues": null
+    },
+    {
+      "to": "0x46A58Dc65587D4D7B8198C6A25eEdf5b2535Da94",
+      "value": "0",
+      "data": "0x334c2ef3d9ff4fd6b39a3e3dd43c41d05662a5547de4a878bc97a65bcb352ade493cdc6b",
+      "contractMethod": null,
+      "contractInputsValues": null
+    },
+    {
+      "to": "0x2b82D24437ff66Fb173eabDfD67ee2ACeb8bEb1e",
+      "value": "0",
+      "data": "0x334c2ef3d9ff4fd6b39a3e3dd43c41d05662a5547de4a878bc97a65bcb352ade493cdc6b",
+      "contractMethod": null,
+      "contractInputsValues": null
+    },
+    {
+      "to": "0x16b3e4a3CA36D3A4bCA281767f15C7ADeF4ab163",
+      "value": "0",
+      "data": "0x334c2ef3aea63ef983458674f54ee50cdaa7b09d80a5c6c03ed505f51c90b0f2b54abb01",
+      "contractMethod": null,
+      "contractInputsValues": null
+    },
+    {
+      "to": "0x46A58Dc65587D4D7B8198C6A25eEdf5b2535Da94",
+      "value": "0",
+      "data": "0x334c2ef3aea63ef983458674f54ee50cdaa7b09d80a5c6c03ed505f51c90b0f2b54abb01",
+      "contractMethod": null,
+      "contractInputsValues": null
+    },
+    {
+      "to": "0x2b82D24437ff66Fb173eabDfD67ee2ACeb8bEb1e",
+      "value": "0",
+      "data": "0x334c2ef3aea63ef983458674f54ee50cdaa7b09d80a5c6c03ed505f51c90b0f2b54abb01",
+      "contractMethod": null,
+      "contractInputsValues": null
+    }
+  ]
+}

--- a/deployments/verifiers/zelle.ts
+++ b/deployments/verifiers/zelle.ts
@@ -6,9 +6,15 @@ export const ZELLE_CURRENCIES: any = [
 ];
 
 // Payment method hashes
+export const ZELLE_PAYMENT_METHOD_HASH = calculatePaymentMethodHash("zelle");
 export const ZELLE_CITI_PAYMENT_METHOD_HASH = calculatePaymentMethodHash("zelle-citi");
 export const ZELLE_CHASE_PAYMENT_METHOD_HASH = calculatePaymentMethodHash("zelle-chase");
 export const ZELLE_BOFA_PAYMENT_METHOD_HASH = calculatePaymentMethodHash("zelle-bofa");
+
+export const ZELLE_PROVIDER_CONFIG = {
+  paymentMethodHash: ZELLE_PAYMENT_METHOD_HASH,
+  currencies: ZELLE_CURRENCIES
+};
 
 export const ZELLE_CITI_PROVIDER_CONFIG = {
   paymentMethodHash: ZELLE_CITI_PAYMENT_METHOD_HASH,

--- a/test/deploy/10_n26PaymentMethod.spec.ts
+++ b/test/deploy/10_n26PaymentMethod.spec.ts
@@ -1,15 +1,13 @@
 import "module-alias/register";
 
-import { deployments, ethers } from "hardhat";
+import { deployments } from "hardhat";
 
 import {
   UnifiedPaymentVerifier,
   PaymentVerifierRegistry,
-  Escrow,
 } from "../../utils/contracts";
 import {
   UnifiedPaymentVerifier__factory,
-  Escrow__factory,
   PaymentVerifierRegistry__factory,
 } from "../../typechain";
 
@@ -20,24 +18,14 @@ import {
 import {
   Account
 } from "../../utils/test/types";
-import {
-  Address
-} from "../../utils/types";
 
-import {
-  MULTI_SIG,
-} from "../../deployments/parameters";
-import { N26_PROVIDER_CONFIG } from "../../deployments/verifiers/n26";
 import { N26_PAYMENT_METHOD_HASH } from "../../deployments/verifiers/n26";
 
 const expect = getWaffleExpect();
 
 describe("N26 Payment Method Configuration", () => {
   let deployer: Account;
-  let multiSig: Address;
-  let escrowAddress: string;
 
-  let escrow: Escrow;
   let unifiedPaymentVerifier: UnifiedPaymentVerifier;
   let paymentVerifierRegistry: PaymentVerifierRegistry;
 
@@ -52,11 +40,6 @@ describe("N26 Payment Method Configuration", () => {
       deployer,
     ] = await getAccounts();
 
-    multiSig = MULTI_SIG[network] ? MULTI_SIG[network] : deployer.address;
-
-    escrowAddress = getDeployedContractAddress(network, "Escrow");
-    escrow = new Escrow__factory(deployer.wallet).attach(escrowAddress);
-
     const paymentVerifierRegistryAddress = getDeployedContractAddress(network, "PaymentVerifierRegistry");
     paymentVerifierRegistry = new PaymentVerifierRegistry__factory(deployer.wallet).attach(paymentVerifierRegistryAddress);
 
@@ -65,28 +48,21 @@ describe("N26 Payment Method Configuration", () => {
   });
 
   describe("Payment Method Registry", async () => {
-    it("should add N26 payment method to the registry", async () => {
+    it("should remove N26 payment method from the registry", async () => {
       const isPaymentMethod = await paymentVerifierRegistry.isPaymentMethod(N26_PAYMENT_METHOD_HASH);
-      expect(isPaymentMethod).to.be.true;
+      expect(isPaymentMethod).to.be.false;
     });
 
-    it("should add N26 currencies to the registry", async () => {
+    it("should remove N26 currencies from the registry", async () => {
       const currencies = await paymentVerifierRegistry.getCurrencies(N26_PAYMENT_METHOD_HASH);
-      expect(currencies).to.deep.eq(N26_PROVIDER_CONFIG.currencies);
-    });
-
-    it("should only support EUR currency for N26", async () => {
-      const currencies = await paymentVerifierRegistry.getCurrencies(N26_PAYMENT_METHOD_HASH);
-      // N26 only supports EUR
-      expect(currencies.length).to.eq(1);
-      expect(currencies[0]).to.eq(N26_PROVIDER_CONFIG.currencies[0]);
+      expect(currencies).to.deep.eq([]);
     });
   });
 
   describe("Unified Verifier Configuration", async () => {
-    it("should add N26 payment method to unified verifier", async () => {
+    it("should remove N26 payment method from unified verifier", async () => {
       const paymentMethods = await unifiedPaymentVerifier.getPaymentMethods();
-      expect(paymentMethods).to.include(N26_PAYMENT_METHOD_HASH);
+      expect(paymentMethods).to.not.include(N26_PAYMENT_METHOD_HASH);
     });
   });
 });

--- a/test/deploy/13_luxonPaymentMethod.spec.ts
+++ b/test/deploy/13_luxonPaymentMethod.spec.ts
@@ -1,15 +1,13 @@
 import "module-alias/register";
 
-import { deployments, ethers } from "hardhat";
+import { deployments } from "hardhat";
 
 import {
   UnifiedPaymentVerifier,
   PaymentVerifierRegistry,
-  Escrow,
 } from "../../utils/contracts";
 import {
   UnifiedPaymentVerifier__factory,
-  Escrow__factory,
   PaymentVerifierRegistry__factory,
 } from "../../typechain";
 
@@ -20,24 +18,14 @@ import {
 import {
   Account
 } from "../../utils/test/types";
-import {
-  Address
-} from "../../utils/types";
 
-import {
-  MULTI_SIG,
-} from "../../deployments/parameters";
-import { LUXON_PROVIDER_CONFIG } from "../../deployments/verifiers/luxon";
 import { LUXON_PAYMENT_METHOD_HASH } from "../../deployments/verifiers/luxon";
 
 const expect = getWaffleExpect();
 
 describe("Luxon Payment Method Configuration", () => {
   let deployer: Account;
-  let multiSig: Address;
-  let escrowAddress: string;
 
-  let escrow: Escrow;
   let unifiedPaymentVerifier: UnifiedPaymentVerifier;
   let paymentVerifierRegistry: PaymentVerifierRegistry;
 
@@ -52,11 +40,6 @@ describe("Luxon Payment Method Configuration", () => {
       deployer,
     ] = await getAccounts();
 
-    multiSig = MULTI_SIG[network] ? MULTI_SIG[network] : deployer.address;
-
-    escrowAddress = getDeployedContractAddress(network, "Escrow");
-    escrow = new Escrow__factory(deployer.wallet).attach(escrowAddress);
-
     const paymentVerifierRegistryAddress = getDeployedContractAddress(network, "PaymentVerifierRegistry");
     paymentVerifierRegistry = new PaymentVerifierRegistry__factory(deployer.wallet).attach(paymentVerifierRegistryAddress);
 
@@ -65,29 +48,21 @@ describe("Luxon Payment Method Configuration", () => {
   });
 
   describe("Payment Method Registry", async () => {
-    it("should add Luxon payment method to the registry", async () => {
+    it("should remove Luxon payment method from the registry", async () => {
       const isPaymentMethod = await paymentVerifierRegistry.isPaymentMethod(LUXON_PAYMENT_METHOD_HASH);
-      expect(isPaymentMethod).to.be.true;
+      expect(isPaymentMethod).to.be.false;
     });
 
-    it("should add Luxon currencies to the registry", async () => {
+    it("should remove Luxon currencies from the registry", async () => {
       const currencies = await paymentVerifierRegistry.getCurrencies(LUXON_PAYMENT_METHOD_HASH);
-      expect(currencies).to.deep.eq(LUXON_PROVIDER_CONFIG.currencies);
-    });
-
-    it("should support USD, EUR, and GBP for Luxon", async () => {
-      const currencies = await paymentVerifierRegistry.getCurrencies(LUXON_PAYMENT_METHOD_HASH);
-      expect(currencies.length).to.eq(3);
-      expect(currencies[0]).to.eq(LUXON_PROVIDER_CONFIG.currencies[0]);
-      expect(currencies[1]).to.eq(LUXON_PROVIDER_CONFIG.currencies[1]);
-      expect(currencies[2]).to.eq(LUXON_PROVIDER_CONFIG.currencies[2]);
+      expect(currencies).to.deep.eq([]);
     });
   });
 
   describe("Unified Verifier Configuration", async () => {
-    it("should add Luxon payment method to unified verifier", async () => {
+    it("should remove Luxon payment method from unified verifier", async () => {
       const paymentMethods = await unifiedPaymentVerifier.getPaymentMethods();
-      expect(paymentMethods).to.include(LUXON_PAYMENT_METHOD_HASH);
+      expect(paymentMethods).to.not.include(LUXON_PAYMENT_METHOD_HASH);
     });
   });
 });

--- a/test/deploy/16_v2PaymentMethods.spec.ts
+++ b/test/deploy/16_v2PaymentMethods.spec.ts
@@ -31,7 +31,6 @@ import {
 } from "../../deployments/verifiers/zelle";
 import { PAYPAL_PROVIDER_CONFIG } from "../../deployments/verifiers/paypal";
 import { MONZO_PROVIDER_CONFIG } from "../../deployments/verifiers/monzo";
-import { N26_PROVIDER_CONFIG } from "../../deployments/verifiers/n26";
 import { ALIPAY_PROVIDER_CONFIG } from "../../deployments/verifiers/alipay";
 import { CHIME_PROVIDER_CONFIG } from "../../deployments/verifiers/chime";
 
@@ -48,7 +47,6 @@ const ALL_PAYMENT_METHODS = [
   { name: "Zelle BofA", config: ZELLE_BOFA_PROVIDER_CONFIG },
   { name: "PayPal", config: PAYPAL_PROVIDER_CONFIG },
   { name: "Monzo", config: MONZO_PROVIDER_CONFIG },
-  { name: "N26", config: N26_PROVIDER_CONFIG },
   { name: "Alipay", config: ALIPAY_PROVIDER_CONFIG },
   { name: "Chime", config: CHIME_PROVIDER_CONFIG },
 ];

--- a/test/deploy/25_genericZellePaymentMethod.spec.ts
+++ b/test/deploy/25_genericZellePaymentMethod.spec.ts
@@ -1,0 +1,111 @@
+import "module-alias/register";
+
+import { deployments } from "hardhat";
+
+import {
+  UnifiedPaymentVerifier,
+  PaymentVerifierRegistry,
+} from "../../utils/contracts";
+import {
+  UnifiedPaymentVerifier__factory,
+  PaymentVerifierRegistry__factory,
+} from "../../typechain";
+
+import {
+  getAccounts,
+  getWaffleExpect,
+} from "../../utils/test";
+import { Account } from "../../utils/test/types";
+
+import {
+  ZELLE_PROVIDER_CONFIG,
+  ZELLE_CITI_PROVIDER_CONFIG,
+  ZELLE_CHASE_PROVIDER_CONFIG,
+  ZELLE_BOFA_PROVIDER_CONFIG,
+} from "../../deployments/verifiers/zelle";
+import { LUXON_PROVIDER_CONFIG } from "../../deployments/verifiers/luxon";
+import { N26_PROVIDER_CONFIG } from "../../deployments/verifiers/n26";
+
+const expect = getWaffleExpect();
+
+const LEGACY_ZELLE_METHODS = [
+  { name: "Zelle Citi", config: ZELLE_CITI_PROVIDER_CONFIG },
+  { name: "Zelle Chase", config: ZELLE_CHASE_PROVIDER_CONFIG },
+  { name: "Zelle BofA", config: ZELLE_BOFA_PROVIDER_CONFIG },
+];
+
+const REMOVED_PAYMENT_METHODS = [
+  { name: "N26", config: N26_PROVIDER_CONFIG },
+  { name: "Luxon", config: LUXON_PROVIDER_CONFIG },
+];
+
+const EXPECTED_ZELLE_PAYMENT_METHOD_HASH = "0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3";
+
+describe("Generic Zelle Payment Method Configuration", () => {
+  let deployer: Account;
+
+  let paymentVerifierRegistry: PaymentVerifierRegistry;
+  let legacyUnifiedPaymentVerifier: UnifiedPaymentVerifier;
+  let unifiedPaymentVerifierV2: UnifiedPaymentVerifier;
+  let v2VerifierAddress: string;
+
+  const network: string = deployments.getNetworkName();
+
+  function getDeployedContractAddress(network: string, contractName: string): string {
+    return require(`../../deployments/${network}/${contractName}.json`).address;
+  }
+
+  before(async () => {
+    [deployer] = await getAccounts();
+
+    const paymentVerifierRegistryAddress = getDeployedContractAddress(network, "PaymentVerifierRegistry");
+    paymentVerifierRegistry = new PaymentVerifierRegistry__factory(deployer.wallet).attach(paymentVerifierRegistryAddress);
+
+    const legacyVerifierAddress = getDeployedContractAddress(network, "UnifiedPaymentVerifier");
+    legacyUnifiedPaymentVerifier = new UnifiedPaymentVerifier__factory(deployer.wallet).attach(legacyVerifierAddress);
+
+    v2VerifierAddress = getDeployedContractAddress(network, "UnifiedPaymentVerifierV2");
+    unifiedPaymentVerifierV2 = new UnifiedPaymentVerifier__factory(deployer.wallet).attach(v2VerifierAddress);
+  });
+
+  it("uses keccak256 zelle as the generic payment method hash", async () => {
+    expect(ZELLE_PROVIDER_CONFIG.paymentMethodHash).to.eq(EXPECTED_ZELLE_PAYMENT_METHOD_HASH);
+  });
+
+  it("registers generic Zelle in PaymentVerifierRegistry with V2 verifier", async () => {
+    const isPaymentMethod = await paymentVerifierRegistry.isPaymentMethod(ZELLE_PROVIDER_CONFIG.paymentMethodHash);
+    const verifier = await paymentVerifierRegistry.getVerifier(ZELLE_PROVIDER_CONFIG.paymentMethodHash);
+    const currencies = await paymentVerifierRegistry.getCurrencies(ZELLE_PROVIDER_CONFIG.paymentMethodHash);
+
+    expect(isPaymentMethod).to.be.true;
+    expect(verifier).to.eq(v2VerifierAddress);
+    expect(currencies).to.deep.eq(ZELLE_PROVIDER_CONFIG.currencies);
+  });
+
+  it("registers generic Zelle in UnifiedPaymentVerifierV2", async () => {
+    const paymentMethods = await unifiedPaymentVerifierV2.getPaymentMethods();
+    expect(paymentMethods).to.include(ZELLE_PROVIDER_CONFIG.paymentMethodHash);
+  });
+
+  for (const { name, config } of LEGACY_ZELLE_METHODS) {
+    it(`keeps ${name} registered for drain support`, async () => {
+      const isPaymentMethod = await paymentVerifierRegistry.isPaymentMethod(config.paymentMethodHash);
+      const paymentMethods = await unifiedPaymentVerifierV2.getPaymentMethods();
+
+      expect(isPaymentMethod).to.be.true;
+      expect(paymentMethods).to.include(config.paymentMethodHash);
+    });
+  }
+
+  for (const { name, config } of REMOVED_PAYMENT_METHODS) {
+    it(`removes ${name} from payment method surfaces`, async () => {
+      const isPaymentMethod = await paymentVerifierRegistry.isPaymentMethod(config.paymentMethodHash);
+      const legacyPaymentMethods = await legacyUnifiedPaymentVerifier.getPaymentMethods();
+      const paymentMethods = await unifiedPaymentVerifierV2.getPaymentMethods();
+
+      expect(isPaymentMethod).to.be.false;
+      expect(legacyPaymentMethods).to.not.include(config.paymentMethodHash);
+      expect(paymentMethods).to.not.include(config.paymentMethodHash);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Add generic `zelle` payment method config using `keccak256("zelle")` / `0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3`.
- Add new append-only deploy script `deploy/25_add_generic_zelle_payment_method.ts` to register generic `zelle` with `UnifiedPaymentVerifierV2` and `PaymentVerifierRegistry`.
- In the same deploy stage, remove `n26` and `luxon` from `PaymentVerifierRegistry`, legacy `UnifiedPaymentVerifier`, `UnifiedPaymentVerifierV2`, and persisted payment-method snapshots.
- Leave previous deploy scripts unchanged; existing `zelle-citi`, `zelle-chase`, and `zelle-bofa` remain registered/exported for historical fulfillment and drain support.
- Update tracked `deployments/outputs/platforms/base*.json` payment-method surfaces so package extraction exposes generic `zelle` and no longer exposes `n26`/`luxon`.

## Hard cutover semantics
- Contracts keep all four Zelle hashes registered during migration so existing bank-specific deposits can still be read, fulfilled, and drained.
- Downstream new-deposit catalogs should expose only generic `zelle` for new Zelle liquidity.
- Legacy bank-specific Zelle hashes are drain-only compatibility and are not for new liquidity.
- `n26` and `luxon` are removed as payment methods in this cutover stage.

## Base staging deploy
- Ran `yarn deploy:base_staging` on June 22, 2026.
- `MultiAttestationVerifier`: `0x9855a39aC5975069632e91160d8712CBfF19e864`.
- Generic `zelle` is registered in `PaymentVerifierRegistry` and points to `UnifiedPaymentVerifierV2` at `0x7750f8Cc276f21B7Db1477FA044Bf3FD4951Bf20`.
- `n26` and `luxon` are absent from `PaymentVerifierRegistry`, legacy `UnifiedPaymentVerifier`, and `UnifiedPaymentVerifierV2`.
- Added the base staging generic Zelle platform snapshot `deployments/outputs/platforms/snapshots/base_staging/zelle_2026-06-22T00-41-48.json`.

## Base production deploy
- Ran `yarn deploy:base` on June 22, 2026.
- The production owner-gated stage emitted a Safe Transaction Builder batch instead of executing the registry/verifier mutations directly.
- Safe batch: `deployments/outputs/safe-batches/base_2026-06-22T02-11-17.json`.
- Batch safe: `0x0bC26FF515411396DD588Abd6Ef6846E04470227`; chainId `8453`; 8 transactions.
- Added the base production generic Zelle platform snapshot `deployments/outputs/platforms/snapshots/base/zelle_2026-06-22T02-11-08.json`.

## Base production Safe transactions
| # | Target | Function | Required calldata |
|---|---|---|---|
| 1 | `UnifiedPaymentVerifierV2` `0x46A58Dc65587D4D7B8198C6A25eEdf5b2535Da94` | `addPaymentMethod(bytes32)` with generic `zelle` | `0x3992eaf6f752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3` |
| 2 | `PaymentVerifierRegistry` `0x2b82D24437ff66Fb173eabDfD67ee2ACeb8bEb1e` | `addPaymentMethod(bytes32,address,bytes32[])` with generic `zelle`, UPV V2, `[USD]` | `0xdbcb3005f752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd300000000000000000000000046a58dc65587d4d7b8198c6a25eedf5b2535da9400000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000001c4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e` |
| 3 | Legacy `UnifiedPaymentVerifier` `0x16b3e4a3CA36D3A4bCA281767f15C7ADeF4ab163` | `removePaymentMethod(bytes32)` for `n26` | `0x334c2ef3d9ff4fd6b39a3e3dd43c41d05662a5547de4a878bc97a65bcb352ade493cdc6b` |
| 4 | `UnifiedPaymentVerifierV2` `0x46A58Dc65587D4D7B8198C6A25eEdf5b2535Da94` | `removePaymentMethod(bytes32)` for `n26` | `0x334c2ef3d9ff4fd6b39a3e3dd43c41d05662a5547de4a878bc97a65bcb352ade493cdc6b` |
| 5 | `PaymentVerifierRegistry` `0x2b82D24437ff66Fb173eabDfD67ee2ACeb8bEb1e` | `removePaymentMethod(bytes32)` for `n26` | `0x334c2ef3d9ff4fd6b39a3e3dd43c41d05662a5547de4a878bc97a65bcb352ade493cdc6b` |
| 6 | Legacy `UnifiedPaymentVerifier` `0x16b3e4a3CA36D3A4bCA281767f15C7ADeF4ab163` | `removePaymentMethod(bytes32)` for `luxon` | `0x334c2ef3aea63ef983458674f54ee50cdaa7b09d80a5c6c03ed505f51c90b0f2b54abb01` |
| 7 | `UnifiedPaymentVerifierV2` `0x46A58Dc65587D4D7B8198C6A25eEdf5b2535Da94` | `removePaymentMethod(bytes32)` for `luxon` | `0x334c2ef3aea63ef983458674f54ee50cdaa7b09d80a5c6c03ed505f51c90b0f2b54abb01` |
| 8 | `PaymentVerifierRegistry` `0x2b82D24437ff66Fb173eabDfD67ee2ACeb8bEb1e` | `removePaymentMethod(bytes32)` for `luxon` | `0x334c2ef3aea63ef983458674f54ee50cdaa7b09d80a5c6c03ed505f51c90b0f2b54abb01` |

Hashes and currencies:
- Generic `zelle`: `0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3`.
- `n26`: `0xd9ff4fd6b39a3e3dd43c41d05662a5547de4a878bc97a65bcb352ade493cdc6b`.
- `luxon`: `0xaea63ef983458674f54ee50cdaa7b09d80a5c6c03ed505f51c90b0f2b54abb01`.
- `USD`: `0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e`.

## Changed files
- `deployments/verifiers/zelle.ts`: exports generic `ZELLE_PAYMENT_METHOD_HASH` and provider config.
- `deploy/25_add_generic_zelle_payment_method.ts`: append-only stage that adds generic Zelle and removes N26/Luxon from verifier and snapshot surfaces.
- `deployments/helpers.ts`: adds shared unified-verifier and payment-method snapshot removal helpers.
- `deployments/outputs/platforms/base*.json`: add generic `zelle`; remove `n26`/`luxon` from base and base_staging outputs.
- `deployments/outputs/platforms/snapshots/base_staging/zelle_2026-06-22T00-41-48.json`: base staging deployment snapshot for generic Zelle.
- `deployments/outputs/platforms/snapshots/base/zelle_2026-06-22T02-11-08.json`: base production snapshot for generic Zelle.
- `deployments/outputs/safe-batches/base_2026-06-22T02-11-17.json`: base production Safe batch for the hard-cutover registry/verifier migration.
- `test/deploy/25_genericZellePaymentMethod.spec.ts`: proves generic Zelle is registered, legacy Zelle variants remain, and N26/Luxon are removed.
- `test/deploy/10_n26PaymentMethod.spec.ts`, `test/deploy/13_luxonPaymentMethod.spec.ts`, `test/deploy/16_v2PaymentMethods.spec.ts`: update final deploy-state expectations after deploy 25.

## Verification
- `yarn node -e "const {utils}=require('ethers'); console.log(utils.keccak256(utils.toUtf8Bytes('zelle')))"` -> `0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3`
- `BASE_DEPLOY_PRIVATE_KEY=<configured key> yarn deploy:base_staging` -> added generic Zelle, removed N26/Luxon, exported base staging outputs
- Live base staging read check -> `zelleRegistry=true`, `zelleInV2=true`, `n26Registry=false`, `n26Legacy=false`, `n26V2=false`, `luxonRegistry=false`, `luxonLegacy=false`, `luxonV2=false`
- `BASE_DEPLOY_PRIVATE_KEY=<configured key> yarn deploy:base` -> emitted `deployments/outputs/safe-batches/base_2026-06-22T02-11-17.json` with 8 Safe transactions for generic Zelle add plus N26/Luxon removal; exported base production outputs
- Decoded `deployments/outputs/safe-batches/base_2026-06-22T02-11-17.json` with ethers interfaces -> 8 expected calls, no extra registry/verifier calls
- `git diff --check` -> clean
- `BASE_DEPLOY_PRIVATE_KEY=<configured key> TESTNET_DEPLOY_PRIVATE_KEY=<configured key> yarn pkg:extract` -> generated package paymentMethods contain generic `zelle` and no `n26`/`luxon`
- `rg -n '"(n26|luxon)"|d9ff4fd6|aea63ef9' deployments/outputs/platforms/base*.json packages/contracts/paymentMethods/base*.json packages/contracts/paymentMethods/lookups.json` -> no matches
- `BASE_DEPLOY_PRIVATE_KEY=<hardhat test key> TESTNET_DEPLOY_PRIVATE_KEY=<hardhat test key> DEPLOY_TX_DELAY_MS=0 yarn hardhat deploy --network localhost --reset` -> deploy 25 added generic Zelle and removed N26/Luxon from registry, legacy UPV, UPV V2, and localhost payment-method snapshot
- `BASE_DEPLOY_PRIVATE_KEY=<hardhat test key> TESTNET_DEPLOY_PRIVATE_KEY=<hardhat test key> yarn hardhat test test/deploy/*.ts --network localhost` -> 176 passing
- Previous full suite on this branch: `BASE_DEPLOY_PRIVATE_KEY=<hardhat test key> TESTNET_DEPLOY_PRIVATE_KEY=<hardhat test key> yarn test:fast` -> 1141 passing, 5 pending

Note: commands emit Hardhat Node 23 unsupported-version warning in this local environment.
