### PR TITLE
feat: retire legacy Zelle payment methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,16 +599,16 @@ Configures the v2 verifier and registry for all supported methods:
 - save payment method snapshots
 - emit Safe batch calldata when the deployer is not the registry owner
 
-This script currently covers:
+This historical script configured:
 
 - Venmo
 - Revolut
 - Cash App
 - Wise
 - Mercado Pago
-- Zelle Citi
-- Zelle Chase
-- Zelle Bank of America
+- Zelle Citi (retired by `deploy/26_retire_legacy_zelle_payment_methods.ts`)
+- Zelle Chase (retired by `deploy/26_retire_legacy_zelle_payment_methods.ts`)
+- Zelle Bank of America (retired by `deploy/26_retire_legacy_zelle_payment_methods.ts`)
 - PayPal
 - Monzo
 - N26
@@ -641,17 +641,14 @@ This script currently covers:
 
 ## Supported Payment Methods
 
-The repository contains deployment coverage for the following payment rails in the current v2 configuration flow:
+The current v2 configuration supports the following payment rails:
 
 - Venmo
 - Revolut
 - Cash App
 - Wise
 - Mercado Pago
-- Zelle:
-  - Citi
-  - Chase
-  - Bank of America
+- Zelle
 - PayPal
 - Monzo
 - N26

--- a/deploy/22_redeploy_upv_v2.ts
+++ b/deploy/22_redeploy_upv_v2.ts
@@ -22,11 +22,7 @@ import { REVOLUT_PROVIDER_CONFIG } from "../deployments/verifiers/revolut";
 import { CASHAPP_PROVIDER_CONFIG } from "../deployments/verifiers/cashapp";
 import { WISE_PROVIDER_CONFIG } from "../deployments/verifiers/wise";
 import { MERCADOPAGO_PROVIDER_CONFIG } from "../deployments/verifiers/mercadopago";
-import {
-  ZELLE_CITI_PROVIDER_CONFIG,
-  ZELLE_CHASE_PROVIDER_CONFIG,
-  ZELLE_BOFA_PROVIDER_CONFIG,
-} from "../deployments/verifiers/zelle";
+import { ZELLE_PROVIDER_CONFIG } from "../deployments/verifiers/zelle";
 import { PAYPAL_PROVIDER_CONFIG } from "../deployments/verifiers/paypal";
 import { MONZO_PROVIDER_CONFIG } from "../deployments/verifiers/monzo";
 import { N26_PROVIDER_CONFIG } from "../deployments/verifiers/n26";
