### PR TITLE
chore: use Curator RPC proxy for Base reads

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -2,6 +2,8 @@ INFURA_TOKEN=
 # We use ETHERSCAN_KEY as the env variable name so that other networks keys aren't ignored in favor of ETHERSCAN_API_KEY
 ETHERSCAN_KEY= 
 BASESCAN_API_KEY=
-ALCHEMY_API_KEY=
+# Base RPC defaults to the Curator proxy (https://api.zkp2p.xyz/v2/rpc/base); set these only to override.
+BASE_RPC_URL=
+BASE_SEPOLIA_RPC_URL=
 TESTNET_DEPLOY_PRIVATE_KEY=ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 BASE_DEPLOY_PRIVATE_KEY=ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Run Foundry fork tests
         env:
-          ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
+          BASE_RPC_URL: https://api.zkp2p.xyz/v2/rpc/base
         run: |
           echo "Running fork tests..."
           yarn test:forge:fork

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ import { getAccounts } from "@utils/test";
 
 - `hardhat.config.ts`: Solidity 0.8.18, optimizer 200 runs, viaIR enabled, ethers v5
 - `foundry.toml`: Solidity 0.8.18, optimizer 800 runs, viaIR enabled, fuzz 256 runs, invariant depth 15
-- `.env`: `BASE_DEPLOY_PRIVATE_KEY`, `TESTNET_DEPLOY_PRIVATE_KEY`, `ALCHEMY_API_KEY`, `BASESCAN_API_KEY`
+- `.env`: `BASE_DEPLOY_PRIVATE_KEY`, `TESTNET_DEPLOY_PRIVATE_KEY`, `BASESCAN_API_KEY` (Base RPC defaults to the Curator proxy `https://api.zkp2p.xyz/v2/rpc/base`; override with `BASE_RPC_URL` / `BASE_SEPOLIA_RPC_URL`)
 - `tsconfig.json`: CommonJS, strict mode, path aliases
 
 ## Style

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -75,7 +75,7 @@ const config: HardhatUserConfig = {
       },
     },
     base_sepolia: {
-      url: "https://base-sepolia.g.alchemy.com/v2/" + process.env.ALCHEMY_API_KEY,
+      url: process.env.BASE_SEPOLIA_RPC_URL || "https://sepolia.base.org",
       // @ts-ignore
       accounts: [
         `0x${process.env.TESTNET_DEPLOY_PRIVATE_KEY}`,
@@ -89,7 +89,7 @@ const config: HardhatUserConfig = {
       ]
     },
     base: {
-      url: "https://base-mainnet.g.alchemy.com/v2/" + process.env.ALCHEMY_API_KEY,
+      url: process.env.BASE_RPC_URL || "https://api.zkp2p.xyz/v2/rpc/base",
       // @ts-ignore
       accounts: [
         `0x${process.env.BASE_DEPLOY_PRIVATE_KEY}`,

--- a/test-foundry/fork/AcrossBridgeHookFork.t.sol
+++ b/test-foundry/fork/AcrossBridgeHookFork.t.sol
@@ -252,13 +252,16 @@ contract AcrossBridgeHookForkTest is Test {
     }
 
     function _getRpcUrl() internal view returns (string memory) {
+        // Prefer an explicit override, then legacy Alchemy key, then the Curator Base RPC proxy default.
+        (string memory rpcUrl, bool hasUrl) = _tryEnvString("BASE_RPC_URL");
+        if (hasUrl && bytes(rpcUrl).length > 0) {
+            return rpcUrl;
+        }
         (string memory apiKey, bool ok) = _tryEnvString("ALCHEMY_API_KEY");
         if (ok && bytes(apiKey).length > 0) {
             return string(abi.encodePacked("https://base-mainnet.g.alchemy.com/v2/", apiKey));
         }
-        (string memory rpcUrl, bool hasUrl) = _tryEnvString("BASE_RPC_URL");
-        require(hasUrl && bytes(rpcUrl).length > 0, "Set ALCHEMY_API_KEY or BASE_RPC_URL");
-        return rpcUrl;
+        return "https://api.zkp2p.xyz/v2/rpc/base";
     }
 
     function _tryEnvString(string memory key) internal view returns (string memory, bool) {


### PR DESCRIPTION
## Summary
Migrate the contracts repo off the Alchemy API key for Base RPC, defaulting to the public Curator RPC proxy (`https://api.zkp2p.xyz/v2/rpc/base`). Removes the local/CI `ALCHEMY_API_KEY` dependency.

- `hardhat.config.ts`: `base` → Curator proxy (override with `BASE_RPC_URL`); `base_sepolia` → public `https://sepolia.base.org` (override with `BASE_SEPOLIA_RPC_URL`; the proxy is mainnet-only).
- `test-foundry/fork/AcrossBridgeHookFork.t.sol`: `_getRpcUrl()` now resolves `BASE_RPC_URL` → legacy `ALCHEMY_API_KEY` → Curator proxy default (no env required).
- `.github/workflows/foundry.yml`: fork job uses `BASE_RPC_URL=<proxy>` instead of the `ALCHEMY_API_KEY` secret.
- `.env.default` / `CLAUDE.md`: drop `ALCHEMY_API_KEY`, document the proxy default + overrides.

## Testing
- `forge test` on the fork suite runs against the proxy with **no env set** (proxy default path): forks Base, compiles, executes.
- Note: `testFork_DepositNow_BaseToMainnetUSDC` and `testFork_DepositNow_SolanaRecipientBase58` fail **identically (same gas)** on both the proxy and the public `developer-access-mainnet.base.org` RPC — pre-existing, live-Across-state failures at the latest forked block, **not** caused by this RPC swap. `testFork_DepositNow_FallbackOnBridgeFailure` passes.
- Proxy verified to serve `eth_call`, `eth_getCode`, `eth_getStorageAt`, and historical block reads.