### PR TITLE
feat: snapshot chargeback witness epochs

### DIFF
--- a/contracts/RiskManager.sol
+++ b/contracts/RiskManager.sol
@@ -8,7 +8,7 @@ import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuar
 import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
-import { IAttestationVerifier } from "./interfaces/IAttestationVerifier.sol";
+import { IEpochAttestationVerifier } from "./interfaces/IEpochAttestationVerifier.sol";
 import { IEscrowV2 } from "./interfaces/IEscrowV2.sol";
 import { IIntentRiskHook } from "./interfaces/IIntentRiskHook.sol";
 import { IOrchestratorV3 } from "./interfaces/IOrchestratorV3.sol";
@@ -106,7 +106,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
     /* ============ Mutable Governance State ============ */
 
     /// @notice Verifier that authenticates typed chargeback attestations.
-    IAttestationVerifier public attestationVerifier;
+    IEpochAttestationVerifier public attestationVerifier;
 
     /// @notice Canonical post-intent hook used only by deferred-payout positions.
     address public deferredPayoutHook;
@@ -149,7 +149,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         address _owner,
         IOrchestratorV3 _orchestrator,
         IStakeVault _stakeVault,
-        IAttestationVerifier _attestationVerifier
+        IEpochAttestationVerifier _attestationVerifier
     ) Ownable() EIP712("ZKP2P RiskManager", "1") {
         if (
             _owner == address(0)
@@ -160,6 +160,9 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             revert ZeroAddress();
         }
         if (address(_attestationVerifier).code.length == 0) revert ZeroAddress();
+        if (_attestationVerifier.currentEpoch() == 0) {
+            revert InvalidAttestationVerifier(address(_attestationVerifier));
+        }
 
         orchestrator = _orchestrator;
         stakeVault = _stakeVault;
@@ -260,6 +263,8 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         position.consumedFreeTake = consumedFreeTake;
         position.deferredPayoutHook = mode == RiskMode.DEFERRED_PAYOUT ? deferredPayoutHook : address(0);
         position.payoutRecipient = intent.to;
+        position.attestationVerifier = address(attestationVerifier);
+        position.attestationVerifierEpoch = attestationVerifier.currentEpoch();
         position.chargebackReserveBps = config.chargeback.reserveBps;
         position.griefingPenaltyBpsPerHour = config.griefing.griefingPenaltyBpsPerHour;
         position.riskWindow = config.chargeback.riskWindow;
@@ -279,6 +284,11 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         }
 
         _emitRiskPositionCreated(_intentHash, position, chargebackReserve);
+        emit RiskVerifierSnapshotted(
+            _intentHash,
+            position.attestationVerifier,
+            position.attestationVerifierEpoch
+        );
     }
 
     /** @dev Emits the complete admission snapshot from storage to keep admission stack usage bounded. */
@@ -498,7 +508,12 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
         _validateAttestation(_attestation, position);
         bytes32 digest = _hashTypedDataV4(_hashChargebackAttestation(_attestation));