@@ -46,9 +42,7 @@ const ALL_PAYMENT_METHODS = [
   { key: "cashapp", config: CASHAPP_PROVIDER_CONFIG },
   { key: "wise", config: WISE_PROVIDER_CONFIG },
   { key: "mercadopago", config: MERCADOPAGO_PROVIDER_CONFIG },
-  { key: "zelle-citi", config: ZELLE_CITI_PROVIDER_CONFIG },
-  { key: "zelle-chase", config: ZELLE_CHASE_PROVIDER_CONFIG },
-  { key: "zelle-bofa", config: ZELLE_BOFA_PROVIDER_CONFIG },
+  { key: "zelle", config: ZELLE_PROVIDER_CONFIG },
   { key: "paypal", config: PAYPAL_PROVIDER_CONFIG },
   { key: "monzo", config: MONZO_PROVIDER_CONFIG },
   { key: "n26", config: N26_PROVIDER_CONFIG },

--- a/deploy/26_retire_legacy_zelle_payment_methods.ts
+++ b/deploy/26_retire_legacy_zelle_payment_methods.ts
@@ -1,0 +1,152 @@
+import "module-alias/register";
+
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { ethers } from "hardhat";
+
+import {
+  getDeployedContractAddress,
+  removePaymentMethodFromRegistry,
+  removePaymentMethodFromUnifiedVerifier,
+  removePaymentMethodSnapshot,
+  waitForDeploymentDelay,
+} from "../deployments/helpers";
+
+export const GENERIC_ZELLE_PAYMENT_METHOD_HASH =
+  "0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3";
+
+export const RETIRED_ZELLE_PAYMENT_METHODS = [
+  {
+    key: "zelle-citi",
+    hash: "0x817260692b75e93c7fbc51c71637d4075a975e221e1ebc1abeddfabd731fd90d",
+  },
+  {
+    key: "zelle-chase",
+    hash: "0x6aa1d1401e79ad0549dced8b1b96fb72c41cd02b32a7d9ea1fed54ba9e17152e",
+  },
+  {
+    key: "zelle-bofa",
+    hash: "0x4bc42b322a3ad413b91b2fde30549ca70d6ee900eded1681de91aaf32ffd7ab5",
+  },
+] as const;
+
+type VerifierContracts = {
+  paymentVerifierRegistry: any;
+  legacyUnifiedPaymentVerifier: any;
+  unifiedPaymentVerifierV2: any;
+};
+
+async function assertGenericZelleProtected(
+  contracts: VerifierContracts,
+  unifiedPaymentVerifierV2Address: string
+): Promise<void> {
+  const expectedGenericHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("zelle"));
+  if (GENERIC_ZELLE_PAYMENT_METHOD_HASH !== expectedGenericHash) {
+    throw new Error("Generic Zelle hash does not match keccak256(zelle)");
+  }
+
+  const retiredHashes = new Set<string>();
+  for (const { key, hash } of RETIRED_ZELLE_PAYMENT_METHODS) {
+    const expectedRetiredHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(key));
+    if (hash !== expectedRetiredHash || String(hash) === GENERIC_ZELLE_PAYMENT_METHOD_HASH) {
+      throw new Error(`Invalid retired Zelle payment method hash for ${key}`);
+    }
+    retiredHashes.add(hash);
+  }
+  if (retiredHashes.size !== RETIRED_ZELLE_PAYMENT_METHODS.length) {
+    throw new Error("Retired Zelle payment method hashes must be unique");
+  }
+
+  const genericRegistered = await contracts.paymentVerifierRegistry.isPaymentMethod(
+    GENERIC_ZELLE_PAYMENT_METHOD_HASH
+  );
+  const genericVerifier = await contracts.paymentVerifierRegistry.getVerifier(
+    GENERIC_ZELLE_PAYMENT_METHOD_HASH
+  );
+  const v2PaymentMethods = await contracts.unifiedPaymentVerifierV2.getPaymentMethods();
+
+  if (
+    !genericRegistered ||
+    genericVerifier.toLowerCase() !== unifiedPaymentVerifierV2Address.toLowerCase() ||
+    !v2PaymentMethods.includes(GENERIC_ZELLE_PAYMENT_METHOD_HASH)
+  ) {
+    throw new Error("Generic Zelle must remain registered exclusively to UnifiedPaymentVerifierV2");
+  }
+}
+
+export async function retireLegacyZelleVerifierRegistrations(
+  hre: HardhatRuntimeEnvironment,
+  contracts: VerifierContracts,
+  unifiedPaymentVerifierV2Address: string
+): Promise<void> {
+  await assertGenericZelleProtected(contracts, unifiedPaymentVerifierV2Address);
+
+  // Shut the active routing gate before removing verifier allowlist entries.
+  for (const { hash } of RETIRED_ZELLE_PAYMENT_METHODS) {
+    await removePaymentMethodFromRegistry(hre, contracts.paymentVerifierRegistry, hash);
+  }
+  for (const { hash } of RETIRED_ZELLE_PAYMENT_METHODS) {
+    await removePaymentMethodFromUnifiedVerifier(hre, contracts.legacyUnifiedPaymentVerifier, hash);
+  }
+  for (const { hash } of RETIRED_ZELLE_PAYMENT_METHODS) {
+    await removePaymentMethodFromUnifiedVerifier(hre, contracts.unifiedPaymentVerifierV2, hash);
+  }
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const network = hre.deployments.getNetworkName();
+  const legacyVerifierAddress = getDeployedContractAddress(network, "UnifiedPaymentVerifier");
+  const unifiedPaymentVerifierV2Address = getDeployedContractAddress(network, "UnifiedPaymentVerifierV2");
+  const paymentVerifierRegistryAddress = getDeployedContractAddress(network, "PaymentVerifierRegistry");
+
+  const contracts: VerifierContracts = {
+    paymentVerifierRegistry: await ethers.getContractAt("PaymentVerifierRegistry", paymentVerifierRegistryAddress),
+    legacyUnifiedPaymentVerifier: await ethers.getContractAt("UnifiedPaymentVerifier", legacyVerifierAddress),
+    unifiedPaymentVerifierV2: await ethers.getContractAt("UnifiedPaymentVerifier", unifiedPaymentVerifierV2Address),
+  };
+
+  console.log("\nRetiring legacy Zelle payment methods");
+  await retireLegacyZelleVerifierRegistrations(hre, contracts, unifiedPaymentVerifierV2Address);
+
+  for (const { key } of RETIRED_ZELLE_PAYMENT_METHODS) {
+    removePaymentMethodSnapshot(network, key);
+  }
+
+  await waitForDeploymentDelay(hre);
+};
+
+func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> => {
+  const network = hre.deployments.getNetworkName();
+
+  try {
+    const legacyVerifierAddress = getDeployedContractAddress(network, "UnifiedPaymentVerifier");
+    const unifiedPaymentVerifierV2Address = getDeployedContractAddress(network, "UnifiedPaymentVerifierV2");
+    const paymentVerifierRegistryAddress = getDeployedContractAddress(network, "PaymentVerifierRegistry");
+    const contracts: VerifierContracts = {
+      paymentVerifierRegistry: await ethers.getContractAt("PaymentVerifierRegistry", paymentVerifierRegistryAddress),
+      legacyUnifiedPaymentVerifier: await ethers.getContractAt("UnifiedPaymentVerifier", legacyVerifierAddress),
+      unifiedPaymentVerifierV2: await ethers.getContractAt("UnifiedPaymentVerifier", unifiedPaymentVerifierV2Address),
+    };
+
+    await assertGenericZelleProtected(contracts, unifiedPaymentVerifierV2Address);
+
+    const legacyPaymentMethods = await contracts.legacyUnifiedPaymentVerifier.getPaymentMethods();
+    const v2PaymentMethods = await contracts.unifiedPaymentVerifierV2.getPaymentMethods();
+    const retiredMethodsAbsent = await Promise.all(
+      RETIRED_ZELLE_PAYMENT_METHODS.map(async ({ hash }) =>
+        !(await contracts.paymentVerifierRegistry.isPaymentMethod(hash)) &&
+        !legacyPaymentMethods.includes(hash) &&
+        !v2PaymentMethods.includes(hash)
+      )
+    );
+
+    return retiredMethodsAbsent.every(Boolean);
+  } catch {
+    return false;
+  }
+};
+
+func.tags = ["26_retire_legacy_zelle_payment_methods"];
+func.dependencies = ["25_add_generic_zelle_payment_method"];
+
+export default func;

--- a/deployments/outputs/platforms/base.json
+++ b/deployments/outputs/platforms/base.json
@@ -95,27 +95,6 @@
       ],
       "updatedAt": "2026-06-22T02:11:08.890Z"
     },
