### PR TITLE
feat: move protocol risk onchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ Smart contracts for the ZKP2P fiat on/off-ramp, with the current repository cent
 
 The repository still contains legacy v1 contracts and deploy scripts because v2 is deployed on top of shared protocol infrastructure, but the active development work over the last month has been concentrated in the v2 contracts, periphery, and deployment pipeline.
 
+## Open onchain risk candidate
+
+The additive open-protocol candidate moves identity, reputation, platform risk,
+stake maturity, and chargeback compensation into contracts while reusing every
+existing EscrowV2 deposit. Its design, rollout boundaries, and threat model are
+documented in:
+
+- [`../docs/onchain-risk/01-design-principles.md`](../docs/onchain-risk/01-design-principles.md)
+- [`../docs/onchain-risk/02-architecture.md`](../docs/onchain-risk/02-architecture.md)
+- [`../docs/onchain-risk/03-migration-and-stack-impact.md`](../docs/onchain-risk/03-migration-and-stack-impact.md)
+- [`../docs/onchain-risk/04-threat-model.md`](../docs/onchain-risk/04-threat-model.md)
+
+The deployment script is opt-in and does not modify any live environment unless
+an operator explicitly sets `DEPLOY_ONCHAIN_RISK=true`.
+
 ## Table of Contents
 
 - [What Landed Recently](#what-landed-recently)
@@ -299,8 +314,8 @@ For each `(paymentMethod, currency)` pair, the deposit can use:
 
 - validates the escrow and deposit
 - verifies payment-method and currency support
-- runs the generic pre-intent hook, if present
-- runs the dedicated whitelist hook, if present
+- asks the public risk manager to validate identity, reputation, and stake
+- ignores legacy gating signatures and maker eligibility hooks
 - snapshots deposit min amount and manager fee terms
 - stores the intent
 - locks funds on `EscrowV2`
@@ -367,14 +382,14 @@ This split keeps settlement safety inside escrow while letting pricing move quic
 
 v2 introduces a clearer extension model around the intent lifecycle.
 
-### Pre-Intent Hooks
+### Pre-Intent Hook Compatibility
 
-Executed during `signalIntent`, before funds are locked:
-
-- generic hook slot: arbitrary eligibility or policy checks
-- whitelist hook slot: dedicated private-liquidity control
-
-These hooks are configured per deposit by the depositor or delegate.
+The generic and whitelist hook setters/getters remain in the ABI so existing
+clients and deposit tooling do not break. A legacy deployment with no risk
+manager preserves hook execution. Once an onchain risk manager is selected,
+`OrchestratorV2.signalIntent` does not execute either hook and rejects new
+non-zero hook configuration: maker-controlled eligibility would reintroduce a
+private gate into the open protocol. `preIntentHookData` is ignored in that mode.
 
 ### Post-Intent Hooks
 
@@ -386,7 +401,10 @@ Executed during `fulfillIntent`, after verification and escrow release:
 
 ### Registries as Safety Gates
 
-The hook and orchestrator registry model prevents arbitrary external contracts from being inserted into the settlement path without explicit whitelisting.
+The orchestrator and payment-verifier registries remain settlement safety
+gates. Post-intent hooks are selected by the taker and must be deployed contract
+addresses; maker pre-intent hooks are legacy-only controls and cannot be newly
+configured on the open deployment.
 
 ## Payment Verification Model
 

--- a/contracts/OrchestratorV2.sol
+++ b/contracts/OrchestratorV2.sol
@@ -2,15 +2,13 @@
 
 pragma solidity ^0.8.18;
 
-import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import { SignatureChecker } from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { Pausable } from "@openzeppelin/contracts/security/Pausable.sol";
-import { SignatureChecker } from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
-import { AddressArrayUtils } from "./external/AddressArrayUtils.sol";
-import { Bytes32ArrayUtils } from "./external/Bytes32ArrayUtils.sol";
 import { IOrchestratorV2 } from "./interfaces/IOrchestratorV2.sol";
 import { IReferralFee } from "./interfaces/IReferralFee.sol";
 import { IEscrow } from "./interfaces/IEscrow.sol";
@@ -21,19 +19,18 @@ import { IPreIntentHook } from "./interfaces/IPreIntentHook.sol";
 import { IPaymentVerifier } from "./interfaces/IPaymentVerifier.sol";
 import { IPaymentVerifierRegistry } from "./interfaces/IPaymentVerifierRegistry.sol";
 import { IRelayerRegistry } from "./interfaces/IRelayerRegistry.sol";
+import { IProtocolRiskManager } from "./interfaces/IProtocolRiskManager.sol";
 import { ReferralFeeLib } from "./lib/ReferralFeeLib.sol";
 
 /**
  * @title OrchestratorV2
  * @notice Orchestrator contract for the ZKP2P protocol. This contract is responsible for managing the intent (order) 
- * lifecycle and orchestrating the P2P trading of fiat currency and onchain assets.
+     * lifecycle and orchestrating the P2P trading of fiat currency and onchain assets.
  */
 contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
 
-    using AddressArrayUtils for address[];
-    using Bytes32ArrayUtils for bytes32[];
-    using ECDSA for bytes32;
     using SafeERC20 for IERC20;
+    using ECDSA for bytes32;
     using SignatureChecker for address;
 
 
@@ -42,6 +39,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
     uint256 constant CIRCOM_PRIME_FIELD = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
     uint256 constant MAX_PROTOCOL_FEE = 5e16;      // 5% max protocol fee
     uint256 constant MAX_MANAGER_FEE = 5e16;       // 5% max manager fee
+    uint256 constant BPS = 10_000;
 
     /* ============ State Variables ============ */
 
@@ -49,6 +47,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
 
     mapping(bytes32 => Intent) internal intents;                       // Mapping of intentHashes to intent structs
     mapping(address => bytes32[]) internal accountIntents;             // Mapping of address to array of intentHashes
+    mapping(bytes32 => uint256) internal intentAccountIndexes;         // O(1) swap-and-pop index in accountIntents
 
     // Snapshot of the minimum per-intent amount at the time of lock (signal)
     // Used to prevent fulfillments that pay out less than the deposit's min intent amount.
@@ -57,6 +56,11 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
     // Snapshot of per-intent manager fee terms at the time of signal
     mapping(bytes32 => address) internal intentManagerFeeRecipient;
     mapping(bytes32 => uint256) internal intentManagerFee;
+
+    // Risk module and effective protocol fee are snapshotted per intent. This allows governance
+    // to upgrade the module without moving active collateral positions between modules.
+    mapping(bytes32 => IProtocolRiskManager) internal intentRiskManagers;
+    mapping(bytes32 => uint256) internal intentProtocolFees;
 
     // Optional pre-intent hooks configured per escrow + depositId.
     mapping(address => mapping(uint256 => IPreIntentHook)) internal depositPreIntentHooks;
@@ -68,6 +72,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
     IEscrowRegistry public escrowRegistry;                              // Registry of escrow contracts
     IPaymentVerifierRegistry public  paymentVerifierRegistry;          // Registry of payment verifiers
     IRelayerRegistry public relayerRegistry;                           // Registry of relayers
+    IProtocolRiskManager public riskManager;                           // Onchain identity/reputation/stake policy
 
     // Protocol fee configuration
     uint256 public protocolFee;                                     // Protocol fee taken from taker (in preciseUnits, 1e16 = 1%)
@@ -103,9 +108,9 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
 
     /**
      * @notice Signals intent to pay the depositor defined in the _depositId the _amount * deposit conversionRate off-chain at 
-     * their given _payeeId in order to unlock _amount of funds on-chain. Caller must provide a signature from the deposit's gating
-     * service to prove their eligibility to take liquidity. This function captures and stores all values required for fullfilling
-     * the intent to give strong guarantees to the buyer. Locks liquidity for the corresponding deposit on the escrow contract.
+     * their given _payeeId in order to unlock _amount of funds on-chain. Eligibility is evaluated by the public
+     * risk manager instead of a backend signature or maker-selected allowlist. This function captures and stores
+     * all values required for fulfilling the intent and locks liquidity in the existing escrow contract.
      *
      * @param _params                   Struct containing all the intent parameters
      */
@@ -116,8 +121,13 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
     {
         // Checks
         _validateSignalIntent(_params);
-        _executeHookIfSet(depositPreIntentHooks[_params.escrow][_params.depositId], _params);
-        _executeHookIfSet(depositWhitelistHooks[_params.escrow][_params.depositId], _params);
+        IProtocolRiskManager currentRiskManager = riskManager;
+        if (address(currentRiskManager) == address(0)) {
+            // Preserve legacy deployments. The additive open deployment sets its risk manager
+            // before registry authorization, so maker-controlled eligibility hooks stay disabled.
+            _executeHookIfSet(depositPreIntentHooks[_params.escrow][_params.depositId], _params);
+            _executeHookIfSet(depositWhitelistHooks[_params.escrow][_params.depositId], _params);
+        }
 
         // Effects
         bytes32 intentHash = _calculateIntentHash();
@@ -132,6 +142,24 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         if (managerFee > MAX_MANAGER_FEE) revert FeeExceedsMaximum(managerFee, MAX_MANAGER_FEE);  // policy cap (e.g., 5%)
         intentManagerFeeRecipient[intentHash] = managerFeeRecipient;
         intentManagerFee[intentHash] = managerFee;
+
+        uint16 feeDiscountBps;
+        if (address(currentRiskManager) != address(0)) {
+            feeDiscountBps = currentRiskManager.onIntentSignaled(
+                IProtocolRiskManager.SignalContext({
+                    intentHash: intentHash,
+                    taker: msg.sender,
+                    maker: dep.depositor,
+                    token: address(dep.token),
+                    paymentMethod: _params.paymentMethod,
+                    amount: _params.amount
+                })
+            );
+            if (feeDiscountBps > BPS) revert FeeExceedsMaximum(feeDiscountBps, BPS);
+        }
+        uint256 effectiveProtocolFee = (protocolFee * (BPS - feeDiscountBps)) / BPS;
+        intentRiskManagers[intentHash] = currentRiskManager;
+        intentProtocolFees[intentHash] = effectiveProtocolFee;
         
         intentMinAtSignal[intentHash] = dep.intentAmountRange.min;
         Intent storage storedIntent = intents[intentHash];
@@ -158,6 +186,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
             );
         }
 
+        intentAccountIndexes[intentHash] = accountIntents[msg.sender].length;
         accountIntents[msg.sender].push(intentHash);
         intentCounter++;
 
@@ -176,6 +205,12 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
 
         // Emit manager fee snapshot last for easier indexing
         emit IntentManagerFeeSnapshotted(intentHash, managerFeeRecipient, managerFee);
+        emit IntentRiskPolicySnapshotted(
+            intentHash,
+            address(currentRiskManager),
+            effectiveProtocolFee,
+            feeDiscountBps
+        );
 
         // Interactions
         IEscrow(_params.escrow).lockFunds(_params.depositId, intentHash, _params.amount);
@@ -187,7 +222,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
      *
      * @param _intentHash    Hash of intent being cancelled
      */
-    function cancelIntent(bytes32 _intentHash) external {
+    function cancelIntent(bytes32 _intentHash) external nonReentrant {
         // Checks
         Intent memory intent = intents[_intentHash];
         
@@ -195,6 +230,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         if (intent.owner != msg.sender) revert UnauthorizedCaller(msg.sender, intent.owner);
 
         // Effects
+        _resolveRiskAbandonment(_intentHash, false);
         _pruneIntent(_intentHash);
 
         // Interactions
@@ -210,6 +246,9 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
      * @param _hook         Hook address (address(0) to remove).
      */
     function setDepositPreIntentHook(address _escrow, uint256 _depositId, IPreIntentHook _hook) external nonReentrant {
+        if (address(riskManager) != address(0) && address(_hook) != address(0)) {
+            revert LegacyEligibilityHookDisabled();
+        }
         _validateAndAuthorizeHookSetter(_escrow, _depositId, _hook);
 
         depositPreIntentHooks[_escrow][_depositId] = _hook;
@@ -228,6 +267,9 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
      * @param _hook         Hook address (address(0) to remove).
      */
     function setDepositWhitelistHook(address _escrow, uint256 _depositId, IPreIntentHook _hook) external nonReentrant {
+        if (address(riskManager) != address(0) && address(_hook) != address(0)) {
+            revert LegacyEligibilityHookDisabled();
+        }
         _validateAndAuthorizeHookSetter(_escrow, _depositId, _hook);
 
         depositWhitelistHooks[_escrow][_depositId] = _hook;
@@ -254,6 +296,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         // Snapshot manager fee terms before pruning (pruning deletes the mappings).
         address managerFeeRecipient = intentManagerFeeRecipient[_params.intentHash];
         uint256 managerFee = intentManagerFee[_params.intentHash];
+        uint256 effectiveProtocolFee = intentProtocolFees[_params.intentHash];
         
         address verifier = paymentVerifierRegistry.getVerifier(intent.paymentMethod);
         if (verifier == address(0)) revert PaymentMethodDoesNotExist(intent.paymentMethod);
@@ -273,8 +316,12 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         if (minAtSignal > 0 && verificationResult.releaseAmount < minAtSignal) {
             revert AmountBelowMin(verificationResult.releaseAmount, minAtSignal);
         }
+        if (verificationResult.releaseAmount > intent.amount) {
+            revert AmountAboveMax(verificationResult.releaseAmount, intent.amount);
+        }
 
         // Effects
+        _resolveRiskFulfillment(_params.intentHash, verificationResult.releaseAmount, true);
         _pruneIntent(_params.intentHash);
 
         // Interactions
@@ -287,7 +334,8 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
             verificationResult.releaseAmount,
             _params.postIntentHookData,
             managerFeeRecipient,
-            managerFee
+            managerFee,
+            effectiveProtocolFee
         );
     }
 
@@ -309,14 +357,24 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         // Snapshot manager fee terms before pruning (pruning deletes the mappings).
         address managerFeeRecipient = intentManagerFeeRecipient[_intentHash];
         uint256 managerFee = intentManagerFee[_intentHash];
+        uint256 effectiveProtocolFee = intentProtocolFees[_intentHash];
         
         // Effects
+        _resolveRiskFulfillment(_intentHash, intent.amount, false);
         _pruneIntent(_intentHash);
 
         // Interactions
         IEscrow(intent.escrow).unlockAndTransferFunds(intent.depositId, _intentHash, intent.amount, address(this));
 
-        _collectFeesAndTransferFunds(deposit.token, _intentHash, intent, intent.amount, managerFeeRecipient, managerFee);
+        _collectFeesAndTransferFunds(
+            deposit.token,
+            _intentHash,
+            intent,
+            intent.amount,
+            managerFeeRecipient,
+            managerFee,
+            effectiveProtocolFee
+        );
     }
 
     /* ============ Escrow Functions ============ */
@@ -336,6 +394,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
                     intent.timestamp != 0 && // Only prune if intent exists on this contract; otherwise skip
                     intent.escrow == msg.sender // Ensure only the escrow that owns the intent can prune it; otherwise skip
                 ) {
+                    _resolveRiskAbandonment(intentHash, true);
                     _pruneIntent(intentHash);
                 }
             }
@@ -351,7 +410,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
      *
      * @param _intentHashes    Array of intent hashes to check and clean up
      */