-        if (!attestationVerifier.verify(digest, _signatures, _verificationData)) {
+        if (!IEpochAttestationVerifier(position.attestationVerifier).verifyAtEpoch(
+            position.attestationVerifierEpoch,
+            digest,
+            _signatures,
+            _verificationData
+        )) {
             revert AttestationVerificationFailed();
         }
 
@@ -562,8 +577,11 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
      */
     function setAttestationVerifier(address _verifier) external override onlyOwner {
         if (_verifier == address(0) || _verifier.code.length == 0) revert ZeroAddress();
+        if (IEpochAttestationVerifier(_verifier).currentEpoch() == 0) {
+            revert InvalidAttestationVerifier(_verifier);
+        }
         address previousVerifier = address(attestationVerifier);
-        attestationVerifier = IAttestationVerifier(_verifier);
+        attestationVerifier = IEpochAttestationVerifier(_verifier);
         emit AttestationVerifierUpdated(previousVerifier, _verifier);
     }
 

--- a/contracts/interfaces/IEpochAttestationVerifier.sol
+++ b/contracts/interfaces/IEpochAttestationVerifier.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import { IAttestationVerifier } from "./IAttestationVerifier.sol";
+
+/**
+ * @title IEpochAttestationVerifier
+ * @notice Attestation verifier with immutable historical witness epochs.
+ * @dev Consumers snapshot an epoch when economic exposure is admitted and verify against that
+ *      epoch even after governance activates a later witness configuration.
+ */
+interface IEpochAttestationVerifier is IAttestationVerifier {
+    function currentEpoch() external view returns (uint64);
+
+    function epochAt(uint64 _timestamp) external view returns (uint64);
+
+    function verifyAtEpoch(
+        uint64 _epoch,
+        bytes32 _digest,
+        bytes[] calldata _sigs,
+        bytes calldata _data
+    ) external view returns (bool isValid);
+}

--- a/contracts/interfaces/IRiskManager.sol
+++ b/contracts/interfaces/IRiskManager.sol
@@ -92,6 +92,10 @@ interface IRiskManager is IIntentRiskHook {
         address deferredPayoutHook;
         /// @notice Original intent recipient entitled to unslashed deferred proceeds.
         address payoutRecipient;
+        /// @notice Chargeback verifier contract snapshotted when the position was admitted.
+        address attestationVerifier;
+        /// @notice Immutable witness epoch used for every later chargeback against this position.
+        uint64 attestationVerifierEpoch;
         /// @notice Snapshotted chargeback reserve ratio applied to the exact released amount.
         uint16 chargebackReserveBps;
         /// @notice Snapshotted hourly slope used by the time-linear cancellation formula.
@@ -181,6 +185,11 @@ interface IRiskManager is IIntentRiskHook {
         uint256 maxGriefingBond,
         uint256 chargebackReserve,
         uint256 initialReservation
+    );
+    event RiskVerifierSnapshotted(
+        bytes32 indexed intentHash,
+        address indexed attestationVerifier,
+        uint64 indexed attestationVerifierEpoch
     );
     event FreeTakeConsumed(
         bytes32 indexed intentHash,
@@ -273,6 +282,7 @@ interface IRiskManager is IIntentRiskHook {
     error InsufficientDeferredPayoutCoverage(uint256 availableCoverage, uint256 requiredCoverage);
     error PositionNotMature(uint64 coverageDeadline, uint64 currentTime);
     error InvalidAttestation();
+    error InvalidAttestationVerifier(address verifier);
     error AttestationNotYetValid(uint64 validAfter, uint64 currentTime);
     error AttestationExpired(uint64 validUntil, uint64 currentTime);
     error ChargebackWindowClosed(uint64 coverageDeadline, uint64 currentTime);

--- a/contracts/mocks/AttestationVerifierMock.sol
+++ b/contracts/mocks/AttestationVerifierMock.sol
@@ -2,17 +2,27 @@
 
 pragma solidity ^0.8.18;
 
-import { IAttestationVerifier } from "../interfaces/IAttestationVerifier.sol";
+import { IEpochAttestationVerifier } from "../interfaces/IEpochAttestationVerifier.sol";
 
 /**
  * @title AttestationVerifierMock
  * @notice Configurable verifier used by RiskManager unit and integration tests.
  */
-contract AttestationVerifierMock is IAttestationVerifier {
+contract AttestationVerifierMock is IEpochAttestationVerifier {
     bool public result = true;
+    uint64 public override currentEpoch = 1;
+    mapping(uint64 => uint8) public epochResults;
 
     function setResult(bool _result) external {
         result = _result;
+    }
+
+    function setCurrentEpoch(uint64 _epoch) external {
+        currentEpoch = _epoch;
+    }
+
+    function setEpochResult(uint64 _epoch, bool _result) external {
+        epochResults[_epoch] = _result ? 1 : 2;
     }
 
     function verify(
@@ -21,5 +31,21 @@ contract AttestationVerifierMock is IAttestationVerifier {
         bytes calldata
     ) external view override returns (bool isValid) {
         return result;
+    }
+
+    function verifyAtEpoch(
+        uint64 _epoch,
+        bytes32,
+        bytes[] calldata,
+        bytes calldata
+    ) external view override returns (bool isValid) {
+        uint8 epochResult = epochResults[_epoch];
+        if (epochResult == 1) return true;
+        if (epochResult == 2) return false;
+        return result;
+    }
+
+    function epochAt(uint64) external pure override returns (uint64) {
+        return 1;
     }
 }

--- a/contracts/mocks/RiskManagerHarnessMocks.sol
+++ b/contracts/mocks/RiskManagerHarnessMocks.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.18;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { IEscrowV2 } from "../interfaces/IEscrowV2.sol";
-import { IAttestationVerifier } from "../interfaces/IAttestationVerifier.sol";
+import { IEpochAttestationVerifier } from "../interfaces/IEpochAttestationVerifier.sol";
 import { IIntentRiskHook } from "../interfaces/IIntentRiskHook.sol";
 import { IOrchestratorV3 } from "../interfaces/IOrchestratorV3.sol";
 import { IRiskManager } from "../interfaces/IRiskManager.sol";
@@ -23,7 +23,7 @@ contract RiskManagerStateHarness is RiskManager {
         address _owner,
         IOrchestratorV3 _orchestrator,
         IStakeVault _stakeVault,
-        IAttestationVerifier _attestationVerifier
+        IEpochAttestationVerifier _attestationVerifier
     ) RiskManager(_owner, _orchestrator, _stakeVault, _attestationVerifier) { }
 
     function forcePosition(
@@ -40,6 +40,8 @@ contract RiskManagerStateHarness is RiskManager {
         position.status = _status;
         position.deferredPayoutHook = _deferredPayoutHook;
         position.paymentMethod = _paymentMethod;
+        position.attestationVerifier = address(attestationVerifier);
+        position.attestationVerifierEpoch = attestationVerifier.currentEpoch();
         position.chargebackReserveBps = _chargebackReserveBps;
         position.coverageDeadline = _coverageDeadline;
     }

--- a/contracts/unifiedVerifier/EpochMultiAttestationVerifier.sol
+++ b/contracts/unifiedVerifier/EpochMultiAttestationVerifier.sol
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
+import { IEpochAttestationVerifier } from "../interfaces/IEpochAttestationVerifier.sol";
+import { ThresholdSigVerifierUtils } from "../lib/ThresholdSigVerifierUtils.sol";
+
+/**
+ * @title EpochMultiAttestationVerifier
+ * @notice Threshold verifier with delayed, atomic witness-set changes and immutable history.
+ * @dev Payment and chargeback deployments must use separate instances and credentials. Every
+ *      epoch is immutably constrained to an independent 2-of-3 witness set; deployments additionally
+ *      choose the governance delay applied before a complete replacement set can activate.
+ */
+contract EpochMultiAttestationVerifier is IEpochAttestationVerifier, Ownable {
+    uint256 public constant REQUIRED_WITNESS_COUNT = 3;
+    uint256 public constant REQUIRED_SIGNATURES = 2;
+
+    uint64 public immutable configChangeDelay;
+    uint64 public override currentEpoch;
+    uint64 public pendingActivationTime;
+    uint256 public pendingThreshold;
+
+    mapping(uint64 => address[]) private epochWitnesses;
+    mapping(uint64 => uint256) public requiredSignaturesAtEpoch;
+    mapping(uint64 => uint64) public epochActivatedAt;
+    address[] private pendingWitnesses;
+
+    event ConfigurationProposed(bytes32 indexed configHash, uint64 activationTime);
+    event ConfigurationCancelled(bytes32 indexed configHash);
+    event ConfigurationActivated(uint64 indexed epoch, uint256 threshold, address[] witnesses);
+
+    constructor(
+        address[] memory _initialWitnesses,
+        uint256 _initialThreshold,
+        uint64 _configChangeDelay
+    ) Ownable() {
+        _validateConfiguration(_initialWitnesses, _initialThreshold);
+
+        configChangeDelay = _configChangeDelay;
+        currentEpoch = 1;
+        epochActivatedAt[1] = uint64(block.timestamp);
+        requiredSignaturesAtEpoch[1] = _initialThreshold;
+        _storeWitnesses(epochWitnesses[1], _initialWitnesses);
+
+        emit ConfigurationActivated(1, _initialThreshold, _initialWitnesses);
+    }
+
+    function verify(
+        bytes32 _digest,
+        bytes[] calldata _sigs,
+        bytes calldata
+    ) external view override returns (bool isValid) {
+        return _verifyAtEpoch(currentEpoch, _digest, _sigs);
+    }
+
+    function verifyAtEpoch(
+        uint64 _epoch,
+        bytes32 _digest,
+        bytes[] calldata _sigs,
+        bytes calldata
+    ) external view override returns (bool isValid) {
+        return _verifyAtEpoch(_epoch, _digest, _sigs);
+    }
+
+    function proposeConfiguration(
+        address[] calldata _witnesses,
+        uint256 _threshold
+    ) external onlyOwner {
+        _validateConfiguration(_witnesses, _threshold);
+
+        delete pendingWitnesses;
+        for (uint256 witnessIndex = 0; witnessIndex < _witnesses.length; witnessIndex++) {
+            pendingWitnesses.push(_witnesses[witnessIndex]);
+        }
+
+        pendingThreshold = _threshold;
+        pendingActivationTime = uint64(block.timestamp) + configChangeDelay;
+
+        emit ConfigurationProposed(_configurationHash(_witnesses, _threshold), pendingActivationTime);
+    }
+
+    function cancelPendingConfiguration() external onlyOwner {
+        bytes32 configHash = pendingConfigurationHash();
+        require(configHash != bytes32(0), "EMAV: no pending config");
+
+        _clearPendingConfiguration();
+        emit ConfigurationCancelled(configHash);
+    }
+
+    function activatePendingConfiguration() external {
+        require(pendingActivationTime != 0, "EMAV: no pending config");
+        require(block.timestamp >= pendingActivationTime, "EMAV: delay active");
+
+        uint64 nextEpoch = currentEpoch + 1;
+        uint256 threshold = pendingThreshold;
+        address[] memory witnesses_ = pendingWitnesses;
+
+        currentEpoch = nextEpoch;
+        epochActivatedAt[nextEpoch] = uint64(block.timestamp);
+        requiredSignaturesAtEpoch[nextEpoch] = threshold;
+        _storeWitnesses(epochWitnesses[nextEpoch], witnesses_);
+        _clearPendingConfiguration();
+
+        emit ConfigurationActivated(nextEpoch, threshold, witnesses_);
+    }
+
+    function epochAt(uint64 _timestamp) external view override returns (uint64 epoch) {
+        if (_timestamp < epochActivatedAt[1]) return 0;
+
+        uint64 low = 1;
+        uint64 high = currentEpoch;
+        while (low < high) {
+            uint64 middle = low + (high - low + 1) / 2;
+            if (epochActivatedAt[middle] <= _timestamp) low = middle;
+            else high = middle - 1;
+        }
+        return low;
+    }
+
+    function witnessesAtEpoch(uint64 _epoch) external view returns (address[] memory) {
+        return epochWitnesses[_epoch];
+    }
+
+    function witnesses() external view returns (address[] memory) {
+        return epochWitnesses[currentEpoch];
+    }
+
+    function requiredSignatures() external view returns (uint256) {
+        return requiredSignaturesAtEpoch[currentEpoch];
+    }
+
+    function isWitnessAtEpoch(uint64 _epoch, address _witness) public view returns (bool) {
+        address[] storage witnesses_ = epochWitnesses[_epoch];
+        for (uint256 witnessIndex = 0; witnessIndex < witnesses_.length; witnessIndex++) {
+            if (witnesses_[witnessIndex] == _witness) return true;
+        }
+        return false;
+    }
+
+    function isWitness(address _witness) external view returns (bool) {
+        return isWitnessAtEpoch(currentEpoch, _witness);
+    }
+
+    function pendingConfigurationHash() public view returns (bytes32) {
+        if (pendingActivationTime == 0) return bytes32(0);
+        return _configurationHash(pendingWitnesses, pendingThreshold);
+    }
+
+    function _verifyAtEpoch(
+        uint64 _epoch,
+        bytes32 _digest,
+        bytes[] calldata _sigs
+    ) internal view returns (bool) {
+        uint256 threshold = requiredSignaturesAtEpoch[_epoch];
+        require(threshold != 0, "EMAV: unknown epoch");
+        return ThresholdSigVerifierUtils.verifyWitnessSignatures(
+            _digest,
+            _sigs,
+            epochWitnesses[_epoch],
+            threshold
+        );
+    }
+
+    function _validateConfiguration(address[] memory _witnesses, uint256 _threshold) internal pure {
+        require(_witnesses.length == REQUIRED_WITNESS_COUNT, "EMAV: witness count must be three");
+        require(_threshold == REQUIRED_SIGNATURES, "EMAV: threshold must be two");
+
+        for (uint256 witnessIndex = 0; witnessIndex < _witnesses.length; witnessIndex++) {
+            address witness = _witnesses[witnessIndex];
+            require(witness != address(0), "EMAV: zero witness");
+            for (uint256 priorIndex = 0; priorIndex < witnessIndex; priorIndex++) {
+                require(_witnesses[priorIndex] != witness, "EMAV: duplicate witness");
+            }
+        }
+    }
+
+    function _storeWitnesses(address[] storage _destination, address[] memory _witnesses) internal {
+        for (uint256 witnessIndex = 0; witnessIndex < _witnesses.length; witnessIndex++) {
+            _destination.push(_witnesses[witnessIndex]);
+        }
+    }
+
+    function _clearPendingConfiguration() internal {
+        delete pendingWitnesses;
+        delete pendingThreshold;
+        delete pendingActivationTime;
+    }
+
+    function _configurationHash(address[] memory _witnesses, uint256 _threshold) internal pure returns (bytes32) {
+        return keccak256(abi.encode(_witnesses, _threshold));
+    }
+}

--- a/deploy/26_deploy_stake_risk_system.ts
+++ b/deploy/26_deploy_stake_risk_system.ts
@@ -24,6 +24,38 @@ import {
 const PAYPAL = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("paypal"));
 const VENMO = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("venmo"));
 const ZELLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("zelle"));
+const CHARGEBACK_WITNESS_THRESHOLD = 2;
+const CHARGEBACK_VERIFIER_CHANGE_DELAY = 2 * 24 * 60 * 60;
+const LOCAL_CHARGEBACK_WITNESSES = [
+  "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+  "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+  "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
+];
+
+export function chargebackWitnessConfigForNetwork(
+  network: string,
+  configuredWitnesses = process.env.CHARGEBACK_WITNESS_ADDRESSES,
+) {
+  const witnesses = network === "localhost" || network === "hardhat"
+    ? LOCAL_CHARGEBACK_WITNESSES
+    : (configuredWitnesses ?? "").split(",").map((address) => address.trim()).filter(Boolean);
+
+  if (witnesses.length !== 3) {
+    throw new Error(`${network} chargeback authorization requires exactly three independent witnesses`);
+  }
+  if (new Set(witnesses.map((address) => address.toLowerCase())).size !== witnesses.length) {
+    throw new Error(`${network} chargeback witnesses must be unique`);
+  }
+  for (const witness of witnesses) {
+    if (!ethers.utils.isAddress(witness)) throw new Error(`${network} has an invalid chargeback witness address`);
+  }
+
+  return {
+    witnesses,
+    threshold: CHARGEBACK_WITNESS_THRESHOLD,
+    configChangeDelay: CHARGEBACK_VERIFIER_CHANGE_DELAY,
+  };
+}
 
 function platformRiskConfigMatches(actual: any, expected: any): boolean {
   return actual.enabled === expected.enabled
@@ -58,12 +90,12 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const chainId = (await ethers.provider.getNetwork()).chainId;
   const [deployer] = await hre.getUnnamedAccounts();
   const multiSig = MULTI_SIG[network] ? MULTI_SIG[network] : deployer;
+  const chargebackWitnessConfig = chargebackWitnessConfigForNetwork(network);
 
   const escrowRegistryAddress = getDeployedContractAddress(network, "EscrowRegistry");
   const paymentVerifierRegistryAddress = getDeployedContractAddress(network, "PaymentVerifierRegistry");
   const relayerRegistryAddress = getDeployedContractAddress(network, "RelayerRegistry");
   const orchestratorRegistryAddress = getDeployedContractAddress(network, "OrchestratorRegistry");
-  const attestationVerifierAddress = getDeployedContractAddress(network, "MultiAttestationVerifier");
   const stakeTokenAddress = USDC[network]
     ? USDC[network]
     : getDeployedContractAddress(network, "USDCMock");
@@ -109,9 +141,22 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log("StakeVault deployed at", stakeVault.address);
   if (stakeVault.newlyDeployed) await waitForDeploymentDelay(hre);
 
+  // Chargeback credentials are intentionally isolated from payment attestation witnesses.
+  const chargebackVerifier = await deploy("ChargebackAttestationVerifier", {
+    contract: "EpochMultiAttestationVerifier",
+    from: deployer,
+    args: [
+      chargebackWitnessConfig.witnesses,
+      chargebackWitnessConfig.threshold,
+      chargebackWitnessConfig.configChangeDelay,
+    ],
+  });
+  console.log("ChargebackAttestationVerifier deployed at", chargebackVerifier.address);
+  if (chargebackVerifier.newlyDeployed) await waitForDeploymentDelay(hre);
+
   const riskManager = await deploy("RiskManager", {
     from: deployer,
-    args: [deployer, orchestratorV3.address, stakeVault.address, attestationVerifierAddress],
+    args: [deployer, orchestratorV3.address, stakeVault.address, chargebackVerifier.address],
   });
   console.log("RiskManager deployed at", riskManager.address);
   if (riskManager.newlyDeployed) await waitForDeploymentDelay(hre);
@@ -125,6 +170,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const stakeVaultContract = await ethers.getContractAt("StakeVault", stakeVault.address);
   const riskManagerContract = await ethers.getContractAt("RiskManager", riskManager.address);
+  const chargebackVerifierContract = await ethers.getContractAt(
+    "EpochMultiAttestationVerifier",
+    chargebackVerifier.address,
+  );
   const orchestratorV3Contract = await ethers.getContractAt("OrchestratorV3", orchestratorV3.address);
   const orchestratorRegistry = await ethers.getContractAt("OrchestratorRegistry", orchestratorRegistryAddress);
 
@@ -165,6 +214,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   await setNewOwner(hre, orchestratorV3Contract, multiSig);
   await setNewOwner(hre, riskManagerContract, multiSig);
   await setNewOwner(hre, stakeVaultContract, multiSig);
+  await setNewOwner(hre, chargebackVerifierContract, multiSig);
   console.log("Stake risk system ownership transferred to", multiSig);
 };
 

--- a/test-foundry/fuzz/RiskManagerMathFuzz.t.sol
+++ b/test-foundry/fuzz/RiskManagerMathFuzz.t.sol
@@ -5,10 +5,10 @@ pragma solidity ^0.8.18;
 import { Test } from "forge-std/Test.sol";
 
 import { RiskManager } from "../../contracts/RiskManager.sol";
-import { IAttestationVerifier } from "../../contracts/interfaces/IAttestationVerifier.sol";
 import { IOrchestratorV3 } from "../../contracts/interfaces/IOrchestratorV3.sol";
 import { IRiskManager } from "../../contracts/interfaces/IRiskManager.sol";
 import { IStakeVault } from "../../contracts/interfaces/IStakeVault.sol";
+import { AttestationVerifierMock } from "../../contracts/mocks/AttestationVerifierMock.sol";
 
 contract RiskManagerMathFuzzTest is Test {
     RiskManager internal manager;
@@ -18,7 +18,7 @@ contract RiskManagerMathFuzzTest is Test {
             address(this),
             IOrchestratorV3(address(this)),
             IStakeVault(address(this)),
-            IAttestationVerifier(address(this))
+            new AttestationVerifierMock()
         );
     }
 

--- a/test/deploy/26_stakeRiskSystem.spec.ts
+++ b/test/deploy/26_stakeRiskSystem.spec.ts
@@ -4,12 +4,11 @@ import { expect } from "chai";
 import hre, { deployments, ethers } from "hardhat";
 
 import deployStakeRiskSystem, {
+  chargebackWitnessConfigForNetwork,
   stakeRiskPlatformPolicyForNetwork,
 } from "../../deploy/26_deploy_stake_risk_system";
 import {
   MULTI_SIG,
-  MULTI_WITNESS_ADDRESSES,
-  MULTI_WITNESS_THRESHOLD,
   RISK_CALLBACK_GAS_LIMIT,
   STAKE_VAULT_BASE_EXIT_DELAY,
 } from "../../deployments/parameters";
@@ -33,6 +32,10 @@ describe("Affine stake risk system deployment", () => {
       orchestrator: await ethers.getContractAt("OrchestratorV3", deployedAddress("OrchestratorV3")),
       vault: await ethers.getContractAt("StakeVault", deployedAddress("StakeVault")),
       manager: await ethers.getContractAt("RiskManager", deployedAddress("RiskManager")),
+      chargebackVerifier: await ethers.getContractAt(
+        "EpochMultiAttestationVerifier",
+        deployedAddress("ChargebackAttestationVerifier"),
+      ),
       deferredHook: await ethers.getContractAt("DeferredPayoutHook", deployedAddress("DeferredPayoutHook")),
       orchestratorRegistry: await ethers.getContractAt(
         "OrchestratorRegistry",
@@ -50,15 +53,17 @@ describe("Affine stake risk system deployment", () => {
   it("deploys the replacement risk components", async () => {
     expect(deployedAddress("StakeVault")).to.properAddress;
     expect(deployedAddress("RiskManager")).to.properAddress;
+    expect(deployedAddress("ChargebackAttestationVerifier")).to.properAddress;
     expect(deployedAddress("DeferredPayoutHook")).to.properAddress;
   });
 
   it("transfers every owned component to the configured multisig", async () => {
-    const { deployer, orchestrator, vault, manager } = await contracts();
+    const { deployer, orchestrator, vault, manager, chargebackVerifier } = await contracts();
     const expectedOwner = MULTI_SIG[network] || deployer.address;
     expect(await orchestrator.owner()).to.eq(expectedOwner);
     expect(await vault.owner()).to.eq(expectedOwner);
     expect(await manager.owner()).to.eq(expectedOwner);
+    expect(await chargebackVerifier.owner()).to.eq(expectedOwner);
   });
 
   it("wires RiskManager as the vault controller", async () => {
@@ -134,13 +139,14 @@ describe("Affine stake risk system deployment", () => {
   it("uses the deployed modular attestation verifier and RiskManager EIP-712 domain", async () => {
     const { deployer, manager } = await contracts();
     const verifier = await ethers.getContractAt(
-      "MultiAttestationVerifier",
-      deployedAddress("MultiAttestationVerifier"),
+      "EpochMultiAttestationVerifier",
+      deployedAddress("ChargebackAttestationVerifier"),
     );
+    const witnessConfig = chargebackWitnessConfigForNetwork(network);
     expect(await manager.attestationVerifier()).to.eq(verifier.address);
-    expect((await verifier.requiredSignatures()).toNumber()).to.eq(MULTI_WITNESS_THRESHOLD[network]);
+    expect((await verifier.requiredSignatures()).toNumber()).to.eq(witnessConfig.threshold);
     expect((await verifier.witnesses()).map((w) => w.toLowerCase())).to.have.members(
-      MULTI_WITNESS_ADDRESSES[network].map((w) => w.toLowerCase()),
+      witnessConfig.witnesses.map((w) => w.toLowerCase()),
     );
 
     const { chainId } = await ethers.provider.getNetwork();
@@ -177,8 +183,12 @@ describe("Affine stake risk system deployment", () => {
     // Local deployments use the deployer as their witness, while live networks
     // intentionally keep witness keys separate from the deployment key.
     if (await verifier.isWitness(deployer.address)) {
-      const signature = await deployer._signTypedData(domain, types, chargeback);
-      expect(await verifier.verify(digest, [signature], "0x")).to.eq(true);
+      const [, secondWitness] = await ethers.getSigners();
+      const signatures = [
+        await deployer._signTypedData(domain, types, chargeback),
+        await secondWitness._signTypedData(domain, types, chargeback),
+      ];
+      expect(await verifier.verify(digest, signatures, "0x")).to.eq(true);
     }
   });
 

--- a/test/staking/riskManager.coverage.spec.ts
+++ b/test/staking/riskManager.coverage.spec.ts
@@ -153,9 +153,10 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
   describe("constructor and governance", () => {
     it("rejects a zero owner", async () => {
       const { orchestrator, vault, verifier } = await loadFixture(deployHarnessFixture);
-      await expect((await ethers.getContractFactory("RiskManager")).deploy(
-        ZERO, orchestrator.address, vault.address, verifier.address,
-      )).to.be.revertedWithCustomError(await ethers.getContractFactory("RiskManager"), "ZeroAddress");
+      const factory = await ethers.getContractFactory("RiskManager");
+      await expect(factory.deploy(
+        ZERO, orchestrator.address, vault.address, verifier.address, { gasLimit: 8_000_000 },
+      )).to.be.revertedWithCustomError(factory, "ZeroAddress");
     });
 
     it("rejects a zero orchestrator", async () => {

--- a/test/staking/riskManager.coverage.spec.ts
+++ b/test/staking/riskManager.coverage.spec.ts
@@ -991,6 +991,70 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       expect((await fixture.manager.getRiskPosition(intentHash)).slashedAmount).to.eq(usdc(10));
     });
 
+    it("keeps each position bound to its admission-time verifier and witness epoch", async () => {
+      const fixture = await loadFixture(deployHarnessFixture);
+      const admittedBeforeRotation = ethers.utils.id("claim-before-verifier-rotation");
+      await createPosition(fixture, admittedBeforeRotation);
+      await fixture.orchestrator.fulfillPosition(fixture.manager.address, admittedBeforeRotation, usdc(50));
+
+      const originalPosition = await fixture.manager.getRiskPosition(admittedBeforeRotation);
+      expect(originalPosition.attestationVerifier).to.eq(fixture.verifier.address);
+      expect(originalPosition.attestationVerifierEpoch).to.eq(1);
+
+      const replacement = await (await ethers.getContractFactory("AttestationVerifierMock")).deploy();
+      await replacement.setResult(false);
+      await fixture.manager.setAttestationVerifier(replacement.address);
+
+      await fixture.manager.submitChargeback(
+        await validAttestation(fixture, admittedBeforeRotation),
+        [],
+        "0x",
+      );
+
+      const admittedAfterRotation = ethers.utils.id("claim-after-verifier-rotation");
+      await createPosition(fixture, admittedAfterRotation);
+      await fixture.orchestrator.fulfillPosition(fixture.manager.address, admittedAfterRotation, usdc(50));
+      const replacementPosition = await fixture.manager.getRiskPosition(admittedAfterRotation);
+      expect(replacementPosition.attestationVerifier).to.eq(replacement.address);
+      expect(replacementPosition.attestationVerifierEpoch).to.eq(1);
+
+      await expect(
+        fixture.manager.submitChargeback(
+          await validAttestation(fixture, admittedAfterRotation, { nonce: 2 }),
+          [],
+          "0x",
+        ),
+      ).to.be.revertedWithCustomError(fixture.manager, "AttestationVerificationFailed");
+    });
+
+    it("does not move an admitted position to a newly activated witness epoch", async () => {
+      const fixture = await loadFixture(deployHarnessFixture);
+      const admittedAtEpochOne = ethers.utils.id("claim-at-witness-epoch-one");
+      await createPosition(fixture, admittedAtEpochOne);
+      await fixture.orchestrator.fulfillPosition(fixture.manager.address, admittedAtEpochOne, usdc(50));
+
+      await fixture.verifier.setEpochResult(1, true);
+      await fixture.verifier.setCurrentEpoch(2);
+      await fixture.verifier.setEpochResult(2, false);
+      await fixture.manager.submitChargeback(
+        await validAttestation(fixture, admittedAtEpochOne),
+        [],
+        "0x",
+      );
+
+      const admittedAtEpochTwo = ethers.utils.id("claim-at-witness-epoch-two");
+      await createPosition(fixture, admittedAtEpochTwo);
+      await fixture.orchestrator.fulfillPosition(fixture.manager.address, admittedAtEpochTwo, usdc(50));
+      expect((await fixture.manager.getRiskPosition(admittedAtEpochTwo)).attestationVerifierEpoch).to.eq(2);
+      await expect(
+        fixture.manager.submitChargeback(
+          await validAttestation(fixture, admittedAtEpochTwo, { nonce: 2 }),
+          [],
+          "0x",
+        ),
+      ).to.be.revertedWithCustomError(fixture.manager, "AttestationVerificationFailed");
+    });
+
     it("rejects a claim against a released non-chargebackable position", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
       const intentHash = ethers.utils.id("claim-free-position");

--- a/test/unifiedVerifier/EpochMultiAttestationVerifier.spec.ts
+++ b/test/unifiedVerifier/EpochMultiAttestationVerifier.spec.ts
@@ -1,0 +1,113 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+
+describe("EpochMultiAttestationVerifier", () => {
+  const DELAY = 2 * 24 * 60 * 60;
+  const domain = {
+    name: "Epoch verifier test",
+    version: "1",
+    chainId: 31337,
+    verifyingContract: ethers.constants.AddressZero,
+  };
+  const types = { TestAttestation: [{ name: "value", type: "uint256" }] };
+  const value = { value: 42 };
+
+  async function deployFixture() {
+    const [owner, witnessA, witnessB, witnessC, witnessD, witnessE, witnessF, other] =
+      await ethers.getSigners();
+    const verifier = await (await ethers.getContractFactory("EpochMultiAttestationVerifier")).deploy(
+      [witnessA.address, witnessB.address, witnessC.address],
+      2,
+      DELAY,
+    );
+    return { owner, witnessA, witnessB, witnessC, witnessD, witnessE, witnessF, other, verifier };
+  }
+
+  async function signature(signer: Awaited<ReturnType<typeof ethers.getSigners>>[number]) {
+    return signer._signTypedData(domain, types, value);
+  }
+
+  function digest() {
+    return ethers.utils._TypedDataEncoder.hash(domain, types, value);
+  }
+
+  it("requires the configured 2-of-3 independent signatures", async () => {
+    const { witnessA, witnessB, verifier } = await deployFixture();
+    const sigA = await signature(witnessA);
+    const sigB = await signature(witnessB);
+
+    await expect(verifier.verify(digest(), [sigA], "0x")).to.be.revertedWith(
+      "ThresholdSigVerifierUtils: req threshold exceeds signatures",
+    );
+    expect(await verifier.verify(digest(), [sigA, sigB], "0x")).to.eq(true);
+  });
+
+  it("activates a complete witness configuration only after the governance delay", async () => {
+    const { witnessA, witnessB, witnessD, witnessE, witnessF, verifier } = await deployFixture();
+    const epochOneTimestamp = await verifier.epochActivatedAt(1);
+    const epochOneSigA = await signature(witnessA);
+    const epochOneSigB = await signature(witnessB);
+
+    await verifier.proposeConfiguration([witnessD.address, witnessE.address, witnessF.address], 2);
+    expect(await verifier.currentEpoch()).to.eq(1);
+    expect(await verifier.isWitness(witnessA.address)).to.eq(true);
+    await expect(verifier.activatePendingConfiguration()).to.be.revertedWith("EMAV: delay active");
+
+    await time.increase(DELAY);
+    await verifier.activatePendingConfiguration();
+    expect(await verifier.currentEpoch()).to.eq(2);
+    expect(await verifier.isWitness(witnessA.address)).to.eq(false);
+    expect(await verifier.isWitness(witnessD.address)).to.eq(true);
+    expect(await verifier.epochAt(epochOneTimestamp)).to.eq(1);
+    expect(await verifier.epochAt(await time.latest())).to.eq(2);
+
+    expect(await verifier.verifyAtEpoch(1, digest(), [epochOneSigA, epochOneSigB], "0x")).to.eq(true);
+    await expect(verifier.verify(digest(), [epochOneSigA, epochOneSigB], "0x")).to.be.revertedWith(
+      "ThresholdSigVerifierUtils: Not enough valid witness signatures",
+    );
+  });
+
+  it("supports cancellation without mutating the active epoch", async () => {
+    const { witnessD, witnessE, witnessF, verifier } = await deployFixture();
+    await verifier.proposeConfiguration([witnessD.address, witnessE.address, witnessF.address], 2);
+    expect(await verifier.pendingConfigurationHash()).to.not.eq(ethers.constants.HashZero);
+
+    await verifier.cancelPendingConfiguration();
+    expect(await verifier.pendingConfigurationHash()).to.eq(ethers.constants.HashZero);
+    expect(await verifier.currentEpoch()).to.eq(1);
+  });
+
+  it("immutably enforces 2-of-3 and rejects duplicate or zero witnesses", async () => {
+    const { witnessA, witnessB, witnessC, witnessD, verifier } = await deployFixture();
+    await expect(
+      verifier.proposeConfiguration([witnessA.address, witnessA.address, witnessB.address], 2),
+    ).to.be.revertedWith(
+      "EMAV: duplicate witness",
+    );
+    await expect(
+      verifier.proposeConfiguration([ethers.constants.AddressZero, witnessB.address, witnessC.address], 2),
+    ).to.be.revertedWith("EMAV: zero witness");
+    await expect(verifier.proposeConfiguration([witnessA.address, witnessB.address], 2)).to.be.revertedWith(
+      "EMAV: witness count must be three",
+    );
+    await expect(
+      verifier.proposeConfiguration([witnessA.address, witnessB.address, witnessC.address, witnessD.address], 2),
+    ).to.be.revertedWith("EMAV: witness count must be three");
+    await expect(verifier.proposeConfiguration([witnessA.address, witnessB.address, witnessC.address], 1)).to.be.revertedWith(
+      "EMAV: threshold must be two",
+    );
+  });
+
+  it("restricts proposal and cancellation to governance", async () => {
+    const { witnessD, witnessE, witnessF, other, verifier } = await deployFixture();
+    await expect(
+      verifier.connect(other).proposeConfiguration([witnessD.address, witnessE.address, witnessF.address], 2),
+    ).to.be.revertedWith("Ownable: caller is not the owner");
+
+    await verifier.proposeConfiguration([witnessD.address, witnessE.address, witnessF.address], 2);
+    await expect(verifier.connect(other).cancelPendingConfiguration()).to.be.revertedWith(
+      "Ownable: caller is not the owner",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add an immutable historical 2-of-3 EpochMultiAttestationVerifier with delayed atomic witness-set changes
- snapshot the chargeback verifier address and witness epoch when RiskManager admits an intent
- verify every later chargeback against that admission-time verifier epoch
- deploy a dedicated chargeback verifier with credentials separate from payment attestations

## Security and rollout gate

Chargebackable rollout remains BLOCKED. This PR fixes the chargeback witness domain, but the payment verifier still has an immediately mutable verifier setter and no admission-time verifier-address history. A companion contracts change must use a separate 2-of-3 payment witness set, delayed verifier/witness changes, and resolve the payment verifier address plus witness epoch at IntentSnapshot.signalTimestamp.

Do not deploy or enable chargebacks until:
1. the payment-verifier companion is reviewed and deployed
2. three independently operated chargeback KMS witnesses and three disjoint payment witnesses are provisioned
3. the new RiskManager release and Indexer coordinates are deployed together
4. the evidence-to-RiskManager staging E2E passes

PR #279 remains evidence-only and its signature is not compatible with RiskManager.submitChargeback.

## Validation

- hardhat compile: pass
- EpochMultiAttestationVerifier + RiskManager ordered focused suites: 128 passing
- focused verifier/RiskManager suites: 163 passing
- Foundry unit, fuzz, and invariant suites: pass
- full Hardhat aggregate reached an order-dependent custom-error matcher failure; the affected RiskManager file passes 123/123 alone and 128/128 after the new epoch verifier suite
- deployment tests require repository-local deployment artifacts; no deployment was performed