-    "zelle-citi": {
-      "paymentMethodHash": "0x817260692b75e93c7fbc51c71637d4075a975e221e1ebc1abeddfabd731fd90d",
-      "currencies": [
-        "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
-      ],
-      "updatedAt": "2026-03-16T12:46:13.287Z"
-    },
-    "zelle-chase": {
-      "paymentMethodHash": "0x6aa1d1401e79ad0549dced8b1b96fb72c41cd02b32a7d9ea1fed54ba9e17152e",
-      "currencies": [
-        "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
-      ],
-      "updatedAt": "2026-03-16T12:46:25.382Z"
-    },
-    "zelle-bofa": {
-      "paymentMethodHash": "0x4bc42b322a3ad413b91b2fde30549ca70d6ee900eded1681de91aaf32ffd7ab5",
-      "currencies": [
-        "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
-      ],
-      "updatedAt": "2026-03-16T12:46:39.462Z"
-    },
     "paypal": {
       "paymentMethodHash": "0x3ccc3d4d5e769b1f82dc4988485551dc0cd3c7a3926d7d8a4dde91507199490f",
       "currencies": [

--- a/deployments/outputs/platforms/base_sepolia.json
+++ b/deployments/outputs/platforms/base_sepolia.json
@@ -79,27 +79,6 @@
       ],
       "updatedAt": "2026-06-22T00:31:56.103Z"
     },
-    "zelle-citi": {
-      "paymentMethodHash": "0x817260692b75e93c7fbc51c71637d4075a975e221e1ebc1abeddfabd731fd90d",
-      "currencies": [
-        "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
-      ],
-      "updatedAt": "2025-09-30T05:03:21.196Z"
-    },
-    "zelle-chase": {
-      "paymentMethodHash": "0x6aa1d1401e79ad0549dced8b1b96fb72c41cd02b32a7d9ea1fed54ba9e17152e",
-      "currencies": [
-        "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
-      ],
-      "updatedAt": "2025-09-30T05:03:39.765Z"
-    },
-    "zelle-bofa": {
-      "paymentMethodHash": "0x4bc42b322a3ad413b91b2fde30549ca70d6ee900eded1681de91aaf32ffd7ab5",
-      "currencies": [
-        "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
-      ],
-      "updatedAt": "2025-09-30T05:03:55.199Z"
-    },
     "paypal": {
       "paymentMethodHash": "0x3ccc3d4d5e769b1f82dc4988485551dc0cd3c7a3926d7d8a4dde91507199490f",
       "currencies": [

--- a/deployments/outputs/platforms/base_staging.json
+++ b/deployments/outputs/platforms/base_staging.json
@@ -95,27 +95,6 @@
       ],
       "updatedAt": "2026-06-22T00:41:48.697Z"
     },
-    "zelle-citi": {
-      "paymentMethodHash": "0x817260692b75e93c7fbc51c71637d4075a975e221e1ebc1abeddfabd731fd90d",
-      "currencies": [
-        "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
-      ],
-      "updatedAt": "2026-03-16T12:16:55.737Z"
-    },
-    "zelle-chase": {
-      "paymentMethodHash": "0x6aa1d1401e79ad0549dced8b1b96fb72c41cd02b32a7d9ea1fed54ba9e17152e",
-      "currencies": [
-        "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
-      ],
-      "updatedAt": "2026-03-16T12:17:48.993Z"
-    },
-    "zelle-bofa": {
-      "paymentMethodHash": "0x4bc42b322a3ad413b91b2fde30549ca70d6ee900eded1681de91aaf32ffd7ab5",
-      "currencies": [
-        "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
-      ],
-      "updatedAt": "2026-03-16T12:18:44.617Z"
-    },
     "paypal": {
       "paymentMethodHash": "0x3ccc3d4d5e769b1f82dc4988485551dc0cd3c7a3926d7d8a4dde91507199490f",
       "currencies": [

--- a/deployments/outputs/platforms/localhost.json
+++ b/deployments/outputs/platforms/localhost.json
@@ -88,27 +88,6 @@
       ],
       "updatedAt": "2026-02-20T09:59:06.372Z"
     },
