### PR TITLE
feat(payment-methods): retain retired method labels (n26/luxon); publish contracts-v2 0.2.4

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/contracts-v2",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "description": "ZKP2P V2 smart contract interfaces and utilities",
   "main": "./_cjs/index.js",
   "module": "./_esm/index.js",

--- a/packages/contracts/scripts/extractors/paymentMethods.ts
+++ b/packages/contracts/scripts/extractors/paymentMethods.ts
@@ -242,6 +242,24 @@ ${networks.map(net => `  ${net}: require('./${net}.json')`).join(',\n')}
     }
   }
 
+  // Retired on-chain payment methods (removed from the active PaymentVerifierRegistry
+  // via governance, e.g. n26 / luxon). Their payment-method hashes are immutable
+  // on-chain history, so we keep them resolvable for LABELING ONLY: historical
+  // deposits / intents / stats must still render the correct platform name long after
+  // the method leaves the active registry. They are added to hashToName but NOT
+  // nameToHash — offering/eligibility is gated at the product layer (curator), and
+  // leaving them out of nameToHash keeps them unselectable for new liquidity.
+  const RETIRED_METHOD_HASH_TO_NAME: Record<string, string> = {
+    '0xd9ff4fd6b39a3e3dd43c41d05662a5547de4a878bc97a65bcb352ade493cdc6b': 'n26',
+    '0xaea63ef983458674f54ee50cdaa7b09d80a5c6c03ed505f51c90b0f2b54abb01': 'luxon',
+  };
+  for (const [hash, name] of Object.entries(RETIRED_METHOD_HASH_TO_NAME)) {
+    const normalized = hash.toLowerCase();
+    if (!hashToName[normalized]) {
+      hashToName[normalized] = name;
+    }
+  }
+
   // bytes32 encoding of "zelle" (ethers.utils.formatBytes32String("zelle"))
   // This is a fixed constant — it never changes
   const zelleUnspecifiedHash = '0x7a656c6c65000000000000000000000000000000000000000000000000000000';


### PR DESCRIPTION
## What
Follow-up to #159 (generic Zelle cutover). #159 removed `n26` and `luxon` from the active on-chain registry, which also dropped them from the extracted `lookups.json` name↔hash maps. The indexer and web/SDK clients both resolve platform names from `lookups.hashToName`, so every **historical** n26/luxon deposit, intent, and stat would resolve to `"unknown"` after the next indexer re-sync or client package bump.

This keeps their immutable on-chain hashes resolvable for **labeling only**.

## Change
- Extractor injects retired methods (`n26`, `luxon`) into `hashToName` **but not `nameToHash`**:
  - ✅ historical rows render the correct platform name (indexer + clients)
  - ✅ they stay **unselectable for new liquidity** (absent from `nameToHash`)
  - ✅ preserves the indexer invariant that n26/luxon are absent from `METHOD_NAME_TO_HASH`
  - offering/eligibility remains gated at the product layer (curator `RETIRED_ONCHAIN_METHOD_PLATFORMS` deny list)
- Bumps `@zkp2p/contracts-v2` → `0.2.4` (supersedes the transient `0.2.3` that dropped these labels).

## Verification
Replayed the extractor's lookups loop against `base`/`base_staging`/`base_sepolia` outputs + the retired merge:
- `nameToHash`: generic `zelle` present (correct hash), **n26/luxon = false**, zelle-bofa/chase/citi present
- `hashToName`: generic zelle→`zelle`, n26→`n26`, luxon→`luxon`, zelle-bofa→`zelle-bofa`
- `zelleVariantHashes`: 3

Generated artifacts (`paymentMethods/*.json`, `lookups.json`) are produced at publish time via `prepublishOnly: yarn build && yarn test`; no generated files committed.

## Follow-ups (after publish)
- Bump indexer → `0.2.4` (its #167 `"n26" not in METHOD_NAME_TO_HASH` test stays green)
- Clients adopt `0.2.4` (not `0.2.3`); historical n26/luxon labels resolve with no client-side alias needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)