-    function cleanupOrphanedIntents(bytes32[] calldata _intentHashes) external {
+    function cleanupOrphanedIntents(bytes32[] calldata _intentHashes) external nonReentrant {
         for (uint256 i = 0; i < _intentHashes.length; i++) {
             bytes32 intentHash = _intentHashes[i];
             Intent memory intent = intents[intentHash];
@@ -367,12 +426,27 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
 
             // If intent doesn't exist on escrow, it's orphaned — prune it
             if (escrowIntent.intentHash == bytes32(0)) {
+                _resolveRiskAbandonment(intentHash, true);
                 _pruneIntent(intentHash);
             }
         }
     }
 
     /* ============ Governance Functions ============ */
+
+    /**
+     * @notice GOVERNANCE ONLY: Updates the onchain risk module used for newly signaled intents.
+     * @dev Existing intents keep their snapshotted module. Setting address(0) is supported only
+     *      as an explicit emergency/open-mode action; production deployments should set a module.
+     */
+    function setRiskManager(IProtocolRiskManager _riskManager) external onlyOwner {
+        address riskManagerAddress = address(_riskManager);
+        if (riskManagerAddress != address(0) && riskManagerAddress.code.length == 0) {
+            revert InvalidRiskManager(riskManagerAddress);
+        }
+        riskManager = _riskManager;
+        emit RiskManagerUpdated(riskManagerAddress);
+    }
 
     /**
      * @notice GOVERNANCE ONLY: Updates the escrow registry address.
@@ -412,7 +486,8 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
     }
 
     /**
-     * @notice GOVERNANCE ONLY: Sets whether all accounts can signal multiple intents.
+     * @notice GOVERNANCE ONLY: Retained for ABI compatibility. Open OrchestratorV2 does not impose
+     * a per-account intent-count limit; collateral and reputation provide the economic constraint.
      *
      * @param _allowMultiple   True to allow all accounts to signal multiple intents, false to restrict to whitelisted relayers only
      */
@@ -447,6 +522,10 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
      * - Intent pruning by escrow (pruneIntents)
      * - All governance functions
      * - All view functions
+     *
+     * Manual release remains callable while paused, but intentionally does not bypass the
+     * snapshotted risk module. If collateral activation fails, settlement fails atomically and
+     * the taker can still cancel; governance cannot release assets without recording exposure.
      */
     function pauseOrchestrator() external onlyOwner {
         _pause();
@@ -481,16 +560,29 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         return intentMinAtSignal[_intentHash];
     }
 
+    function getIntentRiskManager(bytes32 _intentHash) external view returns (IProtocolRiskManager) {
+        return intentRiskManagers[_intentHash];
+    }
+
+    function getIntentProtocolFee(bytes32 _intentHash) external view returns (uint256) {
+        return intentProtocolFees[_intentHash];
+    }
+
+    function hasActiveIntent(bytes32 _intentHash) external view returns (bool) {
+        return intents[_intentHash].timestamp != 0;
+    }
+
     /* ============ Internal Functions ============ */
 
     /**
      * @notice Validates an intent before it is signaled.
      */
     function _validateSignalIntent(SignalIntentParams calldata _intent) internal view {
-        // Check if account can have multiple intents
-        bool canHaveMultipleIntents = relayerRegistry.isWhitelistedRelayer(msg.sender) || allowMultipleIntents;
-        if (!canHaveMultipleIntents && accountIntents[msg.sender].length > 0) {
-            revert AccountHasActiveIntent(msg.sender, accountIntents[msg.sender][0]);
+        if (address(riskManager) == address(0)) {
+            bool canHaveMultipleIntents = relayerRegistry.isWhitelistedRelayer(msg.sender) || allowMultipleIntents;
+            if (!canHaveMultipleIntents && accountIntents[msg.sender].length > 0) {
+                revert AccountHasActiveIntent(msg.sender, accountIntents[msg.sender][0]);
+            }
         }
 
         if (_intent.to == address(0)) revert ZeroAddress();
@@ -523,15 +615,18 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         if (minConversionRate == 0) revert CurrencyNotSupported(_intent.paymentMethod, _intent.fiatCurrency);
         if (_intent.conversionRate < minConversionRate) revert RateBelowMinimum(_intent.conversionRate, minConversionRate);
 
-        address intentGatingService = IEscrow(_intent.escrow).getDepositGatingService(_intent.depositId, _intent.paymentMethod);
-        if (intentGatingService != address(0)) {
-            // Check if signature has expired
-            if (block.timestamp > _intent.signatureExpiration) {
-                revert SignatureExpired(_intent.signatureExpiration, block.timestamp);
-            }
-
-            if (!_isValidIntentGatingSignature(_intent, intentGatingService, msg.sender)) {
-                revert InvalidSignature();
+        if (address(riskManager) == address(0)) {
+            address intentGatingService = IEscrow(_intent.escrow).getDepositGatingService(
+                _intent.depositId,
+                _intent.paymentMethod
+            );
+            if (intentGatingService != address(0)) {
+                if (block.timestamp > _intent.signatureExpiration) {
+                    revert SignatureExpired(_intent.signatureExpiration, block.timestamp);
+                }
+                if (!_isValidIntentGatingSignature(_intent, intentGatingService, msg.sender)) {
+                    revert InvalidSignature();
+                }
             }
         }
     }
@@ -556,10 +651,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         }
     }
 
-    /**
-     * @notice Executes a pre-intent hook if the address is non-zero.
-     * @dev Shared by both the generic pre-intent hook and the dedicated whitelist hook.
-     */
+    /** @notice Executes a legacy pre-intent hook only when no public risk manager is configured. */
     function _executeHookIfSet(IPreIntentHook _hook, SignalIntentParams calldata _params) internal {
         if (address(_hook) == address(0)) return;
 
@@ -603,11 +695,22 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
     function _pruneIntent(bytes32 _intentHash) internal {
         Intent memory intent = intents[_intentHash];
 
-        accountIntents[intent.owner].removeStorage(_intentHash);
+        bytes32[] storage ownerIntents = accountIntents[intent.owner];
+        uint256 removeIndex = intentAccountIndexes[_intentHash];
+        uint256 lastIndex = ownerIntents.length - 1;
+        if (removeIndex != lastIndex) {
+            bytes32 movedIntentHash = ownerIntents[lastIndex];
+            ownerIntents[removeIndex] = movedIntentHash;
+            intentAccountIndexes[movedIntentHash] = removeIndex;
+        }
+        ownerIntents.pop();
+        delete intentAccountIndexes[_intentHash];
         delete intents[_intentHash];
         delete intentMinAtSignal[_intentHash];
         delete intentManagerFeeRecipient[_intentHash];
         delete intentManagerFee[_intentHash];
+        delete intentRiskManagers[_intentHash];
+        delete intentProtocolFees[_intentHash];
 
         emit IntentPruned(_intentHash);
     }
@@ -621,15 +724,16 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         Intent memory _intent, 
         uint256 _releaseAmount,
         address _managerFeeRecipient,
-        uint256 _managerFee
+        uint256 _managerFee,
+        uint256 _effectiveProtocolFee
     ) internal returns (uint256 netFees) {
         uint256 protocolFeeAmount;
         uint256 referralFeeAmount;
         uint256 managerFeeAmount;
 
         // Calculate protocol fee (taken from taker) - based on release amount
-        if (protocolFeeRecipient != address(0) && protocolFee > 0) {
-            protocolFeeAmount = (_releaseAmount * protocolFee) / PRECISE_UNIT;
+        if (protocolFeeRecipient != address(0) && _effectiveProtocolFee > 0) {
+            protocolFeeAmount = (_releaseAmount * _effectiveProtocolFee) / PRECISE_UNIT;
             _token.safeTransfer(protocolFeeRecipient, protocolFeeAmount);
         }
         
@@ -660,7 +764,8 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         Intent memory _intent,
         uint256 _releaseAmount,
         address _managerFeeRecipient,
-        uint256 _managerFee
+        uint256 _managerFee,
+        uint256 _effectiveProtocolFee
     ) internal {
         uint256 netFees = _calculateAndTransferFees(
             _token,
@@ -668,7 +773,8 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
             _intent,
             _releaseAmount,
             _managerFeeRecipient,
-            _managerFee
+            _managerFee,
+            _effectiveProtocolFee
         );
         uint256 netAmount = _releaseAmount - netFees;
 
@@ -692,7 +798,8 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         uint256 _releaseAmount,
         bytes memory _postIntentHookData,
         address _managerFeeRecipient,
-        uint256 _managerFee
+        uint256 _managerFee,
+        uint256 _effectiveProtocolFee
     ) internal {
         uint256 netFees = _calculateAndTransferFees(
             _token,
@@ -700,7 +807,8 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
             _intent,
             _releaseAmount,
             _managerFeeRecipient,
-            _managerFee
+            _managerFee,
+            _effectiveProtocolFee
         );
         uint256 netAmount = _releaseAmount - netFees;
 
@@ -755,18 +863,12 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         );
     }
 
-    /**
-     * @notice Checks if a intent gating service signature is valid.
-     */
+    /** @notice Validates the legacy backend signature when no public risk manager is set. */
     function _isValidIntentGatingSignature(
         SignalIntentParams calldata _intent,
         address _intentGatingService,
         address _caller
-    )
-        internal
-        view
-        returns(bool)
-    {
+    ) internal view returns (bool) {
         bytes memory message = abi.encodePacked(
             address(this),
             _intent.escrow,
@@ -784,5 +886,29 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
 
         bytes32 verifierPayload = keccak256(message).toEthSignedMessageHash();
         return _intentGatingService.isValidSignatureNow(verifierPayload, _intent.gatingServiceSignature);
+    }
+
+    function _resolveRiskFulfillment(
+        bytes32 _intentHash,
+        uint256 _releaseAmount,
+        bool _paymentProofVerified
+    ) internal {
+        IProtocolRiskManager snapshottedRiskManager = intentRiskManagers[_intentHash];
+        if (address(snapshottedRiskManager) != address(0)) {
+            snapshottedRiskManager.onIntentFulfilled(_intentHash, _releaseAmount, _paymentProofVerified);
+        }
+    }
+
+    function _resolveRiskAbandonment(bytes32 _intentHash, bool _expired) internal {
+        IProtocolRiskManager snapshottedRiskManager = intentRiskManagers[_intentHash];
+        if (address(snapshottedRiskManager) != address(0)) {
+            try snapshottedRiskManager.onIntentAbandoned(_intentHash, _expired) {
+                // No-op: the reservation was resolved synchronously.
+            } catch (bytes memory reason) {
+                // Never strand maker liquidity because an auxiliary risk callback failed.
+                // ProtocolRiskManager exposes recoverOrphanedReservation after this intent is pruned.
+                emit IntentRiskCallbackFailed(_intentHash, address(snapshottedRiskManager), reason);
+            }
+        }
     }
 }

--- a/contracts/interfaces/IIdentityRegistry.sol
+++ b/contracts/interfaces/IIdentityRegistry.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+/**
+ * @title IIdentityRegistry
+ * @notice Public registry of TEE-attested, platform-unique protocol identities.
+ */
+interface IIdentityRegistry {
+    struct IdentityAttestation {
+        bytes32 method;
+        bytes32 actionType;
+        address account;
+        bytes32 payeeIdHash;
+        bytes32 dataHash;
+        uint256 issuedAtMs;
+        uint256 validUntilMs;
+    }
+
+    function registerIdentity(
+        IdentityAttestation calldata attestation,
+        address attestor,
+        bytes calldata signature
+    ) external returns (bytes32 identityKey);
+
+    function isVerifiedAccount(address account) external view returns (bool);
+    function isQuarantined(address account) external view returns (bool);
+    function getAccountNode(address account) external view returns (bytes32);
+    function getIdentityOwner(bytes32 method, bytes32 payeeIdHash) external view returns (address);
+}

--- a/contracts/interfaces/IOrchestratorV2.sol
+++ b/contracts/interfaces/IOrchestratorV2.sol
@@ -6,11 +6,12 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IPostIntentHookV2 } from "./IPostIntentHookV2.sol";
 import { IPreIntentHook } from "./IPreIntentHook.sol";
 import { IReferralFee } from "./IReferralFee.sol";
+import { IProtocolRiskManager } from "./IProtocolRiskManager.sol";
 
 /**
  * @title IOrchestratorV2
- * @notice Interface for the V2 orchestrator with pre-intent hooks, whitelist hooks,
- *         manager fee support, and cleanupOrphanedIntents.
+ * @notice Interface for the open V2 orchestrator with onchain risk policy, manager fees,
+ *         compatibility-only pre-intent hook fields, and cleanupOrphanedIntents.
  */
 interface IOrchestratorV2 {
 
@@ -41,10 +42,10 @@ interface IOrchestratorV2 {
         bytes32 fiatCurrency;                       // The currency code for offchain payment
         uint256 conversionRate;                     // The conversion rate agreed offchain
         IReferralFee.ReferralFee[] referralFees;    // Referral fee recipients and fee rates paid by the taker
-        bytes gatingServiceSignature;               // Signature from the deposit's gating service
-        uint256 signatureExpiration;                // Timestamp when the gating service signature expires
+        bytes gatingServiceSignature;               // Deprecated compatibility field; ignored by the open orchestrator
+        uint256 signatureExpiration;                // Deprecated compatibility field; ignored by the open orchestrator
         IPostIntentHookV2 postIntentHook;           // Optional post-intent hook (address(0) for no hook)
-        bytes preIntentHookData;                    // Ephemeral data passed only to the pre-intent hook during signalIntent
+        bytes preIntentHookData;                    // Deprecated compatibility field; ignored by the open orchestrator
         bytes data;                                 // Signal data persisted in Intent and forwarded as post-intent hook signalHookData
     }
 
@@ -90,6 +91,15 @@ interface IOrchestratorV2 {
     event DepositPreIntentHookSet(address indexed escrow, uint256 indexed depositId, address indexed hook, address setter);
     event DepositWhitelistHookSet(address indexed escrow, uint256 indexed depositId, address indexed hook, address setter);
 
+    event RiskManagerUpdated(address indexed riskManager);
+    event IntentRiskPolicySnapshotted(
+        bytes32 indexed intentHash,
+        address indexed riskManager,
+        uint256 effectiveProtocolFee,
+        uint16 feeDiscountBps
+    );
+    event IntentRiskCallbackFailed(bytes32 indexed intentHash, address indexed riskManager, bytes reason);
+
     event AllowMultipleIntentsUpdated(bool allowMultiple);
 
     event PaymentVerifierRegistryUpdated(address indexed paymentVerifierRegistry);
@@ -132,6 +142,8 @@ interface IOrchestratorV2 {
     error AccountHasActiveIntent(address account, bytes32 existingIntent);
     error InvalidPostIntentHook(address hook);
     error InvalidPreIntentHook(address hook);
+    error InvalidRiskManager(address riskManager);
+    error LegacyEligibilityHookDisabled();
     error InvalidSignature();
     error SignatureExpired(uint256 expiration, uint256 currentTime);
 
@@ -149,12 +161,17 @@ interface IOrchestratorV2 {
     function getAccountIntents(address account) external view returns (bytes32[] memory);
     function getDepositPreIntentHook(address escrow, uint256 depositId) external view returns (IPreIntentHook);
     function getDepositWhitelistHook(address escrow, uint256 depositId) external view returns (IPreIntentHook);
+    function getIntentRiskManager(bytes32 intentHash) external view returns (IProtocolRiskManager);
+    function getIntentProtocolFee(bytes32 intentHash) external view returns (uint256);
+    function hasActiveIntent(bytes32 intentHash) external view returns (bool);
 
     /* ============ External Functions for Users ============ */
 
     function signalIntent(SignalIntentParams calldata params) external;
     function setDepositPreIntentHook(address escrow, uint256 depositId, IPreIntentHook hook) external;
     function setDepositWhitelistHook(address escrow, uint256 depositId, IPreIntentHook hook) external;
+
+    function setRiskManager(IProtocolRiskManager riskManager) external;
 
     function cancelIntent(bytes32 intentHash) external;
 

--- a/contracts/interfaces/IProtocolRiskManager.sol
+++ b/contracts/interfaces/IProtocolRiskManager.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+/**
+ * @title IProtocolRiskManager
+ * @notice Onchain policy boundary called by the orchestrator for intent lifecycle risk checks.
+ */
+interface IProtocolRiskManager {
+    struct SignalContext {
+        bytes32 intentHash;
+        address taker;
+        address maker;
+        address token;
+        bytes32 paymentMethod;
+        uint256 amount;
+    }
+
+    /**
+     * @notice Validates and reserves an intent without imposing an amount or intent-count cap.
+     * @return feeDiscountBps Percentage discount applied to the protocol fee (10_000 = 100%).
+     */
+    function onIntentSignaled(SignalContext calldata context) external returns (uint16 feeDiscountBps);
+
+    function onIntentFulfilled(bytes32 intentHash, uint256 releaseAmount, bool paymentProofVerified) external;
+    function onIntentAbandoned(bytes32 intentHash, bool expired) external;
+    function syncReputation(bytes32 intentHash) external returns (bool synced);
+}

--- a/contracts/interfaces/IReputationRegistry.sol
+++ b/contracts/interfaces/IReputationRegistry.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+/**
+ * @title IReputationRegistry
+ * @notice Mutable protocol reputation state updated by authorized lifecycle reporters.
+ */
+interface IReputationRegistry {
+    struct Profile {
+        int256 score;
+        uint256 successfulVolume;
+        uint64 successfulInteractions;
+        uint64 abandonedIntents;
+        uint64 chargebacks;
+    }
+
+    function getProfile(address account) external view returns (Profile memory);
+    function getScore(address account) external view returns (int256);
+    function recordSuccess(address taker, address maker, uint256 amount) external;
+    function recordAbandonment(address taker, uint256 amount, bool expired) external;
+    function recordChargeback(address taker, uint256 previousAmount, uint256 newCumulativeAmount) external;
+}

--- a/contracts/interfaces/IStakeVault.sol
+++ b/contracts/interfaces/IStakeVault.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @title IStakeVault
+ * @notice USDC collateral vault used for intent bonds and chargeback exposure.
+ * @dev Maker compensation is credited internally and withdrawn with `withdraw`, never pushed.
+ */
+interface IStakeVault {
+    struct MaturitySchedule {
+        uint32 cliffSeconds;
+        uint32 stepTwoSeconds;
+        uint32 finalMaturitySeconds;
+        uint16 retentionBpsAfterCliff;
+        uint16 retentionBpsAfterStepTwo;
+    }
+
+    function stakeToken() external view returns (IERC20);
+    function openChargebackClaims(address account) external view returns (uint256);
+    function reputationHolds(address account) external view returns (uint256);
+    function hasReputationHold(bytes32 intentHash) external view returns (bool);
+    function hasOpenChargebackClaim(bytes32 intentHash) external view returns (bool);
+
+    function reserve(
+        bytes32 intentHash,
+        address taker,
+        address maker,
+        bytes32 paymentMethod,
+        uint256 bondAmount,
+        uint256 riskAmount
+    ) external;
+
+    function activate(
+        bytes32 intentHash,
+        uint256 activatedRiskAmount,
+        MaturitySchedule calldata schedule
+    ) external;
+
+    function abandon(bytes32 intentHash, uint16 bondSlashBps) external returns (uint256 slashedBond);
+    function resolveChargeback(bytes32 intentHash, uint256 amount, bool finalClaim)
+        external
+        returns (uint256 paidToMaker);
+    function clearReputationHold(bytes32 intentHash) external;
+    function closeChargebackClaim(bytes32 intentHash) external;
+}

--- a/contracts/mocks/IntentStatusOrchestratorMock.sol
+++ b/contracts/mocks/IntentStatusOrchestratorMock.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { IProtocolRiskManager } from "../interfaces/IProtocolRiskManager.sol";
+
+/** @notice Minimal orchestrator lifecycle surface for risk recovery tests. */
+contract IntentStatusOrchestratorMock {
+    mapping(bytes32 => bool) public activeIntents;
+
+    function signal(IProtocolRiskManager manager, IProtocolRiskManager.SignalContext calldata context)
+        external
+        returns (uint16 feeDiscountBps)
+    {
+        activeIntents[context.intentHash] = true;
+        return manager.onIntentSignaled(context);
+    }
+
+    function dropIntent(bytes32 intentHash) external {
+        activeIntents[intentHash] = false;
+    }
+
+    function hasActiveIntent(bytes32 intentHash) external view returns (bool) {
+        return activeIntents[intentHash];
+    }
+}

--- a/contracts/mocks/ProtocolRiskManagerMock.sol
+++ b/contracts/mocks/ProtocolRiskManagerMock.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { IProtocolRiskManager } from "../interfaces/IProtocolRiskManager.sol";
+
+contract ProtocolRiskManagerMock is IProtocolRiskManager {
+    uint16 public feeDiscountBps;
+    mapping(bytes32 => SignalContext) private signalContexts;
+    mapping(bytes32 => uint256) public fulfilledAmounts;
+    mapping(bytes32 => bool) public paymentProofVerified;
+    mapping(bytes32 => bool) public abandoned;
+    mapping(bytes32 => bool) public expired;
+    bool public revertOnAbandon;
+
+    function setFeeDiscountBps(uint16 feeDiscountBps_) external {
+        feeDiscountBps = feeDiscountBps_;
+    }
+
+    function setRevertOnAbandon(bool revertOnAbandon_) external {
+        revertOnAbandon = revertOnAbandon_;
+    }
+
+    function onIntentSignaled(SignalContext calldata context) external override returns (uint16) {
+        signalContexts[context.intentHash] = context;
+        return feeDiscountBps;
+    }
+
+    function onIntentFulfilled(bytes32 intentHash, uint256 releaseAmount, bool paymentProofVerified_) external override {
+        fulfilledAmounts[intentHash] = releaseAmount;
+        paymentProofVerified[intentHash] = paymentProofVerified_;
+    }
+
+    function onIntentAbandoned(bytes32 intentHash, bool expired_) external override {
+        require(!revertOnAbandon, "ProtocolRiskManagerMock: abandon failed");
+        abandoned[intentHash] = true;
+        expired[intentHash] = expired_;
+    }
+
+    function syncReputation(bytes32) external pure override returns (bool) {
+        return true;
+    }
+
+    function getSignalContext(bytes32 intentHash) external view returns (SignalContext memory) {
+        return signalContexts[intentHash];
+    }
+}

--- a/contracts/risk/IdentityRegistry.sol
+++ b/contracts/risk/IdentityRegistry.sol
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { SignatureChecker } from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+
+import { IIdentityRegistry } from "../interfaces/IIdentityRegistry.sol";
+
+/**
+ * @title IdentityRegistry
+ * @notice Registers unique platform identities from the existing Attestor identity EIP-712 payload.
+ * @dev Identity bindings are intentionally non-transferable. Governance can deactivate a compromised
+ *      binding, but its platform identifier remains burned so reputation cannot be reset onto a new wallet.
+ */
+contract IdentityRegistry is Ownable, IIdentityRegistry {
+    using SignatureChecker for address;
+
+    bytes32 public constant IDENTITY_TYPEHASH = keccak256(
+        "IdentityAttestation(bytes32 method,bytes32 actionType,address callerAddress,bytes32 payeeIdHash,bytes32 dataHash,uint256 issuedAt,uint256 validUntil)"
+    );
+    bytes32 public constant DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,string version)");
+    bytes32 public constant DOMAIN_SEPARATOR = keccak256(
+        abi.encode(
+            DOMAIN_TYPEHASH,
+            keccak256("ZKP2PIdentityVerifier"),
+            keccak256("1")
+        )
+    );
+    uint256 public constant MAX_FUTURE_ISSUANCE_MS = 5 minutes * 1_000;
+    uint256 public constant MAX_IDENTITIES_PER_ACCOUNT = 16;
+
+    mapping(address => bool) public trustedAttestors;
+    mapping(bytes32 => bool) public acceptedActionTypes;
+    mapping(bytes32 => address) private identityOwners;
+    mapping(bytes32 => bool) public activeIdentities;
+    mapping(address => uint256) public activeIdentityCount;
+    mapping(address => bool) private quarantinedAccounts;
+    mapping(address => bytes32) private accountNodes;
+    mapping(address => bytes32[]) private accountIdentities;
+
+    event TrustedAttestorUpdated(address indexed attestor, bool trusted);
+    event AcceptedActionTypeUpdated(bytes32 indexed actionType, bool accepted);
+    event IdentityRegistered(
+        bytes32 indexed identityKey,
+        address indexed account,
+        bytes32 indexed method,
+        bytes32 payeeIdHash,
+        bytes32 actionType,
+        bytes32 dataHash
+    );
+    event IdentityStatusUpdated(bytes32 indexed identityKey, address indexed account, bool active);
+    event AccountQuarantineUpdated(address indexed account, bool quarantined);
+
+    error ZeroAddress();
+    error InvalidIdentity();
+    error UntrustedAttestor(address attestor);
+    error UnsupportedActionType(bytes32 actionType);
+    error InvalidAttestationTime(uint256 issuedAtMs, uint256 validUntilMs, uint256 currentTimeMs);
+    error InvalidAttestationSignature();
+    error UnauthorizedAccount(address caller, address attestedAccount);
+    error IdentityAlreadyBound(bytes32 identityKey, address account);
+    error IdentityNotFound(bytes32 identityKey);
+    error IdentityAlreadyInState(bytes32 identityKey, bool active);
+    error TooManyAccountIdentities(address account);
+    error AccountAlreadyInQuarantineState(address account, bool quarantined);
+
+    constructor(address owner_) {
+        if (owner_ == address(0)) revert ZeroAddress();
+        transferOwnership(owner_);
+    }
+
+    /** @notice Adds or removes an Attestor signing key. Use a multisig/timelock as owner in production. */
+    function setTrustedAttestor(address attestor, bool trusted) external onlyOwner {
+        if (attestor == address(0)) revert ZeroAddress();
+        trustedAttestors[attestor] = trusted;
+        emit TrustedAttestorUpdated(attestor, trusted);
+    }
+
+    /** @notice Restricts portable Attestor payloads to explicit identity-registration actions. */
+    function setAcceptedActionType(bytes32 actionType, bool accepted) external onlyOwner {
+        if (actionType == bytes32(0)) revert InvalidIdentity();
+        acceptedActionTypes[actionType] = accepted;
+        emit AcceptedActionTypeUpdated(actionType, accepted);
+    }
+
+    /**
+     * @notice Registers a unique platform identity from an Attestor-signed EIP-712 payload.
+     * @dev The attested wallet must submit its own registration. This prevents infrastructure or
+     *      a stale payload holder from publishing a permanent wallet-to-platform binding.
+     */
+    function registerIdentity(
+        IdentityAttestation calldata attestation,
+        address attestor,
+        bytes calldata signature
+    ) external override returns (bytes32 identityKey) {
+        if (!trustedAttestors[attestor]) revert UntrustedAttestor(attestor);
+        if (msg.sender != attestation.account) {
+            revert UnauthorizedAccount(msg.sender, attestation.account);
+        }
+        if (
+            attestation.account == address(0)
+                || attestation.method == bytes32(0)
+                || attestation.actionType == bytes32(0)
+                || attestation.payeeIdHash == bytes32(0)
+                || attestation.dataHash == bytes32(0)
+        ) revert InvalidIdentity();
+        if (!acceptedActionTypes[attestation.actionType]) {
+            revert UnsupportedActionType(attestation.actionType);
+        }
+
+        uint256 currentTimeMs = block.timestamp * 1_000;
+        if (
+            attestation.issuedAtMs > currentTimeMs + MAX_FUTURE_ISSUANCE_MS
+                || attestation.validUntilMs < currentTimeMs
+                || attestation.validUntilMs < attestation.issuedAtMs
+        ) {
+            revert InvalidAttestationTime(attestation.issuedAtMs, attestation.validUntilMs, currentTimeMs);
+        }
+
+        bytes32 structHash = keccak256(
+            abi.encode(
+                IDENTITY_TYPEHASH,
+                attestation.method,
+                attestation.actionType,
+                attestation.account,
+                attestation.payeeIdHash,
+                attestation.dataHash,
+                attestation.issuedAtMs,
+                attestation.validUntilMs
+            )
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash));
+        if (!attestor.isValidSignatureNow(digest, signature)) revert InvalidAttestationSignature();
+
+        identityKey = keccak256(abi.encode(attestation.method, attestation.payeeIdHash));
+        address existingOwner = identityOwners[identityKey];
+        if (existingOwner != address(0)) revert IdentityAlreadyBound(identityKey, existingOwner);
+
+        identityOwners[identityKey] = attestation.account;
+        activeIdentities[identityKey] = true;
+        activeIdentityCount[attestation.account] += 1;
+        if (accountIdentities[attestation.account].length >= MAX_IDENTITIES_PER_ACCOUNT) {
+            revert TooManyAccountIdentities(attestation.account);
+        }
+        accountIdentities[attestation.account].push(identityKey);
+        if (accountNodes[attestation.account] == bytes32(0)) {
+            accountNodes[attestation.account] = identityKey;
+        }
+
+        emit IdentityRegistered(
+            identityKey,
+            attestation.account,
+            attestation.method,
+            attestation.payeeIdHash,
+            attestation.actionType,
+            attestation.dataHash
+        );
+    }
+
+    /**
+     * @notice Deactivates or reactivates a known identity without freeing its unique identifier.
+     * @dev This is an emergency safety valve, not a reputation reset or transfer mechanism.
+     */
+    function setIdentityStatus(bytes32 identityKey, bool active) external onlyOwner {
+        address account = identityOwners[identityKey];
+        if (account == address(0)) revert IdentityNotFound(identityKey);
+        if (activeIdentities[identityKey] == active) revert IdentityAlreadyInState(identityKey, active);
+
+        activeIdentities[identityKey] = active;
+        if (active) {
+            activeIdentityCount[account] += 1;
+            if (accountNodes[account] == bytes32(0)) accountNodes[account] = identityKey;
+        } else {
+            activeIdentityCount[account] -= 1;
+            if (accountNodes[account] == identityKey) {
+                accountNodes[account] = _findActiveAccountNode(account, identityKey);
+            }
+        }
+        emit IdentityStatusUpdated(identityKey, account, active);
+    }
+
+    /**
+     * @notice Quarantines a wallet without deleting its identity bindings or reputation history.
+     * @dev Use this when a primary identity is proven fraudulent or compromised. Unquarantining
+     *      is explicit so rotating to another already-bound identity cannot bypass the response.
+     */
+    function setAccountQuarantine(address account, bool quarantined) external onlyOwner {
+        if (account == address(0)) revert ZeroAddress();
+        if (quarantinedAccounts[account] == quarantined) {
+            revert AccountAlreadyInQuarantineState(account, quarantined);
+        }
+        quarantinedAccounts[account] = quarantined;
+        emit AccountQuarantineUpdated(account, quarantined);
+    }
+
+    function isVerifiedAccount(address account) external view override returns (bool) {
+        return activeIdentityCount[account] > 0 && !quarantinedAccounts[account];
+    }
+
+    function isQuarantined(address account) external view override returns (bool) {
+        return quarantinedAccounts[account];
+    }
+
+    function getAccountNode(address account) external view override returns (bytes32) {
+        bytes32 node = accountNodes[account];
+        return activeIdentityCount[account] > 0 && activeIdentities[node] ? node : bytes32(0);
+    }
+
+    function getIdentityOwner(bytes32 method, bytes32 payeeIdHash) external view override returns (address) {
+        bytes32 identityKey = keccak256(abi.encode(method, payeeIdHash));
+        return activeIdentities[identityKey] ? identityOwners[identityKey] : address(0);
+    }
+
+    function getAccountIdentities(address account) external view returns (bytes32[] memory) {
+        return accountIdentities[account];
+    }
+
+    function _findActiveAccountNode(address account, bytes32 excludedIdentity) internal view returns (bytes32) {
+        bytes32[] storage identities = accountIdentities[account];
+        for (uint256 i = 0; i < identities.length; ++i) {
+            bytes32 candidate = identities[i];
+            if (candidate != excludedIdentity && activeIdentities[candidate]) return candidate;
+        }
+        return bytes32(0);
+    }
+}

--- a/contracts/risk/ProtocolRiskManager.sol
+++ b/contracts/risk/ProtocolRiskManager.sol
@@ -1,0 +1,630 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import { SignatureChecker } from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import { IIdentityRegistry } from "../interfaces/IIdentityRegistry.sol";
+import { IOrchestratorRegistry } from "../interfaces/IOrchestratorRegistry.sol";
+import { IProtocolRiskManager } from "../interfaces/IProtocolRiskManager.sol";
+import { IReputationRegistry } from "../interfaces/IReputationRegistry.sol";
+import { IStakeVault } from "../interfaces/IStakeVault.sol";
+
+interface IIntentStatusView {
+    function hasActiveIntent(bytes32 intentHash) external view returns (bool);
+}
+
+/**
+ * @title ProtocolRiskManager
+ * @notice Transparent onchain platform policy, reputation tiers, stake quoting, and lifecycle accounting.
+ * @dev There are deliberately no per-tier amount caps or active-intent count limits. Access is controlled
+ *      by unique identity, a configurable minimum reputation floor, and capital reserved per intent.
+ *      Orchestrators snapshot this contract per intent, so a later module upgrade cannot strand positions.
+ */
+contract ProtocolRiskManager is Ownable, EIP712, IProtocolRiskManager {
+    using SignatureChecker for address;
+
+    uint16 private constant BPS = 10_000;
+    uint16 private constant MAX_STAKE_BPS = 20_000;
+    uint16 private constant MAX_TIER_STAKE_MULTIPLIER_BPS = 20_000;
+    uint256 public constant MAX_FUTURE_ISSUANCE = 5 minutes;
+    uint256 public constant MAX_OPEN_CLAIM_SECONDS = 30 days;
+
+    bytes32 public constant CHARGEBACK_TYPEHASH = keccak256(
+        "ChargebackAttestation(bytes32 intentHash,address taker,address maker,uint256 amount,bytes32 paymentMethod,bytes32 evidenceHash,bool finalClaim,uint256 issuedAt,uint256 validUntil)"
+    );
+
+    enum IntentRiskStatus {
+        None,
+        Reserved,
+        Fulfilled,
+        Abandoned,
+        ChargedBack
+    }
+
+    struct PlatformRiskConfig {
+        bool configured;
+        bool enabled;
+        bool identityRequired;
+        bool makerIdentityRequired;
+        bool chargebackable;
+        int256 minReputation;
+        uint16 baseStakeBps;
+        uint16 abandonmentSlashBps;
+        uint96 signalBond;
+        IStakeVault.MaturitySchedule maturitySchedule;
+    }
+
+    struct TierConfig {
+        int256 minReputation;
+        uint16 feeDiscountBps;
+        uint16 stakeMultiplierBps;
+    }
+
+    struct IntentRisk {
+        address orchestrator;
+        address taker;
+        address maker;
+        bytes32 paymentMethod;
+        uint256 signaledAmount;
+        uint256 releaseAmount;
+        uint16 feeDiscountBps;
+        uint16 baseStakeBps;
+        uint16 tierStakeMultiplierBps;
+        uint16 abandonmentSlashBps;
+        uint256 cumulativeChargebackAmount;
+        uint256 cumulativeCompensation;
+        uint256 reputationChargebackAmount;
+        uint64 lastChargebackAt;
+        bool abandonmentExpired;
+        bool abandonmentReputationRecorded;
+        IStakeVault.MaturitySchedule maturitySchedule;
+        IntentRiskStatus status;
+    }
+
+    struct ChargebackAttestation {
+        bytes32 intentHash;
+        address taker;
+        address maker;
+        uint256 amount;
+        bytes32 paymentMethod;
+        bytes32 evidenceHash;
+        bool finalClaim;
+        uint256 issuedAt;
+        uint256 validUntil;
+    }
+
+    IIdentityRegistry public immutable identityRegistry;
+    IReputationRegistry public immutable reputationRegistry;
+    IStakeVault public immutable stakeVault;
+    IOrchestratorRegistry public immutable orchestratorRegistry;
+
+    mapping(bytes32 => PlatformRiskConfig) public platformRiskConfigs;
+    mapping(bytes32 => IntentRisk) public intentRisks;
+    mapping(bytes32 => bool) public usedChargebackEvidence;
+    mapping(address => bool) public trustedChargebackAttestors;
+    TierConfig[] private tierConfigs;
+
+    event PlatformRiskConfigUpdated(bytes32 indexed paymentMethod, PlatformRiskConfig config);
+    event TierConfigsUpdated(uint256 tierCount);
+    event TrustedChargebackAttestorUpdated(address indexed attestor, bool trusted);
+    event IntentRiskReserved(
+        bytes32 indexed intentHash,
+        address indexed taker,
+        bytes32 indexed paymentMethod,
+        uint8 tier,
+        uint256 bondAmount,
+        uint256 riskAmount,
+        uint16 feeDiscountBps
+    );
+    event IntentRiskFulfilled(
+        bytes32 indexed intentHash,
+        uint256 releaseAmount,
+        uint256 activatedRiskAmount,
+        bool paymentProofVerified
+    );
+    event IntentRiskAbandoned(bytes32 indexed intentHash, bool expired);
+    event ReputationUpdateFailed(bytes32 indexed intentHash, bytes reason);
+    event ReputationSynchronized(bytes32 indexed intentHash, uint256 chargebackAmount, bool abandonmentRecorded);
+    event ChargebackResolved(
+        bytes32 indexed intentHash,
+        address indexed taker,
+        address indexed maker,
+        uint256 attestedAmount,
+        uint256 paidAmount,
+        bool finalClaim,
+        bytes32 evidenceHash
+    );
+    event StaleChargebackClaimClosed(bytes32 indexed intentHash, address indexed taker);
+
+    error ZeroAddress();
+    error UnauthorizedOrchestrator(address caller);
+    error InvalidPlatformConfig(bytes32 paymentMethod);
+    error PlatformNotConfigured(bytes32 paymentMethod);
+    error PlatformDisabled(bytes32 paymentMethod);
+    error IdentityRequired(address account);
+    error AccountQuarantined(address account);
+    error ReputationBelowMinimum(address account, int256 score, int256 minimum);
+    error SelfInteraction(address account);
+    error UnsupportedCollateralToken(address token, address requiredToken);
+    error IntentRiskAlreadyExists(bytes32 intentHash);
+    error IntentRiskNotFound(bytes32 intentHash);
+    error InvalidIntentRiskStatus(bytes32 intentHash, IntentRiskStatus status);
+    error IntentOrchestratorMismatch(address caller, address expected);
+    error InvalidTierConfig(uint256 index);
+    error UntrustedChargebackAttestor(address attestor);
+    error InvalidChargebackAttestation();
+    error InvalidChargebackTime(uint256 issuedAt, uint256 validUntil, uint256 currentTime);
+    error InvalidChargebackSignature();
+    error IntentStillActive(bytes32 intentHash);
+    error ChargebackEvidenceAlreadyUsed(bytes32 evidenceKey);
+    error AccountRiskHold(address account, uint256 openClaimCount, uint256 reputationHoldCount);
+    error ChargebackClaimNotStale(bytes32 intentHash, uint256 eligibleAt, uint256 currentTime);
+
+    modifier onlyOrchestrator() {
+        if (!orchestratorRegistry.isOrchestrator(msg.sender)) revert UnauthorizedOrchestrator(msg.sender);
+        _;
+    }
+
+    constructor(
+        address owner_,
+        IOrchestratorRegistry orchestratorRegistry_,
+        IIdentityRegistry identityRegistry_,
+        IReputationRegistry reputationRegistry_,
+        IStakeVault stakeVault_
+    ) EIP712("ZKP2PChargebackVerifier", "1") {
+        if (
+            owner_ == address(0)
+                || address(orchestratorRegistry_) == address(0)
+                || address(identityRegistry_) == address(0)
+                || address(reputationRegistry_) == address(0)
+                || address(stakeVault_) == address(0)
+        ) revert ZeroAddress();
+
+        orchestratorRegistry = orchestratorRegistry_;
+        identityRegistry = identityRegistry_;
+        reputationRegistry = reputationRegistry_;
+        stakeVault = stakeVault_;
+        _setDefaultTiers();
+        transferOwnership(owner_);
+    }
+
+    /** @notice Stores every platform risk lever onchain in one auditable record. */
+    function setPlatformRiskConfig(bytes32 paymentMethod, PlatformRiskConfig calldata config) external onlyOwner {
+        if (paymentMethod == bytes32(0) || !config.configured) revert InvalidPlatformConfig(paymentMethod);
+        if (
+            config.baseStakeBps > MAX_STAKE_BPS
+                || config.abandonmentSlashBps > BPS
+                || (config.chargebackable && config.baseStakeBps < BPS)
+                || (!config.chargebackable && config.baseStakeBps != 0)
+        ) revert InvalidPlatformConfig(paymentMethod);
+
+        if (config.chargebackable) {
+            IStakeVault.MaturitySchedule calldata schedule = config.maturitySchedule;
+            if (
+                schedule.cliffSeconds == 0
+                    || schedule.stepTwoSeconds <= schedule.cliffSeconds
+                    || schedule.finalMaturitySeconds <= schedule.stepTwoSeconds
+                    || schedule.retentionBpsAfterCliff != BPS
+                    || schedule.retentionBpsAfterStepTwo != BPS
+            ) revert InvalidPlatformConfig(paymentMethod);
+        }
+
+        platformRiskConfigs[paymentMethod] = config;
+        emit PlatformRiskConfigUpdated(paymentMethod, config);
+    }
+
+    /**
+     * @notice Replaces the ordered tier table after monotonicity checks.
+     * @dev Discounts are a percentage of the protocol fee, not an amount cap. Stake multipliers
+     *      must fall as reputation rises. At least one bootstrap tier is always required.
+     */
+    function setTierConfigs(TierConfig[] calldata configs) external onlyOwner {
+        if (configs.length == 0 || configs.length > 16) revert InvalidTierConfig(0);
+        delete tierConfigs;
+        for (uint256 i = 0; i < configs.length; ++i) {
+            TierConfig calldata config = configs[i];
+            if (
+                config.feeDiscountBps > BPS
+                    || config.stakeMultiplierBps < BPS
+                    || config.stakeMultiplierBps > MAX_TIER_STAKE_MULTIPLIER_BPS
+                    || (i > 0 && config.minReputation <= configs[i - 1].minReputation)
+                    || (i > 0 && config.feeDiscountBps < configs[i - 1].feeDiscountBps)
+                    || (i > 0 && config.stakeMultiplierBps > configs[i - 1].stakeMultiplierBps)
+            ) revert InvalidTierConfig(i);
+            tierConfigs.push(config);
+        }
+        emit TierConfigsUpdated(configs.length);
+    }
+
+    function setTrustedChargebackAttestor(address attestor, bool trusted) external onlyOwner {
+        if (attestor == address(0)) revert ZeroAddress();
+        trustedChargebackAttestors[attestor] = trusted;
+        emit TrustedChargebackAttestorUpdated(attestor, trusted);
+    }
+
+    function getTierConfig(uint256 tier) external view returns (TierConfig memory) {
+        return tierConfigs[tier];
+    }
+
+    function getTierCount() external view returns (uint256) {
+        return tierConfigs.length;
+    }
+
+    function getTier(address account) public view returns (uint8 tier) {
+        int256 score = reputationRegistry.getScore(account);
+        for (uint256 i = 1; i < tierConfigs.length; ++i) {
+            if (score < tierConfigs[i].minReputation) break;
+            tier = uint8(i);
+        }
+    }
+
+    /** @notice Validates identity/reputation policy and reserves bond plus chargeback collateral. */
+    function onIntentSignaled(SignalContext calldata context)
+        external
+        override
+        onlyOrchestrator
+        returns (uint16 feeDiscountBps)
+    {
+        if (intentRisks[context.intentHash].status != IntentRiskStatus.None) {
+            revert IntentRiskAlreadyExists(context.intentHash);
+        }
+        if (context.taker == context.maker) revert SelfInteraction(context.taker);
+        uint256 openClaimCount = stakeVault.openChargebackClaims(context.taker);
+        uint256 reputationHoldCount = stakeVault.reputationHolds(context.taker);
+        if (openClaimCount > 0 || reputationHoldCount > 0) {
+            revert AccountRiskHold(context.taker, openClaimCount, reputationHoldCount);
+        }
+        PlatformRiskConfig memory platform = platformRiskConfigs[context.paymentMethod];
+        if (!platform.configured) revert PlatformNotConfigured(context.paymentMethod);
+        if (!platform.enabled) revert PlatformDisabled(context.paymentMethod);
+        if (identityRegistry.isQuarantined(context.taker)) revert AccountQuarantined(context.taker);
+        if (identityRegistry.isQuarantined(context.maker)) revert AccountQuarantined(context.maker);
+        if (platform.identityRequired && !identityRegistry.isVerifiedAccount(context.taker)) {
+            revert IdentityRequired(context.taker);
+        }
+        if (platform.makerIdentityRequired && !identityRegistry.isVerifiedAccount(context.maker)) {
+            revert IdentityRequired(context.maker);
+        }
+
+        int256 score = reputationRegistry.getScore(context.taker);
+        if (score < platform.minReputation) {
+            revert ReputationBelowMinimum(context.taker, score, platform.minReputation);
+        }
+
+        uint8 tier = getTier(context.taker);
+        TierConfig memory tierConfig = tierConfigs[tier];
+        uint256 riskAmount = _calculateRiskAmount(
+            context.amount,
+            platform.baseStakeBps,
+            tierConfig.stakeMultiplierBps
+        );
+        uint256 bondAmount = platform.signalBond;
+        if (
+            bondAmount + riskAmount > 0
+                && context.token != address(stakeVault.stakeToken())
+        ) {
+            revert UnsupportedCollateralToken(context.token, address(stakeVault.stakeToken()));
+        }
+
+        intentRisks[context.intentHash] = IntentRisk({
+            orchestrator: msg.sender,
+            taker: context.taker,
+            maker: context.maker,
+            paymentMethod: context.paymentMethod,
+            signaledAmount: context.amount,
+            releaseAmount: 0,
+            feeDiscountBps: tierConfig.feeDiscountBps,
+            baseStakeBps: platform.baseStakeBps,
+            tierStakeMultiplierBps: tierConfig.stakeMultiplierBps,
+            abandonmentSlashBps: platform.abandonmentSlashBps,
+            cumulativeChargebackAmount: 0,
+            cumulativeCompensation: 0,
+            reputationChargebackAmount: 0,
+            lastChargebackAt: 0,
+            abandonmentExpired: false,
+            abandonmentReputationRecorded: false,
+            maturitySchedule: platform.maturitySchedule,
+            status: IntentRiskStatus.Reserved
+        });
+
+        stakeVault.reserve(
+            context.intentHash,
+            context.taker,
+            context.maker,
+            context.paymentMethod,
+            bondAmount,
+            riskAmount
+        );
+
+        feeDiscountBps = tierConfig.feeDiscountBps;
+        emit IntentRiskReserved(
+            context.intentHash,
+            context.taker,
+            context.paymentMethod,
+            tier,
+            bondAmount,
+            riskAmount,
+            feeDiscountBps
+        );
+    }
+
+    /** @notice Activates chargeback collateral and records a successful graph interaction. */
+    function onIntentFulfilled(bytes32 intentHash, uint256 releaseAmount, bool paymentProofVerified)
+        external
+        override
+    {
+        IntentRisk storage intentRisk = _getReservedIntentRisk(intentHash);
+        _validateIntentOrchestrator(intentRisk);
+        if (releaseAmount == 0 || releaseAmount > intentRisk.signaledAmount) {
+            revert InvalidChargebackAttestation();
+        }
+
+        uint256 activatedRiskAmount = _calculateRiskAmount(
+            releaseAmount,
+            intentRisk.baseStakeBps,
+            intentRisk.tierStakeMultiplierBps
+        );
+        stakeVault.activate(intentHash, activatedRiskAmount, intentRisk.maturitySchedule);
+        if (paymentProofVerified) {
+            try reputationRegistry.recordSuccess(intentRisk.taker, intentRisk.maker, releaseAmount) {
+                // Reputation is accounted synchronously when its reporter authorization is healthy.
+            } catch (bytes memory reason) {
+                // Settlement and collateral accounting must not depend on the reputation reporter.
+                emit ReputationUpdateFailed(intentHash, reason);
+            }
+        }
+
+        intentRisk.releaseAmount = releaseAmount;
+        intentRisk.status = IntentRiskStatus.Fulfilled;
+        emit IntentRiskFulfilled(intentHash, releaseAmount, activatedRiskAmount, paymentProofVerified);
+    }
+
+    /** @notice Releases a reservation, applies the bond slash, and records an abandonment penalty. */
+    function onIntentAbandoned(bytes32 intentHash, bool expired) external override {
+        IntentRisk storage intentRisk = _getReservedIntentRisk(intentHash);
+        _validateIntentOrchestrator(intentRisk);
+
+        stakeVault.abandon(intentHash, intentRisk.abandonmentSlashBps);
+        intentRisk.abandonmentExpired = expired;
+        intentRisk.status = IntentRiskStatus.Abandoned;
+        _syncAbandonmentReputation(intentHash, intentRisk);
+        emit IntentRiskAbandoned(intentHash, expired);
+    }
+
+    /**
+     * @notice Resolves a reservation if Orchestrator fail-open pruning skipped a broken callback.
+     * @dev Anyone may call, but only after the snapshotted orchestrator confirms the intent is gone.
+     */
+    function recoverOrphanedReservation(bytes32 intentHash) external {
+        IntentRisk storage intentRisk = _getReservedIntentRisk(intentHash);
+        if (IIntentStatusView(intentRisk.orchestrator).hasActiveIntent(intentHash)) {
+            revert IntentStillActive(intentHash);
+        }
+
+        stakeVault.abandon(intentHash, intentRisk.abandonmentSlashBps);
+        // Recovery is deliberately conservative because the failed callback's cancellation/expiry
+        // classification is no longer authoritative after the orchestrator prunes its intent.
+        intentRisk.abandonmentExpired = true;
+        intentRisk.status = IntentRiskStatus.Abandoned;
+        _syncAbandonmentReputation(intentHash, intentRisk);
+        emit IntentRiskAbandoned(intentHash, true);
+    }
+
+    /**
+     * @notice Credits a maker from still-locked collateral after a trusted Attestor confirms a chargeback.
+     * @dev The EIP-712 domain includes chain id and this verifying contract, preventing cross-chain replay.
+     */
+    function resolveChargeback(
+        ChargebackAttestation calldata attestation,
+        address attestor,
+        bytes calldata signature
+    ) external returns (uint256 paidAmount) {
+        if (!trustedChargebackAttestors[attestor]) revert UntrustedChargebackAttestor(attestor);
+        IntentRisk storage intentRisk = intentRisks[attestation.intentHash];
+        if (intentRisk.status != IntentRiskStatus.Fulfilled) {
+            revert InvalidIntentRiskStatus(attestation.intentHash, intentRisk.status);
+        }
+        if (
+            attestation.taker != intentRisk.taker
+                || attestation.maker != intentRisk.maker
+                || attestation.paymentMethod != intentRisk.paymentMethod
+                || attestation.amount == 0
+                || attestation.evidenceHash == bytes32(0)
+        ) revert InvalidChargebackAttestation();
+        uint256 remainingChargebackAmount = intentRisk.releaseAmount - intentRisk.cumulativeChargebackAmount;
+        if (attestation.amount > remainingChargebackAmount) revert InvalidChargebackAttestation();
+        bytes32 evidenceKey = keccak256(abi.encode(attestation.intentHash, attestation.evidenceHash));
+        if (usedChargebackEvidence[evidenceKey]) revert ChargebackEvidenceAlreadyUsed(evidenceKey);
+        if (
+            attestation.issuedAt > block.timestamp + MAX_FUTURE_ISSUANCE
+                || attestation.validUntil < block.timestamp
+                || attestation.validUntil < attestation.issuedAt
+        ) {
+            revert InvalidChargebackTime(attestation.issuedAt, attestation.validUntil, block.timestamp);
+        }
+
+        bytes32 structHash = keccak256(
+            abi.encode(
+                CHARGEBACK_TYPEHASH,
+                attestation.intentHash,
+                attestation.taker,
+                attestation.maker,
+                attestation.amount,
+                attestation.paymentMethod,
+                attestation.evidenceHash,
+                attestation.finalClaim,
+                attestation.issuedAt,
+                attestation.validUntil
+            )
+        );
+        if (!attestor.isValidSignatureNow(_hashTypedDataV4(structHash), signature)) {
+            revert InvalidChargebackSignature();
+        }
+
+        if (!attestation.finalClaim && attestation.amount == remainingChargebackAmount) {
+            revert InvalidChargebackAttestation();
+        }
+        usedChargebackEvidence[evidenceKey] = true;
+        paidAmount = stakeVault.resolveChargeback(
+            attestation.intentHash,
+            attestation.amount,
+            attestation.finalClaim
+        );
+        intentRisk.cumulativeChargebackAmount += attestation.amount;
+        intentRisk.cumulativeCompensation += paidAmount;
+        if (attestation.finalClaim) {
+            intentRisk.lastChargebackAt = 0;
+            intentRisk.status = IntentRiskStatus.ChargedBack;
+        } else {
+            intentRisk.lastChargebackAt = uint64(block.timestamp);
+        }
+        _syncChargebackReputation(attestation.intentHash, intentRisk);
+
+        emit ChargebackResolved(
+            attestation.intentHash,
+            attestation.taker,
+            attestation.maker,
+            attestation.amount,
+            paidAmount,
+            attestation.finalClaim,
+            attestation.evidenceHash
+        );
+    }
+
+    /**
+     * @notice Permissionlessly removes an access freeze if a partial claim is not finalized in time.
+     * @dev This does not release collateral or prevent a later valid attestation. It only restores
+     *      protocol access after the Attestor's bounded finalization window lapses.
+     */
+    function closeStaleChargebackClaim(bytes32 intentHash) external {
+        IntentRisk storage intentRisk = intentRisks[intentHash];
+        if (intentRisk.status != IntentRiskStatus.Fulfilled || !stakeVault.hasOpenChargebackClaim(intentHash)) {
+            revert InvalidIntentRiskStatus(intentHash, intentRisk.status);
+        }
+        uint256 eligibleAt = uint256(intentRisk.lastChargebackAt) + MAX_OPEN_CLAIM_SECONDS;
+        if (intentRisk.lastChargebackAt == 0 || block.timestamp < eligibleAt) {
+            revert ChargebackClaimNotStale(intentHash, eligibleAt, block.timestamp);
+        }
+
+        stakeVault.closeChargebackClaim(intentHash);
+        intentRisk.lastChargebackAt = 0;
+        emit StaleChargebackClaimClosed(intentHash, intentRisk.taker);
+    }
+
+    /**
+     * @notice Permissionlessly retries a negative reputation update that previously failed.
+     * @dev StakeVault keeps a shared account hold until synchronization succeeds, so a manager
+     *      upgrade cannot let an account bypass a pending abandonment or chargeback penalty.
+     */
+    function syncReputation(bytes32 intentHash) external override returns (bool synced) {
+        IntentRisk storage intentRisk = intentRisks[intentHash];
+        if (intentRisk.status == IntentRiskStatus.None) revert IntentRiskNotFound(intentHash);
+        if (intentRisk.status == IntentRiskStatus.Abandoned) {
+            return _syncAbandonmentReputation(intentHash, intentRisk);
+        }
+        if (
+            intentRisk.status == IntentRiskStatus.Fulfilled
+                || intentRisk.status == IntentRiskStatus.ChargedBack
+        ) {
+            return _syncChargebackReputation(intentHash, intentRisk);
+        }
+        revert InvalidIntentRiskStatus(intentHash, intentRisk.status);
+    }
+
+    function _getReservedIntentRisk(bytes32 intentHash) internal view returns (IntentRisk storage intentRisk) {
+        intentRisk = intentRisks[intentHash];
+        if (intentRisk.status == IntentRiskStatus.None) revert IntentRiskNotFound(intentHash);
+        if (intentRisk.status != IntentRiskStatus.Reserved) {
+            revert InvalidIntentRiskStatus(intentHash, intentRisk.status);
+        }
+    }
+
+    function _validateIntentOrchestrator(IntentRisk storage intentRisk) internal view {
+        if (intentRisk.orchestrator != msg.sender) {
+            revert IntentOrchestratorMismatch(msg.sender, intentRisk.orchestrator);
+        }
+    }
+
+    function _calculateRiskAmount(uint256 amount, uint16 baseStakeBps, uint16 multiplierBps)
+        internal
+        pure
+        returns (uint256)
+    {
+        uint256 baseAmount = Math.mulDiv(amount, baseStakeBps, BPS);
+        return Math.mulDiv(baseAmount, multiplierBps, BPS);
+    }
+
+    function _syncAbandonmentReputation(bytes32 intentHash, IntentRisk storage intentRisk)
+        internal
+        returns (bool)
+    {
+        if (!intentRisk.abandonmentReputationRecorded) {
+            try reputationRegistry.recordAbandonment(
+                intentRisk.taker,
+                intentRisk.signaledAmount,
+                intentRisk.abandonmentExpired
+            ) {
+                intentRisk.abandonmentReputationRecorded = true;
+            } catch (bytes memory reason) {
+                emit ReputationUpdateFailed(intentHash, reason);
+                return false;
+            }
+        }
+        return _clearReputationHold(intentHash, intentRisk);
+    }
+
+    function _syncChargebackReputation(bytes32 intentHash, IntentRisk storage intentRisk)
+        internal
+        returns (bool)
+    {
+        uint256 targetAmount = intentRisk.cumulativeChargebackAmount;
+        if (intentRisk.reputationChargebackAmount < targetAmount) {
+            try reputationRegistry.recordChargeback(
+                intentRisk.taker,
+                intentRisk.reputationChargebackAmount,
+                targetAmount
+            ) {
+                intentRisk.reputationChargebackAmount = targetAmount;
+            } catch (bytes memory reason) {
+                emit ReputationUpdateFailed(intentHash, reason);
+                return false;
+            }
+        }
+        return _clearReputationHold(intentHash, intentRisk);
+    }
+
+    function _clearReputationHold(bytes32 intentHash, IntentRisk storage intentRisk)
+        internal
+        returns (bool)
+    {
+        if (stakeVault.hasReputationHold(intentHash)) {
+            try stakeVault.clearReputationHold(intentHash) {
+                emit ReputationSynchronized(
+                    intentHash,
+                    intentRisk.reputationChargebackAmount,
+                    intentRisk.abandonmentReputationRecorded
+                );
+            } catch (bytes memory reason) {
+                emit ReputationUpdateFailed(intentHash, reason);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function _setDefaultTiers() internal {
+        // Starter: permissionless bootstrap, full fee, 125% of configured platform stake.
+        tierConfigs.push(TierConfig({ minReputation: 0, feeDiscountBps: 0, stakeMultiplierBps: 12_500 }));
+        // Proven: consistent completion history.
+        tierConfigs.push(TierConfig({ minReputation: 100, feeDiscountBps: 1_000, stakeMultiplierBps: 10_000 }));
+        // Trusted: diverse, higher-weight graph participation.
+        tierConfigs.push(TierConfig({ minReputation: 500, feeDiscountBps: 2_500, stakeMultiplierBps: 10_000 }));
+        // Anchor: long-lived, highly connected protocol participant.
+        tierConfigs.push(TierConfig({ minReputation: 2_000, feeDiscountBps: 4_000, stakeMultiplierBps: 10_000 }));
+        emit TierConfigsUpdated(4);
+    }
+}

--- a/contracts/risk/ReputationRegistry.sol
+++ b/contracts/risk/ReputationRegistry.sol
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
+import { IIdentityRegistry } from "../interfaces/IIdentityRegistry.sol";
+import { IReputationRegistry } from "../interfaces/IReputationRegistry.sol";
+
+/**
+ * @title ReputationRegistry
+ * @notice A bounded, sybil-resistant interaction graph for protocol reputation.
+ * @dev Reputation is intentionally O(1) to update. Each pair of verified identities forms an edge.
+ *      Only increases in sqrt(cumulative pair volume) earn graph points, which gives diminishing
+ *      returns to repeated self-dealing between the same two nodes. Reputable counterparties add
+ *      more weight, without requiring an unbounded graph traversal.
+ */
+contract ReputationRegistry is Ownable, IReputationRegistry {
+    using SafeCast for uint256;
+
+    uint256 private constant MAX_BASE_PENALTY = 1_000_000;
+    uint256 private constant MAX_SCORE_MULTIPLIER_BPS_PER_POINT = 10_000;
+    struct Edge {
+        uint256 cumulativeVolume;
+        uint256 weight;
+        uint64 successfulInteractions;
+        uint64 lastInteractionAt;
+    }
+
+    IIdentityRegistry public immutable identityRegistry;
+    mapping(address => bool) public authorizedUpdaters;
+    mapping(address => Profile) private profiles;
+    mapping(bytes32 => Edge) public edges;
+
+    uint256 public pointUnit = 1e6; // One USDC when collateral uses six decimals.
+    uint256 public maxEdgeWeight = 100;
+    uint256 public baseAbandonmentPenalty = 10;
+    uint256 public baseChargebackPenalty = 100;
+    uint256 public scoreMultiplierBpsPerPoint = 10;
+    uint256 public maxCounterpartyMultiplierBps = 20_000;
+
+    event AuthorizedUpdaterUpdated(address indexed updater, bool authorized);
+    event ReputationConfigUpdated(
+        uint256 pointUnit,
+        uint256 maxEdgeWeight,
+        uint256 baseAbandonmentPenalty,
+        uint256 baseChargebackPenalty,
+        uint256 scoreMultiplierBpsPerPoint,
+        uint256 maxCounterpartyMultiplierBps
+    );
+    event ReputationChanged(address indexed account, int256 delta, int256 newScore, bytes32 indexed reason);
+    event EdgeUpdated(
+        bytes32 indexed edgeKey,
+        bytes32 indexed firstNode,
+        bytes32 indexed secondNode,
+        uint256 cumulativeVolume,
+        uint256 weight,
+        uint256 weightDelta
+    );
+
+    error ZeroAddress();
+    error UnauthorizedUpdater(address caller);
+    error InvalidConfig();
+    error InvalidInteraction(address taker, address maker);
+
+    modifier onlyUpdater() {
+        if (!authorizedUpdaters[msg.sender]) revert UnauthorizedUpdater(msg.sender);
+        _;
+    }
+
+    constructor(address owner_, address identityRegistry_) {
+        if (owner_ == address(0) || identityRegistry_ == address(0)) revert ZeroAddress();
+        identityRegistry = IIdentityRegistry(identityRegistry_);
+        transferOwnership(owner_);
+    }
+
+    function setAuthorizedUpdater(address updater, bool authorized) external onlyOwner {
+        if (updater == address(0)) revert ZeroAddress();
+        authorizedUpdaters[updater] = authorized;
+        emit AuthorizedUpdaterUpdated(updater, authorized);
+    }
+
+    /** @notice Updates transparent scoring constants. Existing scores and edges are never rewritten. */
+    function setReputationConfig(
+        uint256 pointUnit_,
+        uint256 maxEdgeWeight_,
+        uint256 baseAbandonmentPenalty_,
+        uint256 baseChargebackPenalty_,
+        uint256 scoreMultiplierBpsPerPoint_,
+        uint256 maxCounterpartyMultiplierBps_
+    ) external onlyOwner {
+        if (
+            pointUnit_ == 0
+                || maxEdgeWeight_ == 0
+                || maxEdgeWeight_ > 1_000_000
+                || baseAbandonmentPenalty_ == 0
+                || baseAbandonmentPenalty_ > MAX_BASE_PENALTY
+                || baseChargebackPenalty_ == 0
+                || baseChargebackPenalty_ > MAX_BASE_PENALTY
+                || scoreMultiplierBpsPerPoint_ == 0
+                || scoreMultiplierBpsPerPoint_ > MAX_SCORE_MULTIPLIER_BPS_PER_POINT
+                || maxCounterpartyMultiplierBps_ < 10_000
+                || maxCounterpartyMultiplierBps_ > 50_000
+        ) revert InvalidConfig();
+
+        pointUnit = pointUnit_;
+        maxEdgeWeight = maxEdgeWeight_;
+        baseAbandonmentPenalty = baseAbandonmentPenalty_;
+        baseChargebackPenalty = baseChargebackPenalty_;
+        scoreMultiplierBpsPerPoint = scoreMultiplierBpsPerPoint_;
+        maxCounterpartyMultiplierBps = maxCounterpartyMultiplierBps_;
+
+        emit ReputationConfigUpdated(
+            pointUnit_,
+            maxEdgeWeight_,
+            baseAbandonmentPenalty_,
+            baseChargebackPenalty_,
+            scoreMultiplierBpsPerPoint_,
+            maxCounterpartyMultiplierBps_
+        );
+    }
+
+    function getProfile(address account) external view override returns (Profile memory) {
+        return profiles[account];
+    }
+
+    function getScore(address account) external view override returns (int256) {
+        return profiles[account].score;
+    }
+
+    /**
+     * @notice Records a successful interaction and updates the bounded identity graph.
+     * @dev Only a verified, distinct identity pair can earn the bounded graph-weight increment.
+     *      There is no flat per-fill reward, so repeating a saturated edge earns zero points.
+     */
+    function recordSuccess(address taker, address maker, uint256 amount) external override onlyUpdater {
+        if (taker == maker) revert InvalidInteraction(taker, maker);
+        uint256 takerReward;
+        uint256 makerReward;
+        bytes32 takerNode = identityRegistry.getAccountNode(taker);
+        bytes32 makerNode = identityRegistry.getAccountNode(maker);
+
+        if (takerNode != bytes32(0) && makerNode != bytes32(0) && takerNode != makerNode) {
+            (bytes32 firstNode, bytes32 secondNode) = takerNode < makerNode
+                ? (takerNode, makerNode)
+                : (makerNode, takerNode);
+            bytes32 edgeKey = keccak256(abi.encode(firstNode, secondNode));
+            Edge storage edge = edges[edgeKey];
+            edge.cumulativeVolume += amount;
+
+            uint256 newWeight = Math.min(Math.sqrt(edge.cumulativeVolume / pointUnit), maxEdgeWeight);
+            uint256 weightDelta = newWeight > edge.weight ? newWeight - edge.weight : 0;
+            edge.weight = newWeight;
+            edge.successfulInteractions += 1;
+            edge.lastInteractionAt = uint64(block.timestamp);
+
+            takerReward += (weightDelta * _counterpartyMultiplierBps(maker)) / 10_000;
+            makerReward += (weightDelta * _counterpartyMultiplierBps(taker)) / 10_000;
+
+            emit EdgeUpdated(
+                edgeKey,
+                firstNode,
+                secondNode,
+                edge.cumulativeVolume,
+                edge.weight,
+                weightDelta
+            );
+        }
+
+        Profile storage takerProfile = profiles[taker];
+        takerProfile.successfulVolume += amount;
+        takerProfile.successfulInteractions += 1;
+        if (takerReward > 0) _applyDelta(taker, takerReward.toInt256(), keccak256("SUCCESS"));
+
+        Profile storage makerProfile = profiles[maker];
+        makerProfile.successfulVolume += amount;
+        makerProfile.successfulInteractions += 1;
+        if (makerReward > 0) _applyDelta(maker, makerReward.toInt256(), keccak256("SUCCESS"));
+    }
+
+    /** @notice Records a cancelled or expired lock as negative behavior. */
+    function recordAbandonment(address taker, uint256 amount, bool expired) external override onlyUpdater {
+        uint256 volumePenalty = Math.min(Math.sqrt(amount / pointUnit), maxEdgeWeight);
+        uint256 penalty = baseAbandonmentPenalty + volumePenalty;
+        if (expired) penalty += baseAbandonmentPenalty;
+
+        profiles[taker].abandonedIntents += 1;
+        _applyDelta(taker, -penalty.toInt256(), expired ? keccak256("EXPIRED") : keccak256("CANCELLED"));
+    }
+
+    /** @notice Records a proven chargeback as a high-severity negative event. */
+    function recordChargeback(address taker, uint256 previousAmount, uint256 newCumulativeAmount)
+        external
+        override
+        onlyUpdater
+    {
+        if (newCumulativeAmount <= previousAmount) revert InvalidConfig();
+        uint256 previousWeight = Math.min(Math.sqrt(previousAmount / pointUnit), maxEdgeWeight);
+        uint256 newWeight = Math.min(Math.sqrt(newCumulativeAmount / pointUnit), maxEdgeWeight);
+        uint256 penalty = newWeight - previousWeight;
+        if (previousAmount == 0) {
+            penalty += baseChargebackPenalty;
+            profiles[taker].chargebacks += 1;
+        }
+        _applyDelta(taker, -penalty.toInt256(), keccak256("CHARGEBACK"));
+    }
+
+    function _counterpartyMultiplierBps(address account) internal view returns (uint256) {
+        int256 score = profiles[account].score;
+        if (score <= 0) return 10_000;
+
+        uint256 positiveScore = uint256(score);
+        uint256 maximumExtraBps = maxCounterpartyMultiplierBps - 10_000;
+        if (positiveScore >= maximumExtraBps / scoreMultiplierBpsPerPoint) {
+            return maxCounterpartyMultiplierBps;
+        }
+        return 10_000 + (positiveScore * scoreMultiplierBpsPerPoint);
+    }
+
+    function _applyDelta(address account, int256 delta, bytes32 reason) internal {
+        profiles[account].score += delta;
+        emit ReputationChanged(account, delta, profiles[account].score, reason);
+    }
+}

--- a/contracts/risk/StakeVault.sol
+++ b/contracts/risk/StakeVault.sol
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import { IStakeVault } from "../interfaces/IStakeVault.sol";
+
+/**
+ * @title StakeVault
+ * @notice Holds USDC collateral without iterating over a user's positions.
+ * @dev Every intent is an independently checkpointable position. Users choose which matured
+ *      positions to checkpoint, making gas cost proportional to the batch they submit rather
+ *      than to lifetime protocol usage.
+ */
+contract StakeVault is Ownable, ReentrancyGuard, IStakeVault {
+    using SafeERC20 for IERC20;
+
+    uint16 private constant BPS = 10_000;
+
+    enum PositionStatus {
+        None,
+        Reserved,
+        Active,
+        Abandoned,
+        Matured,
+        ChargedBack
+    }
+
+    struct Position {
+        address manager;
+        address taker;
+        address maker;
+        bytes32 paymentMethod;
+        uint256 bondAmount;
+        uint256 reservedRiskAmount;
+        uint256 activatedRiskAmount;
+        uint256 releasedRiskAmount;
+        uint256 slashedRiskAmount;
+        uint64 activatedAt;
+        bool chargebackClaimOpen;
+        bool reputationHoldOpen;
+        MaturitySchedule schedule;
+        PositionStatus status;
+    }
+
+    IERC20 public immutable override stakeToken;
+    mapping(address => bool) public authorizedManagers;
+    mapping(address => uint256) public balances;
+    mapping(address => uint256) public reservedBalances;
+    mapping(address => uint256) public lockedBalances;
+    mapping(bytes32 => Position) public positions;
+    mapping(bytes32 => bool) public usedIntentHashes;
+    mapping(address => uint256) public override openChargebackClaims;
+    mapping(address => uint256) public override reputationHolds;
+
+    event AuthorizedManagerUpdated(address indexed manager, bool authorized);
+    event Deposited(address indexed account, uint256 amount);
+    event Withdrawn(address indexed account, address indexed recipient, uint256 amount);
+    event CollateralReserved(
+        bytes32 indexed intentHash,
+        address indexed taker,
+        address indexed maker,
+        uint256 bondAmount,
+        uint256 riskAmount
+    );
+    event ReservationAbandoned(bytes32 indexed intentHash, uint256 bondSlashed, address indexed maker);
+    event ExposureActivated(
+        bytes32 indexed intentHash,
+        address indexed taker,
+        uint256 riskAmount,
+        uint256 activatedAt
+    );
+    event ExposureCheckpointed(bytes32 indexed intentHash, uint256 releasedAmount, uint256 remainingLocked);
+    event ChargebackPaid(bytes32 indexed intentHash, address indexed maker, uint256 amount);
+    event ChargebackClaimStatusUpdated(bytes32 indexed intentHash, address indexed taker, bool open);
+    event ReputationHoldStatusUpdated(bytes32 indexed intentHash, address indexed taker, bool open);
+
+    error ZeroAddress();
+    error ZeroAmount();
+    error UnauthorizedManager(address caller);
+    error InsufficientAvailableStake(address account, uint256 available, uint256 required);
+    error IntentHashAlreadyUsed(bytes32 intentHash);
+    error InvalidPositionStatus(bytes32 intentHash, PositionStatus status);
+    error InvalidMaturitySchedule();
+    error RiskAmountExceedsReservation(uint256 requested, uint256 reserved);
+    error InvalidSlashBps(uint256 slashBps);
+    error UnauthorizedPositionOwner(address caller, address owner);
+    error ReputationHoldNotFound(bytes32 intentHash);
+    error ChargebackClaimNotFound(bytes32 intentHash);
+
+    modifier onlyManager() {
+        if (!authorizedManagers[msg.sender]) revert UnauthorizedManager(msg.sender);
+        _;
+    }
+
+    constructor(address owner_, IERC20 stakeToken_) {
+        if (owner_ == address(0) || address(stakeToken_) == address(0)) revert ZeroAddress();
+        stakeToken = stakeToken_;
+        transferOwnership(owner_);
+    }
+
+    function setAuthorizedManager(address manager, bool authorized) external onlyOwner {
+        if (manager == address(0)) revert ZeroAddress();
+        authorizedManagers[manager] = authorized;
+        emit AuthorizedManagerUpdated(manager, authorized);
+    }
+
+    /** @notice Adds freely withdrawable stake to the caller's balance. */
+    function deposit(uint256 amount) external nonReentrant {
+        if (amount == 0) revert ZeroAmount();
+        balances[msg.sender] += amount;
+        stakeToken.safeTransferFrom(msg.sender, address(this), amount);
+        emit Deposited(msg.sender, amount);
+    }
+
+    /** @notice Withdraws stake that is neither reserved nor locked by active chargeback exposure. */
+    function withdraw(uint256 amount, address recipient) external nonReentrant {
+        if (recipient == address(0)) revert ZeroAddress();
+        if (amount == 0) revert ZeroAmount();
+        uint256 available = availableBalance(msg.sender);
+        if (amount > available) revert InsufficientAvailableStake(msg.sender, available, amount);
+
+        balances[msg.sender] -= amount;
+        stakeToken.safeTransfer(recipient, amount);
+        emit Withdrawn(msg.sender, recipient, amount);
+    }
+
+    function availableBalance(address account) public view returns (uint256) {
+        return balances[account] - reservedBalances[account] - lockedBalances[account];
+    }
+
+    /** @notice Reserves free collateral for a newly signaled intent. */
+    function reserve(
+        bytes32 intentHash,
+        address taker,
+        address maker,
+        bytes32 paymentMethod,
+        uint256 bondAmount,
+        uint256 riskAmount
+    ) external override onlyManager {
+        if (taker == address(0) || maker == address(0)) revert ZeroAddress();
+        if (usedIntentHashes[intentHash]) revert IntentHashAlreadyUsed(intentHash);
+
+        uint256 required = bondAmount + riskAmount;
+        uint256 available = availableBalance(taker);
+        if (required > available) revert InsufficientAvailableStake(taker, available, required);
+
+        usedIntentHashes[intentHash] = true;
+        reservedBalances[taker] += required;
+        positions[intentHash] = Position({
+            manager: msg.sender,
+            taker: taker,
+            maker: maker,
+            paymentMethod: paymentMethod,
+            bondAmount: bondAmount,
+            reservedRiskAmount: riskAmount,
+            activatedRiskAmount: 0,
+            releasedRiskAmount: 0,
+            slashedRiskAmount: 0,
+            activatedAt: 0,
+            chargebackClaimOpen: false,
+            reputationHoldOpen: false,
+            schedule: MaturitySchedule({
+                cliffSeconds: 0,
+                stepTwoSeconds: 0,
+                finalMaturitySeconds: 0,
+                retentionBpsAfterCliff: 0,
+                retentionBpsAfterStepTwo: 0
+            }),
+            status: PositionStatus.Reserved
+        });
+
+        emit CollateralReserved(intentHash, taker, maker, bondAmount, riskAmount);
+    }
+
+    /** @notice Converts a reservation into a maturing chargeback exposure. */
+    function activate(
+        bytes32 intentHash,
+        uint256 activatedRiskAmount,
+        MaturitySchedule calldata schedule
+    ) external override {
+        Position storage position = positions[intentHash];
+        _validatePositionManager(position);
+        if (position.status != PositionStatus.Reserved) {
+            revert InvalidPositionStatus(intentHash, position.status);
+        }
+        if (activatedRiskAmount > position.reservedRiskAmount) {
+            revert RiskAmountExceedsReservation(activatedRiskAmount, position.reservedRiskAmount);
+        }
+        if (activatedRiskAmount > 0) _validateSchedule(schedule);
+
+        uint256 totalReservation = position.bondAmount + position.reservedRiskAmount;
+        reservedBalances[position.taker] -= totalReservation;
+
+        position.bondAmount = 0;
+        position.activatedRiskAmount = activatedRiskAmount;
+        position.activatedAt = uint64(block.timestamp);
+        position.schedule = schedule;
+
+        if (activatedRiskAmount == 0) {
+            position.status = PositionStatus.Matured;
+        } else {
+            lockedBalances[position.taker] += activatedRiskAmount;
+            position.status = PositionStatus.Active;
+        }
+
+        emit ExposureActivated(intentHash, position.taker, activatedRiskAmount, block.timestamp);
+    }
+
+    /** @notice Resolves a reservation and optionally credits its slashed bond to the maker. */
+    function abandon(bytes32 intentHash, uint16 bondSlashBps)
+        external
+        override
+        nonReentrant
+        returns (uint256 slashedBond)
+    {
+        if (bondSlashBps > BPS) revert InvalidSlashBps(bondSlashBps);
+        Position storage position = positions[intentHash];
+        _validatePositionManager(position);
+        if (position.status != PositionStatus.Reserved) {
+            revert InvalidPositionStatus(intentHash, position.status);
+        }
+
+        uint256 totalReservation = position.bondAmount + position.reservedRiskAmount;
+        reservedBalances[position.taker] -= totalReservation;
+        slashedBond = (position.bondAmount * bondSlashBps) / BPS;
+        if (slashedBond > 0) {
+            balances[position.taker] -= slashedBond;
+            balances[position.maker] += slashedBond;
+        }
+
+        position.status = PositionStatus.Abandoned;
+        _openReputationHold(intentHash, position);
+        emit ReservationAbandoned(intentHash, slashedBond, position.maker);
+    }
+
+    /**
+     * @notice Releases collateral that has matured under the position's transparent step schedule.
+     * @return releasedAmount Amount newly made withdrawable.
+     */
+    function checkpoint(bytes32 intentHash) public returns (uint256 releasedAmount) {
+        Position storage position = positions[intentHash];
+        if (position.status != PositionStatus.Active) {
+            revert InvalidPositionStatus(intentHash, position.status);
+        }
+
+        uint256 currentLocked = position.activatedRiskAmount
+            - position.releasedRiskAmount
+            - position.slashedRiskAmount;
+        uint256 requiredLocked = _requiredLocked(position);
+        if (requiredLocked < currentLocked) {
+            releasedAmount = currentLocked - requiredLocked;
+            position.releasedRiskAmount += releasedAmount;
+            lockedBalances[position.taker] -= releasedAmount;
+        }
+        if (requiredLocked == 0) position.status = PositionStatus.Matured;
+
+        emit ExposureCheckpointed(intentHash, releasedAmount, requiredLocked);
+    }
+
+    /** @notice Checkpoints caller-owned positions in a bounded caller-selected batch. */
+    function checkpointMany(bytes32[] calldata intentHashes) external returns (uint256 totalReleased) {
+        for (uint256 i = 0; i < intentHashes.length; ++i) {
+            Position storage position = positions[intentHashes[i]];
+            if (position.taker != msg.sender) revert UnauthorizedPositionOwner(msg.sender, position.taker);
+            if (position.status == PositionStatus.Active) {
+                totalReleased += checkpoint(intentHashes[i]);
+            }
+        }
+    }
+
+    /** @notice Credits a proven chargeback from the still-locked portion of a position. */
+    function resolveChargeback(bytes32 intentHash, uint256 amount, bool finalClaim)
+        external
+        override
+        nonReentrant
+        returns (uint256 paidToMaker)
+    {
+        Position storage position = positions[intentHash];
+        _validatePositionManager(position);
+        if (position.status != PositionStatus.Active && position.status != PositionStatus.Matured) {
+            revert InvalidPositionStatus(intentHash, position.status);
+        }
+
+        _openReputationHold(intentHash, position);
+
+        uint256 currentLocked;
+        if (position.status == PositionStatus.Active) {
+            currentLocked = position.activatedRiskAmount
+                - position.releasedRiskAmount
+                - position.slashedRiskAmount;
+            uint256 requiredLocked = _requiredLocked(position);
+            if (requiredLocked < currentLocked) {
+                uint256 newlyMatured = currentLocked - requiredLocked;
+                position.releasedRiskAmount += newlyMatured;
+                lockedBalances[position.taker] -= newlyMatured;
+                currentLocked = requiredLocked;
+            }
+        }
+
+        paidToMaker = Math.min(amount, currentLocked);
+        position.slashedRiskAmount += paidToMaker;
+        if (paidToMaker > 0) {
+            balances[position.taker] -= paidToMaker;
+            lockedBalances[position.taker] -= paidToMaker;
+            balances[position.maker] += paidToMaker;
+        }
+
+        uint256 remainingLocked = currentLocked - paidToMaker;
+        if (finalClaim) {
+            // The Attestor has now accounted for the full release amount, so collateral above
+            // the final compensated claim is no longer exposed and becomes freely withdrawable.
+            if (remainingLocked > 0) {
+                position.releasedRiskAmount += remainingLocked;
+                lockedBalances[position.taker] -= remainingLocked;
+            }
+            if (position.chargebackClaimOpen) {
+                position.chargebackClaimOpen = false;
+                openChargebackClaims[position.taker] -= 1;
+                emit ChargebackClaimStatusUpdated(intentHash, position.taker, false);
+            }
+            position.status = PositionStatus.ChargedBack;
+        } else if (remainingLocked == 0) {
+            position.status = PositionStatus.Matured;
+        }
+        if (!finalClaim && !position.chargebackClaimOpen) {
+            position.chargebackClaimOpen = true;
+            openChargebackClaims[position.taker] += 1;
+            emit ChargebackClaimStatusUpdated(intentHash, position.taker, true);
+        }
+
+        emit ChargebackPaid(intentHash, position.maker, paidToMaker);
+    }
+
+    /**
+     * @notice Clears the durable account hold after the position manager synchronizes its
+     *         negative reputation update. Exact manager authorization survives manager rotation.
+     */
+    function clearReputationHold(bytes32 intentHash) external override {
+        Position storage position = positions[intentHash];
+        _validatePositionManager(position);
+        if (!position.reputationHoldOpen) revert ReputationHoldNotFound(intentHash);
+
+        position.reputationHoldOpen = false;
+        reputationHolds[position.taker] -= 1;
+        emit ReputationHoldStatusUpdated(intentHash, position.taker, false);
+    }
+
+    /** @notice Closes only the access hold; it never releases the position's collateral. */
+    function closeChargebackClaim(bytes32 intentHash) external override {
+        Position storage position = positions[intentHash];
+        _validatePositionManager(position);
+        if (!position.chargebackClaimOpen) revert ChargebackClaimNotFound(intentHash);
+
+        position.chargebackClaimOpen = false;
+        openChargebackClaims[position.taker] -= 1;
+        emit ChargebackClaimStatusUpdated(intentHash, position.taker, false);
+    }
+
+    function getRequiredLocked(bytes32 intentHash) external view returns (uint256) {
+        Position storage position = positions[intentHash];
+        if (position.status != PositionStatus.Active) return 0;
+        return _requiredLocked(position);
+    }
+
+    function hasReputationHold(bytes32 intentHash) external view override returns (bool) {
+        return positions[intentHash].reputationHoldOpen;
+    }
+
+    function hasOpenChargebackClaim(bytes32 intentHash) external view override returns (bool) {
+        return positions[intentHash].chargebackClaimOpen;
+    }
+
+    function _requiredLocked(Position storage position) internal view returns (uint256) {
+        uint256 elapsed = block.timestamp - position.activatedAt;
+        uint256 retentionBps;
+        if (elapsed < position.schedule.cliffSeconds) {
+            retentionBps = BPS;
+        } else if (elapsed < position.schedule.stepTwoSeconds) {
+            retentionBps = position.schedule.retentionBpsAfterCliff;
+        } else if (elapsed < position.schedule.finalMaturitySeconds) {
+            retentionBps = position.schedule.retentionBpsAfterStepTwo;
+        } else {
+            retentionBps = 0;
+        }
+        uint256 nominalRequired = (position.activatedRiskAmount * retentionBps) / BPS;
+        uint256 actualRemaining = position.activatedRiskAmount
+            - position.releasedRiskAmount
+            - position.slashedRiskAmount;
+        return Math.min(nominalRequired, actualRemaining);
+    }
+
+    function _validateSchedule(MaturitySchedule calldata schedule) internal pure {
+        if (
+            schedule.cliffSeconds == 0
+                || schedule.stepTwoSeconds <= schedule.cliffSeconds
+                || schedule.finalMaturitySeconds <= schedule.stepTwoSeconds
+                || schedule.retentionBpsAfterCliff > BPS
+                || schedule.retentionBpsAfterStepTwo > schedule.retentionBpsAfterCliff
+        ) revert InvalidMaturitySchedule();
+    }
+
+    function _validatePositionManager(Position storage position) internal view {
+        if (position.manager != msg.sender) revert UnauthorizedManager(msg.sender);
+    }
+
+    function _openReputationHold(bytes32 intentHash, Position storage position) internal {
+        if (!position.reputationHoldOpen) {
+            position.reputationHoldOpen = true;
+            reputationHolds[position.taker] += 1;
+            emit ReputationHoldStatusUpdated(intentHash, position.taker, true);
+        }
+    }
+}

--- a/deploy/26_deploy_onchain_risk_system.ts
+++ b/deploy/26_deploy_onchain_risk_system.ts
@@ -1,0 +1,306 @@
+import "module-alias/register";
+
+import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+import {
+  addOrchestratorToRegistry,
+  setNewOwner,
+  waitForDeploymentDelay,
+} from "../deployments/helpers";
+import {
+  CHARGEBACK_ATTESTOR_ADDRESSES,
+  IDENTITY_ATTESTOR_ADDRESSES,
+  MULTI_SIG,
+  OPEN_ORCHESTRATOR_PROTOCOL_FEE,
+  ORCHESTRATOR_V2_PROTOCOL_FEE_RECIPIENT,
+  USDC,
+} from "../deployments/parameters";
+import { safeBatchCollector } from "../deployments/safeBatchCollector";
+import { ALIPAY_PAYMENT_METHOD_HASH } from "../deployments/verifiers/alipay";
+import { CASHAPP_PAYMENT_METHOD_HASH } from "../deployments/verifiers/cashapp";
+import { CHIME_PAYMENT_METHOD_HASH } from "../deployments/verifiers/chime";
+import { LUXON_PAYMENT_METHOD_HASH } from "../deployments/verifiers/luxon";
+import { MERCADOPAGO_PAYMENT_METHOD_HASH } from "../deployments/verifiers/mercadopago";
+import { MONZO_PAYMENT_METHOD_HASH } from "../deployments/verifiers/monzo";
+import { N26_PAYMENT_METHOD_HASH } from "../deployments/verifiers/n26";
+import { PAYPAL_PAYMENT_METHOD_HASH } from "../deployments/verifiers/paypal";
+import { REVOLUT_PAYMENT_METHOD_HASH } from "../deployments/verifiers/revolut";
+import { VENMO_PAYMENT_METHOD_HASH } from "../deployments/verifiers/venmo";
+import { WISE_PAYMENT_METHOD_HASH } from "../deployments/verifiers/wise";
+import {
+  ZELLE_BOFA_PAYMENT_METHOD_HASH,
+  ZELLE_CHASE_PAYMENT_METHOD_HASH,
+  ZELLE_CITI_PAYMENT_METHOD_HASH,
+  ZELLE_PAYMENT_METHOD_HASH,
+} from "../deployments/verifiers/zelle";
+import { usdc } from "../utils/common";
+
+const SEVEN_DAYS = 7 * 24 * 60 * 60;
+const THIRTY_DAYS = 30 * 24 * 60 * 60;
+const ONE_HUNDRED_EIGHTY_DAYS = 180 * 24 * 60 * 60;
+const IDENTITY_ACTION_TYPES = [
+  "register_venmo",
+  "register_paypal",
+  "register_wise",
+  "register_cashapp",
+].map((actionType) => ethers.utils.keccak256(ethers.utils.toUtf8Bytes(actionType)));
+
+const CHARGEBACKABLE_METHODS = [
+  VENMO_PAYMENT_METHOD_HASH,
+  CASHAPP_PAYMENT_METHOD_HASH,
+  CHIME_PAYMENT_METHOD_HASH,
+  PAYPAL_PAYMENT_METHOD_HASH,
+  ZELLE_PAYMENT_METHOD_HASH,
+  ZELLE_CITI_PAYMENT_METHOD_HASH,
+  ZELLE_CHASE_PAYMENT_METHOD_HASH,
+  ZELLE_BOFA_PAYMENT_METHOD_HASH,
+];
+
+const IRREVERSIBLE_METHODS = [
+  REVOLUT_PAYMENT_METHOD_HASH,
+  WISE_PAYMENT_METHOD_HASH,
+  MONZO_PAYMENT_METHOD_HASH,
+  MERCADOPAGO_PAYMENT_METHOD_HASH,
+  LUXON_PAYMENT_METHOD_HASH,
+  N26_PAYMENT_METHOD_HASH,
+  ALIPAY_PAYMENT_METHOD_HASH,
+];
+
+/**
+ * Opt-in deployment for the additive onchain risk system.
+ *
+ * Production/staging execution is intentionally gated by DEPLOY_ONCHAIN_RISK=true.
+ * Review the generated Safe batch and deployment runbook before enabling it. The script deploys
+ * a new orchestrator and reuses the existing EscrowV2, so maker deposits are not migrated.
+ */
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deploy } = hre.deployments;
+  const network = hre.deployments.getNetworkName();
+  const chainId = (await ethers.provider.getNetwork()).chainId;
+  const [deployer] = await hre.getUnnamedAccounts();
+  const multiSig = MULTI_SIG[network] || deployer;
+
+  const orchestratorRegistryAddress = (await hre.deployments.get("OrchestratorRegistry")).address;
+  const escrowRegistryAddress = (await hre.deployments.get("EscrowRegistry")).address;
+  const paymentVerifierRegistryAddress = (await hre.deployments.get("PaymentVerifierRegistry")).address;
+  const relayerRegistryAddress = (await hre.deployments.get("RelayerRegistry")).address;
+  const stakeTokenAddress = USDC[network] || (await hre.deployments.get("USDCMock")).address;
+
+  const identityRegistry = await deploy("IdentityRegistry", {
+    from: deployer,
+    args: [deployer],
+  });
+  const reputationRegistry = await deploy("ReputationRegistry", {
+    from: deployer,
+    args: [deployer, identityRegistry.address],
+  });
+  const stakeVault = await deploy("StakeVault", {
+    from: deployer,
+    args: [deployer, stakeTokenAddress],
+  });
+  const protocolRiskManager = await deploy("ProtocolRiskManager", {
+    from: deployer,
+    args: [
+      deployer,
+      orchestratorRegistryAddress,
+      identityRegistry.address,
+      reputationRegistry.address,
+      stakeVault.address,
+    ],
+  });
+  const openOrchestrator = await deploy("OpenOrchestratorV2", {
+    contract: "OrchestratorV2",
+    from: deployer,
+    args: [
+      deployer,
+      chainId,
+      escrowRegistryAddress,
+      paymentVerifierRegistryAddress,
+      relayerRegistryAddress,
+      OPEN_ORCHESTRATOR_PROTOCOL_FEE[network] ?? OPEN_ORCHESTRATOR_PROTOCOL_FEE.localhost,
+      ORCHESTRATOR_V2_PROTOCOL_FEE_RECIPIENT[network] || deployer,
+    ],
+  });
+
+  const identityRegistryContract = await ethers.getContractAt("IdentityRegistry", identityRegistry.address);
+  const reputationRegistryContract = await ethers.getContractAt("ReputationRegistry", reputationRegistry.address);
+  const stakeVaultContract = await ethers.getContractAt("StakeVault", stakeVault.address);
+  const protocolRiskManagerContract = await ethers.getContractAt(
+    "ProtocolRiskManager",
+    protocolRiskManager.address,
+  );
+  const openOrchestratorContract = await ethers.getContractAt("OrchestratorV2", openOrchestrator.address);
+  const orchestratorRegistryContract = await ethers.getContractAt(
+    "OrchestratorRegistry",
+    orchestratorRegistryAddress,
+  );
+
+  const ownerCallOrQueue = async (
+    contract: any,
+    functionName: string,
+    args: any[],
+    description: string,
+  ): Promise<void> => {
+    const currentOwner = (await contract.owner()).toLowerCase();
+    const data = contract.interface.encodeFunctionData(functionName, args);
+    if (currentOwner === deployer.toLowerCase()) {
+      await contract[functionName](...args);
+      return;
+    }
+    if (currentOwner === multiSig.toLowerCase()) {
+      safeBatchCollector.add(contract.address, data, description);
+      return;
+    }
+    throw new Error(
+      `${description}: owner ${currentOwner} is neither deployer ${deployer} nor multisig ${multiSig}`,
+    );
+  };
+
+  if (!(await reputationRegistryContract.authorizedUpdaters(protocolRiskManager.address))) {
+    await ownerCallOrQueue(
+      reputationRegistryContract,
+      "setAuthorizedUpdater",
+      [protocolRiskManager.address, true],
+      "Authorize ProtocolRiskManager in ReputationRegistry",
+    );
+  }
+  if (!(await stakeVaultContract.authorizedManagers(protocolRiskManager.address))) {
+    await ownerCallOrQueue(
+      stakeVaultContract,
+      "setAuthorizedManager",
+      [protocolRiskManager.address, true],
+      "Authorize ProtocolRiskManager in StakeVault",
+    );
+  }
+  if ((await openOrchestratorContract.riskManager()).toLowerCase() !== protocolRiskManager.address.toLowerCase()) {
+    await ownerCallOrQueue(
+      openOrchestratorContract,
+      "setRiskManager",
+      [protocolRiskManager.address],
+      "Set OpenOrchestratorV2 risk manager",
+    );
+  }
+  // Dark deployment invariant: registry authorization must never make the new path callable
+  // before downstream indexing, Attestor, and client stake/identity flows are ready.
+  if (!(await openOrchestratorContract.paused())) {
+    const currentOwner = (await openOrchestratorContract.owner()).toLowerCase();
+    if (currentOwner === deployer.toLowerCase()) {
+      await ownerCallOrQueue(
+        openOrchestratorContract,
+        "pauseOrchestrator",
+        [],
+        "Pause OpenOrchestratorV2",
+      );
+    } else {
+      console.warn(
+        `OpenOrchestratorV2 ${openOrchestrator.address} is already multisig-owned and unpaused; `
+          + "the deploy retry will not queue a production pause",
+      );
+    }
+  }
+
+  for (const attestor of IDENTITY_ATTESTOR_ADDRESSES[network] || []) {
+    if (!(await identityRegistryContract.trustedAttestors(attestor))) {
+      await ownerCallOrQueue(
+        identityRegistryContract,
+        "setTrustedAttestor",
+        [attestor, true],
+        `Trust identity Attestor ${attestor}`,
+      );
+    }
+  }
+  for (const attestor of CHARGEBACK_ATTESTOR_ADDRESSES[network] || []) {
+    if (!(await protocolRiskManagerContract.trustedChargebackAttestors(attestor))) {
+      await ownerCallOrQueue(
+        protocolRiskManagerContract,
+        "setTrustedChargebackAttestor",
+        [attestor, true],
+        `Trust chargeback Attestor ${attestor}`,
+      );
+    }
+  }
+  for (const actionType of IDENTITY_ACTION_TYPES) {
+    if (!(await identityRegistryContract.acceptedActionTypes(actionType))) {
+      await ownerCallOrQueue(
+        identityRegistryContract,
+        "setAcceptedActionType",
+        [actionType, true],
+        `Accept identity action type ${actionType}`,
+      );
+    }
+  }
+
+  const sharedConfig = {
+    configured: true,
+    enabled: false, // Enable in the reviewed cutover Safe batch, never during dark deployment.
+    identityRequired: true,
+    makerIdentityRequired: false, // Enable only after existing makers have registered.
+    minReputation: -100,
+    abandonmentSlashBps: 5_000,
+    signalBond: usdc(1),
+  };
+  for (const paymentMethod of CHARGEBACKABLE_METHODS) {
+    const config = {
+      ...sharedConfig,
+      chargebackable: true,
+      baseStakeBps: 10_000,
+      maturitySchedule: {
+        cliffSeconds: SEVEN_DAYS,
+        stepTwoSeconds: THIRTY_DAYS,
+        finalMaturitySeconds: ONE_HUNDRED_EIGHTY_DAYS,
+        retentionBpsAfterCliff: 10_000,
+        retentionBpsAfterStepTwo: 10_000,
+      },
+    };
+    const current = await protocolRiskManagerContract.platformRiskConfigs(paymentMethod);
+    if (!current.configured) {
+      await ownerCallOrQueue(
+        protocolRiskManagerContract,
+        "setPlatformRiskConfig",
+        [paymentMethod, config],
+        `Configure disabled chargeback policy ${paymentMethod}`,
+      );
+    }
+  }
+  for (const paymentMethod of IRREVERSIBLE_METHODS) {
+    const config = {
+      ...sharedConfig,
+      chargebackable: false,
+      baseStakeBps: 0,
+      maturitySchedule: {
+        cliffSeconds: 0,
+        stepTwoSeconds: 0,
+        finalMaturitySeconds: 0,
+        retentionBpsAfterCliff: 0,
+        retentionBpsAfterStepTwo: 0,
+      },
+    };
+    const current = await protocolRiskManagerContract.platformRiskConfigs(paymentMethod);
+    if (!current.configured) {
+      await ownerCallOrQueue(
+        protocolRiskManagerContract,
+        "setPlatformRiskConfig",
+        [paymentMethod, config],
+        `Configure disabled irreversible policy ${paymentMethod}`,
+      );
+    }
+  }
+
+  await addOrchestratorToRegistry(hre, orchestratorRegistryContract, openOrchestrator.address);
+
+  await setNewOwner(hre, identityRegistryContract, multiSig);
+  await setNewOwner(hre, reputationRegistryContract, multiSig);
+  await setNewOwner(hre, stakeVaultContract, multiSig);
+  await setNewOwner(hre, protocolRiskManagerContract, multiSig);
+  await setNewOwner(hre, openOrchestratorContract, multiSig);
+
+  await waitForDeploymentDelay(hre);
+};
+
+func.skip = async (): Promise<boolean> => process.env.DEPLOY_ONCHAIN_RISK !== "true";
+func.tags = ["26_deploy_onchain_risk_system"];
+func.dependencies = ["25_add_generic_zelle_payment_method"];
+
+export default func;

--- a/deployments/parameters.ts
+++ b/deployments/parameters.ts
@@ -46,6 +46,7 @@ export const MAX_INTENTS_PER_DEPOSIT: any = {
 
 export const MULTI_SIG: any = {
   "localhost": "",
+  "hardhat": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "base": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
   "base_staging": "",
   "base_sepolia": "",
@@ -66,6 +67,25 @@ export const MULTI_WITNESS_ADDRESSES: Record<string, string[]> = {
   ],
   base_sepolia: ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"],
   localhost: ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"],
+};
+
+// These roles are intentionally separate from payment proof witnesses and from
+// each other. Production values stay empty until reviewed, role-specific
+// ERC-1271/threshold signers are provisioned in the cutover Safe batch.
+export const IDENTITY_ATTESTOR_ADDRESSES: Record<string, string[]> = {
+  base: [],
+  base_staging: [],
+  base_sepolia: [],
+  localhost: ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"],
+  hardhat: ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"],
+};
+
+export const CHARGEBACK_ATTESTOR_ADDRESSES: Record<string, string[]> = {
+  base: [],
+  base_staging: [],
+  base_sepolia: [],
+  localhost: ["0x70997970C51812dc3A010C7d01b50e0d17dc79C8"],
+  hardhat: ["0x70997970C51812dc3A010C7d01b50e0d17dc79C8"],
 };
 
 export const MULTI_WITNESS_THRESHOLD: Record<string, number> = {
@@ -129,6 +149,15 @@ export const ORCHESTRATOR_V2_PROTOCOL_FEE_RECIPIENT: any = {
   "base": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
   "base_staging": "",
   "base_sepolia": "",
+};
+
+// Open orchestrator charges every successful take. Reputation tiers discount
+// this base fee but never alter the maker's quoted conversion rate.
+export const OPEN_ORCHESTRATOR_PROTOCOL_FEE: any = {
+  "localhost": ether(.003),
+  "base": ether(.003),
+  "base_staging": ether(.003),
+  "base_sepolia": ether(.003),
 };
 
 // Pyth Network contract addresses

--- a/docs/onchain-risk/01-design-principles.md
+++ b/docs/onchain-risk/01-design-principles.md
@@ -1,0 +1,135 @@
+# Onchain Risk Redesign: Design Principles and Decision Log
+
+Status: implementation candidate. No production deployment or configuration mutation is part of this change.
+
+## Problem statement
+
+Curator currently decides whether a taker may signal an intent by combining a
+database-backed tier table, per-platform caps, cooldowns, active-intent checks,
+make-to-take rules, blocklists, and a backend signature. That gives the backend
+effective control over protocol access even though settlement is onchain.
+
+The target system makes the contract state authoritative. Curator may still
+serve quotes, maker metadata, and compatibility responses, but it cannot grant
+or deny access to the open orchestrator.
+
+## Goals
+
+1. Anyone with a unique Attestor-verified identity can take without a maker
+   allowlist or Curator signature.
+2. There is no per-user intent-count limit and no tier-based amount cap.
+3. Liquidity griefing and chargeback risk are priced with capital rather than
+   hidden backend policy.
+4. Platform configs, reputation thresholds, tier discounts, stake multipliers,
+   and maturity curves are readable onchain.
+5. Existing `EscrowV2` deposits do not migrate.
+6. Existing clients can keep the current `SignalIntentParams` ABI during the
+   transition.
+
+## Decisions and rejected alternatives
+
+### Keep EscrowV2 unchanged
+
+The new orchestrator remains authorized through `OrchestratorRegistry`, so it
+can lock and settle every existing EscrowV2 deposit. Replacing EscrowV2 solely
+to delete its active-slot safeguard would force maker deposit migration for no
+material user benefit.
+
+EscrowV2's `maxIntentsPerDeposit` remains a bounded-array/gas safety limit. It
+is shared by all users of one deposit, is not a taker quota, and can be raised
+by governance. Existing maker min/max per-intent settings also remain for ABI
+and deposit compatibility. The new risk system adds no amount cap.
+
+### Preserve calldata, retire authorization semantics
+
+`gatingServiceSignature`, `signatureExpiration`, pre-intent hook setters, and
+whitelist-hook getters remain in the ABI. The open orchestrator does not use
+legacy signatures or stored hooks and rejects new non-zero eligibility-hook
+configuration. A zero-risk legacy deployment preserves its old checks. This
+lets clients migrate incrementally without leaving a maker- or
+backend-controlled bypass—or a control that only appears active—in the open
+execution path.
+
+### Use capital-bounded concurrency, not count-bounded concurrency
+
+Unlimited free locks are an obvious griefing vector. A configurable `signalBond`
+is reserved for every active intent. If the intent expires or is cancelled, a
+configured share is credited to the maker's vault balance and reputation falls. There is no
+count limit: concurrency is bounded by the user's voluntarily posted capital.
+
+### Use a bounded graph, not global graph traversal
+
+Computing PageRank, EigenTrust, or arbitrary neighbor walks onchain is too
+expensive and makes transaction cost depend on global protocol growth.
+Instead, each verified identity pair has a single edge:
+
+```text
+edge weight = min(sqrt(cumulative pair volume / point unit), edge cap)
+reward      = change in edge weight × counterparty reputation multiplier
+```
+
+Only payment-proof-verified settlements and only the change in square-root
+weight earn points. Manual maker releases earn no points. Repeated volume between the
+same two identities therefore has diminishing returns and a hard ceiling.
+Interactions with reputable counterparties weigh more, capped at 2x by
+default. Updates remain constant-time.
+
+### Use signed scores
+
+Reputation can go below zero. An abandonment must matter even for a new user;
+clamping at zero would make fresh identities free to grief. Platform configs
+set a minimum score. The proposed deployment uses `-100`, which permits recovery
+after ordinary cancellations but generally blocks an identity after a proven
+chargeback.
+
+### Do not decay payer collateral before the dispute window closes
+
+The proposed inverse-log decay was rejected during adversarial review. A
+malicious payer can choose when to initiate many chargebacks, so historical
+post-day-7 frequency is not a safe basis for withdrawing collateral. Without a
+separately funded insurance pool, taker stake must cover the maker's full loss
+through the configured enforceable dispute window. The initial conservative
+curve is:
+
+| Age | Collateral still locked |
+|---|---:|
+| 0–180 days | at least 100% |
+| 180+ days | 0% |
+
+The contract rejects chargebackable configs whose intermediate retention or
+tier multiplier would take coverage below 100%. The exact final maturity must
+be validated per rail before cutover. A future funded insurance layer could
+cover a declining tail, but reputation alone cannot make an undercollateralized
+maker whole. Existing positions keep their snapshotted schedule.
+
+### Snapshot policy per intent
+
+The orchestrator snapshots both the risk-manager address and the effective
+protocol fee. The risk manager snapshots stake and maturity parameters. A
+governance update therefore affects only new intents and cannot retroactively
+move collateral or change fees for an already locked user.
+
+## Initial reputation tiers
+
+Tiers do not cap take size. They only discount the protocol fee and reduce
+chargeback collateral as earned reputation increases.
+
+| Tier | Minimum score | Protocol-fee discount | Stake multiplier |
+|---|---:|---:|---:|
+| Starter | 0 | 0% | 125% |
+| Proven | 100 | 10% | 100% |
+| Trusted | 500 | 25% | 100% |
+| Anchor | 2,000 | 40% | 100% |
+
+An account below zero still resolves to Starter for quoting, but the platform's
+minimum reputation policy can reject it.
+
+## Why this is simpler
+
+- One public platform config replaces caps, cooldowns, reversible-rail flags,
+  and hidden fallback tables as the execution authority.
+- Four contracts have one responsibility each.
+- Signal and lifecycle index updates are O(1); view arrays and matured-withdrawal
+  batches are caller-bounded.
+- Existing escrow custody, payment verification, post-intent hooks, and signal
+  calldata remain compatible.

--- a/docs/onchain-risk/02-architecture.md
+++ b/docs/onchain-risk/02-architecture.md
@@ -1,0 +1,167 @@
+# Onchain Risk Architecture
+
+## Components
+
+### `IdentityRegistry`
+
+- Verifies the existing `ZKP2PIdentityVerifier` EIP-712 attestation.
+- Requires the attested wallet itself to submit registration; infrastructure
+  cannot publish a permanent binding from a stale payload.
+- Binds `(payment method, payeeIdHash)` to one wallet permanently.
+- Allows multiple platform identities on one wallet.
+- Supports emergency deactivation without freeing the identifier for a
+  reputation reset.
+- Supports explicit wallet quarantine so rotating the primary identity does
+  not preserve access after fraud or compromise.
+- Accepts only owner-allowlisted `register_*` action types, limiting accidental
+  reuse of the portable attestation domain.
+- Keeps trusted Attestor keys in public owner-managed state.
+
+The current Attestor identity timestamps are milliseconds; the contract
+deliberately compares them against `block.timestamp * 1_000`.
+
+### `ReputationRegistry`
+
+- Stores a signed score and auditable behavior counters.
+- Stores a bounded edge per pair of verified identity nodes.
+- Applies success, cancellation/expiry, and chargeback updates only from an
+  authorized lifecycle reporter.
+- Exposes scoring constants as governance state.
+
+Default behavior:
+
+- payment-proof-verified intent: new graph-edge weight only;
+- cancelled intent: `-(10 + sqrt(amount / 1 USDC))`;
+- expired intent: another `-10` on top of cancellation penalty;
+- chargeback: `-(100 + sqrt(attested amount / 1 USDC))`.
+
+Volume-derived contributions are capped by the edge cap.
+Manual maker releases activate collateral but do not earn reputation, and a
+taker cannot signal against its own deposit through the risk manager.
+
+### `StakeVault`
+
+- Custodies the configured stake token (USDC in the proposed deployment).
+- Separates free, reserved, and locked balances.
+- Reserves a signal bond and chargeback collateral at signal time.
+- Releases the bond on fulfillment or transfers its configured slash to the
+  maker on abandonment.
+- Activates only the collateral needed for the verified release amount; excess
+  reservation becomes free.
+- Lets users checkpoint selected matured positions, avoiding unbounded arrays.
+- Credits valid chargeback compensation to the maker's freely withdrawable
+  vault balance, avoiding push-payment liveness failures.
+- Keeps open-claim and pending-reputation holds in shared vault state so a new
+  risk manager cannot bypass an old manager's unresolved negative event.
+
+### `ProtocolRiskManager`
+
+- Stores platform enablement, identity requirements, minimum reputation,
+  signal bond, stake ratio, bond slash, and maturity schedule.
+- Stores the ordered reputation tiers.
+- Quotes and reserves signal-time capital without amount/count caps.
+- Calls reputation and stake modules on fulfillment or abandonment.
+- Verifies chain- and contract-bound chargeback EIP-712 attestations.
+- Lets anyone close an access-only partial-claim hold after a 30-day Attestor
+  finalization timeout; collateral and later valid attestations remain intact.
+
+### `OrchestratorV2`
+
+- Ignores legacy Curator gating signatures.
+- Does not execute maker-controlled pre-intent or whitelist eligibility hooks.
+- Rejects non-zero legacy eligibility-hook configuration once the risk manager
+  is active; zero-risk legacy deployments preserve their old behavior.
+- Allows multiple active intents per account.
+- Calls and snapshots the current onchain risk manager.
+- Applies the snapshotted reputation fee discount.
+- Reports fulfillment, cancellation, expiry, and orphan cleanup to the
+  snapshotted manager.
+
+## Signal and settlement flow
+
+```mermaid
+sequenceDiagram
+    participant U as Taker
+    participant I as IdentityRegistry
+    participant O as Open OrchestratorV2
+    participant R as ProtocolRiskManager
+    participant S as StakeVault
+    participant E as Existing EscrowV2
+    participant V as Payment Verifier
+
+    U->>I: registerIdentity(attestation)
+    U->>S: deposit(USDC)
+    U->>O: signalIntent(existing calldata)
+    O->>R: onIntentSignaled(context)
+    R->>I: verify unique identity
+    R->>S: reserve(bond + risk collateral)
+    O->>E: lockFunds(existing deposit)
+    U->>O: fulfillIntent(payment proof)
+    O->>V: verifyPayment
+    O->>R: onIntentFulfilled(release amount)
+    R->>S: activate(maturing risk collateral)
+    R->>R: update graph reputation
+    O->>E: unlockAndTransferFunds
+    O->>U: net funds after snapshotted fees
+```
+
+Signal and fulfillment calls are atomic: a failed risk reservation prevents the
+escrow lock, while a failed fulfillment callback prevents settlement and leaves
+the prior intent state intact. Abandonment deliberately fails open so broken
+auxiliary accounting cannot strand maker liquidity; the old manager can recover
+the orphaned reservation permissionlessly, and StakeVault keeps a durable hold
+until any failed negative-reputation update is replayed.
+
+The maker's manual release uses the same fail-closed fulfillment callback. This
+is deliberate: a settlement must not transfer escrowed assets without activating
+its snapshotted collateral exposure. If that immutable module fails, cancellation
+remains available but neither proof fulfillment nor manual release bypasses it.
+
+## Chargeback typed data
+
+Domain:
+
+```text
+name:              ZKP2PChargebackVerifier
+version:           1
+chainId:           settlement chain id
+verifyingContract: ProtocolRiskManager address
+```
+
+Type:
+
+```text
+ChargebackAttestation(
+  bytes32 intentHash,
+  address taker,
+  address maker,
+  uint256 amount,
+  bytes32 paymentMethod,
+  bytes32 evidenceHash,
+  bool finalClaim,
+  uint256 issuedAt,
+  uint256 validUntil
+)
+```
+
+The Attestor service should produce this only after independently verifying a
+platform chargeback. Anyone may relay it. The contract validates the trusted
+signer, time window, intent parties, platform, cumulative amount ceiling,
+evidence hash, chain, and verifying contract. Multiple partial attestations are
+supported; each evidence hash is single-use and the remaining collateral stays
+on its original maturity curve until the Attestor explicitly marks the claim
+final. A non-final claim for the entire remaining release amount is rejected.
+Each partial claim applies the incremental reputation penalty immediately. If
+that update fails, anyone can retry it and the shared vault hold blocks new
+takes in the meantime. Only finalization frees collateral above the cumulative
+compensated amount. If the Attestor never finalizes, anyone may close only the
+access freeze after 30 days; the collateral schedule and ability to submit a
+later valid claim are unchanged.
+
+## Upgrade model
+
+These contracts are deliberately non-proxy contracts. New policy logic is
+deployed as a new risk manager, then selected on the orchestrator. Old intents
+retain their original manager. This makes upgrades visible and avoids storage
+layout risk in the collateral path. Open-claim and pending-reputation counters
+live in the shared StakeVault, so selecting a new manager does not reset them.

--- a/docs/onchain-risk/03-migration-and-stack-impact.md
+++ b/docs/onchain-risk/03-migration-and-stack-impact.md
@@ -1,0 +1,117 @@
+# Onchain Risk Migration and Stack Impact
+
+## Deployment safety
+
+`contracts/deploy/26_deploy_onchain_risk_system.ts` is opt-in and skips unless
+`DEPLOY_ONCHAIN_RISK=true`. It deploys:
+
+1. `IdentityRegistry`
+2. `ReputationRegistry`
+3. `StakeVault`
+4. `ProtocolRiskManager`
+5. `OpenOrchestratorV2` using the `OrchestratorV2` implementation
+
+It reuses the deployed `EscrowV2`, `EscrowRegistry`,
+`PaymentVerifierRegistry`, `RelayerRegistry`, and `OrchestratorRegistry`.
+Existing deposits remain in place.
+
+The script stores these proposed initial policies with every platform disabled
+and the orchestrator paused. Cutover must enable them explicitly:
+
+- all platforms require a registered identity;
+- makers are not initially required to register, avoiding an abrupt existing
+  deposit outage;
+- all signals reserve a 1 USDC bond and slash 50% on abandonment;
+- successful takes pay a 0.30% base protocol fee before reputation discount;
+- chargebackable platforms reserve 100% base collateral, adjusted by tier;
+- minimum reputation is `-100`;
+- reversible rails keep at least 100% coverage for a conservative 180-day
+  placeholder window; confirm each rail's enforceable dispute window before cutover.
+
+## Staged rollout
+
+### Stage 0: review and audit
+
+- Audit the four new modules and OrchestratorV2 diff.
+- Confirm live Attestor signers from deployment state.
+- Decide the governance owner/timelock and emergency process.
+- Measure current chargeback timing before accepting the proposed curve.
+- Benchmark worst-case expired-intent pruning with the live
+  `maxIntentsPerDeposit`; lower the shared limit if a full withdrawal does not
+  fit the operational gas budget.
+
+### Stage 1: deploy dark
+
+- Deploy modules and the open orchestrator without publishing it to clients.
+- Keep the open orchestrator paused; the deployment script pauses it before registry authorization.
+- Add the open orchestrator to `OrchestratorRegistry`.
+- Provision distinct threshold/ERC-1271 signers for payment proofs, identity,
+  and chargebacks; register only the role-specific keys in each registry.
+- Verify onchain configs and package ABI output.
+
+### Stage 2: identity and stake UX
+
+- Add identity registration and StakeVault deposit/checkpoint views to clients.
+- Add indexed views for identity registrations, reputation changes, platform
+  configs, positions, and chargebacks.
+- Keep Curator's signed-intent response shape temporarily; clients may pass
+  empty legacy signature fields.
+
+### Stage 3: route traffic
+
+- Enumerate deposits with non-zero legacy gating services and notify affected
+  makers that the open orchestrator will not enforce those controls; obtain
+  acknowledgment or let them withdraw before enabling traffic.
+- Point quote/client orchestration to `OpenOrchestratorV2`.
+- Enable reviewed platform configs and unpause atomically with the traffic cutover.
+- Stop treating Curator tier/cap/cooldown decisions as authoritative.
+- Monitor abandonment, bond slashes, stake utilization, and settlement errors.
+- Publish the incremental `removeFunds` recovery procedure for makers whose
+  deposits contain a large expired-intent batch.
+- Treat fulfillment and maker manual release as fail-closed on the snapshotted
+  risk module; cancellation is the recovery path if activation cannot complete.
+
+### Stage 4: remove dead backend control plane
+
+- Delete Curator signature gating, tier/cap/cooldown enforcement, and the
+  corresponding PeerHQ mutation surfaces after all supported clients have
+  moved.
+- Keep quote discovery, maker metadata, and other non-authoritative backend
+  services independently deployable.
+
+## Compatibility matrix
+
+| Boundary | Impact |
+|---|---|
+| EscrowV2 custody | No code/storage change; no deposit migration |
+| Signal calldata | Existing tuple preserved; two signature fields deprecated |
+| Intent events | Existing events preserved; one additive risk snapshot event |
+| Post-intent hooks | Preserved |
+| Maker pre-intent/whitelist hooks | Legacy zero-risk deployments preserve them; open deployment rejects new non-zero config and does not execute old state |
+| Payment verifier | Preserved |
+| Protocol fee | Same fee unit and recipient; per-intent discount is additive |
+| Indexer | Add entities/handlers for new events before public rollout |
+| Curator | Remove authority; retain quote/metadata compatibility during rollout |
+| Attestor | Existing identity payload works; add chargeback typed-data generation |
+| PeerHQ | Replace DB tier/risk editors with read-only onchain policy views or governance transaction builders |
+| Clients/Pay/mobile | Add registration/stake flows and new orchestrator address; existing signal ABI remains usable |
+
+## Package/deploy order
+
+1. Deploy the paused/disabled dark contracts from reviewed source artifacts.
+2. Export their network deployment outputs, then publish the additive contracts package/ABIs.
+3. Deploy indexer handlers/schema.
+4. Add Attestor chargeback generation and client identity/stake UX.
+5. Enable platform configs, unpause, and route traffic environment-by-environment.
+6. Retire Curator authority after observability confirms parity.
+
+The package ABI extractor reads `deployments/outputs/*Contracts.ts`; therefore
+the dark deployment/output export must precede package publication. The paused
+orchestrator prevents this ordering from exposing a callable path early.
+
+## Deliberate follow-ups
+
+This PR defines and tests the contract boundary. It does not add the Attestor
+chargeback API, indexer entities, Curator deletion migration, client UI, or any
+live deployment coordinates. Keeping those follow-ups explicit allows the
+contracts to be audited before backend code is removed.

--- a/docs/onchain-risk/04-threat-model.md
+++ b/docs/onchain-risk/04-threat-model.md
@@ -1,0 +1,66 @@
+# Onchain Risk Threat Model
+
+## Assets and invariants
+
+- EscrowV2 maker liquidity must remain under existing custody rules.
+- A user's free StakeVault balance must equal deposits minus withdrawals,
+  active reservations, active locks, and paid slashes.
+- Only a snapshotted orchestrator may resolve an intent's risk position.
+- Only trusted Attestor keys may register identity or authorize chargeback.
+- The same platform identity cannot seed a second wallet.
+- Governance changes must not rewrite active intent terms.
+
+## Threats and controls
+
+| Threat | Control | Residual risk |
+|---|---|---|
+| Many wallets controlled by one person | One wallet per Attestor-verified platform account | A person with multiple real platform accounts can register multiple identities |
+| Two identities wash-trade reputation | No flat fill reward, proof-verified settlement only, square-root pair edge, edge cap, counterparty weighting | Coordinated identity farms remain possible; tune caps from observed data |
+| Maker manually releases self-dealing intent | Taker and maker must differ; manual releases earn no reputation | Two separately verified controlled identities can still build one capped edge |
+| Fresh identity griefs deposits | Per-intent signal bond, abandonment slash, signed negative score | Very cheap deposits may still be griefed if bond is configured too low |
+| Unlimited active-intent DoS | Capital reservation plus existing per-deposit active-slot safeguard | Governance must size the shared EscrowV2 slot limit for real concurrency |
+| Full deposit withdrawal prunes many expired risk positions | Signal bonds price each lock; `removeFunds` can reclaim expired liquidity incrementally | Each prune adds several cross-module calls, so the live slot limit requires a pre-cutover gas benchmark |
+| Risk config disables a platform | Public owner transaction and events | Governance remains a policy trust point; use timelock/multisig |
+| Attestor key compromise | Public signer allowlist, emergency deactivation, contract-wallet signatures | Compromised key can register identities or authorize chargebacks until removed |
+| One signer compromise crosses trust domains | Dark deploy leaves production identity/chargeback roles empty; cutover requires distinct threshold/ERC-1271 signers for payment, identity, and chargeback | Each role remains a powerful trust root within its narrow domain |
+| Existing portable identity payload is published without consent | The attested wallet must submit its own registration transaction | A compromised wallet can still register its valid payload on multiple deployments |
+| Cross-chain chargeback replay | EIP-712 chain id and verifying contract | Identity attestations use the portable Attestor domain but require the wallet on each destination chain |
+| Portable identity domain is reused for another action | IdentityRegistry accepts only explicitly allowlisted `register_*` action hashes | Governance must update the allowlist when Attestor adds a supported identity platform |
+| Chargeback submitted after maturity | Vault pays only still-locked collateral | Maker receives no stake compensation after final maturity |
+| Chargeback exceeds collateral | Each payment is capped at remaining lock; cumulative attested claims cannot exceed release amount; configured coverage stays at least 100% before maturity | Maker may receive partial compensation only after an incorrectly short final maturity or stake-token impairment |
+| Partial chargeback frees future coverage | Partial evidence is single-use and residual collateral keeps maturing until the final cumulative claim | A late claim can still exceed then-available collateral |
+| Attestor never finalizes a partial claim | Anyone can close the access-only hold after 30 days; collateral and later attestations are unaffected | The payer can resume while a dispute remains operationally unresolved |
+| Payer strategically waits for collateral decay | Chargebackable configs require at least 100% retention and tier-adjusted coverage through final maturity | Governance must set final maturity at or beyond the rail's real dispute window |
+| Policy changes during an intent | Risk manager, fee, stake ratio, tier multiplier, and maturity schedule are snapshotted | Trusted module code itself is immutable; upgrades require a new deployment |
+| Risk-manager upgrade strands locks | Orchestrator snapshots manager per intent | Old manager must remain deployed and authorized until its last position resolves |
+| Risk-manager upgrade bypasses an old claim | Shared StakeVault counters block new takes while any claim or negative-reputation sync is open | Old immutable manager must remain callable so anyone can finish synchronization |
+| Revoked identity rotates to another node | Owner can quarantine the whole wallet without deleting identity or score history | Governance must define evidence and appeal policy for quarantine |
+| Unbounded user history causes gas DoS | Position lookup by intent hash; user-supplied checkpoint batches | Wallet/indexer must help users discover matured positions |
+| Maker is token-blacklisted during a slash or chargeback | Compensation is credited internally and pulled to a chosen recipient | Stake-token deposit/withdraw still depends on canonical USDC behavior |
+| Reentrancy during token withdrawal | Vault and orchestrator transfer paths use reentrancy guards and SafeERC20 | Stake token must be reviewed; proposed token is canonical USDC |
+| Verifier reports more than locked intent | Orchestrator rejects `releaseAmount > intent.amount` | Payment verifier remains trusted for proof semantics |
+| Snapshotted risk module fails during settlement | Proof and manual fulfillment fail atomically; taker cancellation remains available | A taker who already paid fiat needs maker/offchain remediation; no unsafe collateral bypass exists |
+
+## Governance recommendations
+
+- Put every owner behind the same timelocked multisig or a clearly documented
+  separation-of-duties model.
+- Never reuse the payment-proof witness for identity or chargeback signing, and
+  keep identity and chargeback keys role-separated from each other.
+- Emit and index all config changes before enabling client traffic.
+- Require delayed changes for platform enablement, stake ratios, maturity, tier
+  thresholds, and trusted signer additions.
+- Keep pause authority on the orchestrator for emergency settlement safety;
+  cancellation and maturity recovery must remain available.
+- Do not enable `makerIdentityRequired` until existing maker coverage is high.
+
+## Audit focus
+
+1. StakeVault accounting across reserve, partial fulfillment, abandonment,
+   checkpoint, withdrawal, and chargeback.
+2. EIP-712 compatibility with Attestor's millisecond identity fields.
+3. Orchestrator callback ordering and atomic rollback behavior.
+4. Contract size and gas cost for signal/fulfill.
+5. Worst-case EscrowV2 expiry pruning at the configured per-deposit slot limit.
+6. Reputation farming economics and initial parameter calibration.
+7. Governance key and upgrade operational procedures.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "etherscan:base": "yarn hardhat --network base etherscan-verify-with-delay --delay 600",
     "etherscan:base_staging": "yarn hardhat --network base_staging etherscan-verify-with-delay --delay 600",
     "etherscan:base_sepolia": "yarn hardhat --network base_sepolia etherscan-verify-with-delay --delay 600",
-    "test": "npx hardhat test test/libs/*.ts test/hooks/*.ts test/periphery/*.ts test/unifiedVerifier/*.ts test/registries/*.ts test/escrow/*.ts test/escrowV2/*.ts test/orchestrator/*.ts test/orchestratorV2/*.ts test/rateManager/*.ts",
+    "test": "npx hardhat test test/libs/*.ts test/hooks/*.ts test/periphery/*.ts test/unifiedVerifier/*.ts test/registries/*.ts test/escrow/*.ts test/escrowV2/*.ts test/orchestrator/*.ts test/orchestratorV2/*.ts test/rateManager/*.ts test/risk/*.ts",
     "test:all": "yarn test && yarn test:forge",
     "test:integration": "npx hardhat test test/integration/*.ts",
     "test:clean": "yarn build && yarn test",

--- a/test/deploy/26_onchainRiskSystem.spec.ts
+++ b/test/deploy/26_onchainRiskSystem.spec.ts
@@ -1,0 +1,125 @@
+import "module-alias/register";
+
+import { expect } from "chai";
+import hre, { deployments, ethers, getUnnamedAccounts } from "hardhat";
+
+import deployOnchainRiskSystem from "../../deploy/26_deploy_onchain_risk_system";
+import {
+  CHARGEBACK_ATTESTOR_ADDRESSES,
+  IDENTITY_ATTESTOR_ADDRESSES,
+  MULTI_SIG,
+} from "../../deployments/parameters";
+import { PAYPAL_PAYMENT_METHOD_HASH } from "../../deployments/verifiers/paypal";
+import { WISE_PAYMENT_METHOD_HASH } from "../../deployments/verifiers/wise";
+
+describe("Onchain risk system dark deployment", () => {
+  const network = deployments.getNetworkName();
+  const deploymentNames = [
+    "OrchestratorRegistry",
+    "EscrowRegistry",
+    "PaymentVerifierRegistry",
+    "RelayerRegistry",
+    "USDCMock",
+    "IdentityRegistry",
+    "ReputationRegistry",
+    "StakeVault",
+    "ProtocolRiskManager",
+    "OpenOrchestratorV2",
+  ];
+
+  before(async () => {
+    process.env.DEPLOY_ONCHAIN_RISK = "true";
+    for (const name of deploymentNames) await deployments.delete(name);
+    const saveDependency = async (name: string, args: any[] = []): Promise<void> => {
+      const factory = await ethers.getContractFactory(name);
+      const contract = await factory.deploy(...args);
+      await contract.deployed();
+      const artifact = await deployments.getArtifact(name);
+      await deployments.save(name, { address: contract.address, abi: artifact.abi });
+    };
+
+    await saveDependency("OrchestratorRegistry");
+    await saveDependency("EscrowRegistry");
+    await saveDependency("PaymentVerifierRegistry");
+    await saveDependency("RelayerRegistry");
+    await saveDependency("USDCMock", [ethers.utils.parseUnits("1000000", 6), "USDC", "USDC"]);
+    await deployOnchainRiskSystem(hre);
+    await deployOnchainRiskSystem(hre); // Idempotent retry must preserve the dark-deploy state.
+  });
+
+  after(async () => {
+    delete process.env.DEPLOY_ONCHAIN_RISK;
+    for (const name of deploymentNames) await deployments.delete(name);
+  });
+
+  it("registers only a paused open orchestrator with its risk manager wired", async () => {
+    const openDeployment = await deployments.get("OpenOrchestratorV2");
+    const riskDeployment = await deployments.get("ProtocolRiskManager");
+    const registryDeployment = await deployments.get("OrchestratorRegistry");
+    const orchestrator = await ethers.getContractAt("OrchestratorV2", openDeployment.address);
+    const registry = await ethers.getContractAt("OrchestratorRegistry", registryDeployment.address);
+
+    expect(await orchestrator.paused()).to.equal(true);
+    expect(await orchestrator.riskManager()).to.equal(riskDeployment.address);
+    expect(await registry.isOrchestrator(openDeployment.address)).to.equal(true);
+  });
+
+  it("keeps representative reversible and irreversible platform configs disabled", async () => {
+    const riskDeployment = await deployments.get("ProtocolRiskManager");
+    const riskManager = await ethers.getContractAt("ProtocolRiskManager", riskDeployment.address);
+    const reversible = await riskManager.platformRiskConfigs(PAYPAL_PAYMENT_METHOD_HASH);
+    const irreversible = await riskManager.platformRiskConfigs(WISE_PAYMENT_METHOD_HASH);
+
+    expect(reversible.configured).to.equal(true);
+    expect(reversible.enabled).to.equal(false);
+    expect(reversible.chargebackable).to.equal(true);
+    expect(reversible.baseStakeBps).to.equal(10_000);
+    expect(irreversible.configured).to.equal(true);
+    expect(irreversible.enabled).to.equal(false);
+    expect(irreversible.chargebackable).to.equal(false);
+    expect(irreversible.baseStakeBps).to.equal(0);
+  });
+
+  it("wires reporters, witnesses, and multisig ownership", async () => {
+    const [deployer] = await getUnnamedAccounts();
+    const expectedOwner = MULTI_SIG[network] || deployer;
+    const identityDeployment = await deployments.get("IdentityRegistry");
+    const reputationDeployment = await deployments.get("ReputationRegistry");
+    const vaultDeployment = await deployments.get("StakeVault");
+    const riskDeployment = await deployments.get("ProtocolRiskManager");
+    const openDeployment = await deployments.get("OpenOrchestratorV2");
+    const identity = await ethers.getContractAt("IdentityRegistry", identityDeployment.address);
+    const reputation = await ethers.getContractAt("ReputationRegistry", reputationDeployment.address);
+    const vault = await ethers.getContractAt("StakeVault", vaultDeployment.address);
+    const riskManager = await ethers.getContractAt("ProtocolRiskManager", riskDeployment.address);
+    const orchestrator = await ethers.getContractAt("OrchestratorV2", openDeployment.address);
+
+    expect(await reputation.authorizedUpdaters(riskDeployment.address)).to.equal(true);
+    expect(await vault.authorizedManagers(riskDeployment.address)).to.equal(true);
+    for (const witness of IDENTITY_ATTESTOR_ADDRESSES[network] || []) {
+      expect(await identity.trustedAttestors(witness)).to.equal(true);
+      expect(await riskManager.trustedChargebackAttestors(witness)).to.equal(false);
+    }
+    for (const witness of CHARGEBACK_ATTESTOR_ADDRESSES[network] || []) {
+      expect(await riskManager.trustedChargebackAttestors(witness)).to.equal(true);
+      expect(await identity.trustedAttestors(witness)).to.equal(false);
+    }
+    for (const actionType of ["register_venmo", "register_paypal", "register_wise", "register_cashapp"]) {
+      const actionTypeHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(actionType));
+      expect(await identity.acceptedActionTypes(actionTypeHash)).to.equal(true);
+    }
+    for (const contract of [identity, reputation, vault, riskManager, orchestrator]) {
+      expect(await contract.owner()).to.equal(expectedOwner);
+    }
+  });
+
+  it("does not queue or execute a pause when rerun after multisig cutover", async () => {
+    const openDeployment = await deployments.get("OpenOrchestratorV2");
+    const orchestrator = await ethers.getContractAt("OrchestratorV2", openDeployment.address);
+    const multisigSigner = await ethers.getSigner(MULTI_SIG[network]);
+    await orchestrator.connect(multisigSigner).unpauseOrchestrator();
+
+    await deployOnchainRiskSystem(hre);
+    expect(await orchestrator.paused()).to.equal(false);
+  });
+});

--- a/test/deploy/26_onchainRiskSystem.spec.ts
+++ b/test/deploy/26_onchainRiskSystem.spec.ts
@@ -14,6 +14,7 @@ import { WISE_PAYMENT_METHOD_HASH } from "../../deployments/verifiers/wise";
 
 describe("Onchain risk system dark deployment", () => {
   const network = deployments.getNetworkName();
+  const configuredMultiSig = MULTI_SIG[network];
   const deploymentNames = [
     "OrchestratorRegistry",
     "EscrowRegistry",
@@ -29,6 +30,8 @@ describe("Onchain risk system dark deployment", () => {
 
   before(async () => {
     process.env.DEPLOY_ONCHAIN_RISK = "true";
+    const [, localMultiSig] = await getUnnamedAccounts();
+    MULTI_SIG[network] ||= localMultiSig;
     for (const name of deploymentNames) await deployments.delete(name);
     const saveDependency = async (name: string, args: any[] = []): Promise<void> => {
       const factory = await ethers.getContractFactory(name);
@@ -49,6 +52,7 @@ describe("Onchain risk system dark deployment", () => {
 
   after(async () => {
     delete process.env.DEPLOY_ONCHAIN_RISK;
+    MULTI_SIG[network] = configuredMultiSig;
     for (const name of deploymentNames) await deployments.delete(name);
   });
 

--- a/test/deploy/26_onchainRiskSystem.spec.ts
+++ b/test/deploy/26_onchainRiskSystem.spec.ts
@@ -114,10 +114,11 @@ describe("Onchain risk system dark deployment", () => {
   });
 
   it("does not queue or execute a pause when rerun after multisig cutover", async () => {
+    const [deployer] = await getUnnamedAccounts();
     const openDeployment = await deployments.get("OpenOrchestratorV2");
     const orchestrator = await ethers.getContractAt("OrchestratorV2", openDeployment.address);
-    const multisigSigner = await ethers.getSigner(MULTI_SIG[network]);
-    await orchestrator.connect(multisigSigner).unpauseOrchestrator();
+    const ownerSigner = await ethers.getSigner(MULTI_SIG[network] || deployer);
+    await orchestrator.connect(ownerSigner).unpauseOrchestrator();
 
     await deployOnchainRiskSystem(hre);
     expect(await orchestrator.paused()).to.equal(false);

--- a/test/orchestratorV2/orchestratorV2.spec.ts
+++ b/test/orchestratorV2/orchestratorV2.spec.ts
@@ -162,6 +162,71 @@ describe("OrchestratorV2", () => {
       expect(feeEvent?.args?.fee).to.eq(ether(0.01));
     });
 
+    it("snapshots the onchain risk module and discounted protocol fee", async () => {
+      const riskManagerMock = await (
+        await ethers.getContractFactory("ProtocolRiskManagerMock", owner.wallet)
+      ).deploy();
+      await riskManagerMock.setFeeDiscountBps(5_000);
+      await orchestrator.connect(owner.wallet).setProtocolFee(ether(0.01));
+      await orchestrator.connect(owner.wallet).setRiskManager(riskManagerMock.address);
+
+      const tx = await subject();
+      const receipt = await tx.wait();
+      const signalEvent = receipt.events?.find((event: any) => event.event === "IntentSignaled");
+      const intentHash = signalEvent?.args?.intentHash;
+
+      expect(await orchestrator.getIntentRiskManager(intentHash)).to.eq(riskManagerMock.address);
+      expect(await orchestrator.getIntentProtocolFee(intentHash)).to.eq(ether(0.005));
+      const context = await riskManagerMock.getSignalContext(intentHash);
+      expect(context.taker).to.eq(taker.address);
+      expect(context.maker).to.eq(depositor.address);
+      expect(context.amount).to.eq(usdc(50));
+
+      await orchestrator.connect(depositor.wallet).releaseFundsToPayer(intentHash);
+      expect(await riskManagerMock.fulfilledAmounts(intentHash)).to.eq(usdc(50));
+      expect(await riskManagerMock.paymentProofVerified(intentHash)).to.eq(false);
+    });
+
+    it("opens taking, rejects dead maker gates, and removes active intents in O(1)", async () => {
+      const riskManagerMock = await (
+        await ethers.getContractFactory("ProtocolRiskManagerMock", owner.wallet)
+      ).deploy();
+      await orchestrator.connect(owner.wallet).setRiskManager(riskManagerMock.address);
+
+      await expect(
+        orchestrator
+          .connect(depositor.wallet)
+          .setDepositPreIntentHook(escrow.address, ZERO, rateManagerMock.address),
+      ).to.be.revertedWithCustomError(orchestrator, "LegacyEligibilityHookDisabled");
+
+      const hashes: string[] = [];
+      for (let i = 0; i < 3; i += 1) {
+        const receipt = await (await subject()).wait();
+        hashes.push(receipt.events?.find((event: any) => event.event === "IntentSignaled")?.args?.intentHash);
+      }
+      await orchestrator.connect(taker.wallet).cancelIntent(hashes[1]);
+
+      const active = await orchestrator.getAccountIntents(taker.address);
+      expect(active.length).to.eq(2);
+      expect(active).to.include(hashes[0]);
+      expect(active).to.include(hashes[2]);
+    });
+
+    it("prunes and unlocks when an abandonment callback fails", async () => {
+      const riskManagerMock = await (
+        await ethers.getContractFactory("ProtocolRiskManagerMock", owner.wallet)
+      ).deploy();
+      await orchestrator.connect(owner.wallet).setRiskManager(riskManagerMock.address);
+      const receipt = await (await subject()).wait();
+      const intentHash = receipt.events?.find((event: any) => event.event === "IntentSignaled")?.args?.intentHash;
+      await riskManagerMock.setRevertOnAbandon(true);
+
+      await expect(orchestrator.connect(taker.wallet).cancelIntent(intentHash))
+        .to.emit(orchestrator, "IntentRiskCallbackFailed")
+        .and.to.emit(orchestrator, "IntentPruned");
+      expect(await orchestrator.hasActiveIntent(intentHash)).to.equal(false);
+    });
+
     describe("when conversion rate is below delegated manager rate", () => {
       beforeEach(async () => {
         subjectConversionRate = ether(1.1);

--- a/test/risk/onchainRisk.spec.ts
+++ b/test/risk/onchainRisk.spec.ts
@@ -1,0 +1,560 @@
+import "module-alias/register";
+
+import { expect } from "chai";
+import { BigNumber, Contract, Signer } from "ethers";
+import { ethers } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+
+const usdc = (value: number | string): BigNumber => ethers.utils.parseUnits(String(value), 6);
+
+describe("Onchain identity, reputation, and risk", () => {
+  let owner: Signer;
+  let taker: Signer;
+  let maker: Signer;
+  let identityAttestor: Signer;
+  let chargebackAttestor: Signer;
+
+  let ownerAddress: string;
+  let takerAddress: string;
+  let makerAddress: string;
+  let paymentMethod: string;
+
+  let token: Contract;
+  let orchestratorRegistry: Contract;
+  let identityRegistry: Contract;
+  let reputationRegistry: Contract;
+  let stakeVault: Contract;
+  let riskManager: Contract;
+
+  async function registerIdentity(account: string, payeeLabel: string, submitter?: Signer): Promise<any> {
+    const issuedAtMs = (await time.latest()) * 1_000;
+    const validUntilMs = issuedAtMs + 30 * 24 * 60 * 60 * 1_000;
+    const actionType = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("register_venmo"));
+    const payeeIdHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(payeeLabel));
+    const dataHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(`identity:${payeeLabel}`));
+    const signature = await (identityAttestor as any)._signTypedData(
+      { name: "ZKP2PIdentityVerifier", version: "1" },
+      {
+        IdentityAttestation: [
+          { name: "method", type: "bytes32" },
+          { name: "actionType", type: "bytes32" },
+          { name: "callerAddress", type: "address" },
+          { name: "payeeIdHash", type: "bytes32" },
+          { name: "dataHash", type: "bytes32" },
+          { name: "issuedAt", type: "uint256" },
+          { name: "validUntil", type: "uint256" },
+        ],
+      },
+      {
+        method: paymentMethod,
+        actionType,
+        callerAddress: account,
+        payeeIdHash,
+        dataHash,
+        issuedAt: issuedAtMs,
+        validUntil: validUntilMs,
+      },
+    );
+
+    return identityRegistry.connect(submitter || await ethers.getSigner(account)).registerIdentity(
+      {
+        method: paymentMethod,
+        actionType,
+        account,
+        payeeIdHash,
+        dataHash,
+        issuedAtMs,
+        validUntilMs,
+      },
+      await identityAttestor.getAddress(),
+      signature,
+    );
+  }
+
+  beforeEach(async () => {
+    [owner, taker, maker, identityAttestor, chargebackAttestor] = await ethers.getSigners();
+    ownerAddress = await owner.getAddress();
+    takerAddress = await taker.getAddress();
+    makerAddress = await maker.getAddress();
+    paymentMethod = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("venmo"));
+
+    token = await (await ethers.getContractFactory("USDCMock", owner)).deploy(usdc(1_000_000), "USDC", "USDC");
+    orchestratorRegistry = await (await ethers.getContractFactory("OrchestratorRegistry", owner)).deploy();
+    identityRegistry = await (
+      await ethers.getContractFactory("IdentityRegistry", owner)
+    ).deploy(ownerAddress);
+    reputationRegistry = await (
+      await ethers.getContractFactory("ReputationRegistry", owner)
+    ).deploy(ownerAddress, identityRegistry.address);
+    stakeVault = await (
+      await ethers.getContractFactory("StakeVault", owner)
+    ).deploy(ownerAddress, token.address);
+    riskManager = await (
+      await ethers.getContractFactory("ProtocolRiskManager", owner)
+    ).deploy(
+      ownerAddress,
+      orchestratorRegistry.address,
+      identityRegistry.address,
+      reputationRegistry.address,
+      stakeVault.address,
+    );
+
+    await orchestratorRegistry.addOrchestrator(ownerAddress);
+    await identityRegistry.setTrustedAttestor(await identityAttestor.getAddress(), true);
+    await identityRegistry.setAcceptedActionType(
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("register_venmo")),
+      true,
+    );
+    await reputationRegistry.setAuthorizedUpdater(riskManager.address, true);
+    await stakeVault.setAuthorizedManager(riskManager.address, true);
+    await riskManager.setTrustedChargebackAttestor(await chargebackAttestor.getAddress(), true);
+
+    await riskManager.setPlatformRiskConfig(paymentMethod, {
+      configured: true,
+      enabled: true,
+      identityRequired: true,
+      makerIdentityRequired: false,
+      chargebackable: true,
+      minReputation: 0,
+      baseStakeBps: 10_000,
+      abandonmentSlashBps: 5_000,
+      signalBond: usdc(1),
+      maturitySchedule: {
+        cliffSeconds: 7 * 24 * 60 * 60,
+        stepTwoSeconds: 30 * 24 * 60 * 60,
+        finalMaturitySeconds: 180 * 24 * 60 * 60,
+        retentionBpsAfterCliff: 10_000,
+        retentionBpsAfterStepTwo: 10_000,
+      },
+    });
+
+    await token.transfer(takerAddress, usdc(500));
+    await token.connect(taker).approve(stakeVault.address, usdc(500));
+    await stakeVault.connect(taker).deposit(usdc(500));
+  });
+
+  it("enforces unique identity and capital instead of backend signatures or amount caps", async () => {
+    const intentHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("intent-1"));
+    const context = {
+      intentHash,
+      taker: takerAddress,
+      maker: makerAddress,
+      token: token.address,
+      paymentMethod,
+      amount: usdc(100),
+    };
+
+    await expect(riskManager.onIntentSignaled(context)).to.be.revertedWithCustomError(
+      riskManager,
+      "IdentityRequired",
+    );
+
+    await expect(registerIdentity(takerAddress, "taker-payee", owner)).to.be.revertedWithCustomError(
+      identityRegistry,
+      "UnauthorizedAccount",
+    );
+    await registerIdentity(takerAddress, "taker-payee");
+    await expect(registerIdentity(makerAddress, "taker-payee")).to.be.revertedWithCustomError(
+      identityRegistry,
+      "IdentityAlreadyBound",
+    );
+    await registerIdentity(makerAddress, "maker-payee");
+
+    await expect(
+      riskManager.onIntentSignaled({ ...context, maker: takerAddress }),
+    ).to.be.revertedWithCustomError(riskManager, "SelfInteraction");
+
+    await expect(riskManager.onIntentSignaled(context))
+      .to.emit(riskManager, "IntentRiskReserved")
+      .withArgs(intentHash, takerAddress, paymentMethod, 0, usdc(1), usdc(125), 0);
+
+    expect(await stakeVault.reservedBalances(takerAddress)).to.equal(usdc(126));
+    await riskManager.onIntentFulfilled(intentHash, usdc(100), true);
+    expect(await stakeVault.lockedBalances(takerAddress)).to.equal(usdc(125));
+
+    const profile = await reputationRegistry.getProfile(takerAddress);
+    expect(profile.successfulInteractions).to.equal(1);
+    expect(profile.score).to.be.gt(0);
+  });
+
+  it("awards no flat reward after a verified graph edge reaches its cap", async () => {
+    await registerIdentity(takerAddress, "taker-payee");
+    await registerIdentity(makerAddress, "maker-payee");
+    await reputationRegistry.setAuthorizedUpdater(ownerAddress, true);
+
+    await reputationRegistry.recordSuccess(takerAddress, makerAddress, usdc(10_000));
+    const cappedScore = (await reputationRegistry.getProfile(takerAddress)).score;
+    expect(cappedScore).to.equal(100);
+
+    await reputationRegistry.recordSuccess(takerAddress, makerAddress, usdc(10_000));
+    expect((await reputationRegistry.getProfile(takerAddress)).score).to.equal(cappedScore);
+  });
+
+  it("rotates the canonical reputation node when an identity is deactivated", async () => {
+    await registerIdentity(takerAddress, "taker-primary");
+    await registerIdentity(takerAddress, "taker-secondary");
+    const identities = await identityRegistry.getAccountIdentities(takerAddress);
+    expect(await identityRegistry.getAccountNode(takerAddress)).to.equal(identities[0]);
+
+    await identityRegistry.setIdentityStatus(identities[0], false);
+    expect(await identityRegistry.isVerifiedAccount(takerAddress)).to.equal(true);
+    expect(await identityRegistry.getAccountNode(takerAddress)).to.equal(identities[1]);
+
+    await identityRegistry.setAccountQuarantine(takerAddress, true);
+    expect(await identityRegistry.isVerifiedAccount(takerAddress)).to.equal(false);
+    expect(await identityRegistry.isQuarantined(takerAddress)).to.equal(true);
+  });
+
+  it("keeps full-window coverage and resolves cumulative signed chargebacks", async () => {
+    await registerIdentity(takerAddress, "taker-payee");
+    await registerIdentity(makerAddress, "maker-payee");
+
+    const intentHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("intent-2"));
+    await riskManager.onIntentSignaled({
+      intentHash,
+      taker: takerAddress,
+      maker: makerAddress,
+      token: token.address,
+      paymentMethod,
+      amount: usdc(100),
+    });
+    await riskManager.onIntentFulfilled(intentHash, usdc(100), true);
+
+    await time.increase(8 * 24 * 60 * 60);
+    expect(await stakeVault.getRequiredLocked(intentHash)).to.equal(usdc(125));
+
+    const issuedAt = await time.latest();
+    const validUntil = issuedAt + 60 * 60;
+    const evidenceHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("chargeback-evidence"));
+    const chainId = (await ethers.provider.getNetwork()).chainId;
+    const chargebackTypes = {
+      ChargebackAttestation: [
+        { name: "intentHash", type: "bytes32" },
+        { name: "taker", type: "address" },
+        { name: "maker", type: "address" },
+        { name: "amount", type: "uint256" },
+        { name: "paymentMethod", type: "bytes32" },
+        { name: "evidenceHash", type: "bytes32" },
+        { name: "finalClaim", type: "bool" },
+        { name: "issuedAt", type: "uint256" },
+        { name: "validUntil", type: "uint256" },
+      ],
+    };
+    const signature = await (chargebackAttestor as any)._signTypedData(
+      {
+        name: "ZKP2PChargebackVerifier",
+        version: "1",
+        chainId,
+        verifyingContract: riskManager.address,
+      },
+      chargebackTypes,
+      {
+        intentHash,
+        taker: takerAddress,
+        maker: makerAddress,
+        amount: usdc(80),
+        paymentMethod,
+        evidenceHash,
+        finalClaim: false,
+        issuedAt,
+        validUntil,
+      },
+    );
+
+    const makerBalanceBefore = await stakeVault.balances(makerAddress);
+    await expect(
+      riskManager.resolveChargeback(
+        {
+          intentHash,
+          taker: takerAddress,
+          maker: makerAddress,
+          amount: usdc(80),
+          paymentMethod,
+          evidenceHash,
+          finalClaim: false,
+          issuedAt,
+          validUntil,
+        },
+        await chargebackAttestor.getAddress(),
+        signature,
+      ),
+    )
+      .to.emit(riskManager, "ChargebackResolved")
+      .withArgs(intentHash, takerAddress, makerAddress, usdc(80), usdc(80), false, evidenceHash);
+
+    expect((await stakeVault.balances(makerAddress)).sub(makerBalanceBefore)).to.equal(usdc(80));
+    expect(await stakeVault.lockedBalances(takerAddress)).to.equal(usdc(45));
+    expect((await reputationRegistry.getProfile(takerAddress)).chargebacks).to.equal(1);
+    expect(await stakeVault.openChargebackClaims(takerAddress)).to.equal(1);
+    expect(await stakeVault.reputationHolds(takerAddress)).to.equal(0);
+    await expect(
+      riskManager.onIntentSignaled({
+        intentHash: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("blocked-by-open-chargeback")),
+        taker: takerAddress,
+        maker: makerAddress,
+        token: token.address,
+        paymentMethod,
+        amount: usdc(10),
+      }),
+    ).to.be.revertedWithCustomError(riskManager, "AccountRiskHold");
+
+    const replacementRiskManager = await (
+      await ethers.getContractFactory("ProtocolRiskManager", owner)
+    ).deploy(
+      ownerAddress,
+      orchestratorRegistry.address,
+      identityRegistry.address,
+      reputationRegistry.address,
+      stakeVault.address,
+    );
+    await replacementRiskManager.setPlatformRiskConfig(paymentMethod, {
+      configured: true,
+      enabled: true,
+      identityRequired: true,
+      makerIdentityRequired: false,
+      chargebackable: true,
+      minReputation: -1_000,
+      baseStakeBps: 10_000,
+      abandonmentSlashBps: 5_000,
+      signalBond: usdc(1),
+      maturitySchedule: {
+        cliffSeconds: 7 * 24 * 60 * 60,
+        stepTwoSeconds: 30 * 24 * 60 * 60,
+        finalMaturitySeconds: 180 * 24 * 60 * 60,
+        retentionBpsAfterCliff: 10_000,
+        retentionBpsAfterStepTwo: 10_000,
+      },
+    });
+    await expect(
+      replacementRiskManager.onIntentSignaled({
+        intentHash: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("blocked-after-manager-upgrade")),
+        taker: takerAddress,
+        maker: makerAddress,
+        token: token.address,
+        paymentMethod,
+        amount: usdc(10),
+      }),
+    ).to.be.revertedWithCustomError(replacementRiskManager, "AccountRiskHold");
+
+    await expect(riskManager.closeStaleChargebackClaim(intentHash)).to.be.revertedWithCustomError(
+      riskManager,
+      "ChargebackClaimNotStale",
+    );
+    await time.increase(await riskManager.MAX_OPEN_CLAIM_SECONDS());
+    await riskManager.connect(maker).closeStaleChargebackClaim(intentHash);
+    expect(await stakeVault.openChargebackClaims(takerAddress)).to.equal(0);
+
+    const finalEvidenceHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("final-chargeback-evidence"));
+    const finalIssuedAt = await time.latest();
+    const finalAttestation = {
+      intentHash,
+      taker: takerAddress,
+      maker: makerAddress,
+      amount: usdc(20),
+      paymentMethod,
+      evidenceHash: finalEvidenceHash,
+      finalClaim: true,
+      issuedAt: finalIssuedAt,
+      validUntil: finalIssuedAt + 60 * 60,
+    };
+    const finalSignature = await (chargebackAttestor as any)._signTypedData(
+      {
+        name: "ZKP2PChargebackVerifier",
+        version: "1",
+        chainId,
+        verifyingContract: riskManager.address,
+      },
+      chargebackTypes,
+      finalAttestation,
+    );
+    await riskManager.resolveChargeback(
+      finalAttestation,
+      await chargebackAttestor.getAddress(),
+      finalSignature,
+    );
+
+    const resolvedRisk = await riskManager.intentRisks(intentHash);
+    expect(resolvedRisk.status).to.equal(4); // ChargedBack
+    expect(resolvedRisk.cumulativeChargebackAmount).to.equal(usdc(100));
+    expect(resolvedRisk.cumulativeCompensation).to.equal(usdc(100));
+    expect(await stakeVault.lockedBalances(takerAddress)).to.equal(0);
+    expect((await reputationRegistry.getProfile(takerAddress)).chargebacks).to.equal(1);
+    expect(await stakeVault.openChargebackClaims(takerAddress)).to.equal(0);
+    expect(await stakeVault.reputationHolds(takerAddress)).to.equal(0);
+  });
+
+  it("penalizes unfulfilled locks and credits the signal bond to the maker", async () => {
+    await registerIdentity(takerAddress, "taker-payee");
+    const intentHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("intent-3"));
+    await riskManager.onIntentSignaled({
+      intentHash,
+      taker: takerAddress,
+      maker: makerAddress,
+      token: token.address,
+      paymentMethod,
+      amount: usdc(10),
+    });
+
+    const makerBalanceBefore = await stakeVault.balances(makerAddress);
+    await riskManager.onIntentAbandoned(intentHash, true);
+
+    expect((await stakeVault.balances(makerAddress)).sub(makerBalanceBefore)).to.equal(usdc(0.5));
+    const profile = await reputationRegistry.getProfile(takerAddress);
+    expect(profile.abandonedIntents).to.equal(1);
+    expect(profile.score).to.be.lt(0);
+
+    const ownerBalanceBefore = await token.balanceOf(ownerAddress);
+    await stakeVault.connect(maker).withdraw(usdc(0.5), ownerAddress);
+    expect((await token.balanceOf(ownerAddress)).sub(ownerBalanceBefore)).to.equal(usdc(0.5));
+  });
+
+  it("replays a failed chargeback penalty without losing its one-time base penalty", async () => {
+    await registerIdentity(takerAddress, "taker-payee");
+    await registerIdentity(makerAddress, "maker-payee");
+    const intentHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("chargeback-reputation-retry"));
+    await riskManager.onIntentSignaled({
+      intentHash,
+      taker: takerAddress,
+      maker: makerAddress,
+      token: token.address,
+      paymentMethod,
+      amount: usdc(100),
+    });
+    await riskManager.onIntentFulfilled(intentHash, usdc(100), true);
+    await reputationRegistry.setAuthorizedUpdater(riskManager.address, false);
+
+    const issuedAt = await time.latest();
+    const attestation = {
+      intentHash,
+      taker: takerAddress,
+      maker: makerAddress,
+      amount: usdc(100),
+      paymentMethod,
+      evidenceHash: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("retry-evidence")),
+      finalClaim: true,
+      issuedAt,
+      validUntil: issuedAt + 60 * 60,
+    };
+    const signature = await (chargebackAttestor as any)._signTypedData(
+      {
+        name: "ZKP2PChargebackVerifier",
+        version: "1",
+        chainId: (await ethers.provider.getNetwork()).chainId,
+        verifyingContract: riskManager.address,
+      },
+      {
+        ChargebackAttestation: [
+          { name: "intentHash", type: "bytes32" },
+          { name: "taker", type: "address" },
+          { name: "maker", type: "address" },
+          { name: "amount", type: "uint256" },
+          { name: "paymentMethod", type: "bytes32" },
+          { name: "evidenceHash", type: "bytes32" },
+          { name: "finalClaim", type: "bool" },
+          { name: "issuedAt", type: "uint256" },
+          { name: "validUntil", type: "uint256" },
+        ],
+      },
+      attestation,
+    );
+
+    await expect(
+      riskManager.resolveChargeback(
+        attestation,
+        await chargebackAttestor.getAddress(),
+        signature,
+      ),
+    ).to.emit(riskManager, "ReputationUpdateFailed");
+    expect((await reputationRegistry.getProfile(takerAddress)).chargebacks).to.equal(0);
+    expect(await stakeVault.openChargebackClaims(takerAddress)).to.equal(0);
+    expect(await stakeVault.reputationHolds(takerAddress)).to.equal(1);
+    await expect(
+      riskManager.onIntentSignaled({
+        intentHash: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("blocked-by-chargeback-sync")),
+        taker: takerAddress,
+        maker: makerAddress,
+        token: token.address,
+        paymentMethod,
+        amount: usdc(10),
+      }),
+    ).to.be.revertedWithCustomError(riskManager, "AccountRiskHold");
+
+    await reputationRegistry.setAuthorizedUpdater(riskManager.address, true);
+    await riskManager.connect(maker).syncReputation(intentHash);
+    await riskManager.connect(maker).syncReputation(intentHash);
+    expect(await stakeVault.reputationHolds(takerAddress)).to.equal(0);
+    expect((await reputationRegistry.getProfile(takerAddress)).chargebacks).to.equal(1);
+    expect((await riskManager.intentRisks(intentHash)).reputationChargebackAmount).to.equal(usdc(100));
+  });
+
+  it("keeps a durable hold and permissionlessly replays a failed abandonment penalty", async () => {
+    await registerIdentity(takerAddress, "taker-payee");
+    const intentHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("intent-reputation-retry"));
+    await riskManager.onIntentSignaled({
+      intentHash,
+      taker: takerAddress,
+      maker: makerAddress,
+      token: token.address,
+      paymentMethod,
+      amount: usdc(10),
+    });
+
+    await reputationRegistry.setAuthorizedUpdater(riskManager.address, false);
+    await expect(riskManager.onIntentAbandoned(intentHash, false)).to.emit(
+      riskManager,
+      "ReputationUpdateFailed",
+    );
+    expect(await stakeVault.reputationHolds(takerAddress)).to.equal(1);
+    await expect(
+      riskManager.onIntentSignaled({
+        intentHash: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("blocked-by-pending-reputation")),
+        taker: takerAddress,
+        maker: makerAddress,
+        token: token.address,
+        paymentMethod,
+        amount: usdc(10),
+      }),
+    ).to.be.revertedWithCustomError(riskManager, "AccountRiskHold");
+
+    await reputationRegistry.setAuthorizedUpdater(riskManager.address, true);
+    await riskManager.connect(maker).syncReputation(intentHash);
+    expect(await stakeVault.reputationHolds(takerAddress)).to.equal(0);
+    expect((await reputationRegistry.getProfile(takerAddress)).abandonedIntents).to.equal(1);
+  });
+
+  it("rejects reputation parameters that could overflow or disable penalties", async () => {
+    await expect(
+      reputationRegistry.setReputationConfig(1, 100, 0, 100, 10, 20_000),
+    ).to.be.revertedWithCustomError(reputationRegistry, "InvalidConfig");
+    await expect(
+      reputationRegistry.setReputationConfig(1, 100, 10, 100, 10_001, 20_000),
+    ).to.be.revertedWithCustomError(reputationRegistry, "InvalidConfig");
+  });
+
+  it("recovers a dropped reservation permissionlessly but never slashes a live intent", async () => {
+    await registerIdentity(takerAddress, "recovery-taker");
+    const lifecycleCaller = await (
+      await ethers.getContractFactory("IntentStatusOrchestratorMock", owner)
+    ).deploy();
+    await orchestratorRegistry.addOrchestrator(lifecycleCaller.address);
+    const intentHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("orphaned-reservation"));
+    await lifecycleCaller.signal(riskManager.address, {
+      intentHash,
+      taker: takerAddress,
+      maker: makerAddress,
+      token: token.address,
+      paymentMethod,
+      amount: usdc(10),
+    });
+
+    await expect(riskManager.connect(maker).recoverOrphanedReservation(intentHash))
+      .to.be.revertedWithCustomError(riskManager, "IntentStillActive");
+
+    await lifecycleCaller.dropIntent(intentHash);
+    await riskManager.connect(maker).recoverOrphanedReservation(intentHash);
+    expect(await stakeVault.reservedBalances(takerAddress)).to.equal(0);
+    expect(await stakeVault.reputationHolds(takerAddress)).to.equal(0);
+    expect(await stakeVault.balances(makerAddress)).to.equal(usdc(0.5));
+    expect((await riskManager.intentRisks(intentHash)).status).to.equal(3); // Abandoned
+  });
+});

--- a/test/risk/onchainRiskIntegration.spec.ts
+++ b/test/risk/onchainRiskIntegration.spec.ts
@@ -1,0 +1,257 @@
+import "module-alias/register";
+
+import { expect } from "chai";
+import { BigNumber, BytesLike, Contract } from "ethers";
+import { ethers } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+
+import DeployHelper from "@utils/deploys";
+import { ether, usdc } from "@utils/common";
+import { ADDRESS_ZERO, EMPTY_ORACLE_RATE_CONFIG, ONE, ZERO } from "@utils/constants";
+import { Currency } from "@utils/protocolUtils";
+import { getAccounts } from "@utils/test";
+import { createSignalIntentParams } from "@utils/test/helpers";
+
+describe("Open orchestrator real risk lifecycle", () => {
+  let owner: any;
+  let maker: any;
+  let taker: any;
+  let identityAttestor: any;
+  let caller: any;
+  let token: any;
+  let escrow: any;
+  let orchestrator: any;
+  let verifier: any;
+  let identityRegistry: Contract;
+  let reputationRegistry: Contract;
+  let stakeVault: Contract;
+  let riskManager: Contract;
+  let paymentMethod: BytesLike;
+  let payeeDetails: BytesLike;
+
+  const intentExpiration = 60 * 60;
+
+  async function registerTakerIdentity(): Promise<void> {
+    const issuedAtMs = (await time.latest()) * 1_000;
+    const actionType = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("register_venmo"));
+    const payeeIdHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("integration-taker"));
+    const dataHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("integration-identity"));
+    const attestation = {
+      method: paymentMethod,
+      actionType,
+      account: taker.address,
+      payeeIdHash,
+      dataHash,
+      issuedAtMs,
+      validUntilMs: issuedAtMs + 30 * 24 * 60 * 60 * 1_000,
+    };
+    const signature = await identityAttestor.wallet._signTypedData(
+      { name: "ZKP2PIdentityVerifier", version: "1" },
+      {
+        IdentityAttestation: [
+          { name: "method", type: "bytes32" },
+          { name: "actionType", type: "bytes32" },
+          { name: "callerAddress", type: "address" },
+          { name: "payeeIdHash", type: "bytes32" },
+          { name: "dataHash", type: "bytes32" },
+          { name: "issuedAt", type: "uint256" },
+          { name: "validUntil", type: "uint256" },
+        ],
+      },
+      {
+        method: attestation.method,
+        actionType: attestation.actionType,
+        callerAddress: attestation.account,
+        payeeIdHash: attestation.payeeIdHash,
+        dataHash: attestation.dataHash,
+        issuedAt: attestation.issuedAtMs,
+        validUntil: attestation.validUntilMs,
+      },
+    );
+    await identityRegistry
+      .connect(taker.wallet)
+      .registerIdentity(attestation, identityAttestor.address, signature);
+  }
+
+  async function signal(amount: BigNumber): Promise<string> {
+    const params = await createSignalIntentParams(
+      orchestrator.address,
+      escrow.address,
+      ZERO,
+      amount,
+      taker.address,
+      paymentMethod,
+      Currency.USD,
+      ether(1),
+      ADDRESS_ZERO,
+      ZERO,
+      null,
+      "1",
+      ADDRESS_ZERO,
+      "0x",
+      undefined,
+      "0x",
+    );
+    const receipt = await (await orchestrator.connect(taker.wallet).signalIntent(params)).wait();
+    return receipt.events.find((event: any) => event.event === "IntentSignaled").args.intentHash;
+  }
+
+  beforeEach(async () => {
+    [owner, maker, taker, identityAttestor, caller] = await getAccounts();
+    const deployer = new DeployHelper(owner.wallet);
+    token = await deployer.deployUSDCMock(usdc(1_000_000), "USDC", "USDC");
+    const paymentVerifierRegistry = await deployer.deployPaymentVerifierRegistry();
+    const relayerRegistry = await deployer.deployRelayerRegistry();
+    const escrowRegistry = await deployer.deployEscrowRegistry();
+    const orchestratorRegistry = await deployer.deployOrchestratorRegistry();
+    verifier = await deployer.deployPaymentVerifierMock();
+
+    paymentMethod = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("venmo"));
+    payeeDetails = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("integration-maker"));
+    await paymentVerifierRegistry.addPaymentMethod(paymentMethod, verifier.address, [Currency.USD]);
+
+    escrow = await deployer.deployEscrowV2(
+      owner.address,
+      ONE,
+      orchestratorRegistry.address,
+      paymentVerifierRegistry.address,
+      owner.address,
+      ZERO,
+      BigNumber.from(20),
+      BigNumber.from(intentExpiration),
+    );
+    orchestrator = await deployer.deployOrchestratorV2(
+      owner.address,
+      ONE,
+      escrowRegistry.address,
+      paymentVerifierRegistry.address,
+      relayerRegistry.address,
+      ZERO,
+      owner.address,
+    );
+    await escrowRegistry.addEscrow(escrow.address);
+    await orchestratorRegistry.addOrchestrator(orchestrator.address);
+    await verifier.setVerificationContext(orchestrator.address, escrow.address);
+
+    identityRegistry = await (
+      await ethers.getContractFactory("IdentityRegistry", owner.wallet)
+    ).deploy(owner.address);
+    reputationRegistry = await (
+      await ethers.getContractFactory("ReputationRegistry", owner.wallet)
+    ).deploy(owner.address, identityRegistry.address);
+    stakeVault = await (
+      await ethers.getContractFactory("StakeVault", owner.wallet)
+    ).deploy(owner.address, token.address);
+    riskManager = await (
+      await ethers.getContractFactory("ProtocolRiskManager", owner.wallet)
+    ).deploy(
+      owner.address,
+      orchestratorRegistry.address,
+      identityRegistry.address,
+      reputationRegistry.address,
+      stakeVault.address,
+    );
+    await identityRegistry.setTrustedAttestor(identityAttestor.address, true);
+    await identityRegistry.setAcceptedActionType(
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("register_venmo")),
+      true,
+    );
+    await reputationRegistry.setAuthorizedUpdater(riskManager.address, true);
+    await stakeVault.setAuthorizedManager(riskManager.address, true);
+    await riskManager.setPlatformRiskConfig(paymentMethod, {
+      configured: true,
+      enabled: true,
+      identityRequired: true,
+      makerIdentityRequired: false,
+      chargebackable: true,
+      minReputation: -1_000,
+      baseStakeBps: 10_000,
+      abandonmentSlashBps: 5_000,
+      signalBond: usdc(1),
+      maturitySchedule: {
+        cliffSeconds: 7 * 24 * 60 * 60,
+        stepTwoSeconds: 30 * 24 * 60 * 60,
+        finalMaturitySeconds: 180 * 24 * 60 * 60,
+        retentionBpsAfterCliff: 10_000,
+        retentionBpsAfterStepTwo: 10_000,
+      },
+    });
+    await orchestrator.setRiskManager(riskManager.address);
+
+    await registerTakerIdentity();
+    await token.transfer(taker.address, usdc(500));
+    await token.connect(taker.wallet).approve(stakeVault.address, usdc(500));
+    await stakeVault.connect(taker.wallet).deposit(usdc(500));
+    await token.transfer(maker.address, usdc(500));
+    await token.connect(maker.wallet).approve(escrow.address, usdc(500));
+    await escrow.connect(maker.wallet).createDeposit({
+      token: token.address,
+      amount: usdc(500),
+      intentAmountRange: { min: usdc(10), max: usdc(200) },
+      paymentMethods: [paymentMethod],
+      paymentMethodData: [{ intentGatingService: ADDRESS_ZERO, payeeDetails, data: "0x" }],
+      currencies: [[{
+        code: Currency.USD,
+        minConversionRate: ether(1),
+        oracleRateConfig: EMPTY_ORACLE_RATE_CONFIG,
+      }]],
+      delegate: ADDRESS_ZERO,
+      intentGuardian: ADDRESS_ZERO,
+      retainOnEmpty: false,
+    });
+  });
+
+  it("signals and fulfills through the real risk and vault modules", async () => {
+    const amount = usdc(100);
+    const intentHash = await signal(amount);
+    expect(await stakeVault.reservedBalances(taker.address)).to.equal(usdc(126));
+
+    const paymentProof = ethers.utils.defaultAbiCoder.encode(
+      ["uint256", "uint256", "bytes32", "bytes32", "bytes32"],
+      [amount, await time.latest(), payeeDetails, Currency.USD, intentHash],
+    );
+    await orchestrator.connect(caller.wallet).fulfillIntent({
+      paymentProof,
+      intentHash,
+      verificationData: "0x",
+      postIntentHookData: "0x",
+    });
+
+    expect(await stakeVault.reservedBalances(taker.address)).to.equal(0);
+    expect(await stakeVault.lockedBalances(taker.address)).to.equal(usdc(125));
+    expect((await riskManager.intentRisks(intentHash)).status).to.equal(2); // Fulfilled
+    expect(await orchestrator.hasActiveIntent(intentHash)).to.equal(false);
+  });
+
+  it("cancels through the real modules and clears the durable reputation hold", async () => {
+    const intentHash = await signal(usdc(10));
+    await orchestrator.connect(taker.wallet).cancelIntent(intentHash);
+
+    expect(await stakeVault.reservedBalances(taker.address)).to.equal(0);
+    expect(await stakeVault.reputationHolds(taker.address)).to.equal(0);
+    expect(await stakeVault.balances(maker.address)).to.equal(usdc(0.5));
+    expect((await riskManager.intentRisks(intentHash)).status).to.equal(3); // Abandoned
+    expect((await reputationRegistry.getProfile(taker.address)).abandonedIntents).to.equal(1);
+  });
+
+  it("expires and prunes through EscrowV2 without stranding risk collateral", async () => {
+    const intentHash = await signal(usdc(10));
+    await time.increase(intentExpiration + 1);
+    await escrow.connect(caller.wallet).pruneExpiredIntents(ZERO);
+
+    expect(await orchestrator.hasActiveIntent(intentHash)).to.equal(false);
+    expect(await stakeVault.reservedBalances(taker.address)).to.equal(0);
+    expect(await stakeVault.reputationHolds(taker.address)).to.equal(0);
+    expect((await riskManager.intentRisks(intentHash)).status).to.equal(3); // Abandoned
+  });
+
+  it("keeps ten real risk-callback prunes below a pinned per-intent gas ceiling", async () => {
+    const intentCount = 10;
+    for (let i = 0; i < intentCount; i += 1) await signal(usdc(10));
+    await time.increase(intentExpiration + 1);
+    const receipt = await (await escrow.connect(caller.wallet).pruneExpiredIntents(ZERO)).wait();
+
+    expect(receipt.gasUsed.div(intentCount)).to.be.lt(BigNumber.from(500_000));
+    expect(await stakeVault.reservedBalances(taker.address)).to.equal(0);
+  });
+});


### PR DESCRIPTION
Transfers zkp2p/protocol PR 10 into the canonical contracts repository while preserving the legacy repository package manager and current network matrix. Adds identity, reputation, stake-vault, and risk-manager contracts; integrates risk callbacks and discounted fees into OrchestratorV2; adds the opt-in dark-deployment script and design, architecture, migration, and threat-model docs. Verification: 24 focused Hardhat tests, GitHub Hardhat Full Suite, Foundry Fast Lane, and git diff check passed. The deployment retry fixture uses a distinct local multisig so the post-ownership-cutover behavior is exercised. No deployment was performed. Source review: https://github.com/zkp2p/protocol/pull/10