-    "zelle-citi": {
-      "paymentMethodHash": "0x817260692b75e93c7fbc51c71637d4075a975e221e1ebc1abeddfabd731fd90d",
-      "currencies": [
-        "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
-      ],
-      "updatedAt": "2026-02-20T09:59:06.457Z"
-    },
-    "zelle-chase": {
-      "paymentMethodHash": "0x6aa1d1401e79ad0549dced8b1b96fb72c41cd02b32a7d9ea1fed54ba9e17152e",
-      "currencies": [
-        "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
-      ],
-      "updatedAt": "2026-02-20T09:59:06.534Z"
-    },
-    "zelle-bofa": {
-      "paymentMethodHash": "0x4bc42b322a3ad413b91b2fde30549ca70d6ee900eded1681de91aaf32ffd7ab5",
-      "currencies": [
-        "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
-      ],
-      "updatedAt": "2026-02-20T09:59:06.621Z"
-    },
     "paypal": {
       "paymentMethodHash": "0x3ccc3d4d5e769b1f82dc4988485551dc0cd3c7a3926d7d8a4dde91507199490f",
       "currencies": [

--- a/packages/contracts/scripts/extractors/paymentMethods.ts
+++ b/packages/contracts/scripts/extractors/paymentMethods.ts
@@ -30,40 +30,6 @@ function ensureDir(dir: string) {
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 }
 
-// Helper to convert BigNumber values to decimal numbers
-function convertToNumber(value: any): number {
-  if (!value) return 30; // Default
-
-  // Handle BigNumber objects
-  if (typeof value === 'object') {
-    if (value._isBigNumber || value.type === 'BigNumber') {
-      // Convert hex to decimal
-      const hex = value.hex || value._hex || '0x1e';
-      return parseInt(hex, 16);
-    }
-    // Handle nested objects (like Zelle with per-bank buffers)
-    if (typeof value === 'object' && !Array.isArray(value)) {
-      // Take the first value if it's an object with multiple entries
-      const firstKey = Object.keys(value)[0];
-      if (firstKey) {
-        return convertToNumber(value[firstKey]);
-      }
-    }
-  }
-
-  // Handle string numbers
-  if (typeof value === 'string') {
-    return parseInt(value);
-  }
-
-  // Already a number
-  if (typeof value === 'number') {
-    return value;
-  }
-
-  return 30; // Default fallback
-}
-
 export async function extractPaymentMethods(): Promise<void> {
   ensureDir(PAYMENT_METHODS_DIR);
 
@@ -252,6 +218,9 @@ ${networks.map(net => `  ${net}: require('./${net}.json')`).join(',\n')}
   const RETIRED_METHOD_HASH_TO_NAME: Record<string, string> = {
     '0xd9ff4fd6b39a3e3dd43c41d05662a5547de4a878bc97a65bcb352ade493cdc6b': 'n26',
     '0xaea63ef983458674f54ee50cdaa7b09d80a5c6c03ed505f51c90b0f2b54abb01': 'luxon',
+    '0x817260692b75e93c7fbc51c71637d4075a975e221e1ebc1abeddfabd731fd90d': 'zelle-citi',
+    '0x6aa1d1401e79ad0549dced8b1b96fb72c41cd02b32a7d9ea1fed54ba9e17152e': 'zelle-chase',
+    '0x4bc42b322a3ad413b91b2fde30549ca70d6ee900eded1681de91aaf32ffd7ab5': 'zelle-bofa',
   };
   for (const [hash, name] of Object.entries(RETIRED_METHOD_HASH_TO_NAME)) {
     const normalized = hash.toLowerCase();

--- a/packages/contracts/test/paymentMethods.test.ts
+++ b/packages/contracts/test/paymentMethods.test.ts
@@ -1,0 +1,39 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { extractPaymentMethods } from "../scripts/extractors/paymentMethods";
+
+const GENERIC_ZELLE_HASH = "0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3";
+const RETIRED_ZELLE_METHODS = {
+  "zelle-citi": "0x817260692b75e93c7fbc51c71637d4075a975e221e1ebc1abeddfabd731fd90d",
+  "zelle-chase": "0x6aa1d1401e79ad0549dced8b1b96fb72c41cd02b32a7d9ea1fed54ba9e17152e",
+  "zelle-bofa": "0x4bc42b322a3ad413b91b2fde30549ca70d6ee900eded1681de91aaf32ffd7ab5",
+} as const;
+
+describe("payment method package extraction", () => {
+  const paymentMethodsDir = path.resolve(__dirname, "../paymentMethods");
+
+  beforeAll(async () => {
+    await extractPaymentMethods();
+  });
+
+  it("publishes only generic Zelle as active while preserving historical reverse labels", () => {
+    const base = JSON.parse(fs.readFileSync(path.join(paymentMethodsDir, "base.json"), "utf8"));
+    const baseStaging = JSON.parse(fs.readFileSync(path.join(paymentMethodsDir, "baseStaging.json"), "utf8"));
+    const lookups = JSON.parse(fs.readFileSync(path.join(paymentMethodsDir, "lookups.json"), "utf8"));
+
+    for (const network of [base, baseStaging]) {
+      expect(network.methods.zelle.paymentMethodHash).toBe(GENERIC_ZELLE_HASH);
+      for (const retiredName of Object.keys(RETIRED_ZELLE_METHODS)) {
+        expect(network.methods[retiredName]).toBeUndefined();
+      }
+    }
+
+    expect(lookups.nameToHash.zelle).toBe(GENERIC_ZELLE_HASH);
+    expect(lookups.zelleVariantHashes).toEqual([]);
+    for (const [retiredName, retiredHash] of Object.entries(RETIRED_ZELLE_METHODS)) {
+      expect(lookups.nameToHash[retiredName]).toBeUndefined();
+      expect(lookups.hashToName[retiredHash]).toBe(retiredName);
+    }
+  });
+});

--- a/test/deploy/07_zellePaymentMethods.spec.ts
+++ b/test/deploy/07_zellePaymentMethods.spec.ts
@@ -5,11 +5,9 @@ import { deployments, ethers } from "hardhat";
 import {
   UnifiedPaymentVerifier,
   PaymentVerifierRegistry,
-  Escrow,
 } from "../../utils/contracts";
 import {
   UnifiedPaymentVerifier__factory,
-  Escrow__factory,
   PaymentVerifierRegistry__factory,
 } from "../../typechain";
 
@@ -18,14 +16,6 @@ import {
   getWaffleExpect,
 } from "../../utils/test";
 import { Account } from "../../utils/test/types";
-import { Address } from "../../utils/types";
-
-import { MULTI_SIG } from "../../deployments/parameters";
-import {
-  ZELLE_CITI_PROVIDER_CONFIG,
-  ZELLE_CHASE_PROVIDER_CONFIG,
-  ZELLE_BOFA_PROVIDER_CONFIG,
-} from "../../deployments/verifiers/zelle";
 import {
   ZELLE_CITI_PAYMENT_METHOD_HASH,
   ZELLE_CHASE_PAYMENT_METHOD_HASH,
@@ -34,13 +24,11 @@ import {
 
 const expect = getWaffleExpect();
 
-describe("Zelle Payment Methods Configuration", () => {
+describe("Legacy Zelle Payment Methods Retirement", () => {
   let deployer: Account;
-  let multiSig: Address;
-  let escrowAddress: string;
 
-  let escrow: Escrow;
   let unifiedPaymentVerifier: UnifiedPaymentVerifier;
+  let unifiedPaymentVerifierV2: UnifiedPaymentVerifier;
   let paymentVerifierRegistry: PaymentVerifierRegistry;
 
   const network: string = deployments.getNetworkName();
@@ -51,78 +39,26 @@ describe("Zelle Payment Methods Configuration", () => {
 
   before(async () => {
     [deployer] = await getAccounts();
-    multiSig = MULTI_SIG[network] ? MULTI_SIG[network] : deployer.address;
-
-    escrowAddress = getDeployedContractAddress(network, "Escrow");
-    escrow = new Escrow__factory(deployer.wallet).attach(escrowAddress);
 
     const paymentVerifierRegistryAddress = getDeployedContractAddress(network, "PaymentVerifierRegistry");
     paymentVerifierRegistry = new PaymentVerifierRegistry__factory(deployer.wallet).attach(paymentVerifierRegistryAddress);
 
     const unifiedPaymentVerifierAddress = getDeployedContractAddress(network, "UnifiedPaymentVerifier");
     unifiedPaymentVerifier = new UnifiedPaymentVerifier__factory(deployer.wallet).attach(unifiedPaymentVerifierAddress);
+
+    const unifiedPaymentVerifierV2Address = getDeployedContractAddress(network, "UnifiedPaymentVerifierV2");
+    unifiedPaymentVerifierV2 = new UnifiedPaymentVerifier__factory(deployer.wallet).attach(unifiedPaymentVerifierV2Address);
   });
 
-  describe("Zelle Citi Payment Method", () => {
-    describe("Payment Method Registry", () => {
-      it("should add Zelle Citi payment method to the registry", async () => {
-        const isPaymentMethod = await paymentVerifierRegistry.isPaymentMethod(ZELLE_CITI_PAYMENT_METHOD_HASH);
-        expect(isPaymentMethod).to.be.true;
-      });
-
-      it("should add Zelle Citi currencies to the registry", async () => {
-        const currencies = await paymentVerifierRegistry.getCurrencies(ZELLE_CITI_PAYMENT_METHOD_HASH);
-        expect(currencies).to.deep.eq(ZELLE_CITI_PROVIDER_CONFIG.currencies);
-      });
+  for (const [name, paymentMethodHash] of [
+    ["Zelle Citi", ZELLE_CITI_PAYMENT_METHOD_HASH],
+    ["Zelle Chase", ZELLE_CHASE_PAYMENT_METHOD_HASH],
+    ["Zelle BofA", ZELLE_BOFA_PAYMENT_METHOD_HASH],
+  ] as const) {
+    it(`removes ${name} from every active payment method surface`, async () => {
+      expect(await paymentVerifierRegistry.isPaymentMethod(paymentMethodHash)).to.be.false;
+      expect(await unifiedPaymentVerifier.getPaymentMethods()).to.not.include(paymentMethodHash);
+      expect(await unifiedPaymentVerifierV2.getPaymentMethods()).to.not.include(paymentMethodHash);
     });
-
-    describe("Unified Verifier Configuration", () => {
-      it("should add Zelle Citi payment method to unified verifier", async () => {
-        const paymentMethods = await unifiedPaymentVerifier.getPaymentMethods();
-        expect(paymentMethods).to.include(ZELLE_CITI_PAYMENT_METHOD_HASH);
-      });
-    });
-  });
-
-  describe("Zelle Chase Payment Method", () => {
-    describe("Payment Method Registry", () => {
-      it("should add Zelle Chase payment method to the registry", async () => {
-        const isPaymentMethod = await paymentVerifierRegistry.isPaymentMethod(ZELLE_CHASE_PAYMENT_METHOD_HASH);
-        expect(isPaymentMethod).to.be.true;
-      });
-
-      it("should add Zelle Chase currencies to the registry", async () => {
-        const currencies = await paymentVerifierRegistry.getCurrencies(ZELLE_CHASE_PAYMENT_METHOD_HASH);
-        expect(currencies).to.deep.eq(ZELLE_CHASE_PROVIDER_CONFIG.currencies);
-      });
-    });
-
-    describe("Unified Verifier Configuration", () => {
-      it("should add Zelle Chase payment method to unified verifier", async () => {
-        const paymentMethods = await unifiedPaymentVerifier.getPaymentMethods();
-        expect(paymentMethods).to.include(ZELLE_CHASE_PAYMENT_METHOD_HASH);
-      });
-    });
-  });
-
-  describe("Zelle Bank of America Payment Method", () => {
-    describe("Payment Method Registry", () => {
-      it("should add Zelle BofA payment method to the registry", async () => {
-        const isPaymentMethod = await paymentVerifierRegistry.isPaymentMethod(ZELLE_BOFA_PAYMENT_METHOD_HASH);
-        expect(isPaymentMethod).to.be.true;
-      });
-
-      it("should add Zelle BofA currencies to the registry", async () => {
-        const currencies = await paymentVerifierRegistry.getCurrencies(ZELLE_BOFA_PAYMENT_METHOD_HASH);
-        expect(currencies).to.deep.eq(ZELLE_BOFA_PROVIDER_CONFIG.currencies);
-      });
-    });
-
-    describe("Unified Verifier Configuration", () => {
-      it("should add Zelle BofA payment method to unified verifier", async () => {
-        const paymentMethods = await unifiedPaymentVerifier.getPaymentMethods();
-        expect(paymentMethods).to.include(ZELLE_BOFA_PAYMENT_METHOD_HASH);
-      });
-    });
-  });
+  }
 });

--- a/test/deploy/16_v2PaymentMethods.spec.ts
+++ b/test/deploy/16_v2PaymentMethods.spec.ts
@@ -24,11 +24,6 @@ import { REVOLUT_PROVIDER_CONFIG } from "../../deployments/verifiers/revolut";
 import { CASHAPP_PROVIDER_CONFIG } from "../../deployments/verifiers/cashapp";
 import { WISE_PROVIDER_CONFIG } from "../../deployments/verifiers/wise";
 import { MERCADOPAGO_PROVIDER_CONFIG } from "../../deployments/verifiers/mercadopago";
-import {
-  ZELLE_CITI_PROVIDER_CONFIG,
-  ZELLE_CHASE_PROVIDER_CONFIG,
-  ZELLE_BOFA_PROVIDER_CONFIG,
-} from "../../deployments/verifiers/zelle";
 import { PAYPAL_PROVIDER_CONFIG } from "../../deployments/verifiers/paypal";
 import { MONZO_PROVIDER_CONFIG } from "../../deployments/verifiers/monzo";
 import { ALIPAY_PROVIDER_CONFIG } from "../../deployments/verifiers/alipay";
@@ -42,9 +37,6 @@ const ALL_PAYMENT_METHODS = [
   { name: "CashApp", config: CASHAPP_PROVIDER_CONFIG },
   { name: "Wise", config: WISE_PROVIDER_CONFIG },
   { name: "MercadoPago", config: MERCADOPAGO_PROVIDER_CONFIG },
-  { name: "Zelle Citi", config: ZELLE_CITI_PROVIDER_CONFIG },
-  { name: "Zelle Chase", config: ZELLE_CHASE_PROVIDER_CONFIG },
-  { name: "Zelle BofA", config: ZELLE_BOFA_PROVIDER_CONFIG },
   { name: "PayPal", config: PAYPAL_PROVIDER_CONFIG },
   { name: "Monzo", config: MONZO_PROVIDER_CONFIG },
   { name: "Alipay", config: ALIPAY_PROVIDER_CONFIG },

--- a/test/deploy/25_genericZellePaymentMethod.spec.ts
+++ b/test/deploy/25_genericZellePaymentMethod.spec.ts
@@ -88,12 +88,14 @@ describe("Generic Zelle Payment Method Configuration", () => {
   });
 
   for (const { name, config } of LEGACY_ZELLE_METHODS) {
-    it(`keeps ${name} registered for drain support`, async () => {
+    it(`removes ${name} from every active payment method surface`, async () => {
       const isPaymentMethod = await paymentVerifierRegistry.isPaymentMethod(config.paymentMethodHash);
+      const legacyPaymentMethods = await legacyUnifiedPaymentVerifier.getPaymentMethods();
       const paymentMethods = await unifiedPaymentVerifierV2.getPaymentMethods();
 
-      expect(isPaymentMethod).to.be.true;
-      expect(paymentMethods).to.include(config.paymentMethodHash);
+      expect(isPaymentMethod).to.be.false;
+      expect(legacyPaymentMethods).to.not.include(config.paymentMethodHash);
+      expect(paymentMethods).to.not.include(config.paymentMethodHash);
     });
   }
 

--- a/test/deploy/26_retireLegacyZellePaymentMethods.spec.ts
+++ b/test/deploy/26_retireLegacyZellePaymentMethods.spec.ts
@@ -1,0 +1,301 @@
+import "module-alias/register";
+
+import { BigNumber, BytesLike } from "ethers";
+import * as hre from "hardhat";
+
+import DeployHelper from "@utils/deploys";
+import { ether, usdc } from "@utils/common";
+import { ADDRESS_ZERO, EMPTY_ORACLE_RATE_CONFIG, ONE, ZERO } from "@utils/constants";
+import {
+  EscrowRegistry,
+  EscrowV2,
+  NullifierRegistry,
+  OrchestratorRegistry,
+  OrchestratorV2,
+  PaymentVerifierRegistry,
+  RelayerRegistry,
+  SimpleAttestationVerifier,
+  UnifiedPaymentVerifier,
+  USDCMock,
+} from "@utils/contracts";
+import { getAccounts, getWaffleExpect } from "@utils/test";
+import { createSignalIntentParams } from "@utils/test/helpers";
+import { Account } from "@utils/test/types";
+import { buildUnifiedPaymentProof } from "@utils/unifiedVerifierUtils";
+import { Currency } from "@utils/protocolUtils";
+import {
+  GENERIC_ZELLE_PAYMENT_METHOD_HASH,
+  RETIRED_ZELLE_PAYMENT_METHODS,
+  retireLegacyZelleVerifierRegistrations,
+} from "../../deploy/26_retire_legacy_zelle_payment_methods";
+
+const { ethers } = hre;
+const expect = getWaffleExpect();
+const ZERO_BYTES = "0x";
+
+describe("Retire legacy Zelle payment methods", () => {
+  let owner: Account;
+  let maker: Account;
+  let taker: Account;
+  let witness: Account;
+
+  let deployer: DeployHelper;
+  let usdcToken: USDCMock;
+  let escrowRegistry: EscrowRegistry;
+  let orchestratorRegistry: OrchestratorRegistry;
+  let paymentVerifierRegistry: PaymentVerifierRegistry;
+  let relayerRegistry: RelayerRegistry;
+  let nullifierRegistry: NullifierRegistry;
+  let escrow: EscrowV2;
+  let orchestrator: OrchestratorV2;
+  let attestationVerifier: SimpleAttestationVerifier;
+  let legacyUnifiedPaymentVerifier: UnifiedPaymentVerifier;
+  let unifiedPaymentVerifierV2: UnifiedPaymentVerifier;
+
+  let chainId: number;
+  let legacyDepositIds: BigNumber[];
+  const currency = Currency.USD;
+  const payeeId = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("zelle-payee"));
+  const conversionRate = ether(1);
+
+  async function createDeposit(paymentMethod: BytesLike, amount: BigNumber): Promise<BigNumber> {
+    const depositId = await escrow.depositCounter();
+    await escrow.connect(maker.wallet).createDeposit({
+      token: usdcToken.address,
+      amount,
+      intentAmountRange: { min: usdc(10), max: usdc(200) },
+      paymentMethods: [paymentMethod],
+      paymentMethodData: [{
+        intentGatingService: ADDRESS_ZERO,
+        payeeDetails: payeeId,
+        data: ZERO_BYTES,
+      }],
+      currencies: [[{
+        code: currency,
+        minConversionRate: conversionRate,
+        oracleRateConfig: EMPTY_ORACLE_RATE_CONFIG,
+      }]],
+      delegate: ADDRESS_ZERO,
+      intentGuardian: ADDRESS_ZERO,
+      retainOnEmpty: false,
+    });
+    return depositId;
+  }
+
+  async function signalIntent(depositId: BigNumber, paymentMethod: BytesLike, amount: BigNumber) {
+    const params = await createSignalIntentParams(
+      orchestrator.address,
+      escrow.address,
+      depositId,
+      amount,
+      taker.address,
+      paymentMethod,
+      currency,
+      conversionRate,
+      ADDRESS_ZERO,
+      ZERO,
+      null,
+      String(chainId),
+      ADDRESS_ZERO,
+      ZERO_BYTES,
+      undefined,
+      ZERO_BYTES
+    );
+    return orchestrator.connect(taker.wallet).signalIntent(params);
+  }
+
+  beforeEach(async () => {
+    [owner, maker, taker, witness] = await getAccounts();
+    deployer = new DeployHelper(owner.wallet);
+    chainId = (await ethers.provider.getNetwork()).chainId;
+
+    usdcToken = await deployer.deployUSDCMock(usdc(1_000_000), "USDC", "USDC");
+    escrowRegistry = await deployer.deployEscrowRegistry();
+    orchestratorRegistry = await deployer.deployOrchestratorRegistry();
+    paymentVerifierRegistry = await deployer.deployPaymentVerifierRegistry();
+    relayerRegistry = await deployer.deployRelayerRegistry();
+    nullifierRegistry = await deployer.deployNullifierRegistry();
+
+    escrow = await deployer.deployEscrowV2(
+      owner.address,
+      BigNumber.from(chainId),
+      orchestratorRegistry.address,
+      paymentVerifierRegistry.address,
+      owner.address,
+      ZERO,
+      BigNumber.from(20),
+      BigNumber.from(60 * 60)
+    );
+    orchestrator = await deployer.deployOrchestratorV2(
+      owner.address,
+      BigNumber.from(chainId),
+      escrowRegistry.address,
+      paymentVerifierRegistry.address,
+      relayerRegistry.address,
+      ZERO,
+      owner.address
+    );
+
+    attestationVerifier = await deployer.deploySimpleAttestationVerifier(witness.address);
+    legacyUnifiedPaymentVerifier = await deployer.deployUnifiedPaymentVerifier(
+      orchestratorRegistry.address,
+      nullifierRegistry.address,
+      attestationVerifier.address
+    );
+    unifiedPaymentVerifierV2 = await deployer.deployUnifiedPaymentVerifier(
+      orchestratorRegistry.address,
+      nullifierRegistry.address,
+      attestationVerifier.address
+    );
+
+    await escrowRegistry.addEscrow(escrow.address);
+    await orchestratorRegistry.addOrchestrator(orchestrator.address);
+    await nullifierRegistry.addWritePermission(unifiedPaymentVerifierV2.address);
+
+    await unifiedPaymentVerifierV2.addPaymentMethod(GENERIC_ZELLE_PAYMENT_METHOD_HASH);
+    await paymentVerifierRegistry.addPaymentMethod(
+      GENERIC_ZELLE_PAYMENT_METHOD_HASH,
+      unifiedPaymentVerifierV2.address,
+      [currency]
+    );
+
+    for (const { hash } of RETIRED_ZELLE_PAYMENT_METHODS) {
+      await legacyUnifiedPaymentVerifier.addPaymentMethod(hash);
+      await unifiedPaymentVerifierV2.addPaymentMethod(hash);
+      await paymentVerifierRegistry.addPaymentMethod(hash, unifiedPaymentVerifierV2.address, [currency]);
+    }
+
+    await usdcToken.transfer(maker.address, usdc(2_000));
+    await usdcToken.connect(maker.wallet).approve(escrow.address, usdc(2_000));
+    legacyDepositIds = [];
+    for (const { hash } of RETIRED_ZELLE_PAYMENT_METHODS) {
+      legacyDepositIds.push(await createDeposit(hash, usdc(300)));
+    }
+  });
+
+  it("hard cuts all legacy methods without deleting deposits and keeps generic Zelle functional", async () => {
+    expect(GENERIC_ZELLE_PAYMENT_METHOD_HASH).to.eq(
+      "0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3"
+    );
+
+    const migrationStartBlock = await ethers.provider.getBlockNumber();
+    const nonceBefore = await owner.wallet.getTransactionCount();
+    await retireLegacyZelleVerifierRegistrations(
+      hre,
+      {
+        paymentVerifierRegistry,
+        legacyUnifiedPaymentVerifier,
+        unifiedPaymentVerifierV2,
+      },
+      unifiedPaymentVerifierV2.address
+    );
+    const nonceAfter = await owner.wallet.getTransactionCount();
+    expect(nonceAfter - nonceBefore).to.eq(9);
+
+    const registryEvents = await paymentVerifierRegistry.queryFilter(
+      paymentVerifierRegistry.filters.PaymentMethodRemoved(),
+      migrationStartBlock + 1
+    );
+    const legacyVerifierEvents = await legacyUnifiedPaymentVerifier.queryFilter(
+      legacyUnifiedPaymentVerifier.filters.PaymentMethodRemoved(),
+      migrationStartBlock + 1
+    );
+    const v2VerifierEvents = await unifiedPaymentVerifierV2.queryFilter(
+      unifiedPaymentVerifierV2.filters.PaymentMethodRemoved(),
+      migrationStartBlock + 1
+    );
+    expect(registryEvents).to.have.length(3);
+    expect(legacyVerifierEvents).to.have.length(3);
+    expect(v2VerifierEvents).to.have.length(3);
+    expect(registryEvents[2].blockNumber).to.be.lessThan(legacyVerifierEvents[0].blockNumber);
+
+    const legacyPaymentMethods = await legacyUnifiedPaymentVerifier.getPaymentMethods();
+    const v2PaymentMethods = await unifiedPaymentVerifierV2.getPaymentMethods();
+    for (const { hash } of RETIRED_ZELLE_PAYMENT_METHODS) {
+      expect(await paymentVerifierRegistry.isPaymentMethod(hash)).to.be.false;
+      expect(await paymentVerifierRegistry.getVerifier(hash)).to.eq(ADDRESS_ZERO);
+      expect(legacyPaymentMethods).to.not.include(hash);
+      expect(v2PaymentMethods).to.not.include(hash);
+    }
+
+    expect(await paymentVerifierRegistry.isPaymentMethod(GENERIC_ZELLE_PAYMENT_METHOD_HASH)).to.be.true;
+    expect(await paymentVerifierRegistry.getVerifier(GENERIC_ZELLE_PAYMENT_METHOD_HASH)).to.eq(
+      unifiedPaymentVerifierV2.address
+    );
+    expect(v2PaymentMethods).to.include(GENERIC_ZELLE_PAYMENT_METHOD_HASH);
+
+    for (const [index, { hash }] of RETIRED_ZELLE_PAYMENT_METHODS.entries()) {
+      const existingLegacyDeposit = await escrow.getDeposit(legacyDepositIds[index]);
+      expect(existingLegacyDeposit.depositor).to.eq(maker.address);
+      expect(existingLegacyDeposit.remainingDeposits).to.eq(usdc(300));
+
+      await expect(
+        createDeposit(hash, usdc(100))
+      ).to.be.revertedWithCustomError(escrow, "PaymentMethodNotWhitelisted");
+      await expect(
+        signalIntent(legacyDepositIds[index], hash, usdc(50))
+      ).to.be.revertedWithCustomError(orchestrator, "PaymentMethodDoesNotExist");
+    }
+    expect(await usdcToken.balanceOf(escrow.address)).to.eq(usdc(900));
+
+    const makerBalanceBeforeWithdrawal = await usdcToken.balanceOf(maker.address);
+    for (const depositId of legacyDepositIds) {
+      await escrow.connect(maker.wallet).withdrawDeposit(depositId);
+    }
+    expect((await usdcToken.balanceOf(maker.address)).sub(makerBalanceBeforeWithdrawal)).to.eq(usdc(900));
+
+    const genericDepositId = await createDeposit(GENERIC_ZELLE_PAYMENT_METHOD_HASH, usdc(300));
+    const signalTx = await signalIntent(genericDepositId, GENERIC_ZELLE_PAYMENT_METHOD_HASH, usdc(50));
+    const signalReceipt = await signalTx.wait();
+    const intentHash = signalReceipt.events?.find((event: any) => event.event === "IntentSignaled")?.args?.intentHash;
+    const intent = await orchestrator.getIntent(intentHash);
+    const paymentTimestamp = BigNumber.from((await ethers.provider.getBlock("latest")).timestamp).mul(1000);
+    const builtProof = await buildUnifiedPaymentProof({
+      verifier: unifiedPaymentVerifierV2.address,
+      witness,
+      chainId,
+      paymentPaymentMethod: GENERIC_ZELLE_PAYMENT_METHOD_HASH,
+      paymentPayeeId: payeeId,
+      paymentAmount: intent.amount,
+      paymentCurrency: currency,
+      paymentTimestamp,
+      paymentPaymentId: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("generic-zelle-payment")),
+      attestationIntentHash: intentHash,
+      attestationReleaseAmount: intent.amount,
+      snapshotIntentHash: intentHash,
+      snapshotIntentAmount: intent.amount,
+      snapshotIntentPaymentMethod: GENERIC_ZELLE_PAYMENT_METHOD_HASH,
+      snapshotIntentFiatCurrency: currency,
+      snapshotIntentPayeeDetails: payeeId,
+      snapshotIntentConversionRate: intent.conversionRate,
+      snapshotIntentSignalTimestamp: intent.timestamp,
+      snapshotIntentTimestampBuffer: ZERO,
+      intentDepositId: genericDepositId,
+      intentEscrow: escrow.address,
+      intentTo: taker.address,
+    });
+
+    const takerBalanceBefore = await usdcToken.balanceOf(taker.address);
+    await expect(
+      orchestrator.fulfillIntent({
+        paymentProof: builtProof.paymentProof,
+        intentHash,
+        verificationData: ZERO_BYTES,
+        postIntentHookData: ZERO_BYTES,
+      })
+    ).to.emit(unifiedPaymentVerifierV2, "PaymentVerified");
+    expect((await usdcToken.balanceOf(taker.address)).sub(takerBalanceBefore)).to.eq(usdc(50));
+
+    const nonceBeforeSecondRun = await owner.wallet.getTransactionCount();
+    await retireLegacyZelleVerifierRegistrations(
+      hre,
+      {
+        paymentVerifierRegistry,
+        legacyUnifiedPaymentVerifier,
+        unifiedPaymentVerifierV2,
+      },
+      unifiedPaymentVerifierV2.address
+    );
+    expect(await owner.wallet.getTransactionCount()).to.eq(nonceBeforeSecondRun);
+  });
+});


### PR DESCRIPTION
Transfers the contracts portion of zkp2p/protocol PR 12. Removes zelle-citi, zelle-chase, and zelle-bofa from active platform artifacts across Base, Base staging, Base Sepolia, and localhost; keeps historical reverse labels; and adds the hard-cut registry and verifier retirement script. Verification: retirement and deployment assertions, package extraction test, package build, GitHub Hardhat Full Suite, Foundry Fast Lane, and git diff check passed. No deployment was performed. Merge first in the coordinated hard cut. Source: https://github.com/zkp2p/protocol/pull/12