### PR TITLE
fix: harden V3 risk admission, callbacks, and lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ The current v3 risk architecture landed in July 2026:
   or protocol-wide exposure ceiling.
 - `2026-07-16`: `OrchestratorV3`, `RiskManager`, `StakeVault`, and `DeferredPayoutHook` were deployed
   to Base staging for integration work. This was not a production rollout.
-- `2026-07-16`: verified fulfillment was bound to exact payment details for direct chargeback
-  authentication. Chargebackable v1 policies are now full-reserve, stake-backed only; deferred payout
-  is rejected.
+- `2026-07-17`: verified fulfillment was bound to exact payment details for direct chargeback
+  authentication. Chargebackable v1 policies retain 100% gross maker compensation and now support a
+  hybrid deferred path backed by exact net proceeds plus retained fee-gap stake.
 
 The v2 surface was built out rapidly between February 20, 2026 and March 11, 2026. The main additions in that window are:
 
@@ -101,18 +101,23 @@ an intent is admitted. Admission callbacks fail closed; terminal callbacks are g
 open so escrow liquidity is not trapped. `OrchestratorV3` retains durable recovery data so `RiskManager`
 can reconcile a failed terminal callback permissionlessly using the original lifecycle timestamp.
 
-For intent amount `A`, hourly griefing slope `s`, intent period `T`, griefing cliff `C`, and chargeback
-reserve ratio `r`, admission reserves the greater pending liability:
+For intent amount `A`, hourly griefing slope `s`, intent period `T`, griefing cliff `C`, chargeback
+reserve ratio `r`, aggregate snapshotted fee rate `f`, and fee precise unit `U = 1e18`, admission uses:
 
 ```text
-G_max(A) = ceil(A * s * (T - C) / (10_000 * 1 hour))
-C(A)     = ceil(A * r / 10_000)
-R(A)     = max(G_max(A), C(A))
+G_max(A)      = ceil(A * s * (T - C) / (10_000 * 1 hour))
+C(A)          = ceil(A * r / 10_000)
+F_max(A)      = floor(A * f / U)
+R_stake(A)    = max(G_max(A), C(A))
+R_deferred(A) = max(G_max(A), F_max(A))
 ```
 
 Cancellation charges only elapsed time after the cliff, capped by the snapshotted intent period. All
 mutable liability inputs are snapshotted at admission. Multiple concurrent intents are allowed whenever
 their aggregate reservations fit the stake owner's free stake; there is no intent-count capacity tier.
+Griefing and post-settlement fee-gap coverage are mutually exclusive, so deferred admission reserves
+their maximum, never their sum. For gross release `R` and independently rounded exact fees `F`, the hook
+records net deferred proceeds `D = R - F` and retains exact stake `S = F`, proving `D + S = R`.
 
 The merged contracts have these roles:
 
@@ -121,15 +126,18 @@ The merged contracts have these roles:
 - `RiskManager`: platform policy, exact reservation math, cancellation penalties, chargeback validation,
   maturity, reconciliation, and slashing instructions.
 - `StakeVault`: the sole stake-token custody and portfolio-accounting boundary.
-- `DeferredPayoutHook`: retained in the general architecture for separately governed future policy, but
-  rejected by the current chargebackable v1 configuration rules.
+- `DeferredPayoutHook`: canonical verified-settlement hook that transfers exact net proceeds into
+  `StakeVault` and resizes the admission reservation to the exact fee gap.
 
 ## Direct Chargeback Model
 
 The current merged chargeback path is deliberately narrow and fail closed:
 
-- Chargebackable platform configs require `reserveBps == 10_000` and
-  `deferredPayoutEnabled == false`, so the full gross released amount is stake-backed at admission.
+- Chargebackable platform configs require `reserveBps == 10_000`, preserving full gross compensation.
+  If stake can cover the gross amount, admission uses ordinary stake backing. Otherwise, an enabled
+  deferred policy requires the canonical hook and enough stake for `R_deferred(A)`.
+- Protocol, manager, and referral fees are distributed immediately from snapshotted terms. The hook
+  defers the exact net amount and retains exact fee-gap stake; settlement never asks for unreserved stake.
 - `UnifiedPaymentVerifierV3` returns the provider payment ID already authenticated inside the signed
   `PaymentDetails`. `OrchestratorV3` passes that value through its fulfillment callback and
   `RiskManager` stores it with the settled position; no payment verifier is snapshotted at admission.
@@ -142,10 +150,14 @@ The current merged chargeback path is deliberately narrow and fail closed:
   `disputeId` must be nonzero. The payment method and gross token amount come from the position rather
   than witness-supplied chargeback fields.
 - A valid claim inside the half-open interval `settledAt <= now < coverageDeadline` compensates the LP
-  for the full gross `releasedAmount`. Partial chargebacks are not supported by this v1 policy.
+  for the full gross `releasedAmount`. Deferred positions slash net proceeds plus the exact retained
+  fee gap atomically. Partial chargebacks are not supported by this v1 policy.
+- At maturity, unslashed deferred proceeds become withdrawable by the beneficiary and the exact retained
+  stake gap unlocks. Cancellation pays only griefing; maker manual release bypasses deferred capture.
 - Replay protection consumes `keccak256(paymentMethod, disputeId)` globally.
 - Fresh deployments require a dedicated three-witness chargeback verifier with a 2-of-3 threshold and
-  a witness set disjoint from payment-attestation witnesses.
+  a witness set disjoint from payment-attestation witnesses, plus a `DeferredPayoutHook` bound to the
+  new `RiskManager`, `StakeVault`, and registered `OrchestratorV3`.
 
 The payment-ID lane is deployed in parallel with the legacy lane. It has a separate
 `PaymentVerifierRegistryV3`, `UnifiedPaymentVerifierV3`, `OrchestratorV3`, and risk stack, while both

--- a/contracts/OrchestratorV2.sol
+++ b/contracts/OrchestratorV2.sol
@@ -141,7 +141,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         if (managerFee > MAX_MANAGER_FEE) revert FeeExceedsMaximum(managerFee, MAX_MANAGER_FEE);  // policy cap (e.g., 5%)
         intentManagerFeeRecipient[intentHash] = managerFeeRecipient;
         intentManagerFee[intentHash] = managerFee;
-        
+
         intentMinAtSignal[intentHash] = dep.intentAmountRange.min;
         Intent storage storedIntent = intents[intentHash];
         storedIntent.owner = msg.sender;
@@ -717,7 +717,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         uint256 _releaseAmount,
         address _managerFeeRecipient,
         uint256 _managerFee
-    ) internal returns (uint256 netFees) {
+    ) internal virtual returns (uint256 netFees) {
         uint256 protocolFeeAmount;
         uint256 referralFeeAmount;
         uint256 managerFeeAmount;

--- a/contracts/OrchestratorV2.sol
+++ b/contracts/OrchestratorV2.sol
@@ -581,7 +581,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
     /**
      * @notice Validates an intent before it is signaled.
      */
-    function _validateSignalIntent(SignalIntentParams calldata _intent) internal view {
+    function _validateSignalIntent(SignalIntentParams calldata _intent) internal {
         // Check if account can have multiple intents
         bool canHaveMultipleIntents = relayerRegistry.isWhitelistedRelayer(msg.sender) || allowMultipleIntents;
         if (!canHaveMultipleIntents && accountIntents[msg.sender].length > 0) {
@@ -625,9 +625,22 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
                 revert SignatureExpired(_intent.signatureExpiration, block.timestamp);
             }
 
-            if (!_isValidIntentGatingSignature(_intent, intentGatingService, msg.sender)) {
-                revert InvalidSignature();
-            }
+            _validateIntentGatingAuthorization(_intent, intentGatingService, msg.sender);
+        }
+    }
+
+    /**
+     * @dev Extension point for orchestrator versions that use one-time gating authorizations.
+     *      V2 retains its legacy signature format; V3 overrides this hook with nonce consumption
+     *      and complete intent-field binding.
+     */
+    function _validateIntentGatingAuthorization(
+        SignalIntentParams calldata _intent,
+        address _intentGatingService,
+        address _caller
+    ) internal virtual {
+        if (!_isValidIntentGatingSignature(_intent, _intentGatingService, _caller)) {
+            revert InvalidSignature();
         }
     }
 

--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -5,11 +5,12 @@ pragma solidity ^0.8.18;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { OrchestratorV2 } from "./OrchestratorV2.sol";
-import { IEscrow } from "./interfaces/IEscrow.sol";
 import { IIntentRiskHook } from "./interfaces/IIntentRiskHook.sol";
 import { IOrchestratorV2 } from "./interfaces/IOrchestratorV2.sol";
 import { IOrchestratorV3 } from "./interfaces/IOrchestratorV3.sol";
 import { BoundedCall } from "./lib/BoundedCall.sol";
+import { OrchestratorV3FeeLib } from "./lib/OrchestratorV3FeeLib.sol";
+import { OrchestratorV3RiskLib } from "./lib/OrchestratorV3RiskLib.sol";
 import { PostIntentHookExecutor as SettlementHookExecutor } from "./lib/SettlementHookExecutor.sol";
 
 /**
@@ -28,6 +29,7 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
 
     mapping(address => mapping(uint256 => IIntentRiskHook)) internal depositRiskHooks;
     mapping(bytes32 => IIntentRiskHook) internal intentRiskHooks;
+    mapping(bytes32 => OrchestratorV3FeeLib.IntentFeeSnapshot) internal intentFeeSnapshots;
     // Historical ABI name retained so existing V3 consumers keep the deployed getter selector.
     mapping(bytes32 => bool) public override intentRequiresPostIntentHook;
     mapping(bytes32 => IntentSettlement) internal failedIntentSettlements;
@@ -104,22 +106,7 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
         uint256 _depositId,
         IIntentRiskHook _hook
     ) external override nonReentrant {
-        if (_escrow == address(0)) revert ZeroAddress();
-
-        address hookAddress = address(_hook);
-        if (hookAddress != address(0) && hookAddress.code.length == 0) {
-            revert InvalidRiskHook(hookAddress);
-        }
-
-        IEscrow.Deposit memory deposit = IEscrow(_escrow).getDeposit(_depositId);
-        bool isDepositorOrDelegate = msg.sender == deposit.depositor
-            || (deposit.delegate != address(0) && msg.sender == deposit.delegate);
-        if (!isDepositorOrDelegate) {
-            revert UnauthorizedCallerOrDelegate(msg.sender, deposit.depositor, deposit.delegate);
-        }
-
-        depositRiskHooks[_escrow][_depositId] = _hook;
-        emit DepositRiskHookSet(_escrow, _depositId, hookAddress, msg.sender);
+        OrchestratorV3RiskLib.setDepositRiskHook(depositRiskHooks, _escrow, _depositId, _hook);
     }
 
     /* ============ Governance Functions ============ */
@@ -150,21 +137,16 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
         return intentRiskHooks[_intentHash];
     }
 
+    /** @notice Returns the effective aggregate fee rate snapshotted for an unresolved intent. */
+    function getIntentTotalFeeRate(bytes32 _intentHash) external view override returns (uint256) {
+        return intentFeeSnapshots[_intentHash].totalFeeRate;
+    }
+
     /**
      * @notice Returns the scalar intent fields required by a risk hook without copying dynamic intent data.
      */
     function getRiskIntent(bytes32 _intentHash) external view override returns (RiskIntentData memory riskIntent) {
-        Intent storage intent = intents[_intentHash];
-        riskIntent = RiskIntentData({
-            owner: intent.owner,
-            to: intent.to,
-            escrow: intent.escrow,
-            depositId: intent.depositId,
-            amount: intent.amount,
-            paymentMethod: intent.paymentMethod,
-            settlementHook: address(intent.settlementHook),
-            createdAt: uint64(intent.timestamp)
-        });
+        return OrchestratorV3RiskLib.getRiskIntent(intents, _intentHash);
     }
 
     /**
@@ -221,19 +203,25 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
      * @notice Snapshots and executes risk admission after V2 stores the intent.
      */
     function _afterIntentSignaled(bytes32 _intentHash) internal override {
-        Intent storage intent = intents[_intentHash];
-        IIntentRiskHook riskHook = depositRiskHooks[intent.escrow][intent.depositId];
-        intentRiskHooks[_intentHash] = riskHook;
-
-        bool requiresSettlementHook = BoundedCall.executeRiskAdmission(
-            riskHook,
+        OrchestratorV3FeeLib.snapshotIntentFees(
+            intentFeeSnapshots,
+            intents,
+            intentManagerFeeRecipient,
+            intentManagerFee,
             _intentHash,
-            address(intent.settlementHook),
+            protocolFeeRecipient,
+            protocolFee
+        );
+
+        OrchestratorV3RiskLib.snapshotAndAdmit(
+            depositRiskHooks,
+            intentRiskHooks,
+            intentRequiresPostIntentHook,
+            intents,
+            _intentHash,
             riskCallbackGasLimit,
             MAX_RISK_CALLBACK_RETURN_DATA
         );
-        intentRequiresPostIntentHook[_intentHash] = requiresSettlementHook;
-        emit IntentRiskHookSnapshotted(_intentHash, address(riskHook), requiresSettlementHook);
     }
 
     /**
@@ -254,25 +242,13 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
         uint256 _releasedAmount,
         bytes32 _paymentId
     ) internal override {
-        bool isSettlement = _resolution != IntentResolution.CANCELLED;
-        uint64 settledAt;
-        uint64 cancelledAt;
-
-        if (isSettlement) {
-            settledAt = uint64(block.timestamp);
-            emit IntentSettlementRecorded(_intentHash, _releasedAmount, settledAt);
-        } else {
-            cancelledAt = uint64(block.timestamp);
-        }
-
-        IIntentRiskHook riskHook = intentRiskHooks[_intentHash];
-
         super._resolveIntent(_intentHash, _resolution, _releasedAmount);
-        delete intentRiskHooks[_intentHash];
-        delete intentRequiresPostIntentHook[_intentHash];
-
-        bool callbackSucceeded = BoundedCall.executeTerminalRiskCallback(
-            riskHook,
+        OrchestratorV3RiskLib.executeTerminalCallback(
+            intentRiskHooks,
+            intentRequiresPostIntentHook,
+            intentFeeSnapshots,
+            failedIntentSettlements,
+            failedIntentCancellations,
             _intentHash,
             uint8(_resolution),
             _releasedAmount,
@@ -280,16 +256,6 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
             riskCallbackGasLimit,
             MAX_RISK_CALLBACK_RETURN_DATA
         );
-        if (isSettlement && !callbackSucceeded) {
-            failedIntentSettlements[_intentHash] = IntentSettlement({
-                releasedAmount: _releasedAmount,
-                paymentId: _paymentId,
-                settledAt: settledAt
-            });
-        } else if (!isSettlement && !callbackSucceeded) {
-            failedIntentCancellations[_intentHash] = IntentCancellation({ cancelledAt: cancelledAt });
-            emit IntentCancellationRecorded(_intentHash, cancelledAt);
-        }
     }
 
     /** @dev Calls the payment-ID-aware verifier ABI used exclusively by the V3 lane. */
@@ -341,11 +307,30 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
         emit IntentFulfilled(_intentHash, fundsTransferredTo, netAmount, _isManualRelease);
     }
 
+    /** @dev Distributes fees using the terms snapshotted before risk admission. */
+    function _calculateAndTransferFees(
+        IERC20 _token,
+        bytes32 _intentHash,
+        Intent memory _intent,
+        uint256 _releaseAmount,
+        address _managerFeeRecipient,
+        uint256 _managerFee
+    ) internal override returns (uint256 netFees) {
+        return OrchestratorV3FeeLib.calculateAndTransferFees(
+            intentFeeSnapshots,
+            _token,
+            _intentHash,
+            _intent,
+            _releaseAmount,
+            _managerFeeRecipient,
+            _managerFee
+        );
+    }
+
     function _setRiskCallbackGasLimit(uint256 _gasLimit) internal {
         if (_gasLimit < MIN_RISK_CALLBACK_GAS_LIMIT) {
             revert RiskCallbackGasLimitTooLow(_gasLimit, MIN_RISK_CALLBACK_GAS_LIMIT);
         }
-
         riskCallbackGasLimit = _gasLimit;
         emit RiskCallbackGasLimitUpdated(_gasLimit);
     }

--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -32,6 +32,7 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
 
     mapping(address => mapping(uint256 => IIntentRiskHook)) internal depositRiskHooks;
     mapping(bytes32 => IIntentRiskHook) internal intentRiskHooks;
+    mapping(bytes32 => uint256) internal intentGatingNonces;
     mapping(bytes32 => OrchestratorV3FeeLib.IntentFeeSnapshot) internal intentFeeSnapshots;
     // Historical ABI name retained so existing V3 consumers keep the deployed getter selector.
     mapping(bytes32 => bool) public override intentRequiresPostIntentHook;
@@ -148,6 +149,36 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
         return intentRiskHooks[_intentHash];
     }
 
+    /** @notice Returns the current single-use gating nonce for one taker and deposit scope. */
+    function getIntentGatingNonce(
+        address _taker,
+        address _escrow,
+        uint256 _depositId,
+        bytes32 _paymentMethod
+    ) external view override returns (uint256) {
+        return OrchestratorV3Validation.intentGatingNonce(
+            intentGatingNonces,
+            _taker,
+            _escrow,
+            _depositId,
+            _paymentMethod
+        );
+    }
+
+    /** @notice Returns the unprefixed message hash the gating service must sign. */
+    function getIntentGatingMessageHash(
+        SignalIntentParams calldata _params,
+        address _taker
+    ) external view override returns (bytes32) {
+        return OrchestratorV3Validation.currentIntentGatingMessageHash(
+            intentGatingNonces,
+            _params,
+            _taker,
+            address(this),
+            chainId
+        );
+    }
+
     /** @notice Returns the effective aggregate fee rate snapshotted for an unresolved intent. */
     function getIntentTotalFeeRate(bytes32 _intentHash) external view override returns (uint256) {
         return intentFeeSnapshots[_intentHash].totalFeeRate;
@@ -209,6 +240,26 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
     }
 
     /* ============ Internal Lifecycle Extensions ============ */
+
+    /**
+     * @dev Consumes one nonce before checking the gating service. A failed signature or any later
+     *      signalIntent revert rolls the nonce back with the transaction. Deposits without a gating
+     *      service never enter this hook and therefore never consume a nonce.
+     */
+    function _validateIntentGatingAuthorization(
+        SignalIntentParams calldata _params,
+        address _intentGatingService,
+        address _caller
+    ) internal override {
+        OrchestratorV3Validation.validateAndConsumeIntentGatingAuthorization(
+            intentGatingNonces,
+            _params,
+            _intentGatingService,
+            _caller,
+            address(this),
+            chainId
+        );
+    }
 
     /**
      * @notice Snapshots and executes risk admission after V2 stores the intent.

--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -12,6 +12,7 @@ import { BoundedCall } from "./lib/BoundedCall.sol";
 import { OrchestratorV3FeeLib } from "./lib/OrchestratorV3FeeLib.sol";
 import { OrchestratorV3RiskLib } from "./lib/OrchestratorV3RiskLib.sol";
 import { PostIntentHookExecutor as SettlementHookExecutor } from "./lib/SettlementHookExecutor.sol";
+import { OrchestratorV3Validation } from "./lib/OrchestratorV3Validation.sol";
 
 /**
  * @title OrchestratorV3
@@ -70,6 +71,14 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
             _protocolFeeRecipient
         )
     {
+        OrchestratorV3Validation.validateConstructor(
+            _chainId,
+            _escrowRegistry,
+            _paymentVerifierRegistry,
+            _relayerRegistry,
+            _protocolFee,
+            _protocolFeeRecipient
+        );
         _setRiskCallbackGasLimit(_riskCallbackGasLimit);
     }
 

--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -192,21 +192,6 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
     }
 
     /**
-     * @notice Enforces deferred payout execution for manual releases that required it at admission.
-     * @dev V1 policy rejects new deferred positions, but retaining the V3 behavior preserves the
-     *      lifecycle semantics for any separately migrated legacy position.
-     */
-    function _shouldExecuteSettlementHookOnManualRelease(
-        bytes32 _intentHash
-    ) internal view override returns (bool) {
-        bool requiresSettlementHook = intentRequiresPostIntentHook[_intentHash];
-        if (requiresSettlementHook && address(intents[_intentHash].settlementHook) == address(0)) {
-            revert RequiredSettlementHookMissing(_intentHash);
-        }
-        return requiresSettlementHook;
-    }
-
-    /**
      * @notice Returns the number of unresolved intents for an account in constant time.
      */
     function getAccountIntentCount(address _account) external view override returns (uint256) {

--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -23,8 +23,10 @@ import { OrchestratorV3Validation } from "./lib/OrchestratorV3Validation.sol";
 contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
     /* ============ Constants ============ */
 
-    uint256 internal constant MIN_RISK_CALLBACK_GAS_LIMIT = 750_000;
-    uint256 internal constant MAX_RISK_CALLBACK_RETURN_DATA = 2_048;
+    uint256 public constant MIN_RISK_CALLBACK_GAS_LIMIT = 750_000;
+    uint256 public constant MAX_RISK_CALLBACK_GAS_LIMIT = 2_000_000;
+    uint256 public constant MAX_RISK_CALLBACK_RETURN_DATA = 2_048;
+    uint256 public constant RISK_CALLBACK_POST_CALL_GAS_RESERVE = 250_000;
 
     /* ============ State Variables ============ */
 
@@ -229,6 +231,7 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
             intents,
             _intentHash,
             riskCallbackGasLimit,
+            RISK_CALLBACK_POST_CALL_GAS_RESERVE,
             MAX_RISK_CALLBACK_RETURN_DATA
         );
     }
@@ -263,6 +266,7 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
             _releasedAmount,
             _paymentId,
             riskCallbackGasLimit,
+            RISK_CALLBACK_POST_CALL_GAS_RESERVE,
             MAX_RISK_CALLBACK_RETURN_DATA
         );
     }
@@ -339,6 +343,9 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
     function _setRiskCallbackGasLimit(uint256 _gasLimit) internal {
         if (_gasLimit < MIN_RISK_CALLBACK_GAS_LIMIT) {
             revert RiskCallbackGasLimitTooLow(_gasLimit, MIN_RISK_CALLBACK_GAS_LIMIT);
+        }
+        if (_gasLimit > MAX_RISK_CALLBACK_GAS_LIMIT) {
+            revert RiskCallbackGasLimitTooHigh(_gasLimit, MAX_RISK_CALLBACK_GAS_LIMIT);
         }
         riskCallbackGasLimit = _gasLimit;
         emit RiskCallbackGasLimitUpdated(_gasLimit);

--- a/contracts/RiskManager.sol
+++ b/contracts/RiskManager.sol
@@ -71,13 +71,20 @@ import { IStakeVault } from "./interfaces/IStakeVault.sol";
  *      7. Escrow intent amounts and StakeVault liabilities must use the same immutable token, otherwise
  *         raw units, griefing penalties, free limits, and chargeback ratios would have no shared meaning.
  *      8. Deferred proceeds must cover the complete configured reserve after fees. A shortfall fails
- *         settlement rather than silently advertising less protection than governance configured.
+ *         admission rather than stranding settlement after the LP has already accepted an intent.
+ *         The exact post-transfer amount is checked again during hook registration.
  */
 contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
     /* ============ Constants ============ */
 
     /// @notice Basis-point denominator shared by both affine curves.
     uint256 public constant BPS_DENOMINATOR = 10_000;
+
+    /// @notice Conversion from one basis point to Orchestrator fee precise units.
+    uint256 public constant BPS_TO_PRECISE_UNIT = 1e14;
+
+    /// @notice Denominator used by Orchestrator fee rates.
+    uint256 public constant PRECISE_UNIT = 1e18;
 
     /// @notice Seconds per hour used to convert the configured hourly griefing slope.
     uint256 public constant SECONDS_PER_HOUR = 1 hours;
@@ -228,6 +235,10 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
                     && config.chargeback.deferredPayoutEnabled
                     && available >= maxGriefingBond
             ) {
+                _validateDeferredPayoutFeasibility(
+                    orchestrator.getIntentTotalFeeRate(_intentHash),
+                    config.chargeback.reserveBps
+                );
                 if (deferredPayoutHook == address(0) || intent.settlementHook != deferredPayoutHook) {
                     revert DeferredPayoutHookRequired(deferredPayoutHook, intent.settlementHook);
                 }
@@ -927,7 +938,6 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
                 _config.chargeback.reserveBps != BPS_DENOMINATOR
                     || _config.chargeback.riskWindow == 0
                     || _config.chargeback.riskWindow > MAX_RISK_WINDOW
-                    || _config.chargeback.deferredPayoutEnabled
             ) {
                 revert InvalidPlatformConfig(_paymentMethod);
             }
@@ -964,6 +974,25 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             revert IntentTokenMismatch(expectedToken, address(_intentToken));
         }
     }
+
+    /**
+     * @dev Proves that every possible full or partial release can fund the configured reserve.
+     *      For release `R`, fee component rates `f_i`, aggregate `F`, and precise reserve rate `B`:
+     *
+     *        sum(floor(R * f_i / U)) <= floor(R * F / U)
+     *
+     *      Therefore `F + B <= U` implies net proceeds are at least
+     *      `R - floor(R * (U - B) / U) = ceil(R * B / U)`. This remains true despite each
+     *      fee being rounded independently. At a 100% reserve, `B == U`, so only `F == 0`
+     *      is feasible. `registerDeferredPayout` retains the exact amount check as defense in depth.
+     */
+    function _validateDeferredPayoutFeasibility(uint256 _totalFee, uint16 _reserveBps) internal pure {
+        uint256 reserveRate = uint256(_reserveBps) * BPS_TO_PRECISE_UNIT;
+        if (_totalFee > PRECISE_UNIT - reserveRate) {
+            revert DeferredPayoutFeesExceedCapacity(_totalFee, _reserveBps);
+        }
+    }
+
 
     /** @dev Returns true only for a whole, non-chargebackable intent within an unused lifetime allowance. */
     function _isFreeTakeEligible(

--- a/contracts/RiskManager.sol
+++ b/contracts/RiskManager.sol
@@ -50,8 +50,9 @@ import { IStakeVault } from "./interfaces/IStakeVault.sol";
  *      - Non-chargebackable settlement releases the full pending reservation immediately.
  *      - Chargebackable settlement resizes stake coverage to the exact released amount and starts the
  *        snapshotted coverage window.
- *      - Deferred payout is an explicit exception: pending stake covers only griefing, while settled
- *        proceeds held in StakeVault replace chargeback stake coverage.
+ *      - Deferred payout is an explicit hybrid: pending stake covers the greater of maximum griefing
+ *        and a safe upper bound on settlement fees, then exact net proceeds plus the retained fee-gap
+ *        stake cover the complete gross release.
  *      - Maturity releases remaining stake coverage; valid chargebacks can consume coverage partially.
  *
  * @dev SECURITY INVARIANTS AND RATIONALE
@@ -70,18 +71,16 @@ import { IStakeVault } from "./interfaces/IStakeVault.sol";
  *      6. This contract never holds tokens. StakeVault is the sole accounting and custody boundary.
  *      7. Escrow intent amounts and StakeVault liabilities must use the same immutable token, otherwise
  *         raw units, griefing penalties, free limits, and chargeback ratios would have no shared meaning.
- *      8. Deferred proceeds must cover the complete configured reserve after fees. A shortfall fails
- *         admission rather than stranding settlement after the LP has already accepted an intent.
- *         The exact post-transfer amount is checked again during hook registration.
+ *      8. Deferred admission reserves max(maxGriefingBond, floor(A * aggregateFeeRate / 1e18)).
+ *         Independently rounded fee components can never exceed that aggregate-floor upper bound.
+ *         At registration, exact net proceeds D resize retained stake to S = R - D, proving D + S = R
+ *         without ever increasing stake after the off-chain payment.
  */
 contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
     /* ============ Constants ============ */
 
     /// @notice Basis-point denominator shared by both affine curves.
     uint256 public constant BPS_DENOMINATOR = 10_000;
-
-    /// @notice Conversion from one basis point to Orchestrator fee precise units.
-    uint256 public constant BPS_TO_PRECISE_UNIT = 1e14;
 
     /// @notice Denominator used by Orchestrator fee rates.
     uint256 public constant PRECISE_UNIT = 1e18;
@@ -205,6 +204,14 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
         (uint256 maxGriefingBond, uint256 chargebackReserve, uint256 requiredReservation) =
             _calculateRequiredReservation(intent.amount, maxIntentPeriod, config);
+        uint256 deferredRequiredReservation = maxGriefingBond;
+        if (config.chargeback.chargebackable && config.chargeback.deferredPayoutEnabled) {
+            uint256 maximumFeeGap = _calculateDeferredFeeGapUpperBound(
+                intent.amount,
+                orchestrator.getIntentTotalFeeRate(_intentHash)
+            );
+            deferredRequiredReservation = _max(maxGriefingBond, maximumFeeGap);
+        }
 
         bool consumedFreeTake = _isFreeTakeEligible(stakeOwner, intent, config);
         RiskMode mode;
@@ -227,20 +234,15 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             if (available >= requiredReservation) {
                 mode = RiskMode.STAKE_BACKED;
                 initialReservation = requiredReservation;
-            } else if (
-                config.chargeback.chargebackable
-                    && config.chargeback.deferredPayoutEnabled
-                    && available >= maxGriefingBond
-            ) {
-                _validateDeferredPayoutFeasibility(
-                    orchestrator.getIntentTotalFeeRate(_intentHash),
-                    config.chargeback.reserveBps
-                );
+            } else if (config.chargeback.chargebackable && config.chargeback.deferredPayoutEnabled) {
+                if (available < deferredRequiredReservation) {
+                    revert InsufficientCollateral(stakeOwner, available, deferredRequiredReservation);
+                }
                 if (deferredPayoutHook == address(0) || intent.settlementHook != deferredPayoutHook) {
                     revert DeferredPayoutHookRequired(deferredPayoutHook, intent.settlementHook);
                 }
                 mode = RiskMode.DEFERRED_PAYOUT;
-                initialReservation = maxGriefingBond;
+                initialReservation = deferredRequiredReservation;
                 requiresSettlementHook = true;
             } else {
                 revert InsufficientCollateral(stakeOwner, available, requiredReservation);
@@ -420,10 +422,10 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
     /**
      * @inheritdoc IRiskManager
-     * @dev The canonical hook transfers net proceeds into StakeVault before calling this function.
-     *      Held proceeds must cover the complete configured reserve after fees; otherwise settlement
-     *      fails closed instead of silently weakening coverage. Any excess remains the beneficiary's
-     *      property but matures on the same deadline.
+     * @dev The canonical hook transfers exact net proceeds D into StakeVault before calling this
+     *      function. Exact stake coverage is S = R - D. Admission already reserved an upper bound on S,
+     *      so registration can only retain or reduce stake after the off-chain payment. The combined
+     *      coverage is therefore exactly D + S = R and matures on one deadline.
      */
     function registerDeferredPayout(
         bytes32 _intentHash,
@@ -443,23 +445,32 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             revert DeferredPayoutExceedsReleasedAmount(_amount, position.releasedAmount);
         }
 
-        uint256 expectedCoverage = _calculateChargebackReserve(
-            position.releasedAmount,
-            position.chargebackReserveBps
-        );
-        if (_amount < expectedCoverage) {
-            revert InsufficientDeferredPayoutCoverage(_amount, expectedCoverage);
+        uint256 stakeCoverage = position.releasedAmount - _amount;
+        uint256 provisionalStakeCoverage = position.reservedAmount;
+        if (stakeCoverage > provisionalStakeCoverage) {
+            revert IncompleteChargebackCoverage(
+                _amount + provisionalStakeCoverage,
+                position.releasedAmount
+            );
         }
 
         position.deferredPayoutAmount = _amount;
-        position.reservedAmount = expectedCoverage;
+        position.reservedAmount = stakeCoverage;
+
+        if (provisionalStakeCoverage != 0) {
+            if (stakeCoverage == 0) {
+                stakeVault.releaseReservation(_intentHash);
+            } else {
+                stakeVault.updateReservation(_intentHash, stakeCoverage, position.coverageDeadline);
+            }
+        }
         stakeVault.recordDeferredPayout(_intentHash, _beneficiary, _amount, position.coverageDeadline);
 
         emit DeferredPayoutRegistered(
             _intentHash,
             _beneficiary,
             _amount,
-            expectedCoverage,
+            stakeCoverage,
             position.coverageDeadline
         );
     }
@@ -499,7 +510,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         position.status = PositionStatus.RELEASED;
         position.reservedAmount = 0;
 
-        if (position.mode == RiskMode.STAKE_BACKED && releasedCoverage != 0) {
+        if (releasedCoverage != 0) {
             stakeVault.releaseReservation(_intentHash);
         }
 
@@ -528,19 +539,36 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         }
 
         uint256 compensatedAmount = position.releasedAmount;
-        if (position.reservedAmount != compensatedAmount) {
-            revert IncompleteChargebackCoverage(position.reservedAmount, compensatedAmount);
+        uint256 deferredCoverage;
+        uint256 stakeCoverage = position.reservedAmount;
+        if (position.mode == RiskMode.DEFERRED_PAYOUT) {
+            deferredCoverage = position.deferredPayoutAmount;
+        }
+        uint256 totalCoverage = deferredCoverage + stakeCoverage;
+        if (totalCoverage != compensatedAmount) {
+            revert IncompleteChargebackCoverage(totalCoverage, compensatedAmount);
         }
 
         usedChargebackNullifiers[nullifier] = true;
         position.slashedAmount = compensatedAmount;
         position.reservedAmount = 0;
+        position.deferredPayoutAmount = 0;
         position.status = PositionStatus.SLASHED;
 
         if (position.mode == RiskMode.STAKE_BACKED) {
-            stakeVault.slashReservation(_attestation.intentHash, position.lp, compensatedAmount);
+            stakeVault.slashReservation(_attestation.intentHash, position.lp, stakeCoverage);
         } else {
-            stakeVault.slashDeferredPayout(_attestation.intentHash, position.lp, compensatedAmount);
+            stakeVault.slashDeferredPayout(_attestation.intentHash, position.lp, deferredCoverage);
+            if (stakeCoverage != 0) {
+                stakeVault.slashReservation(_attestation.intentHash, position.lp, stakeCoverage);
+            }
+            emit HybridCoverageSlashed(
+                _attestation.intentHash,
+                deferredCoverage,
+                stakeCoverage,
+                compensatedAmount,
+                0
+            );
         }
 
         emit ChargebackSettled(
@@ -789,8 +817,9 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
     /**
      * @dev Transitions a pending position at settlement. Griefing liability disappears without penalty.
-     *      Stake-backed coverage is resized to the exact released amount; deferred coverage remains zero
-     *      until the mandatory hook atomically registers transferred proceeds.
+     *      Stake-backed coverage is resized to the exact released amount. Deferred mode retains its
+     *      admission reservation until the mandatory hook atomically registers exact net proceeds and
+     *      can safely shrink the reservation to the exact fee gap.
      */
     function _settlePosition(
         bytes32 _intentHash,
@@ -843,9 +872,8 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             position.reservedAmount = chargebackCoverage;
             stakeVault.updateReservation(_intentHash, chargebackCoverage, coverageDeadline);
         } else if (position.mode == RiskMode.DEFERRED_PAYOUT) {
-            releasedReservation = pendingReservation;
-            position.reservedAmount = 0;
-            if (pendingReservation != 0) stakeVault.releaseReservation(_intentHash);
+            chargebackCoverage = pendingReservation;
+            position.reservedAmount = pendingReservation;
         } else {
             revert PositionModeMismatch(_intentHash, position.mode);
         }
@@ -973,21 +1001,16 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
     }
 
     /**
-     * @dev Proves that every possible full or partial release can fund the configured reserve.
-     *      For release `R`, fee component rates `f_i`, aggregate `F`, and precise reserve rate `B`:
-     *
-     *        sum(floor(R * f_i / U)) <= floor(R * F / U)
-     *
-     *      Therefore `F + B <= U` implies net proceeds are at least
-     *      `R - floor(R * (U - B) / U) = ceil(R * B / U)`. This remains true despite each
-     *      fee being rounded independently. At a 100% reserve, `B == U`, so only `F == 0`
-     *      is feasible. `registerDeferredPayout` retains the exact amount check as defense in depth.
+     * @dev Returns a safe fee-gap upper bound for every release up to `_amount`. For component rates
+     *      `f_i` and aggregate rate `F`, sum(floor(R * f_i / U)) <= floor(R * F / U), and the right
+     *      side is monotonic for R <= A. Exact component rounding is reconciled from hook proceeds.
      */
-    function _validateDeferredPayoutFeasibility(uint256 _totalFee, uint16 _reserveBps) internal pure {
-        uint256 reserveRate = uint256(_reserveBps) * BPS_TO_PRECISE_UNIT;
-        if (_totalFee > PRECISE_UNIT - reserveRate) {
-            revert DeferredPayoutFeesExceedCapacity(_totalFee, _reserveBps);
-        }
+    function _calculateDeferredFeeGapUpperBound(
+        uint256 _amount,
+        uint256 _totalFeeRate
+    ) internal pure returns (uint256) {
+        if (_totalFeeRate == 0) return 0;
+        return Math.mulDiv(_amount, _totalFeeRate, PRECISE_UNIT);
     }
 
     /** @dev Distinguishes an unset dependency from an address without deployed code. */

--- a/contracts/RiskManager.sol
+++ b/contracts/RiskManager.sol
@@ -159,15 +159,12 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         IStakeVault _stakeVault,
         IAttestationVerifier _attestationVerifier
     ) Ownable() EIP712("ZKP2P RiskManager", "1") {
-        if (
-            _owner == address(0)
-                || address(_orchestrator) == address(0)
-                || address(_stakeVault) == address(0)
-                || address(_attestationVerifier) == address(0)
-        ) {
+        if (_owner == address(0)) {
             revert ZeroAddress();
         }
-        if (address(_attestationVerifier).code.length == 0) revert ZeroAddress();
+        _requireContract(address(_orchestrator));
+        _requireContract(address(_stakeVault));
+        _requireContract(address(_attestationVerifier));
 
         orchestrator = _orchestrator;
         stakeVault = _stakeVault;
@@ -591,7 +588,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
      * @inheritdoc IRiskManager
      */
     function setAttestationVerifier(address _verifier) external override onlyOwner {
-        if (_verifier == address(0) || _verifier.code.length == 0) revert ZeroAddress();
+        _requireContract(_verifier);
         address previousVerifier = address(attestationVerifier);
         attestationVerifier = IAttestationVerifier(_verifier);
         emit AttestationVerifierUpdated(previousVerifier, _verifier);
@@ -601,7 +598,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
      * @inheritdoc IRiskManager
      */
     function setDeferredPayoutHook(address _hook) external override onlyOwner {
-        if (_hook != address(0) && _hook.code.length == 0) revert ZeroAddress();
+        if (_hook != address(0)) _requireContract(_hook);
         address previousHook = deferredPayoutHook;
         deferredPayoutHook = _hook;
         emit DeferredPayoutHookUpdated(previousHook, _hook);
@@ -993,6 +990,11 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         }
     }
 
+    /** @dev Distinguishes an unset dependency from an address without deployed code. */
+    function _requireContract(address _account) internal view {
+        if (_account == address(0)) revert ZeroAddress();
+        if (_account.code.length == 0) revert InvalidContract(_account);
+    }
 
     /** @dev Returns true only for a whole, non-chargebackable intent within an unused lifetime allowance. */
     function _isFreeTakeEligible(

--- a/contracts/RiskManager.sol
+++ b/contracts/RiskManager.sol
@@ -231,7 +231,18 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             );
         } else {
             uint256 available = stakeVault.freeStake(stakeOwner);
-            if (available >= requiredReservation) {
+            bool deferredPayoutRequested = config.chargeback.chargebackable
+                && config.chargeback.deferredPayoutEnabled
+                && deferredPayoutHook != address(0)
+                && intent.settlementHook == deferredPayoutHook;
+            if (deferredPayoutRequested) {
+                if (available < deferredRequiredReservation) {
+                    revert InsufficientCollateral(stakeOwner, available, deferredRequiredReservation);
+                }
+                mode = RiskMode.DEFERRED_PAYOUT;
+                initialReservation = deferredRequiredReservation;
+                requiresSettlementHook = true;
+            } else if (available >= requiredReservation) {
                 mode = RiskMode.STAKE_BACKED;
                 initialReservation = requiredReservation;
             } else if (config.chargeback.chargebackable && config.chargeback.deferredPayoutEnabled) {

--- a/contracts/StakeVault.sol
+++ b/contracts/StakeVault.sol
@@ -117,6 +117,8 @@ contract StakeVault is IStakeVault, Ownable, ReentrancyGuard {
         if (_owner == address(0) || address(_stakeToken) == address(0)) {
             revert ZeroAddress();
         }
+        _requireContract(address(_stakeToken));
+        if (_controller != address(0)) _requireContract(_controller);
         if (_controllerChangeDelay < MIN_CONTROLLER_CHANGE_DELAY) {
             revert InvalidControllerChangeDelay(_controllerChangeDelay);
         }
@@ -659,6 +661,7 @@ contract StakeVault is IStakeVault, Ownable, ReentrancyGuard {
      */
     function initializeController(address _controller) external override onlyOwner {
         if (_controller == address(0)) revert ZeroAddress();
+        _requireContract(_controller);
         if (controller != address(0)) revert ControllerAlreadyInitialized(controller);
 
         controller = _controller;
@@ -670,6 +673,7 @@ contract StakeVault is IStakeVault, Ownable, ReentrancyGuard {
      */
     function proposeController(address _controller) external override onlyOwner {
         if (_controller == address(0)) revert ZeroAddress();
+        _requireContract(_controller);
 
         pendingController = _controller;
         pendingControllerValidAt = uint64(block.timestamp) + controllerChangeDelay;
@@ -683,6 +687,7 @@ contract StakeVault is IStakeVault, Ownable, ReentrancyGuard {
     function acceptController() external override {
         if (pendingController == address(0)) revert NoPendingController();
         if (msg.sender != pendingController) revert UnauthorizedController(msg.sender);
+        _requireContract(pendingController);
         if (block.timestamp < pendingControllerValidAt) {
             revert ControllerProposalNotReady(pendingControllerValidAt, uint64(block.timestamp));
         }
@@ -718,6 +723,11 @@ contract StakeVault is IStakeVault, Ownable, ReentrancyGuard {
      */
     function freeStake(address _staker) public view override returns (uint256) {
         return eligibleStake(_staker) - reservedStake[_staker];
+    }
+
+    /** @dev Rejects an address that cannot execute controller or token code. */
+    function _requireContract(address _account) internal view {
+        if (_account.code.length == 0) revert InvalidContract(_account);
     }
 
     /**

--- a/contracts/hooks/DeferredPayoutHook.sol
+++ b/contracts/hooks/DeferredPayoutHook.sol
@@ -26,13 +26,6 @@ contract DeferredPayoutHook is IDeferredPayoutHook {
     IRiskManager public immutable riskManager;
     IOrchestratorRegistry public immutable orchestratorRegistry;
 
-    /* ============ Errors ============ */
-
-    error ZeroAddress();
-    error ZeroAmount();
-    error UnauthorizedOrchestrator(address caller);
-    error InvalidPayoutToken(address expected, address actual);
-
     /* ============ Constructor ============ */
 
     /**
@@ -56,9 +49,18 @@ contract DeferredPayoutHook is IDeferredPayoutHook {
         ) {
             revert ZeroAddress();
         }
+        _requireContract(address(_payoutToken));
+        _requireContract(address(_stakeVault));
+        _requireContract(address(_riskManager));
+        _requireContract(address(_orchestratorRegistry));
+
         address vaultToken = address(_stakeVault.stakeToken());
         if (address(_payoutToken) != vaultToken) {
             revert InvalidPayoutToken(vaultToken, address(_payoutToken));
+        }
+        address managerVault = address(_riskManager.stakeVault());
+        if (managerVault != address(_stakeVault)) {
+            revert RiskManagerStakeVaultMismatch(managerVault, address(_stakeVault));
         }
 
         payoutToken = _payoutToken;
@@ -93,5 +95,10 @@ contract DeferredPayoutHook is IDeferredPayoutHook {
             address(stakeVault),
             _ctx.executableAmount
         );
+    }
+
+    /** @dev Rejects an address that cannot execute the expected dependency interface. */
+    function _requireContract(address _account) internal view {
+        if (_account.code.length == 0) revert InvalidContract(_account);
     }
 }

--- a/contracts/interfaces/IDeferredPayoutHook.sol
+++ b/contracts/interfaces/IDeferredPayoutHook.sol
@@ -21,6 +21,6 @@ interface IDeferredPayoutHook is ISettlementHook {
         bytes32 indexed intentHash,
         address indexed beneficiary,
         address indexed vault,
-        uint256 amount
+        uint256 deferredCoverage
     );
 }

--- a/contracts/interfaces/IDeferredPayoutHook.sol
+++ b/contracts/interfaces/IDeferredPayoutHook.sol
@@ -9,6 +9,14 @@ import { ISettlementHook } from "./ISettlementHook.sol";
  * @notice Required settlement action for intents using deferred-payout risk mode.
  */
 interface IDeferredPayoutHook is ISettlementHook {
+    /* ============ Errors ============ */
+
+    error ZeroAddress();
+    error ZeroAmount();
+    error InvalidContract(address account);
+    error UnauthorizedOrchestrator(address caller);
+    error InvalidPayoutToken(address expected, address actual);
+    error RiskManagerStakeVaultMismatch(address expected, address actual);
     event PayoutDeferred(
         bytes32 indexed intentHash,
         address indexed beneficiary,

--- a/contracts/interfaces/IOrchestratorV3.sol
+++ b/contracts/interfaces/IOrchestratorV3.sol
@@ -43,6 +43,13 @@ interface IOrchestratorV3 is IOrchestratorV2 {
         address indexed feeRecipient,
         uint256 feeRate
     );
+    event IntentGatingAuthorizationConsumed(
+        address indexed taker,
+        address indexed escrow,
+        uint256 indexed depositId,
+        bytes32 paymentMethod,
+        uint256 nonce
+    );
     event RiskHookCallbackFailed(
         bytes32 indexed intentHash,
         address indexed riskHook,
@@ -73,6 +80,27 @@ interface IOrchestratorV3 is IOrchestratorV2 {
 
     function getDepositRiskHook(address _escrow, uint256 _depositId) external view returns (IIntentRiskHook);
     function getIntentRiskHook(bytes32 _intentHash) external view returns (IIntentRiskHook);
+    /**
+     * @notice Returns the nonce that must be included in the taker's next gated authorization.
+     * @dev Nonces are scoped by taker, escrow, deposit, and payment method so independent deposit
+     *      authorizations do not invalidate one another.
+     */
+    function getIntentGatingNonce(
+        address _taker,
+        address _escrow,
+        uint256 _depositId,
+        bytes32 _paymentMethod
+    ) external view returns (uint256);
+    /**
+     * @notice Returns the unprefixed message hash for the current scoped nonce.
+     * @dev The gating service must sign this 32-byte value with EIP-191 `personal_sign`/`signMessage`.
+     *      The hash binds every security-relevant SignalIntentParams field except the signature
+     *      bytes themselves, plus the taker, chain id, verifying orchestrator, and current nonce.
+     */
+    function getIntentGatingMessageHash(
+        SignalIntentParams calldata _params,
+        address _taker
+    ) external view returns (bytes32);
     /**
      * @notice Returns the aggregate fee rate snapshotted before risk admission.
      * @dev Returns zero after an intent reaches a terminal state.

--- a/contracts/interfaces/IOrchestratorV3.sol
+++ b/contracts/interfaces/IOrchestratorV3.sol
@@ -38,6 +38,11 @@ interface IOrchestratorV3 is IOrchestratorV2 {
 
     event DepositRiskHookSet(address indexed escrow, uint256 indexed depositId, address indexed hook, address setter);
     event IntentRiskHookSnapshotted(bytes32 indexed intentHash, address indexed riskHook, bool requiresSettlementHook);
+    event IntentProtocolFeeSnapshotted(
+        bytes32 indexed intentHash,
+        address indexed feeRecipient,
+        uint256 feeRate
+    );
     event RiskHookCallbackFailed(
         bytes32 indexed intentHash,
         address indexed riskHook,
@@ -55,6 +60,8 @@ interface IOrchestratorV3 is IOrchestratorV2 {
     error InvalidRiskHookResponse(address hook, bytes response);
     error RequiredSettlementHookMissing(bytes32 intentHash);
     error RiskCallbackGasLimitTooLow(uint256 gasLimit, uint256 minimum);
+    error InvalidContract(address account);
+    error InvalidChainId(uint256 suppliedChainId, uint256 actualChainId);
 
     /* ============ External Functions ============ */
 
@@ -65,6 +72,11 @@ interface IOrchestratorV3 is IOrchestratorV2 {
 
     function getDepositRiskHook(address _escrow, uint256 _depositId) external view returns (IIntentRiskHook);
     function getIntentRiskHook(bytes32 _intentHash) external view returns (IIntentRiskHook);
+    /**
+     * @notice Returns the aggregate fee rate snapshotted before risk admission.
+     * @dev Returns zero after an intent reaches a terminal state.
+     */
+    function getIntentTotalFeeRate(bytes32 _intentHash) external view returns (uint256);
     /// @dev Historical ABI name retained; the returned policy requires the intent settlement hook.
     function intentRequiresPostIntentHook(bytes32 _intentHash) external view returns (bool);
     function getRiskIntent(bytes32 _intentHash) external view returns (RiskIntentData memory);

--- a/contracts/interfaces/IOrchestratorV3.sol
+++ b/contracts/interfaces/IOrchestratorV3.sol
@@ -60,6 +60,7 @@ interface IOrchestratorV3 is IOrchestratorV2 {
     error InvalidRiskHookResponse(address hook, bytes response);
     error RequiredSettlementHookMissing(bytes32 intentHash);
     error RiskCallbackGasLimitTooLow(uint256 gasLimit, uint256 minimum);
+    error RiskCallbackGasLimitTooHigh(uint256 gasLimit, uint256 maximum);
     error InvalidContract(address account);
     error InvalidChainId(uint256 suppliedChainId, uint256 actualChainId);
 

--- a/contracts/interfaces/IRiskManager.sol
+++ b/contracts/interfaces/IRiskManager.sol
@@ -238,6 +238,7 @@ interface IRiskManager is IIntentRiskHook {
     /* ============ Errors ============ */
 
     error ZeroAddress();
+    error InvalidContract(address account);
     error ZeroAmount();
     error EmptyBatch();
     error UnauthorizedOrchestrator(address caller);
@@ -262,6 +263,7 @@ interface IRiskManager is IIntentRiskHook {
     error DeferredPayoutAlreadyRegistered(bytes32 intentHash);
     error DeferredPayoutExceedsReleasedAmount(uint256 payoutAmount, uint256 releasedAmount);
     error InsufficientDeferredPayoutCoverage(uint256 availableCoverage, uint256 requiredCoverage);
+    error DeferredPayoutFeesExceedCapacity(uint256 totalFee, uint16 reserveBps);
     error PositionNotMature(uint64 coverageDeadline, uint64 currentTime);
     error InvalidAttestation();
     error InvalidPaymentEvidence(bytes32 intentHash);

--- a/contracts/interfaces/IRiskManager.sol
+++ b/contracts/interfaces/IRiskManager.sol
@@ -116,7 +116,7 @@ interface IRiskManager is IIntentRiskHook {
         uint256 maxGriefingBond;
         /// @notice Stake reserved at admission before terminal resizing or release.
         uint256 initialReservation;
-        /// @notice Remaining slashable stake or deferred proceeds for this position.
+        /// @notice Remaining slashable membership-stake coverage for this position.
         uint256 reservedAmount;
         /// @notice Exact amount released from Escrow at settlement before post-hook fees.
         uint256 releasedAmount;
@@ -201,24 +201,31 @@ interface IRiskManager is IIntentRiskHook {
         address indexed stakeOwner,
         address indexed lp,
         RiskMode mode,
-        uint256 releasedAmount,
-        uint256 chargebackCoverage,
-        uint256 releasedReservation,
+        uint256 grossReleasedAmount,
+        uint256 stakeCoverage,
+        uint256 releasedStakeReservation,
         uint64 settledAt,
         uint64 coverageDeadline
     );
     event DeferredPayoutRegistered(
         bytes32 indexed intentHash,
         address indexed beneficiary,
-        uint256 deferredAmount,
-        uint256 chargebackCoverage,
+        uint256 deferredCoverage,
+        uint256 stakeCoverage,
         uint64 coverageDeadline
+    );
+    event HybridCoverageSlashed(
+        bytes32 indexed intentHash,
+        uint256 deferredCoverage,
+        uint256 stakeCoverage,
+        uint256 grossCompensation,
+        uint256 remainingCoverage
     );
     event RiskPositionReleased(
         bytes32 indexed intentHash,
         address indexed stakeOwner,
         RiskMode mode,
-        uint256 releasedCoverage
+        uint256 releasedStakeCoverage
     );
     event ChargebackSettled(
         bytes32 indexed intentHash,
@@ -262,8 +269,6 @@ interface IRiskManager is IIntentRiskHook {
     error IntentTokenMismatch(address expectedToken, address actualToken);
     error DeferredPayoutAlreadyRegistered(bytes32 intentHash);
     error DeferredPayoutExceedsReleasedAmount(uint256 payoutAmount, uint256 releasedAmount);
-    error InsufficientDeferredPayoutCoverage(uint256 availableCoverage, uint256 requiredCoverage);
-    error DeferredPayoutFeesExceedCapacity(uint256 totalFee, uint16 reserveBps);
     error PositionNotMature(uint64 coverageDeadline, uint64 currentTime);
     error InvalidAttestation();
     error InvalidPaymentEvidence(bytes32 intentHash);
@@ -288,7 +293,7 @@ interface IRiskManager is IIntentRiskHook {
 
     /* ============ Lifecycle Functions ============ */
 
-    /** @notice Records net proceeds already transferred to StakeVault by the snapshotted canonical hook. */
+    /** @notice Records exact net deferred coverage and resizes stake coverage to the gross-release gap. */
     function registerDeferredPayout(bytes32 _intentHash, address _beneficiary, uint256 _amount) external;
     /** @notice Permissionlessly applies one durable failed-cancellation record using its original timestamp. */
     function reconcileCancellation(bytes32 _intentHash) external;

--- a/contracts/interfaces/IStakeVault.sol
+++ b/contracts/interfaces/IStakeVault.sol
@@ -9,6 +9,10 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  * @notice Policy-agnostic interface for membership stake and deferred payouts.
  */
 interface IStakeVault {
+    /* ============ Errors ============ */
+
+    error InvalidContract(address account);
+
     /* ============ Structs ============ */
 
     struct ExitRequest {

--- a/contracts/lib/BoundedCall.sol
+++ b/contracts/lib/BoundedCall.sol
@@ -13,6 +13,9 @@ import { IPaymentVerifierV3 } from "../interfaces/IPaymentVerifierV3.sol";
  *      copy unbounded return data and exhaust gas during memory expansion.
  */
 library BoundedCall {
+    /// @dev Conservative allowance for CALL base/cold-access cost and local argument bookkeeping.
+    uint256 internal constant CALL_OVERHEAD_GAS = 10_000;
+
     event RiskHookCallbackFailed(
         bytes32 indexed intentHash,
         address indexed riskHook,
@@ -59,6 +62,7 @@ library BoundedCall {
         bytes32 _intentHash,
         address _settlementHook,
         uint256 _gasLimit,
+        uint256 _postCallGasReserve,
         uint256 _maxReturnDataSize
     ) public returns (bool requiresSettlementHook) {
         if (address(_riskHook) == address(0)) return false;
@@ -66,6 +70,7 @@ library BoundedCall {
         (bool success, bytes memory response) = callWithBoundedReturnData(
             address(_riskHook),
             _gasLimit,
+            _postCallGasReserve,
             _maxReturnDataSize,
             abi.encodeCall(IIntentRiskHook.onIntentCreated, (_intentHash))
         );
@@ -90,6 +95,7 @@ library BoundedCall {
         uint256 _releasedAmount,
         bytes32 _paymentId,
         uint256 _gasLimit,
+        uint256 _postCallGasReserve,
         uint256 _maxReturnDataSize
     ) public returns (bool success) {
         if (address(_riskHook) == address(0)) return true;
@@ -114,6 +120,7 @@ library BoundedCall {
         (success, revertData) = callWithBoundedReturnData(
             address(_riskHook),
             _gasLimit,
+            _postCallGasReserve,
             _maxReturnDataSize,
             callData
         );
@@ -126,6 +133,7 @@ library BoundedCall {
      * @notice Calls a target with a fixed gas allowance and copies at most `_maxReturnDataSize` bytes.
      * @param _target Address receiving the call.
      * @param _gasLimit Maximum gas forwarded to the target.
+     * @param _postCallGasReserve Gas retained for caller-side reconciliation after the call.
      * @param _maxReturnDataSize Maximum number of return-data bytes copied into memory.
      * @param _callData Encoded calldata sent to the target.
      * @return success Whether the target call succeeded.
@@ -134,12 +142,16 @@ library BoundedCall {
     function callWithBoundedReturnData(
         address _target,
         uint256 _gasLimit,
+        uint256 _postCallGasReserve,
         uint256 _maxReturnDataSize,
         bytes memory _callData
     ) internal returns (bool success, bytes memory returnData) {
+        uint256 callGas = _calculateCallGas(gasleft(), _gasLimit, _postCallGasReserve);
+        if (callGas == 0) return (false, bytes(""));
+
         assembly ("memory-safe") {
             success := call(
-                _gasLimit,
+                callGas,
                 _target,
                 0,
                 add(_callData, 0x20),
@@ -159,6 +171,26 @@ library BoundedCall {
                 add(add(returnData, 0x20), and(add(copySize, 0x1f), not(0x1f)))
             )
         }
+    }
+
+    /**
+     * @dev Caps forwarded gas by the configured allowance, EIP-150's 63/64 rule, and the
+     *      amount that leaves the requested reconciliation reserve after conservative CALL overhead.
+     */
+    function _calculateCallGas(
+        uint256 _availableGas,
+        uint256 _gasLimit,
+        uint256 _postCallGasReserve
+    ) internal pure returns (uint256 callGas) {
+        if (_availableGas <= CALL_OVERHEAD_GAS + _postCallGasReserve) return 0;
+
+        uint256 afterOverhead = _availableGas - CALL_OVERHEAD_GAS;
+        uint256 eip150Maximum = afterOverhead - (afterOverhead / 64);
+        uint256 reserveMaximum = afterOverhead - _postCallGasReserve;
+
+        callGas = _gasLimit;
+        if (callGas > eip150Maximum) callGas = eip150Maximum;
+        if (callGas > reserveMaximum) callGas = reserveMaximum;
     }
 
 }

--- a/contracts/lib/OrchestratorV3FeeLib.sol
+++ b/contracts/lib/OrchestratorV3FeeLib.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import { IOrchestratorV2 } from "../interfaces/IOrchestratorV2.sol";
+import { IReferralFee } from "../interfaces/IReferralFee.sol";
+
+/**
+ * @title OrchestratorV3FeeLib
+ * @notice Snapshots and consumes immutable per-intent fee terms for OrchestratorV3.
+ * @dev Keeping fee execution in a linked library leaves OrchestratorV3 below the EIP-170 code-size
+ *      limit while preserving the exact fee distribution behavior inherited from OrchestratorV2.
+ */
+library OrchestratorV3FeeLib {
+    using SafeERC20 for IERC20;
+
+    uint256 internal constant PRECISE_UNIT = 1e18;
+
+    struct IntentFeeSnapshot {
+        address protocolFeeRecipient;
+        uint256 protocolFeeRate;
+        uint256 totalFeeRate;
+    }
+
+    event IntentProtocolFeeSnapshotted(
+        bytes32 indexed intentHash,
+        address indexed feeRecipient,
+        uint256 feeRate
+    );
+    event IntentReferralFeeDistributed(
+        bytes32 indexed intentHash,
+        address indexed feeRecipient,
+        uint256 feeAmount
+    );
+
+    /** @notice Snapshots all fee terms needed to prove deferred-payout feasibility. */
+    function snapshotIntentFees(
+        mapping(bytes32 => IntentFeeSnapshot) storage _feeSnapshots,
+        mapping(bytes32 => IOrchestratorV2.Intent) storage _intents,
+        mapping(bytes32 => address) storage _managerFeeRecipients,
+        mapping(bytes32 => uint256) storage _managerFees,
+        bytes32 _intentHash,
+        address _protocolFeeRecipient,
+        uint256 _protocolFee
+    ) external {
+        IOrchestratorV2.Intent storage intent = _intents[_intentHash];
+        uint256 totalFeeRate;
+        if (_protocolFeeRecipient != address(0)) totalFeeRate = _protocolFee;
+        if (_managerFeeRecipients[_intentHash] != address(0)) {
+            totalFeeRate += _managerFees[_intentHash];
+        }
+        for (uint256 feeIndex = 0; feeIndex < intent.referralFees.length; feeIndex++) {
+            totalFeeRate += intent.referralFees[feeIndex].fee;
+        }
+        _feeSnapshots[_intentHash] = IntentFeeSnapshot({
+            protocolFeeRecipient: _protocolFeeRecipient,
+            protocolFeeRate: _protocolFee,
+            totalFeeRate: totalFeeRate
+        });
+        emit IntentProtocolFeeSnapshotted(_intentHash, _protocolFeeRecipient, _protocolFee);
+    }
+
+    /** @notice Consumes snapshotted protocol terms and distributes every intent fee. */
+    function calculateAndTransferFees(
+        mapping(bytes32 => IntentFeeSnapshot) storage _feeSnapshots,
+        IERC20 _token,
+        bytes32 _intentHash,
+        IOrchestratorV2.Intent memory _intent,
+        uint256 _releaseAmount,
+        address _managerFeeRecipient,
+        uint256 _managerFee
+    ) external returns (uint256 netFees) {
+        IntentFeeSnapshot memory feeSnapshot = _feeSnapshots[_intentHash];
+        delete _feeSnapshots[_intentHash];
+
+        if (feeSnapshot.protocolFeeRecipient != address(0) && feeSnapshot.protocolFeeRate > 0) {
+            uint256 feeAmount = (_releaseAmount * feeSnapshot.protocolFeeRate) / PRECISE_UNIT;
+            netFees = feeAmount;
+            _token.safeTransfer(feeSnapshot.protocolFeeRecipient, feeAmount);
+        }
+        for (uint256 feeIndex = 0; feeIndex < _intent.referralFees.length; feeIndex++) {
+            IReferralFee.ReferralFee memory referralFee = _intent.referralFees[feeIndex];
+            uint256 feeAmount = (_releaseAmount * referralFee.fee) / PRECISE_UNIT;
+            netFees += feeAmount;
+            _token.safeTransfer(referralFee.recipient, feeAmount);
+            emit IntentReferralFeeDistributed(_intentHash, referralFee.recipient, feeAmount);
+        }
+        if (_managerFeeRecipient != address(0) && _managerFee > 0) {
+            uint256 feeAmount = (_releaseAmount * _managerFee) / PRECISE_UNIT;
+            netFees += feeAmount;
+            _token.safeTransfer(_managerFeeRecipient, feeAmount);
+        }
+    }
+}

--- a/contracts/lib/OrchestratorV3RiskLib.sol
+++ b/contracts/lib/OrchestratorV3RiskLib.sol
@@ -78,6 +78,7 @@ library OrchestratorV3RiskLib {
         mapping(bytes32 => IOrchestratorV2.Intent) storage _intents,
         bytes32 _intentHash,
         uint256 _callbackGasLimit,
+        uint256 _postCallGasReserve,
         uint256 _maxReturnData
     ) external {
         IOrchestratorV2.Intent storage intent = _intents[_intentHash];
@@ -89,6 +90,7 @@ library OrchestratorV3RiskLib {
             _intentHash,
             address(intent.settlementHook),
             _callbackGasLimit,
+            _postCallGasReserve,
             _maxReturnData
         );
         _intentRequiresSettlementHook[_intentHash] = requiresSettlementHook;
@@ -107,6 +109,7 @@ library OrchestratorV3RiskLib {
         uint256 _releasedAmount,
         bytes32 _paymentId,
         uint256 _callbackGasLimit,
+        uint256 _postCallGasReserve,
         uint256 _maxReturnData
     ) external {
         bool isSettlement = _resolution != 0;
@@ -125,6 +128,7 @@ library OrchestratorV3RiskLib {
             _releasedAmount,
             _paymentId,
             _callbackGasLimit,
+            _postCallGasReserve,
             _maxReturnData
         );
         RiskCallbackRecorder.recordFailure(

--- a/contracts/lib/OrchestratorV3RiskLib.sol
+++ b/contracts/lib/OrchestratorV3RiskLib.sol
@@ -22,6 +22,7 @@ library OrchestratorV3RiskLib {
     event IntentSettlementRecorded(bytes32 indexed intentHash, uint256 releasedAmount, uint64 settledAt);
 
     error ZeroAddress();
+    error InvalidContract(address account);
     error InvalidRiskHook(address hook);
     error UnauthorizedCallerOrDelegate(address caller, address depositor, address delegate);
 
@@ -33,6 +34,7 @@ library OrchestratorV3RiskLib {
         IIntentRiskHook _hook
     ) external {
         if (_escrow == address(0)) revert ZeroAddress();
+        if (_escrow.code.length == 0) revert InvalidContract(_escrow);
 
         address hookAddress = address(_hook);
         if (hookAddress != address(0) && hookAddress.code.length == 0) {

--- a/contracts/lib/OrchestratorV3RiskLib.sol
+++ b/contracts/lib/OrchestratorV3RiskLib.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { IEscrow } from "../interfaces/IEscrow.sol";
+import { IIntentRiskHook } from "../interfaces/IIntentRiskHook.sol";
+import { IOrchestratorV2 } from "../interfaces/IOrchestratorV2.sol";
+import { IOrchestratorV3 } from "../interfaces/IOrchestratorV3.sol";
+import { BoundedCall } from "./BoundedCall.sol";
+import { OrchestratorV3FeeLib } from "./OrchestratorV3FeeLib.sol";
+import { RiskCallbackRecorder } from "./RiskCallbackRecorder.sol";
+
+/**
+ * @title OrchestratorV3RiskLib
+ * @notice Executes V3 risk-hook selection, admission, and compact intent reads.
+ * @dev The linked library keeps the V3 implementation below the EIP-170 runtime-size limit while
+ *      preserving OrchestratorV3 as the storage, authorization, and event-emitting context.
+ */
+library OrchestratorV3RiskLib {
+    event DepositRiskHookSet(address indexed escrow, uint256 indexed depositId, address indexed hook, address setter);
+    event IntentRiskHookSnapshotted(bytes32 indexed intentHash, address indexed riskHook, bool requiresSettlementHook);
+    event IntentSettlementRecorded(bytes32 indexed intentHash, uint256 releasedAmount, uint64 settledAt);
+
+    error ZeroAddress();
+    error InvalidRiskHook(address hook);
+    error UnauthorizedCallerOrDelegate(address caller, address depositor, address delegate);
+
+    /** @notice Updates the risk hook used by future intents for one depositor-controlled deposit. */
+    function setDepositRiskHook(
+        mapping(address => mapping(uint256 => IIntentRiskHook)) storage _depositRiskHooks,
+        address _escrow,
+        uint256 _depositId,
+        IIntentRiskHook _hook
+    ) external {
+        if (_escrow == address(0)) revert ZeroAddress();
+
+        address hookAddress = address(_hook);
+        if (hookAddress != address(0) && hookAddress.code.length == 0) {
+            revert InvalidRiskHook(hookAddress);
+        }
+
+        IEscrow.Deposit memory deposit = IEscrow(_escrow).getDeposit(_depositId);
+        bool isDepositorOrDelegate = msg.sender == deposit.depositor
+            || (deposit.delegate != address(0) && msg.sender == deposit.delegate);
+        if (!isDepositorOrDelegate) {
+            revert UnauthorizedCallerOrDelegate(msg.sender, deposit.depositor, deposit.delegate);
+        }
+
+        _depositRiskHooks[_escrow][_depositId] = _hook;
+        emit DepositRiskHookSet(_escrow, _depositId, hookAddress, msg.sender);
+    }
+
+    /** @notice Returns the scalar intent fields used by the snapshotted risk hook. */
+    function getRiskIntent(
+        mapping(bytes32 => IOrchestratorV2.Intent) storage _intents,
+        bytes32 _intentHash
+    ) external view returns (IOrchestratorV3.RiskIntentData memory riskIntent) {
+        IOrchestratorV2.Intent storage intent = _intents[_intentHash];
+        riskIntent = IOrchestratorV3.RiskIntentData({
+            owner: intent.owner,
+            to: intent.to,
+            escrow: intent.escrow,
+            depositId: intent.depositId,
+            amount: intent.amount,
+            paymentMethod: intent.paymentMethod,
+            settlementHook: address(intent.settlementHook),
+            createdAt: uint64(intent.timestamp)
+        });
+    }
+
+    /** @notice Snapshots the selected hook and executes fail-closed intent admission. */
+    function snapshotAndAdmit(
+        mapping(address => mapping(uint256 => IIntentRiskHook)) storage _depositRiskHooks,
+        mapping(bytes32 => IIntentRiskHook) storage _intentRiskHooks,
+        mapping(bytes32 => bool) storage _intentRequiresSettlementHook,
+        mapping(bytes32 => IOrchestratorV2.Intent) storage _intents,
+        bytes32 _intentHash,
+        uint256 _callbackGasLimit,
+        uint256 _maxReturnData
+    ) external {
+        IOrchestratorV2.Intent storage intent = _intents[_intentHash];
+        IIntentRiskHook riskHook = _depositRiskHooks[intent.escrow][intent.depositId];
+        _intentRiskHooks[_intentHash] = riskHook;
+
+        bool requiresSettlementHook = BoundedCall.executeRiskAdmission(
+            riskHook,
+            _intentHash,
+            address(intent.settlementHook),
+            _callbackGasLimit,
+            _maxReturnData
+        );
+        _intentRequiresSettlementHook[_intentHash] = requiresSettlementHook;
+        emit IntentRiskHookSnapshotted(_intentHash, address(riskHook), requiresSettlementHook);
+    }
+
+    /** @notice Clears terminal snapshots, invokes the bounded callback, and stores retry data on failure. */
+    function executeTerminalCallback(
+        mapping(bytes32 => IIntentRiskHook) storage _intentRiskHooks,
+        mapping(bytes32 => bool) storage _intentRequiresSettlementHook,
+        mapping(bytes32 => OrchestratorV3FeeLib.IntentFeeSnapshot) storage _intentFeeSnapshots,
+        mapping(bytes32 => IOrchestratorV3.IntentSettlement) storage _failedSettlements,
+        mapping(bytes32 => IOrchestratorV3.IntentCancellation) storage _failedCancellations,
+        bytes32 _intentHash,
+        uint8 _resolution,
+        uint256 _releasedAmount,
+        bytes32 _paymentId,
+        uint256 _callbackGasLimit,
+        uint256 _maxReturnData
+    ) external {
+        bool isSettlement = _resolution != 0;
+        uint64 resolvedAt = uint64(block.timestamp);
+        if (isSettlement) emit IntentSettlementRecorded(_intentHash, _releasedAmount, resolvedAt);
+
+        IIntentRiskHook riskHook = _intentRiskHooks[_intentHash];
+        delete _intentRiskHooks[_intentHash];
+        delete _intentRequiresSettlementHook[_intentHash];
+        if (!isSettlement) delete _intentFeeSnapshots[_intentHash];
+
+        bool callbackSucceeded = BoundedCall.executeTerminalRiskCallback(
+            riskHook,
+            _intentHash,
+            _resolution,
+            _releasedAmount,
+            _paymentId,
+            _callbackGasLimit,
+            _maxReturnData
+        );
+        RiskCallbackRecorder.recordFailure(
+            _failedSettlements,
+            _failedCancellations,
+            _intentHash,
+            _resolution,
+            _releasedAmount,
+            _paymentId,
+            resolvedAt,
+            callbackSucceeded
+        );
+    }
+}

--- a/contracts/lib/OrchestratorV3Validation.sol
+++ b/contracts/lib/OrchestratorV3Validation.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { IOrchestratorV2 } from "../interfaces/IOrchestratorV2.sol";
+import { IOrchestratorV3 } from "../interfaces/IOrchestratorV3.sol";
+
+/**
+ * @title OrchestratorV3Validation
+ * @notice Shared validation for V3-only constructor dependencies.
+ * @dev This library validates deployed code, not implementation identity or code hashes. Registry
+ *      admission remains an explicit governance trust decision.
+ */
+library OrchestratorV3Validation {
+    uint256 internal constant MAX_PROTOCOL_FEE = 5e16;
+
+    /** @notice Validates the V3 constructor inputs that legacy V2 does not validate. */
+    function validateConstructor(
+        uint256 _chainId,
+        address _escrowRegistry,
+        address _paymentVerifierRegistry,
+        address _relayerRegistry,
+        uint256 _protocolFee,
+        address _protocolFeeRecipient
+    ) external view {
+        if (_chainId != block.chainid) {
+            revert IOrchestratorV3.InvalidChainId(_chainId, block.chainid);
+        }
+        if (
+            _escrowRegistry == address(0)
+                || _paymentVerifierRegistry == address(0)
+                || _relayerRegistry == address(0)
+                || _protocolFeeRecipient == address(0)
+        ) {
+            revert IOrchestratorV2.ZeroAddress();
+        }
+        _requireContract(_escrowRegistry);
+        _requireContract(_paymentVerifierRegistry);
+        _requireContract(_relayerRegistry);
+        if (_protocolFee > MAX_PROTOCOL_FEE) {
+            revert IOrchestratorV2.FeeExceedsMaximum(_protocolFee, MAX_PROTOCOL_FEE);
+        }
+    }
+
+    function _requireContract(address _account) private view {
+        if (_account.code.length == 0) revert IOrchestratorV3.InvalidContract(_account);
+    }
+}

--- a/contracts/lib/OrchestratorV3Validation.sol
+++ b/contracts/lib/OrchestratorV3Validation.sol
@@ -2,8 +2,12 @@
 
 pragma solidity ^0.8.18;
 
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import { SignatureChecker } from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+
 import { IOrchestratorV2 } from "../interfaces/IOrchestratorV2.sol";
 import { IOrchestratorV3 } from "../interfaces/IOrchestratorV3.sol";
+import { ReferralFeeLib } from "./ReferralFeeLib.sol";
 
 /**
  * @title OrchestratorV3Validation
@@ -12,7 +16,21 @@ import { IOrchestratorV3 } from "../interfaces/IOrchestratorV3.sol";
  *      admission remains an explicit governance trust decision.
  */
 library OrchestratorV3Validation {
+    using ECDSA for bytes32;
+    using SignatureChecker for address;
+
     uint256 internal constant MAX_PROTOCOL_FEE = 5e16;
+    bytes32 internal constant INTENT_GATING_AUTHORIZATION_TYPEHASH = keccak256(
+        "IntentGatingAuthorization(address verifyingOrchestrator,uint256 chainId,address taker,address escrow,uint256 depositId,uint256 amount,address recipient,bytes32 paymentMethod,bytes32 fiatCurrency,uint256 conversionRate,bytes32 referralFeesHash,address settlementHook,bytes32 preIntentHookDataHash,bytes32 signalHookDataHash,uint256 signatureExpiration,uint256 nonce)"
+    );
+
+    event IntentGatingAuthorizationConsumed(
+        address indexed taker,
+        address indexed escrow,
+        uint256 indexed depositId,
+        bytes32 paymentMethod,
+        uint256 nonce
+    );
 
     /** @notice Validates the V3 constructor inputs that legacy V2 does not validate. */
     function validateConstructor(
@@ -42,6 +60,102 @@ library OrchestratorV3Validation {
         }
     }
 
+    /** @notice Returns the current nonce for one taker's deposit/payment-method authorization stream. */
+    function intentGatingNonce(
+        mapping(bytes32 => uint256) storage _nonces,
+        address _taker,
+        address _escrow,
+        uint256 _depositId,
+        bytes32 _paymentMethod
+    ) external view returns (uint256) {
+        return _nonces[keccak256(abi.encode(_taker, _escrow, _depositId, _paymentMethod))];
+    }
+
+    /** @notice Returns the unprefixed V3 gating authorization hash for the current scoped nonce. */
+    function currentIntentGatingMessageHash(
+        mapping(bytes32 => uint256) storage _nonces,
+        IOrchestratorV2.SignalIntentParams calldata _params,
+        address _taker,
+        address _verifyingOrchestrator,
+        uint256 _chainId
+    ) external view returns (bytes32) {
+        bytes32 scope = keccak256(
+            abi.encode(_taker, _params.escrow, _params.depositId, _params.paymentMethod)
+        );
+        return _intentGatingMessageHash(
+            _params,
+            _taker,
+            _verifyingOrchestrator,
+            _chainId,
+            _nonces[scope]
+        );
+    }
+
+    /** @notice Consumes the current scoped nonce and verifies a single-use V3 authorization. */
+    function validateAndConsumeIntentGatingAuthorization(
+        mapping(bytes32 => uint256) storage _nonces,
+        IOrchestratorV2.SignalIntentParams calldata _params,
+        address _intentGatingService,
+        address _taker,
+        address _verifyingOrchestrator,
+        uint256 _chainId
+    ) external {
+        bytes32 scope = keccak256(
+            abi.encode(_taker, _params.escrow, _params.depositId, _params.paymentMethod)
+        );
+        uint256 nonce = _nonces[scope];
+        _nonces[scope] = nonce + 1;
+
+        bytes32 messageHash = _intentGatingMessageHash(
+            _params,
+            _taker,
+            _verifyingOrchestrator,
+            _chainId,
+            nonce
+        );
+        if (!_intentGatingService.isValidSignatureNow(
+            messageHash.toEthSignedMessageHash(),
+            _params.gatingServiceSignature
+        )) {
+            revert IOrchestratorV2.InvalidSignature();
+        }
+
+        emit IntentGatingAuthorizationConsumed(
+            _taker,
+            _params.escrow,
+            _params.depositId,
+            _params.paymentMethod,
+            nonce
+        );
+    }
+
+    function _intentGatingMessageHash(
+        IOrchestratorV2.SignalIntentParams calldata _params,
+        address _taker,
+        address _verifyingOrchestrator,
+        uint256 _chainId,
+        uint256 _nonce
+    ) private pure returns (bytes32) {
+        return keccak256(abi.encode(
+            INTENT_GATING_AUTHORIZATION_TYPEHASH,
+            _verifyingOrchestrator,
+            _chainId,
+            _taker,
+            _params.escrow,
+            _params.depositId,
+            _params.amount,
+            _params.to,
+            _params.paymentMethod,
+            _params.fiatCurrency,
+            _params.conversionRate,
+            ReferralFeeLib.hashReferralFees(_params.referralFees),
+            address(_params.settlementHook),
+            keccak256(_params.preIntentHookData),
+            keccak256(_params.data),
+            _params.signatureExpiration,
+            _nonce
+        ));
+    }
     function _requireContract(address _account) private view {
         if (_account.code.length == 0) revert IOrchestratorV3.InvalidContract(_account);
     }

--- a/contracts/lib/RiskCallbackRecorder.sol
+++ b/contracts/lib/RiskCallbackRecorder.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { IOrchestratorV3 } from "../interfaces/IOrchestratorV3.sol";
+
+/**
+ * @title RiskCallbackRecorder
+ * @notice Records retry data when a fail-open terminal risk callback does not complete.
+ */
+library RiskCallbackRecorder {
+    event IntentCancellationRecorded(bytes32 indexed intentHash, uint64 cancelledAt);
+
+    /** @notice Stores the canonical terminal data only when the callback failed. */
+    function recordFailure(
+        mapping(bytes32 => IOrchestratorV3.IntentSettlement) storage _failedSettlements,
+        mapping(bytes32 => IOrchestratorV3.IntentCancellation) storage _failedCancellations,
+        bytes32 _intentHash,
+        uint8 _resolution,
+        uint256 _releasedAmount,
+        bytes32 _paymentId,
+        uint64 _resolvedAt,
+        bool _callbackSucceeded
+    ) external {
+        if (_callbackSucceeded) return;
+        if (_resolution != 0) {
+            _failedSettlements[_intentHash] = IOrchestratorV3.IntentSettlement({
+                releasedAmount: _releasedAmount,
+                paymentId: _paymentId,
+                settledAt: _resolvedAt
+            });
+        } else {
+            _failedCancellations[_intentHash] = IOrchestratorV3.IntentCancellation({
+                cancelledAt: _resolvedAt
+            });
+            emit IntentCancellationRecorded(_intentHash, _resolvedAt);
+        }
+    }
+}

--- a/contracts/mocks/IntentRiskHookMock.sol
+++ b/contracts/mocks/IntentRiskHookMock.sol
@@ -11,7 +11,9 @@ import { IIntentRiskHook } from "../interfaces/IIntentRiskHook.sol";
 contract IntentRiskHookMock is IIntentRiskHook {
     bool public requiresSettlementHook;
     bool public revertOnCreate;
+    bool public consumeAllCreateGas;
     bool public revertOnTerminal;
+    bool public consumeAllTerminalGas;
     uint256 public terminalRevertDataSize;
     bytes32 public lastIntentHash;
     bytes32 public lastPaymentId;
@@ -29,8 +31,16 @@ contract IntentRiskHookMock is IIntentRiskHook {
         revertOnCreate = _shouldRevert;
     }
 
+    function setConsumeAllCreateGas(bool _shouldConsume) external {
+        consumeAllCreateGas = _shouldConsume;
+    }
+
     function setRevertOnTerminal(bool _shouldRevert) external {
         revertOnTerminal = _shouldRevert;
+    }
+
+    function setConsumeAllTerminalGas(bool _shouldConsume) external {
+        consumeAllTerminalGas = _shouldConsume;
     }
 
     function setTerminalRevertDataSize(uint256 _size) external {
@@ -38,6 +48,11 @@ contract IntentRiskHookMock is IIntentRiskHook {
     }
 
     function onIntentCreated(bytes32 _intentHash) external override returns (bool) {
+        if (consumeAllCreateGas) {
+            assembly ("memory-safe") {
+                invalid()
+            }
+        }
         if (revertOnCreate) revert("risk admission failed");
         lastIntentHash = _intentHash;
         createdCalls++;
@@ -73,6 +88,11 @@ contract IntentRiskHookMock is IIntentRiskHook {
     }
 
     function _revertWithConfiguredData() internal view {
+        if (consumeAllTerminalGas) {
+            assembly ("memory-safe") {
+                invalid()
+            }
+        }
         uint256 revertDataSize = terminalRevertDataSize;
         if (revertDataSize == 0) return;
 

--- a/contracts/mocks/RiskManagerHarnessMocks.sol
+++ b/contracts/mocks/RiskManagerHarnessMocks.sol
@@ -62,6 +62,7 @@ contract RiskManagerStateHarness is RiskManager {
  */
 contract RiskManagerOrchestratorHarness {
     mapping(bytes32 => IOrchestratorV3.RiskIntentData) internal riskIntents;
+    mapping(bytes32 => uint256) internal totalFeeRates;
     mapping(bytes32 => uint64) internal cancellationTimes;
     mapping(bytes32 => IOrchestratorV3.IntentSettlement) internal settlements;
 
@@ -89,8 +90,16 @@ contract RiskManagerOrchestratorHarness {
         );
     }
 
+    function setIntentTotalFeeRate(bytes32 _intentHash, uint256 _totalFeeRate) external {
+        totalFeeRates[_intentHash] = _totalFeeRate;
+    }
+
     function getRiskIntent(bytes32 _intentHash) external view returns (IOrchestratorV3.RiskIntentData memory) {
         return riskIntents[_intentHash];
+    }
+
+    function getIntentTotalFeeRate(bytes32 _intentHash) external view returns (uint256) {
+        return totalFeeRates[_intentHash];
     }
 
     function getIntentCancellation(bytes32 _intentHash) external view returns (uint64) {

--- a/deploy/26_deploy_stake_risk_system.ts
+++ b/deploy/26_deploy_stake_risk_system.ts
@@ -33,6 +33,9 @@ const LOCAL_CHARGEBACK_WITNESSES = [
 const STAKE_RISK_DEPLOYMENT_NAMES = [
   "BoundedCall",
   "PostIntentHookExecutor",
+  "OrchestratorV3FeeLib",
+  "RiskCallbackRecorder",
+  "OrchestratorV3RiskLib",
   "OrchestratorV3",
   "StakeVault",
   "ChargebackAttestationVerifier",
@@ -147,11 +150,33 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log("PostIntentHookExecutor deployed at", postIntentHookExecutor.address);
   if (postIntentHookExecutor.newlyDeployed) await waitForDeploymentDelay(hre);
 
+
+  const orchestratorV3FeeLib = await deploy("OrchestratorV3FeeLib", { from: deployer, args: [] });
+  console.log("OrchestratorV3FeeLib deployed at", orchestratorV3FeeLib.address);
+  if (orchestratorV3FeeLib.newlyDeployed) await waitForDeploymentDelay(hre);
+
+  const riskCallbackRecorder = await deploy("RiskCallbackRecorder", { from: deployer, args: [] });
+  console.log("RiskCallbackRecorder deployed at", riskCallbackRecorder.address);
+  if (riskCallbackRecorder.newlyDeployed) await waitForDeploymentDelay(hre);
+
+  const orchestratorV3RiskLib = await deploy("OrchestratorV3RiskLib", {
+    from: deployer,
+    libraries: {
+      BoundedCall: boundedCall.address,
+      RiskCallbackRecorder: riskCallbackRecorder.address,
+    },
+    args: [],
+  });
+  console.log("OrchestratorV3RiskLib deployed at", orchestratorV3RiskLib.address);
+  if (orchestratorV3RiskLib.newlyDeployed) await waitForDeploymentDelay(hre);
+
   const orchestratorV3 = await deploy("OrchestratorV3", {
     from: deployer,
     libraries: {
       BoundedCall: boundedCall.address,
       PostIntentHookExecutor: postIntentHookExecutor.address,
+      OrchestratorV3FeeLib: orchestratorV3FeeLib.address,
+      OrchestratorV3RiskLib: orchestratorV3RiskLib.address,
     },
     args: [
       deployer,

--- a/deploy/26_deploy_stake_risk_system.ts
+++ b/deploy/26_deploy_stake_risk_system.ts
@@ -33,6 +33,7 @@ const LOCAL_CHARGEBACK_WITNESSES = [
 const STAKE_RISK_DEPLOYMENT_NAMES = [
   "BoundedCall",
   "PostIntentHookExecutor",
+  "OrchestratorV3Validation",
   "OrchestratorV3FeeLib",
   "RiskCallbackRecorder",
   "OrchestratorV3RiskLib",
@@ -150,6 +151,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log("PostIntentHookExecutor deployed at", postIntentHookExecutor.address);
   if (postIntentHookExecutor.newlyDeployed) await waitForDeploymentDelay(hre);
 
+  const orchestratorV3Validation = await deploy("OrchestratorV3Validation", { from: deployer, args: [] });
+  console.log("OrchestratorV3Validation deployed at", orchestratorV3Validation.address);
+  if (orchestratorV3Validation.newlyDeployed) await waitForDeploymentDelay(hre);
 
   const orchestratorV3FeeLib = await deploy("OrchestratorV3FeeLib", { from: deployer, args: [] });
   console.log("OrchestratorV3FeeLib deployed at", orchestratorV3FeeLib.address);
@@ -175,6 +179,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     libraries: {
       BoundedCall: boundedCall.address,
       PostIntentHookExecutor: postIntentHookExecutor.address,
+      OrchestratorV3Validation: orchestratorV3Validation.address,
       OrchestratorV3FeeLib: orchestratorV3FeeLib.address,
       OrchestratorV3RiskLib: orchestratorV3RiskLib.address,
     },

--- a/deploy/28_deploy_payment_id_risk_system.ts
+++ b/deploy/28_deploy_payment_id_risk_system.ts
@@ -35,6 +35,7 @@ export const PAYMENT_ID_RISK_DEPLOYMENT_NAMES = [
   "PaymentVerifierRegistryV3",
   "UnifiedPaymentVerifierV3",
   "BoundedCallPaymentId",
+  "OrchestratorV3ValidationPaymentId",
   "OrchestratorV3FeeLibPaymentId",
   "RiskCallbackRecorderPaymentId",
   "OrchestratorV3RiskLibPaymentId",
@@ -222,6 +223,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     from: deployer,
     args: [],
   });
+  const orchestratorV3Validation = await deploy("OrchestratorV3ValidationPaymentId", {
+    contract: "OrchestratorV3Validation",
+    from: deployer,
+    args: [],
+  });
   const orchestratorV3FeeLib = await deploy("OrchestratorV3FeeLibPaymentId", {
     contract: "OrchestratorV3FeeLib",
     from: deployer,
@@ -247,6 +253,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     libraries: {
       BoundedCall: boundedCall.address,
       PostIntentHookExecutor: postIntentHookExecutorAddress,
+      OrchestratorV3Validation: orchestratorV3Validation.address,
       OrchestratorV3FeeLib: orchestratorV3FeeLib.address,
       OrchestratorV3RiskLib: orchestratorV3RiskLib.address,
     },

--- a/deploy/28_deploy_payment_id_risk_system.ts
+++ b/deploy/28_deploy_payment_id_risk_system.ts
@@ -35,6 +35,9 @@ export const PAYMENT_ID_RISK_DEPLOYMENT_NAMES = [
   "PaymentVerifierRegistryV3",
   "UnifiedPaymentVerifierV3",
   "BoundedCallPaymentId",
+  "OrchestratorV3FeeLibPaymentId",
+  "RiskCallbackRecorderPaymentId",
+  "OrchestratorV3RiskLibPaymentId",
   "OrchestratorV3PaymentId",
   "StakeVaultPaymentId",
   "ChargebackAttestationVerifierPaymentId",
@@ -219,12 +222,33 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     from: deployer,
     args: [],
   });
+  const orchestratorV3FeeLib = await deploy("OrchestratorV3FeeLibPaymentId", {
+    contract: "OrchestratorV3FeeLib",
+    from: deployer,
+    args: [],
+  });
+  const riskCallbackRecorder = await deploy("RiskCallbackRecorderPaymentId", {
+    contract: "RiskCallbackRecorder",
+    from: deployer,
+    args: [],
+  });
+  const orchestratorV3RiskLib = await deploy("OrchestratorV3RiskLibPaymentId", {
+    contract: "OrchestratorV3RiskLib",
+    from: deployer,
+    libraries: {
+      BoundedCall: boundedCall.address,
+      RiskCallbackRecorder: riskCallbackRecorder.address,
+    },
+    args: [],
+  });
   const orchestratorV3 = await deploy("OrchestratorV3PaymentId", {
     contract: "OrchestratorV3",
     from: deployer,
     libraries: {
       BoundedCall: boundedCall.address,
       PostIntentHookExecutor: postIntentHookExecutorAddress,
+      OrchestratorV3FeeLib: orchestratorV3FeeLib.address,
+      OrchestratorV3RiskLib: orchestratorV3RiskLib.address,
     },
     args: [
       deployer,

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,8 @@ libs = ['node_modules', 'lib']
 test = 'test-foundry'
 cache_path = 'cache_forge'
 optimizer = true
-optimizer_runs = 800
+# Match the Hardhat deployment compiler profile so Foundry size checks model deployable bytecode.
+optimizer_runs = 200
 solc_version = '0.8.18'
 via_ir = true
 

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -177,12 +177,12 @@ The current repository source builds additional exports for the merged v3 archit
 
 - `@zkp2p/contracts-v2/abis/contracts`: source ABIs for `OrchestratorV3`, `RiskManager`, `StakeVault`,
   and `DeferredPayoutHook`, independent of a network deployment.
-- `@zkp2p/contracts-v2/utils/riskMath`: exact `bigint` helpers for affine reservation, capacity, and
-  elapsed cancellation-penalty calculations.
+- `@zkp2p/contracts-v2/utils/riskMath`: exact `bigint` helpers for affine reservation, hybrid deferred
+  fee-gap reservation, capacity, and elapsed cancellation-penalty calculations.
 
 These paths are development source until a later package version is built, validated, and published.
 They must not be imported from npm `0.3.0`. Network-specific v3 address exports describe the recorded
-Base staging affine deployment and do not imply that the final direct-chargeback implementation is live.
+Base staging affine deployment and do not imply that the final hybrid direct-chargeback implementation is live.
 
 ### Export Format Details
 

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -213,6 +213,26 @@ Latest npm version: `0.3.0` (does not include the unpublished source exports abo
 
 ## Development
 
+### OrchestratorV3 gating-signature migration
+
+`OrchestratorV3` treats a deposit gating signature as a single-intent authorization. The
+`SignalIntentParams` tuple is unchanged, but legacy reusable V2 signatures are not valid on V3.
+Curator and client signers must:
+
+1. Build the final `SignalIntentParams`, leaving `gatingServiceSignature` empty.
+2. Read `getIntentGatingNonce(taker, escrow, depositId, paymentMethod)` if the nonce is needed for
+   observability or caching.
+3. Call `getIntentGatingMessageHash(params, taker)` on the exact orchestrator that will receive the
+   intent.
+4. Sign the returned 32-byte hash with EIP-191 `personal_sign`/`signMessage` and place the result in
+   `gatingServiceSignature`.
+
+The signed hash binds the taker, recipient, amount, escrow, deposit, payment method, fiat currency,
+conversion rate, referral fees, settlement hook, pre-intent hook data, persisted signal hook data,
+expiry, chain id, verifying orchestrator, and current scoped nonce. A successful gated intent
+increments the nonce. Failed transactions roll it back, and deposits without a gating service do not
+consume a nonce. Nonces are independent per `(taker, escrow, depositId, paymentMethod)`.
+
 ### Build & Publish
 
 From `packages/contracts`:

--- a/packages/contracts/test/riskMath.spec.ts
+++ b/packages/contracts/test/riskMath.spec.ts
@@ -1,8 +1,10 @@
 import {
   calculateBondedTakingCapacity,
   calculateChargebackReserve,
+  calculateDeferredFeeGapUpperBound,
   calculateFreeTakeCapacity,
   calculateGriefingPenalty,
+  calculateHybridDeferredReservation,
   calculateMaxGriefingBond,
   calculateRequiredReservation,
 } from "../utils/riskMath";
@@ -33,6 +35,25 @@ describe("riskMath", () => {
 
   it("takes the maximum of griefing and chargeback requirements", () => {
     expect(calculateRequiredReservation(1_000_000_000n, terms, 10_000)).toBe(1_000_000_000n);
+  });
+
+  it("floors the aggregate deferred fee-gap upper bound in token units", () => {
+    expect(calculateDeferredFeeGapUpperBound(700_000_000n, 30_000_000_000_000_000n)).toBe(21_000_000n);
+    expect(calculateDeferredFeeGapUpperBound(700_000_000n, 1n)).toBe(0n);
+  });
+
+  it("reserves the maximum rather than summing griefing and deferred fee-gap exposure", () => {
+    expect(calculateHybridDeferredReservation(
+      700_000_000n,
+      terms,
+      30_000_000_000_000_000n,
+    )).toBe(21_000_000n);
+    expect(calculateHybridDeferredReservation(700_000_000n, terms, 0n)).toBe(4_025_000n);
+  });
+
+  it("rejects a deferred fee rate above 100 percent", () => {
+    expect(() => calculateDeferredFeeGapUpperBound(100n, 1_000_000_000_000_000_001n))
+      .toThrow("totalFeeRate");
   });
 
   it("charges nothing at the griefing cliff", () => {

--- a/test-foundry/fuzz/RiskManagerMathFuzz.t.sol
+++ b/test-foundry/fuzz/RiskManagerMathFuzz.t.sol
@@ -125,4 +125,33 @@ contract RiskManagerMathFuzzTest is Test {
         assertLe(griefing, amount);
         assertLe(chargeback, amount);
     }
+
+    function testFuzz_FeasibleAggregateFeesAlwaysFundRoundedReserve(
+        uint96 rawReleaseAmount,
+        uint16 rawReserveBps,
+        uint64 rawProtocolFee,
+        uint64 rawManagerFee,
+        uint64 rawReferralFee
+    ) public pure {
+        uint256 preciseUnit = 1e18;
+        uint256 releaseAmount = bound(uint256(rawReleaseAmount), 1, type(uint96).max);
+        uint16 reserveBps = uint16(bound(uint256(rawReserveBps), 1, 10_000));
+        uint256 reserveRate = uint256(reserveBps) * 1e14;
+        uint256 feeCapacity = preciseUnit - reserveRate;
+        uint256 protocolFee = bound(uint256(rawProtocolFee), 0, feeCapacity);
+        uint256 managerFee = bound(uint256(rawManagerFee), 0, feeCapacity - protocolFee);
+        uint256 referralFee = bound(
+            uint256(rawReferralFee),
+            0,
+            feeCapacity - protocolFee - managerFee
+        );
+
+        uint256 actualFees = (releaseAmount * protocolFee) / preciseUnit
+            + (releaseAmount * managerFee) / preciseUnit
+            + (releaseAmount * referralFee) / preciseUnit;
+        uint256 netProceeds = releaseAmount - actualFees;
+        uint256 roundedReserve = (releaseAmount * reserveBps + 9_999) / 10_000;
+
+        assertGe(netProceeds, roundedReserve);
+    }
 }

--- a/test-foundry/fuzz/RiskManagerMathFuzz.t.sol
+++ b/test-foundry/fuzz/RiskManagerMathFuzz.t.sol
@@ -126,32 +126,53 @@ contract RiskManagerMathFuzzTest is Test {
         assertLe(chargeback, amount);
     }
 
-    function testFuzz_FeasibleAggregateFeesAlwaysFundRoundedReserve(
+    function testFuzz_AggregateFeeFloorUpperBoundsEveryPartialRelease(
+        uint96 rawIntentAmount,
         uint96 rawReleaseAmount,
-        uint16 rawReserveBps,
         uint64 rawProtocolFee,
         uint64 rawManagerFee,
         uint64 rawReferralFee
     ) public pure {
         uint256 preciseUnit = 1e18;
-        uint256 releaseAmount = bound(uint256(rawReleaseAmount), 1, type(uint96).max);
-        uint16 reserveBps = uint16(bound(uint256(rawReserveBps), 1, 10_000));
-        uint256 reserveRate = uint256(reserveBps) * 1e14;
-        uint256 feeCapacity = preciseUnit - reserveRate;
-        uint256 protocolFee = bound(uint256(rawProtocolFee), 0, feeCapacity);
-        uint256 managerFee = bound(uint256(rawManagerFee), 0, feeCapacity - protocolFee);
-        uint256 referralFee = bound(
-            uint256(rawReferralFee),
-            0,
-            feeCapacity - protocolFee - managerFee
-        );
+        uint256 intentAmount = bound(uint256(rawIntentAmount), 1, type(uint96).max);
+        uint256 releaseAmount = bound(uint256(rawReleaseAmount), 1, intentAmount);
+        uint256 protocolFee = bound(uint256(rawProtocolFee), 0, 0.05e18);
+        uint256 managerFee = bound(uint256(rawManagerFee), 0, 0.40e18);
+        uint256 referralFee = bound(uint256(rawReferralFee), 0, 0.15e18);
+        uint256 aggregateRate = protocolFee + managerFee + referralFee;
 
         uint256 actualFees = (releaseAmount * protocolFee) / preciseUnit
             + (releaseAmount * managerFee) / preciseUnit
             + (releaseAmount * referralFee) / preciseUnit;
-        uint256 netProceeds = releaseAmount - actualFees;
-        uint256 roundedReserve = (releaseAmount * reserveBps + 9_999) / 10_000;
+        uint256 releaseUpperBound = (releaseAmount * aggregateRate) / preciseUnit;
+        uint256 admissionUpperBound = (intentAmount * aggregateRate) / preciseUnit;
 
-        assertGe(netProceeds, roundedReserve);
+        assertLe(actualFees, releaseUpperBound);
+        assertLe(releaseUpperBound, admissionUpperBound);
+    }
+
+    function testFuzz_HybridCoverageEqualsGrossReleaseAndNeverNeedsMoreStake(
+        uint96 rawIntentAmount,
+        uint96 rawReleaseAmount,
+        uint64 rawProtocolFee,
+        uint64 rawManagerFee,
+        uint64 rawReferralFee
+    ) public pure {
+        uint256 preciseUnit = 1e18;
+        uint256 intentAmount = bound(uint256(rawIntentAmount), 1, type(uint96).max);
+        uint256 releaseAmount = bound(uint256(rawReleaseAmount), 1, intentAmount);
+        uint256 protocolFee = bound(uint256(rawProtocolFee), 0, 0.05e18);
+        uint256 managerFee = bound(uint256(rawManagerFee), 0, 0.40e18);
+        uint256 referralFee = bound(uint256(rawReferralFee), 0, 0.15e18);
+        uint256 aggregateRate = protocolFee + managerFee + referralFee;
+
+        uint256 exactFeeGap = (releaseAmount * protocolFee) / preciseUnit
+            + (releaseAmount * managerFee) / preciseUnit
+            + (releaseAmount * referralFee) / preciseUnit;
+        uint256 deferredCoverage = releaseAmount - exactFeeGap;
+        uint256 admissionStakeCoverage = (intentAmount * aggregateRate) / preciseUnit;
+
+        assertEq(deferredCoverage + exactFeeGap, releaseAmount);
+        assertLe(exactFeeGap, admissionStakeCoverage);
     }
 }

--- a/test-foundry/invariant/RiskManagerInvariant.t.sol
+++ b/test-foundry/invariant/RiskManagerInvariant.t.sol
@@ -99,6 +99,10 @@ contract RiskManagerInvariantHandler is Test {
         return intents[_intentHash];
     }
 
+    function getIntentTotalFeeRate(bytes32) external pure returns (uint256) {
+        return 0;
+    }
+
     function getIntentSettlement(bytes32) external pure returns (uint256, bytes32, uint64) {
         return (0, bytes32(0), 0);
     }

--- a/test-foundry/invariant/RiskManagerInvariant.t.sol
+++ b/test-foundry/invariant/RiskManagerInvariant.t.sol
@@ -38,14 +38,19 @@ contract RiskManagerInvariantHandler is Test {
 
     RiskManager public manager;
     RiskInvariantEscrow public immutable escrow;
+    StakeVault public immutable vault;
+    IERC20 public immutable token;
     address public immutable stakeOwner;
     uint256 public nonce;
 
     mapping(bytes32 => IOrchestratorV3.RiskIntentData) internal intents;
+    mapping(bytes32 => uint256) internal totalFeeRates;
     bytes32[] internal intentHashes;
 
-    constructor(RiskInvariantEscrow _escrow, address _stakeOwner) {
+    constructor(RiskInvariantEscrow _escrow, StakeVault _vault, address _stakeOwner) {
         escrow = _escrow;
+        vault = _vault;
+        token = _escrow.token();
         stakeOwner = _stakeOwner;
     }
 
@@ -54,9 +59,48 @@ contract RiskManagerInvariantHandler is Test {
         manager = _manager;
     }
 
-    function create(uint96 rawAmount, bool chargebackable) external {
-        uint256 amount = bound(uint256(rawAmount), 1, 10_000e6);
-        bytes32 intentHash = keccak256(abi.encode(++nonce, amount, chargebackable));
+    function create(
+        uint96 rawAmount,
+        bool chargebackable,
+        bool useDeferredPayout,
+        uint16 rawFeeBps
+    ) external {
+        uint256 availableStake = vault.freeStake(stakeOwner);
+        uint256 amount;
+        uint256 totalFeeRate;
+        address settlementHook;
+
+        if (chargebackable && useDeferredPayout) {
+            if (availableStake == 0 || availableStake >= 10_000e6) return;
+            amount = bound(uint256(rawAmount), availableStake + 1, 10_000e6);
+            uint256 feeBps = bound(uint256(rawFeeBps), 0, 500);
+            totalFeeRate = feeBps * 1e14;
+            uint256 feeGapUpperBound = (amount * totalFeeRate) / 1e18;
+            uint256 maxGriefingBond = manager.calculateMaxGriefingBond(
+                amount,
+                6 hours,
+                IRiskManager.GriefingConfig({
+                    griefingCliff: 15 minutes,
+                    griefingPenaltyBpsPerHour: 10,
+                    freeTakeCount: 0,
+                    freeTakeAmount: 0
+                })
+            );
+            uint256 hybridReservation = feeGapUpperBound > maxGriefingBond
+                ? feeGapUpperBound
+                : maxGriefingBond;
+            if (hybridReservation > availableStake) return;
+            settlementHook = address(this);
+        } else if (chargebackable) {
+            if (availableStake == 0) return;
+            amount = bound(uint256(rawAmount), 1, availableStake < 10_000e6 ? availableStake : 10_000e6);
+        } else {
+            amount = bound(uint256(rawAmount), 1, 10_000e6);
+        }
+
+        bytes32 intentHash = keccak256(
+            abi.encode(++nonce, amount, chargebackable, useDeferredPayout, totalFeeRate)
+        );
         intents[intentHash] = IOrchestratorV3.RiskIntentData({
             owner: stakeOwner,
             to: stakeOwner,
@@ -64,14 +108,16 @@ contract RiskManagerInvariantHandler is Test {
             depositId: 0,
             amount: amount,
             paymentMethod: chargebackable ? PAYPAL : ZELLE,
-            settlementHook: address(0),
+            settlementHook: settlementHook,
             createdAt: uint64(block.timestamp)
         });
+        totalFeeRates[intentHash] = totalFeeRate;
 
         try manager.onIntentCreated(intentHash) {
             intentHashes.push(intentHash);
         } catch {
             delete intents[intentHash];
+            delete totalFeeRates[intentHash];
         }
     }
 
@@ -92,15 +138,48 @@ contract RiskManagerInvariantHandler is Test {
         uint256 releasedAmount = bound(uint256(rawReleasedAmount), 1, position.intentAmount);
         bytes32 paymentId = keccak256(abi.encodePacked("payment", intentHash));
         manager.onIntentFulfilled(intentHash, releasedAmount, paymentId);
+        if (position.mode == IRiskManager.RiskMode.DEFERRED_PAYOUT) {
+            uint256 feeGap = (releasedAmount * totalFeeRates[intentHash]) / 1e18;
+            uint256 deferredCoverage = releasedAmount - feeGap;
+            require(token.transfer(address(vault), deferredCoverage), "deferred transfer failed");
+            manager.registerDeferredPayout(intentHash, stakeOwner, deferredCoverage);
+        }
         delete intents[intentHash];
+    }
+
+    function chargeback(uint256 rawIndex) external {
+        if (intentHashes.length == 0) return;
+        bytes32 intentHash = intentHashes[rawIndex % intentHashes.length];
+        IRiskManager.RiskPosition memory position = manager.getRiskPosition(intentHash);
+        if (position.status != IRiskManager.PositionStatus.SETTLED) return;
+        manager.submitChargeback(IRiskManager.ChargebackAttestation({
+            intentHash: intentHash,
+            originalPaymentId: position.paymentId,
+            disputeId: keccak256(abi.encode("dispute", intentHash, ++nonce)),
+            signatures: new bytes[](0)
+        }));
+    }
+
+    function mature(uint256 rawIndex) external {
+        if (intentHashes.length == 0) return;
+        bytes32 intentHash = intentHashes[rawIndex % intentHashes.length];
+        IRiskManager.RiskPosition memory position = manager.getRiskPosition(intentHash);
+        if (position.status != IRiskManager.PositionStatus.SETTLED) return;
+        if (block.timestamp < position.coverageDeadline) vm.warp(position.coverageDeadline);
+        manager.releaseMaturedPosition(intentHash);
+        IStakeVault.DeferredPayout memory payout = vault.getDeferredPayout(intentHash);
+        if (payout.amount != 0) {
+            vm.prank(stakeOwner);
+            vault.withdrawDeferredPayout(intentHash, stakeOwner);
+        }
     }
 
     function getRiskIntent(bytes32 _intentHash) external view returns (IOrchestratorV3.RiskIntentData memory) {
         return intents[_intentHash];
     }
 
-    function getIntentTotalFeeRate(bytes32) external pure returns (uint256) {
-        return 0;
+    function getIntentTotalFeeRate(bytes32 _intentHash) external view returns (uint256) {
+        return totalFeeRates[_intentHash];
     }
 
     function getIntentSettlement(bytes32) external pure returns (uint256, bytes32, uint64) {
@@ -136,9 +215,9 @@ contract RiskManagerInvariantTest is StdInvariant, Test {
         vm.warp(1_000_000);
         token = new USDCMock(2_000_000e6, "USD Coin", "USDC");
         RiskInvariantEscrow escrow = new RiskInvariantEscrow(lp, token);
-        handler = new RiskManagerInvariantHandler(escrow, stakeOwner);
-        AttestationVerifierMock verifier = new AttestationVerifierMock();
         vault = new StakeVault(address(this), token, address(0), 30 days, 1 days);
+        handler = new RiskManagerInvariantHandler(escrow, vault, stakeOwner);
+        AttestationVerifierMock verifier = new AttestationVerifierMock();
         manager = new RiskManager(
             address(this),
             IOrchestratorV3(address(handler)),
@@ -158,12 +237,13 @@ contract RiskManagerInvariantTest is StdInvariant, Test {
             enabled: true,
             chargeback: IRiskManager.ChargebackConfig({
                 chargebackable: true,
-                deferredPayoutEnabled: false,
+                deferredPayoutEnabled: true,
                 reserveBps: 10_000,
                 riskWindow: 30 days
             }),
             griefing: griefing
         }));
+        manager.setDeferredPayoutHook(address(handler));
         griefing.freeTakeCount = 2;
         griefing.freeTakeAmount = 20e6;
         manager.setPlatformRiskConfig(ZELLE, IRiskManager.PlatformRiskConfig({
@@ -177,16 +257,19 @@ contract RiskManagerInvariantTest is StdInvariant, Test {
             griefing: griefing
         }));
 
-        deal(address(token), stakeOwner, 1_000_000e6);
+        deal(address(token), stakeOwner, 1_000e6);
         vm.startPrank(stakeOwner);
         token.approve(address(vault), type(uint256).max);
-        vault.depositStake(1_000_000e6);
+        vault.depositStake(1_000e6);
         vm.stopPrank();
+        deal(address(token), address(handler), 2_000_000e6);
 
-        bytes4[] memory selectors = new bytes4[](3);
+        bytes4[] memory selectors = new bytes4[](5);
         selectors[0] = RiskManagerInvariantHandler.create.selector;
         selectors[1] = RiskManagerInvariantHandler.cancel.selector;
         selectors[2] = RiskManagerInvariantHandler.settle.selector;
+        selectors[3] = RiskManagerInvariantHandler.chargeback.selector;
+        selectors[4] = RiskManagerInvariantHandler.mature.selector;
         targetSelector(FuzzSelector({ addr: address(handler), selectors: selectors }));
     }
 
@@ -200,7 +283,10 @@ contract RiskManagerInvariantTest is StdInvariant, Test {
         for (uint256 index = 0; index < handler.hashCount(); index++) {
             IRiskManager.RiskPosition memory position = manager.getRiskPosition(handler.hashAt(index));
             if (
-                position.mode == IRiskManager.RiskMode.STAKE_BACKED
+                (
+                    position.mode == IRiskManager.RiskMode.STAKE_BACKED
+                        || position.mode == IRiskManager.RiskMode.DEFERRED_PAYOUT
+                )
                     && (
                         position.status == IRiskManager.PositionStatus.PENDING
                             || position.status == IRiskManager.PositionStatus.SETTLED
@@ -219,6 +305,35 @@ contract RiskManagerInvariantTest is StdInvariant, Test {
                 assertEq(position.initialReservation, 0);
                 assertEq(position.reservedAmount, 0);
                 assertEq(position.slashedAmount, 0);
+            }
+        }
+    }
+
+    function invariant_DeferredSettlementAlwaysHasExactGrossCoverage() public view {
+        for (uint256 index = 0; index < handler.hashCount(); index++) {
+            IRiskManager.RiskPosition memory position = manager.getRiskPosition(handler.hashAt(index));
+            if (
+                position.mode == IRiskManager.RiskMode.DEFERRED_PAYOUT
+                    && position.status == IRiskManager.PositionStatus.SETTLED
+            ) {
+                assertEq(
+                    position.deferredPayoutAmount + position.reservedAmount,
+                    position.releasedAmount
+                );
+            }
+            if (
+                position.mode == IRiskManager.RiskMode.DEFERRED_PAYOUT
+                    && position.status == IRiskManager.PositionStatus.SLASHED
+            ) {
+                assertEq(position.deferredPayoutAmount, 0);
+                assertEq(position.reservedAmount, 0);
+                assertEq(position.slashedAmount, position.releasedAmount);
+            }
+            if (
+                position.mode == IRiskManager.RiskMode.DEFERRED_PAYOUT
+                    && position.status == IRiskManager.PositionStatus.RELEASED
+            ) {
+                assertEq(position.reservedAmount, 0);
             }
         }
     }

--- a/test-foundry/unit/BoundedCall.t.sol
+++ b/test-foundry/unit/BoundedCall.t.sol
@@ -10,15 +10,25 @@ contract BoundedCallHarness {
     function execute(
         address _target,
         uint256 _gasLimit,
+        uint256 _postCallGasReserve,
         uint256 _maxReturnDataSize,
         bytes calldata _callData
     ) external returns (bool success, bytes memory returnData) {
         return BoundedCall.callWithBoundedReturnData(
             _target,
             _gasLimit,
+            _postCallGasReserve,
             _maxReturnDataSize,
             _callData
         );
+    }
+
+    function calculateCallGas(
+        uint256 _availableGas,
+        uint256 _gasLimit,
+        uint256 _postCallGasReserve
+    ) external pure returns (uint256) {
+        return BoundedCall._calculateCallGas(_availableGas, _gasLimit, _postCallGasReserve);
     }
 }
 
@@ -53,6 +63,7 @@ contract BoundedCallTest is Test {
         (bool success, bytes memory returnData) = harness.execute(
             address(target),
             100_000,
+            10_000,
             2_048,
             abi.encodeCall(BoundedCallTarget.returnTrue, ())
         );
@@ -66,6 +77,7 @@ contract BoundedCallTest is Test {
         (bool success, bytes memory revertData) = harness.execute(
             address(target),
             100_000,
+            10_000,
             64,
             abi.encodeCall(BoundedCallTarget.revertWithData, (32_768))
         );
@@ -78,11 +90,31 @@ contract BoundedCallTest is Test {
         (bool success, bytes memory revertData) = harness.execute(
             address(target),
             20_000,
+            10_000,
             64,
             abi.encodeCall(BoundedCallTarget.consumeAllGas, ())
         );
 
         assertFalse(success);
         assertEq(revertData.length, 0);
+    }
+
+    function test_ReturnsZeroWhenReconciliationReserveCannotBeRetained() public view {
+        assertEq(harness.calculateCallGas(260_000, 100_000, 250_000), 0);
+    }
+
+    function test_UsesConfiguredGasLimitWhenItIsTheLowestCap() public view {
+        assertEq(harness.calculateCallGas(1_000_000, 100_000, 250_000), 100_000);
+    }
+
+    function test_CapsCallGasByEip150() public view {
+        uint256 afterOverhead = 90_000;
+        uint256 expected = afterOverhead - (afterOverhead / 64);
+
+        assertEq(harness.calculateCallGas(100_000, type(uint256).max, 0), expected);
+    }
+
+    function test_CapsCallGasByReconciliationReserve() public view {
+        assertEq(harness.calculateCallGas(100_000, type(uint256).max, 25_000), 65_000);
     }
 }

--- a/test-foundry/unit/RiskManager.t.sol
+++ b/test-foundry/unit/RiskManager.t.sol
@@ -565,6 +565,27 @@ contract RiskManagerTest is Test {
         manager.registerDeferredPayout(intentHash, taker, 350e6);
     }
 
+    function test_DeferredManualReleaseClearsAuthorizationWithoutFunding() public {
+        _enableDeferredPayouts();
+        _stake(taker, 10e6);
+        bytes32 intentHash = keccak256("deferred-manual-release");
+        _setIntent(intentHash, taker, 700e6, PAYPAL, address(verifier));
+        _createPosition(intentHash);
+
+        vm.prank(address(orchestrator));
+        manager.onIntentReleased(intentHash, 700e6);
+
+        IRiskManager.RiskPosition memory position = manager.getRiskPosition(intentHash);
+        IStakeVault.DeferredPayout memory payout = vault.getDeferredPayout(intentHash);
+        assertEq(uint256(position.status), uint256(IRiskManager.PositionStatus.RELEASED));
+        assertEq(position.paymentId, bytes32(0));
+        assertEq(position.reservedAmount, 0);
+        assertEq(position.deferredPayoutAmount, 0);
+        assertEq(vault.reservedStake(taker), 0);
+        assertEq(payout.beneficiary, address(0));
+        assertEq(payout.amount, 0);
+    }
+
     function test_PlatformChangesDoNotAlterPositionSnapshots() public {
         vm.prank(owner);
         manager.setPlatformRiskConfig(PAYPAL, _chargebackConfig(10_000, 10 days));

--- a/test-foundry/unit/RiskManager.t.sol
+++ b/test-foundry/unit/RiskManager.t.sol
@@ -571,6 +571,30 @@ contract RiskManagerTest is Test {
         assertEq(vault.freeStake(taker), 679e6);
     }
 
+    function test_CanonicalDeferredHookSelectionSurvivesReconciliationCapacityIncrease() public {
+        _enableDeferredPayouts();
+        _stake(taker, 704.025e6);
+
+        bytes32 previousIntent = keccak256("reconciliation-capacity-source");
+        _setIntent(previousIntent, taker, 700e6, PAYPAL, address(0));
+        _createPosition(previousIntent);
+        assertEq(vault.freeStake(taker), 4.025e6);
+
+        bytes32 quotedIntent = keccak256("reconciliation-stable-deferred-selection");
+        _setIntent(quotedIntent, taker, 700e6, PAYPAL, address(verifier));
+        orchestrator.recordSettlementWithoutCallback(previousIntent, 1e6, uint64(block.timestamp));
+        manager.reconcileSettlement(previousIntent);
+        assertEq(vault.freeStake(taker), 703.025e6);
+
+        bool requiresHook = _createPosition(quotedIntent);
+
+        IRiskManager.RiskPosition memory position = manager.getRiskPosition(quotedIntent);
+        assertTrue(requiresHook);
+        assertEq(uint256(position.mode), uint256(IRiskManager.RiskMode.DEFERRED_PAYOUT));
+        assertEq(position.initialReservation, 4.025e6);
+        assertEq(vault.reservedStake(taker), 5.025e6);
+    }
+
     function test_DeferredAdmissionRejectsStakeBelowFeeGapUpperBound() public {
         _enableDeferredPayouts();
         _stake(taker, 10e6);

--- a/test-foundry/unit/RiskManager.t.sol
+++ b/test-foundry/unit/RiskManager.t.sol
@@ -249,6 +249,16 @@ contract RiskManagerTest is Test {
         manager.setPlatformRiskConfig(PAYPAL, config);
     }
 
+    function _fundAndRegisterDeferredPayout(
+        bytes32 _intentHash,
+        address _beneficiary,
+        uint256 _amount
+    ) internal {
+        token.transfer(address(vault), _amount);
+        vm.prank(address(verifier));
+        manager.registerDeferredPayout(_intentHash, _beneficiary, _amount);
+    }
+
     function _chargeback(
         bytes32 _intentHash,
         uint256 _disputeNonce
@@ -512,7 +522,7 @@ contract RiskManagerTest is Test {
         assertEq(uint256(manager.getRiskPosition(intentHash).status), uint256(IRiskManager.PositionStatus.RELEASED));
     }
 
-    function test_DeferredAdmissionReservesOnlyGriefingBond() public {
+    function test_DeferredAdmissionReservesMaxGriefingBondWhenFeeGapIsZero() public {
         _enableDeferredPayouts();
         _stake(taker, 10e6);
         bytes32 intentHash = keccak256("deferred");
@@ -527,18 +537,36 @@ contract RiskManagerTest is Test {
         assertEq(vault.reservedStake(taker), 4.025e6);
     }
 
-    function test_DeferredAdmissionRejectsInfeasibleFeeMixBeforeReservation() public {
+    function test_DeferredAdmissionReservesFeeGapUpperBoundInsteadOfGrossRelease() public {
+        _enableDeferredPayouts();
+        _stake(taker, 25e6);
+        bytes32 intentHash = keccak256("deferred-hybrid-admission");
+        _setIntent(intentHash, taker, 700e6, PAYPAL, address(verifier));
+        orchestrator.setIntentTotalFeeRate(intentHash, 0.03e18);
+
+        bool requiresHook = _createPosition(intentHash);
+
+        IRiskManager.RiskPosition memory position = manager.getRiskPosition(intentHash);
+        assertTrue(requiresHook);
+        assertEq(uint256(position.mode), uint256(IRiskManager.RiskMode.DEFERRED_PAYOUT));
+        assertEq(position.maxGriefingBond, 4.025e6);
+        assertEq(position.initialReservation, 21e6);
+        assertEq(vault.reservedStake(taker), 21e6);
+    }
+
+    function test_DeferredAdmissionRejectsStakeBelowFeeGapUpperBound() public {
         _enableDeferredPayouts();
         _stake(taker, 10e6);
-        bytes32 intentHash = keccak256("deferred-infeasible-fees");
+        bytes32 intentHash = keccak256("deferred-hybrid-undercollateralized");
         _setIntent(intentHash, taker, 700e6, PAYPAL, address(verifier));
-        orchestrator.setIntentTotalFeeRate(intentHash, 1);
+        orchestrator.setIntentTotalFeeRate(intentHash, 0.03e18);
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                IRiskManager.DeferredPayoutFeesExceedCapacity.selector,
-                1,
-                10_000
+                IRiskManager.InsufficientCollateral.selector,
+                taker,
+                10e6,
+                21e6
             )
         );
         _createPosition(intentHash);
@@ -546,7 +574,7 @@ contract RiskManagerTest is Test {
         assertEq(vault.reservedStake(taker), 0);
     }
 
-    function test_DeferredRegistrationRejectsCoverageBelowConfiguredReserve() public {
+    function test_DeferredRegistrationCannotRequireUnreservedStake() public {
         _enableDeferredPayouts();
         _stake(taker, 10e6);
         bytes32 intentHash = keccak256("deferred-shortfall");
@@ -556,13 +584,87 @@ contract RiskManagerTest is Test {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                IRiskManager.InsufficientDeferredPayoutCoverage.selector,
-                350e6,
+                IRiskManager.IncompleteChargebackCoverage.selector,
+                354.025e6,
                 700e6
             )
         );
         vm.prank(address(verifier));
         manager.registerDeferredPayout(intentHash, taker, 350e6);
+    }
+
+    function test_DeferredChargebackSlashesNetProceedsPlusExactFeeGap() public {
+        _enableDeferredPayouts();
+        _stake(taker, 25e6);
+        bytes32 intentHash = keccak256("deferred-hybrid-chargeback");
+        _setIntent(intentHash, taker, 700e6, PAYPAL, address(verifier));
+        orchestrator.setIntentTotalFeeRate(intentHash, 0.03e18);
+        _createPosition(intentHash);
+        orchestrator.fulfillPosition(manager, intentHash, 700e6);
+        _fundAndRegisterDeferredPayout(intentHash, taker, 679e6);
+
+        IRiskManager.RiskPosition memory settled = manager.getRiskPosition(intentHash);
+        assertEq(settled.deferredPayoutAmount, 679e6);
+        assertEq(settled.reservedAmount, 21e6);
+        assertEq(settled.deferredPayoutAmount + settled.reservedAmount, settled.releasedAmount);
+
+        manager.submitChargeback(_chargeback(intentHash, 1));
+
+        IRiskManager.RiskPosition memory slashed = manager.getRiskPosition(intentHash);
+        assertEq(vault.claimableCompensation(maker), 700e6);
+        assertEq(vault.stakeBalance(taker), 4e6);
+        assertEq(vault.reservedStake(taker), 0);
+        assertEq(vault.getDeferredPayout(intentHash).amount, 0);
+        assertEq(slashed.slashedAmount, 700e6);
+        assertEq(slashed.deferredPayoutAmount, 0);
+        assertEq(slashed.reservedAmount, 0);
+        assertEq(vault.totalLiabilities(), token.balanceOf(address(vault)));
+    }
+
+    function test_DeferredMaturityUnlocksFeeGapAndPaysNetProceeds() public {
+        _enableDeferredPayouts();
+        _stake(taker, 25e6);
+        bytes32 intentHash = keccak256("deferred-hybrid-maturity");
+        _setIntent(intentHash, taker, 700e6, PAYPAL, address(verifier));
+        orchestrator.setIntentTotalFeeRate(intentHash, 0.03e18);
+        _createPosition(intentHash);
+        orchestrator.fulfillPosition(manager, intentHash, 700e6);
+        _fundAndRegisterDeferredPayout(intentHash, taker, 679e6);
+        uint64 coverageDeadline = manager.getRiskPosition(intentHash).coverageDeadline;
+        vm.warp(coverageDeadline);
+
+        manager.releaseMaturedPosition(intentHash);
+        uint256 takerBalanceBefore = token.balanceOf(taker);
+        vm.prank(taker);
+        vault.withdrawDeferredPayout(intentHash, taker);
+
+        assertEq(token.balanceOf(taker) - takerBalanceBefore, 679e6);
+        assertEq(vault.stakeBalance(taker), 25e6);
+        assertEq(vault.reservedStake(taker), 0);
+        assertEq(vault.getDeferredPayout(intentHash).amount, 0);
+        assertEq(vault.claimableCompensation(maker), 0);
+        assertEq(vault.totalLiabilities(), token.balanceOf(address(vault)));
+    }
+
+    function test_DeferredHookRegistrationReconcilesFailedSettlementCallback() public {
+        _enableDeferredPayouts();
+        _stake(taker, 25e6);
+        bytes32 intentHash = keccak256("deferred-hybrid-reconcile");
+        _setIntent(intentHash, taker, 700e6, PAYPAL, address(verifier));
+        orchestrator.setIntentTotalFeeRate(intentHash, 0.03e18);
+        _createPosition(intentHash);
+        uint64 settledAt = uint64(block.timestamp + 1 hours);
+        orchestrator.recordSettlementWithoutCallback(intentHash, 700e6, settledAt);
+        vm.warp(settledAt);
+
+        _fundAndRegisterDeferredPayout(intentHash, taker, 679e6);
+
+        IRiskManager.RiskPosition memory position = manager.getRiskPosition(intentHash);
+        assertEq(uint256(position.status), uint256(IRiskManager.PositionStatus.SETTLED));
+        assertEq(position.settledAt, settledAt);
+        assertEq(position.deferredPayoutAmount, 679e6);
+        assertEq(position.reservedAmount, 21e6);
+        assertEq(vault.totalLiabilities(), token.balanceOf(address(vault)));
     }
 
     function test_DeferredManualReleaseClearsAuthorizationWithoutFunding() public {

--- a/test-foundry/unit/RiskManager.t.sol
+++ b/test-foundry/unit/RiskManager.t.sol
@@ -40,6 +40,7 @@ contract RiskEscrowHarness {
 
 contract RiskOrchestratorHarness {
     mapping(bytes32 => IOrchestratorV3.RiskIntentData) internal intents;
+    mapping(bytes32 => uint256) internal totalFeeRates;
     mapping(bytes32 => IOrchestratorV3.IntentSettlement) internal settlements;
     mapping(bytes32 => IOrchestratorV3.IntentCancellation) internal cancellations;
     function setIntent(
@@ -64,6 +65,14 @@ contract RiskOrchestratorHarness {
 
     function getRiskIntent(bytes32 _intentHash) external view returns (IOrchestratorV3.RiskIntentData memory) {
         return intents[_intentHash];
+    }
+
+    function setIntentTotalFeeRate(bytes32 _intentHash, uint256 _totalFeeRate) external {
+        totalFeeRates[_intentHash] = _totalFeeRate;
+    }
+
+    function getIntentTotalFeeRate(bytes32 _intentHash) external view returns (uint256) {
+        return totalFeeRates[_intentHash];
     }
 
     function getIntentSettlement(bytes32 _intentHash) external view returns (uint256, bytes32, uint64) {
@@ -231,6 +240,13 @@ contract RiskManagerTest is Test {
 
     function _createPosition(bytes32 _intentHash) internal returns (bool) {
         return orchestrator.createPosition(manager, _intentHash);
+    }
+
+    function _enableDeferredPayouts() internal {
+        IRiskManager.PlatformRiskConfig memory config = _chargebackConfig(10_000, 30 days);
+        config.chargeback.deferredPayoutEnabled = true;
+        vm.prank(owner);
+        manager.setPlatformRiskConfig(PAYPAL, config);
     }
 
     function _chargeback(
@@ -496,12 +512,57 @@ contract RiskManagerTest is Test {
         assertEq(uint256(manager.getRiskPosition(intentHash).status), uint256(IRiskManager.PositionStatus.RELEASED));
     }
 
-    function test_PlatformConfigurationRejectsDeferredChargebackCoverage() public {
-        IRiskManager.PlatformRiskConfig memory config = _chargebackConfig(10_000, 30 days);
-        config.chargeback.deferredPayoutEnabled = true;
-        vm.expectRevert(abi.encodeWithSelector(IRiskManager.InvalidPlatformConfig.selector, PAYPAL));
-        vm.prank(owner);
-        manager.setPlatformRiskConfig(PAYPAL, config);
+    function test_DeferredAdmissionReservesOnlyGriefingBond() public {
+        _enableDeferredPayouts();
+        _stake(taker, 10e6);
+        bytes32 intentHash = keccak256("deferred");
+        _setIntent(intentHash, taker, 700e6, PAYPAL, address(verifier));
+
+        bool requiresHook = _createPosition(intentHash);
+
+        IRiskManager.RiskPosition memory position = manager.getRiskPosition(intentHash);
+        assertTrue(requiresHook);
+        assertEq(uint256(position.mode), uint256(IRiskManager.RiskMode.DEFERRED_PAYOUT));
+        assertEq(position.initialReservation, 4.025e6);
+        assertEq(vault.reservedStake(taker), 4.025e6);
+    }
+
+    function test_DeferredAdmissionRejectsInfeasibleFeeMixBeforeReservation() public {
+        _enableDeferredPayouts();
+        _stake(taker, 10e6);
+        bytes32 intentHash = keccak256("deferred-infeasible-fees");
+        _setIntent(intentHash, taker, 700e6, PAYPAL, address(verifier));
+        orchestrator.setIntentTotalFeeRate(intentHash, 1);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IRiskManager.DeferredPayoutFeesExceedCapacity.selector,
+                1,
+                10_000
+            )
+        );
+        _createPosition(intentHash);
+
+        assertEq(vault.reservedStake(taker), 0);
+    }
+
+    function test_DeferredRegistrationRejectsCoverageBelowConfiguredReserve() public {
+        _enableDeferredPayouts();
+        _stake(taker, 10e6);
+        bytes32 intentHash = keccak256("deferred-shortfall");
+        _setIntent(intentHash, taker, 700e6, PAYPAL, address(verifier));
+        _createPosition(intentHash);
+        orchestrator.fulfillPosition(manager, intentHash, 700e6);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IRiskManager.InsufficientDeferredPayoutCoverage.selector,
+                350e6,
+                700e6
+            )
+        );
+        vm.prank(address(verifier));
+        manager.registerDeferredPayout(intentHash, taker, 350e6);
     }
 
     function test_PlatformChangesDoNotAlterPositionSnapshots() public {

--- a/test-foundry/unit/RiskManager.t.sol
+++ b/test-foundry/unit/RiskManager.t.sol
@@ -254,7 +254,7 @@ contract RiskManagerTest is Test {
         address _beneficiary,
         uint256 _amount
     ) internal {
-        token.transfer(address(vault), _amount);
+        assertTrue(token.transfer(address(vault), _amount));
         vm.prank(address(verifier));
         manager.registerDeferredPayout(_intentHash, _beneficiary, _amount);
     }

--- a/test-foundry/unit/RiskManager.t.sol
+++ b/test-foundry/unit/RiskManager.t.sol
@@ -554,6 +554,23 @@ contract RiskManagerTest is Test {
         assertEq(vault.reservedStake(taker), 21e6);
     }
 
+    function test_CanonicalDeferredHookSelectsHybridModeWithExcessStake() public {
+        _enableDeferredPayouts();
+        _stake(taker, 700e6);
+        bytes32 intentHash = keccak256("deferred-explicit-mode");
+        _setIntent(intentHash, taker, 700e6, PAYPAL, address(verifier));
+        orchestrator.setIntentTotalFeeRate(intentHash, 0.03e18);
+
+        bool requiresHook = _createPosition(intentHash);
+
+        IRiskManager.RiskPosition memory position = manager.getRiskPosition(intentHash);
+        assertTrue(requiresHook);
+        assertEq(uint256(position.mode), uint256(IRiskManager.RiskMode.DEFERRED_PAYOUT));
+        assertEq(position.initialReservation, 21e6);
+        assertEq(vault.reservedStake(taker), 21e6);
+        assertEq(vault.freeStake(taker), 679e6);
+    }
+
     function test_DeferredAdmissionRejectsStakeBelowFeeGapUpperBound() public {
         _enableDeferredPayouts();
         _stake(taker, 10e6);

--- a/test-foundry/unit/StakeVault.t.sol
+++ b/test-foundry/unit/StakeVault.t.sol
@@ -23,11 +23,37 @@ contract StakeVaultTest is Test {
 
     function setUp() public {
         token = new USDCMock(1_000_000e6, "USD Coin", "USDC");
+        vm.etch(controller, hex"00");
         vault = new StakeVault(owner, token, controller, EXIT_DELAY, DAY);
 
         deal(address(token), staker, 10_000e6);
         vm.prank(staker);
         token.approve(address(vault), type(uint256).max);
+    }
+
+    function test_ConstructorRejectsStakeTokenWithoutCode() public {
+        address eoaToken = makeAddr("eoaToken");
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.InvalidContract.selector, eoaToken));
+        new StakeVault(owner, USDCMock(eoaToken), address(0), EXIT_DELAY, DAY);
+    }
+
+    function test_ConstructorRejectsControllerWithoutCode() public {
+        address eoaController = makeAddr("eoaController");
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.InvalidContract.selector, eoaController));
+        new StakeVault(owner, token, eoaController, EXIT_DELAY, DAY);
+    }
+
+    function test_ControllerAcceptanceRechecksDeployedCode() public {
+        address nextController = makeAddr("ephemeralController");
+        vm.etch(nextController, hex"00");
+        vm.prank(owner);
+        vault.proposeController(nextController);
+        vm.etch(nextController, hex"");
+        vm.warp(block.timestamp + DAY);
+
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.InvalidContract.selector, nextController));
+        vm.prank(nextController);
+        vault.acceptController();
     }
 
     function test_DepositStakeTracksLiabilities() public {
@@ -419,6 +445,7 @@ contract StakeVaultTest is Test {
 
     function test_ControllerHandoverIsDelayedAndTwoStep() public {
         address nextController = makeAddr("nextController");
+        vm.etch(nextController, hex"00");
         vm.prank(owner);
         vault.proposeController(nextController);
 
@@ -434,6 +461,7 @@ contract StakeVaultTest is Test {
 
     function test_PreviousControllerSettlesOnlyItsSnapshottedPositionAfterHandover() public {
         address nextController = makeAddr("nextController");
+        vm.etch(nextController, hex"00");
         bytes32 oldIntent = keccak256("oldIntent");
         bytes32 newIntent = keccak256("newIntent");
         vm.prank(staker);
@@ -464,6 +492,7 @@ contract StakeVaultTest is Test {
 
     function test_PreviousControllerFundsDeferredPositionAfterHandoverAndPause() public {
         address nextController = makeAddr("nextController");
+        vm.etch(nextController, hex"00");
         bytes32 intentHash = keccak256("deferred");
         vm.prank(controller);
         vault.authorizeDeferredPayout(intentHash, staker, uint64(block.timestamp + DAY));

--- a/test/deploy/26_stakeRiskSystem.spec.ts
+++ b/test/deploy/26_stakeRiskSystem.spec.ts
@@ -48,6 +48,7 @@ describe("Affine stake risk system deployment", () => {
   it("deploys the linked orchestrator components", async () => {
     expect(deployedAddress("BoundedCall")).to.properAddress;
     expect(deployedAddress("PostIntentHookExecutor")).to.properAddress;
+    expect(deployedAddress("OrchestratorV3Validation")).to.properAddress;
     expect(deployedAddress("OrchestratorV3FeeLib")).to.properAddress;
     expect(deployedAddress("RiskCallbackRecorder")).to.properAddress;
     expect(deployedAddress("OrchestratorV3RiskLib")).to.properAddress;

--- a/test/deploy/26_stakeRiskSystem.spec.ts
+++ b/test/deploy/26_stakeRiskSystem.spec.ts
@@ -48,6 +48,9 @@ describe("Affine stake risk system deployment", () => {
   it("deploys the linked orchestrator components", async () => {
     expect(deployedAddress("BoundedCall")).to.properAddress;
     expect(deployedAddress("PostIntentHookExecutor")).to.properAddress;
+    expect(deployedAddress("OrchestratorV3FeeLib")).to.properAddress;
+    expect(deployedAddress("RiskCallbackRecorder")).to.properAddress;
+    expect(deployedAddress("OrchestratorV3RiskLib")).to.properAddress;
     expect(deployedAddress("OrchestratorV3")).to.properAddress;
   });
 

--- a/test/staking/orchestratorV3Gating.spec.ts
+++ b/test/staking/orchestratorV3Gating.spec.ts
@@ -1,0 +1,281 @@
+import { expect } from "chai";
+import { BigNumber, Contract } from "ethers";
+import { ethers } from "hardhat";
+import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
+
+const usdc = (amount: string | number) => ethers.utils.parseUnits(String(amount), 6);
+const precise = (amount: string | number) => ethers.utils.parseEther(String(amount));
+const DAY = 24 * 60 * 60;
+const PAYMENT_A = ethers.utils.id("gated-payment-a");
+const PAYMENT_B = ethers.utils.id("gated-payment-b");
+const USD = ethers.utils.id("USD");
+const EUR = ethers.utils.id("EUR");
+const PAYEE = ethers.utils.id("gated-maker-payee");
+const ZERO = ethers.constants.AddressZero;
+
+describe("OrchestratorV3 single-use gating authorizations", () => {
+  async function deployFixture() {
+    const [owner, maker, taker, other, gatingService, referrer] = await ethers.getSigners();
+    const { chainId } = await ethers.provider.getNetwork();
+
+    const token = await (await ethers.getContractFactory("USDCMock"))
+      .deploy(usdc(1_000_000), "USD Coin", "USDC");
+    const paymentVerifierRegistry = await (await ethers.getContractFactory("PaymentVerifierRegistry")).deploy();
+    const escrowRegistry = await (await ethers.getContractFactory("EscrowRegistry")).deploy();
+    const relayerRegistry = await (await ethers.getContractFactory("RelayerRegistry")).deploy();
+    const orchestratorRegistry = await (await ethers.getContractFactory("OrchestratorRegistry")).deploy();
+    const verifier = await (await ethers.getContractFactory("PaymentVerifierMock")).deploy();
+    await paymentVerifierRegistry.addPaymentMethod(PAYMENT_A, verifier.address, [USD, EUR]);
+    await paymentVerifierRegistry.addPaymentMethod(PAYMENT_B, verifier.address, [USD, EUR]);
+
+    const escrow = await (await ethers.getContractFactory("EscrowV2")).deploy(
+      owner.address,
+      chainId,
+      orchestratorRegistry.address,
+      paymentVerifierRegistry.address,
+      owner.address,
+      0,
+      100,
+      6 * 60 * 60,
+    );
+    const boundedCall = await (await ethers.getContractFactory("BoundedCall")).deploy();
+    const feeLib = await (await ethers.getContractFactory("OrchestratorV3FeeLib")).deploy();
+    const postIntentHookExecutor = await (await ethers.getContractFactory("PostIntentHookExecutor")).deploy();
+    const callbackRecorder = await (await ethers.getContractFactory("RiskCallbackRecorder")).deploy();
+    const riskLib = await (await ethers.getContractFactory("OrchestratorV3RiskLib", {
+      libraries: {
+        BoundedCall: boundedCall.address,
+        RiskCallbackRecorder: callbackRecorder.address,
+      },
+    })).deploy();
+    const validation = await (await ethers.getContractFactory("OrchestratorV3Validation")).deploy();
+    const orchestratorFactory = await ethers.getContractFactory("OrchestratorV3", {
+      libraries: {
+        BoundedCall: boundedCall.address,
+        OrchestratorV3FeeLib: feeLib.address,
+        PostIntentHookExecutor: postIntentHookExecutor.address,
+        OrchestratorV3RiskLib: riskLib.address,
+        OrchestratorV3Validation: validation.address,
+      },
+    });
+    const orchestratorArgs = [
+      owner.address,
+      chainId,
+      escrowRegistry.address,
+      paymentVerifierRegistry.address,
+      relayerRegistry.address,
+      0,
+      owner.address,
+      2_000_000,
+    ] as const;
+    const orchestrator = await orchestratorFactory.deploy(...orchestratorArgs);
+
+    await escrowRegistry.addEscrow(escrow.address);
+    await orchestratorRegistry.addOrchestrator(orchestrator.address);
+    await orchestrator.setAllowMultipleIntents(true);
+    await token.transfer(maker.address, usdc(10_000));
+    await token.connect(maker).approve(escrow.address, ethers.constants.MaxUint256);
+
+    const currencyConfig = [
+      { code: USD, minConversionRate: precise(1), oracleRateConfig: {
+        adapter: ZERO, adapterConfig: "0x", spreadBps: 0, maxStaleness: 0,
+      } },
+      { code: EUR, minConversionRate: precise(1), oracleRateConfig: {
+        adapter: ZERO, adapterConfig: "0x", spreadBps: 0, maxStaleness: 0,
+      } },
+    ];
+    await escrow.connect(maker).createDeposit({
+      token: token.address,
+      amount: usdc(5_000),
+      intentAmountRange: { min: usdc(1), max: usdc(1_000) },
+      paymentMethods: [PAYMENT_A, PAYMENT_B],
+      paymentMethodData: [
+        { intentGatingService: gatingService.address, payeeDetails: PAYEE, data: "0x" },
+        { intentGatingService: gatingService.address, payeeDetails: PAYEE, data: "0x" },
+      ],
+      currencies: [currencyConfig, currencyConfig],
+      delegate: ZERO,
+      intentGuardian: ZERO,
+      retainOnEmpty: true,
+    });
+    await escrow.connect(maker).createDeposit({
+      token: token.address,
+      amount: usdc(1_000),
+      intentAmountRange: { min: usdc(1), max: usdc(1_000) },
+      paymentMethods: [PAYMENT_A],
+      paymentMethodData: [{ intentGatingService: ZERO, payeeDetails: PAYEE, data: "0x" }],
+      currencies: [currencyConfig],
+      delegate: ZERO,
+      intentGuardian: ZERO,
+      retainOnEmpty: true,
+    });
+
+    return {
+      owner,
+      maker,
+      taker,
+      other,
+      gatingService,
+      referrer,
+      escrow,
+      orchestrator,
+      verifier,
+      orchestratorFactory,
+      orchestratorArgs,
+    };
+  }
+
+  async function baseParams(escrow: Contract, taker: string, depositId = 0) {
+    return {
+      escrow: escrow.address,
+      depositId,
+      amount: usdc(10),
+      to: taker,
+      paymentMethod: PAYMENT_A,
+      fiatCurrency: USD,
+      conversionRate: precise(1),
+      referralFees: [] as Array<{ recipient: string; fee: BigNumber }>,
+      gatingServiceSignature: "0x",
+      signatureExpiration: (await time.latest()) + DAY,
+      settlementHook: ZERO,
+      preIntentHookData: "0x",
+      data: "0x",
+    };
+  }
+
+  async function signParams(
+    orchestrator: Contract,
+    params: Awaited<ReturnType<typeof baseParams>>,
+    taker: string,
+    signer: any,
+  ) {
+    const messageHash = await orchestrator.getIntentGatingMessageHash(params, taker);
+    return {
+      ...params,
+      gatingServiceSignature: await signer.signMessage(ethers.utils.arrayify(messageHash)),
+    };
+  }
+
+  async function expectInvalid(
+    orchestrator: Contract,
+    caller: any,
+    params: Awaited<ReturnType<typeof baseParams>>,
+  ) {
+    await expect(orchestrator.connect(caller).signalIntent(params))
+      .to.be.revertedWithCustomError(orchestrator, "InvalidSignature");
+  }
+
+  it("consumes the current scoped nonce after a valid authorization", async () => {
+    const { taker, gatingService, escrow, orchestrator } = await loadFixture(deployFixture);
+    const params = await signParams(orchestrator, await baseParams(escrow, taker.address), taker.address, gatingService);
+
+    await expect(orchestrator.connect(taker).signalIntent(params))
+      .to.emit(orchestrator, "IntentGatingAuthorizationConsumed")
+      .withArgs(taker.address, escrow.address, 0, PAYMENT_A, 0);
+
+    expect(await orchestrator.getIntentGatingNonce(taker.address, escrow.address, 0, PAYMENT_A)).to.eq(1);
+  });
+
+  it("rejects replaying a consumed authorization", async () => {
+    const { taker, gatingService, escrow, orchestrator } = await loadFixture(deployFixture);
+    const params = await signParams(orchestrator, await baseParams(escrow, taker.address), taker.address, gatingService);
+    await orchestrator.connect(taker).signalIntent(params);
+
+    await expectInvalid(orchestrator, taker, params);
+    expect(await orchestrator.getIntentGatingNonce(taker.address, escrow.address, 0, PAYMENT_A)).to.eq(1);
+  });
+
+  it("does not consume a nonce for a deposit without a gating service", async () => {
+    const { taker, escrow, orchestrator } = await loadFixture(deployFixture);
+    const params = await baseParams(escrow, taker.address, 1);
+    await orchestrator.connect(taker).signalIntent(params);
+    expect(await orchestrator.getIntentGatingNonce(taker.address, escrow.address, 1, PAYMENT_A)).to.eq(0);
+  });
+
+  it("rolls nonce consumption back when the signature is invalid", async () => {
+    const { owner, taker, escrow, orchestrator } = await loadFixture(deployFixture);
+    const params = await signParams(orchestrator, await baseParams(escrow, taker.address), taker.address, owner);
+    await expectInvalid(orchestrator, taker, params);
+    expect(await orchestrator.getIntentGatingNonce(taker.address, escrow.address, 0, PAYMENT_A)).to.eq(0);
+  });
+
+  it("binds the settlement hook", async () => {
+    const { taker, gatingService, escrow, orchestrator, verifier } = await loadFixture(deployFixture);
+    const params = await signParams(orchestrator, await baseParams(escrow, taker.address), taker.address, gatingService);
+    await expectInvalid(orchestrator, taker, { ...params, settlementHook: verifier.address });
+  });
+
+  it("binds persisted signal hook data", async () => {
+    const { taker, gatingService, escrow, orchestrator } = await loadFixture(deployFixture);
+    const params = await signParams(orchestrator, await baseParams(escrow, taker.address), taker.address, gatingService);
+    await expectInvalid(orchestrator, taker, { ...params, data: "0x1234" });
+  });
+
+  it("binds ephemeral pre-intent hook data", async () => {
+    const { taker, gatingService, escrow, orchestrator } = await loadFixture(deployFixture);
+    const params = await signParams(orchestrator, await baseParams(escrow, taker.address), taker.address, gatingService);
+    await expectInvalid(orchestrator, taker, { ...params, preIntentHookData: "0x1234" });
+  });
+
+  it("binds every referral fee", async () => {
+    const { taker, gatingService, referrer, escrow, orchestrator } = await loadFixture(deployFixture);
+    const params = await signParams(orchestrator, await baseParams(escrow, taker.address), taker.address, gatingService);
+    await expectInvalid(orchestrator, taker, {
+      ...params,
+      referralFees: [{ recipient: referrer.address, fee: precise("0.01") }],
+    });
+  });
+
+  it("binds the recipient", async () => {
+    const { taker, other, gatingService, escrow, orchestrator } = await loadFixture(deployFixture);
+    const params = await signParams(orchestrator, await baseParams(escrow, taker.address), taker.address, gatingService);
+    await expectInvalid(orchestrator, taker, { ...params, to: other.address });
+  });
+
+  it("binds the intent amount", async () => {
+    const { taker, gatingService, escrow, orchestrator } = await loadFixture(deployFixture);
+    const params = await signParams(orchestrator, await baseParams(escrow, taker.address), taker.address, gatingService);
+    await expectInvalid(orchestrator, taker, { ...params, amount: params.amount.add(1) });
+  });
+
+  it("binds the payment method and its independent nonce scope", async () => {
+    const { taker, gatingService, escrow, orchestrator } = await loadFixture(deployFixture);
+    const params = await signParams(orchestrator, await baseParams(escrow, taker.address), taker.address, gatingService);
+    await expectInvalid(orchestrator, taker, { ...params, paymentMethod: PAYMENT_B });
+    expect(await orchestrator.getIntentGatingNonce(taker.address, escrow.address, 0, PAYMENT_B)).to.eq(0);
+  });
+
+  it("binds the fiat currency", async () => {
+    const { taker, gatingService, escrow, orchestrator } = await loadFixture(deployFixture);
+    const params = await signParams(orchestrator, await baseParams(escrow, taker.address), taker.address, gatingService);
+    await expectInvalid(orchestrator, taker, { ...params, fiatCurrency: EUR });
+  });
+
+  it("binds the conversion rate", async () => {
+    const { taker, gatingService, escrow, orchestrator } = await loadFixture(deployFixture);
+    const params = await signParams(orchestrator, await baseParams(escrow, taker.address), taker.address, gatingService);
+    await expectInvalid(orchestrator, taker, { ...params, conversionRate: params.conversionRate.add(1) });
+  });
+
+  it("binds the authorization expiry", async () => {
+    const { taker, gatingService, escrow, orchestrator } = await loadFixture(deployFixture);
+    const params = await signParams(orchestrator, await baseParams(escrow, taker.address), taker.address, gatingService);
+    await expectInvalid(orchestrator, taker, { ...params, signatureExpiration: params.signatureExpiration + 1 });
+  });
+
+  it("binds the taker independently from the recipient", async () => {
+    const { taker, other, gatingService, escrow, orchestrator } = await loadFixture(deployFixture);
+    const params = await signParams(orchestrator, await baseParams(escrow, taker.address), taker.address, gatingService);
+    await expectInvalid(orchestrator, other, params);
+  });
+
+  it("binds the exact verifying orchestrator", async () => {
+    const { taker, escrow, orchestrator, orchestratorFactory, orchestratorArgs } =
+      await loadFixture(deployFixture);
+    const secondOrchestrator = await orchestratorFactory.deploy(...orchestratorArgs);
+    const params = await baseParams(escrow, taker.address);
+
+    expect(await secondOrchestrator.getIntentGatingMessageHash(params, taker.address))
+      .to.not.eq(await orchestrator.getIntentGatingMessageHash(params, taker.address));
+  });
+});

--- a/test/staking/orchestratorV3Validation.spec.ts
+++ b/test/staking/orchestratorV3Validation.spec.ts
@@ -5,6 +5,7 @@ import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 
 const MAX_PROTOCOL_FEE = ethers.utils.parseEther("0.05");
 const MIN_CALLBACK_GAS = 750_000;
+const MAX_CALLBACK_GAS = 2_000_000;
 const ZERO = ethers.constants.AddressZero;
 
 describe("OrchestratorV3 constructor validation", () => {
@@ -89,6 +90,13 @@ describe("OrchestratorV3 constructor validation", () => {
     const { factory, validArgs } = await loadFixture(deployFixture);
     await expect(deployWith(factory, validArgs, 6, ZERO))
       .to.be.revertedWithCustomError(factory, "ZeroAddress");
+  });
+
+  it("rejects a callback gas allowance above the reconciliation-safe maximum", async () => {
+    const { factory, validArgs } = await loadFixture(deployFixture);
+    await expect(deployWith(factory, validArgs, 7, MAX_CALLBACK_GAS + 1))
+      .to.be.revertedWithCustomError(factory, "RiskCallbackGasLimitTooHigh")
+      .withArgs(MAX_CALLBACK_GAS + 1, MAX_CALLBACK_GAS);
   });
 
   it("keeps deployed bytecode within the EIP-170 limit", async () => {

--- a/test/staking/orchestratorV3Validation.spec.ts
+++ b/test/staking/orchestratorV3Validation.spec.ts
@@ -95,8 +95,7 @@ describe("OrchestratorV3 constructor validation", () => {
   it("rejects a callback gas allowance above the reconciliation-safe maximum", async () => {
     const { factory, validArgs } = await loadFixture(deployFixture);
     await expect(deployWith(factory, validArgs, 7, MAX_CALLBACK_GAS + 1))
-      .to.be.revertedWithCustomError(factory, "RiskCallbackGasLimitTooHigh")
-      .withArgs(MAX_CALLBACK_GAS + 1, MAX_CALLBACK_GAS);
+      .to.be.revertedWithCustomError(factory, "RiskCallbackGasLimitTooHigh");
   });
 
   it("keeps deployed bytecode within the EIP-170 limit", async () => {

--- a/test/staking/orchestratorV3Validation.spec.ts
+++ b/test/staking/orchestratorV3Validation.spec.ts
@@ -1,0 +1,100 @@
+import { expect } from "chai";
+import { ContractFactory } from "ethers";
+import hre, { artifacts, ethers } from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+
+const MAX_PROTOCOL_FEE = ethers.utils.parseEther("0.05");
+const MIN_CALLBACK_GAS = 750_000;
+const ZERO = ethers.constants.AddressZero;
+
+describe("OrchestratorV3 constructor validation", () => {
+  async function deployFixture() {
+    const [owner, other] = await ethers.getSigners();
+    const { chainId } = await ethers.provider.getNetwork();
+    const boundedCall = await (await ethers.getContractFactory("BoundedCall")).deploy();
+    const feeLib = await (await ethers.getContractFactory("OrchestratorV3FeeLib")).deploy();
+    const postIntentHookExecutor = await (await ethers.getContractFactory("PostIntentHookExecutor")).deploy();
+    const riskCallbackRecorder = await (await ethers.getContractFactory("RiskCallbackRecorder")).deploy();
+    const riskLib = await (await ethers.getContractFactory("OrchestratorV3RiskLib", {
+      libraries: {
+        BoundedCall: boundedCall.address,
+        RiskCallbackRecorder: riskCallbackRecorder.address,
+      },
+    })).deploy();
+    const validation = await (await ethers.getContractFactory("OrchestratorV3Validation")).deploy();
+    const escrowRegistry = await (await ethers.getContractFactory("EscrowRegistry")).deploy();
+    const paymentVerifierRegistry = await (await ethers.getContractFactory("PaymentVerifierRegistry")).deploy();
+    const relayerRegistry = await (await ethers.getContractFactory("RelayerRegistry")).deploy();
+    const factory = await ethers.getContractFactory("OrchestratorV3", {
+      libraries: {
+        BoundedCall: boundedCall.address,
+        OrchestratorV3FeeLib: feeLib.address,
+        PostIntentHookExecutor: postIntentHookExecutor.address,
+        OrchestratorV3RiskLib: riskLib.address,
+        OrchestratorV3Validation: validation.address,
+      },
+    });
+
+    const validArgs = [
+      owner.address,
+      chainId,
+      escrowRegistry.address,
+      paymentVerifierRegistry.address,
+      relayerRegistry.address,
+      MAX_PROTOCOL_FEE,
+      owner.address,
+      MIN_CALLBACK_GAS,
+    ] as const;
+
+    return { owner, other, chainId, factory, validArgs };
+  }
+
+  async function deployWith(factory: ContractFactory, args: readonly unknown[], index: number, value: unknown) {
+    const changedArgs = [...args];
+    changedArgs[index] = value;
+    return factory.deploy(...changedArgs);
+  }
+
+  it("accepts the maximum supported protocol fee", async () => {
+    const { factory, validArgs } = await loadFixture(deployFixture);
+    const orchestrator = await factory.deploy(...validArgs);
+    expect(await orchestrator.protocolFee()).to.eq(MAX_PROTOCOL_FEE);
+  });
+
+  it("rejects a protocol fee above the supported maximum", async () => {
+    const { factory, validArgs } = await loadFixture(deployFixture);
+    await expect(deployWith(factory, validArgs, 5, MAX_PROTOCOL_FEE.add(1)))
+      .to.be.revertedWithCustomError(factory, "FeeExceedsMaximum");
+  });
+
+  it("rejects a chain identifier other than the execution chain", async () => {
+    const { chainId, factory, validArgs } = await loadFixture(deployFixture);
+    await expect(deployWith(factory, validArgs, 1, chainId + 1))
+      .to.be.revertedWithCustomError(factory, "InvalidChainId");
+  });
+
+  it("rejects a zero registry dependency", async () => {
+    const { factory, validArgs } = await loadFixture(deployFixture);
+    await expect(deployWith(factory, validArgs, 2, ZERO))
+      .to.be.revertedWithCustomError(factory, "ZeroAddress");
+  });
+
+  it("rejects a registry dependency without deployed code", async () => {
+    const { other, factory, validArgs } = await loadFixture(deployFixture);
+    await expect(deployWith(factory, validArgs, 3, other.address))
+      .to.be.revertedWithCustomError(factory, "InvalidContract");
+  });
+
+  it("rejects a zero protocol fee recipient", async () => {
+    const { factory, validArgs } = await loadFixture(deployFixture);
+    await expect(deployWith(factory, validArgs, 6, ZERO))
+      .to.be.revertedWithCustomError(factory, "ZeroAddress");
+  });
+
+  it("keeps deployed bytecode within the EIP-170 limit", async () => {
+    if ((hre as any).__SOLIDITY_COVERAGE_RUNNING) return;
+    await loadFixture(deployFixture);
+    const artifact = await artifacts.readArtifact("OrchestratorV3");
+    expect((artifact.deployedBytecode.length - 2) / 2).to.be.at.most(24_576);
+  });
+});

--- a/test/staking/riskManager.coverage.spec.ts
+++ b/test/staking/riskManager.coverage.spec.ts
@@ -539,9 +539,9 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
         .to.be.revertedWithCustomError(fixture.manager, "DeferredPayoutHookRequired");
     });
 
-    it("rejects an infeasible deferred payout fee mix before reserving stake", async () => {
+    it("rejects deferred admission when stake cannot cover the fee-gap upper bound", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("deferred-fees-infeasible");
+      const intentHash = ethers.utils.id("deferred-fee-gap-undercollateralized");
       await fixture.vault.setTakerState(
         fixture.taker.address,
         fixture.taker.address,
@@ -549,11 +549,12 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
         usdc(1),
         false,
       );
-      await fixture.orchestrator.setIntentTotalFeeRate(intentHash, 1);
+      await fixture.orchestrator.setIntentTotalFeeRate(intentHash, ethers.utils.parseUnits("0.5", 18));
       await setRiskIntent(fixture, intentHash, { settlementHook: fixture.orchestrator.address });
 
       await expect(fixture.orchestrator.createPosition(fixture.manager.address, intentHash))
-        .to.be.revertedWithCustomError(fixture.manager, "DeferredPayoutFeesExceedCapacity");
+        .to.be.revertedWithCustomError(fixture.manager, "InsufficientCollateral")
+        .withArgs(fixture.taker.address, usdc(1), usdc(50));
       expect(await fixture.vault.reservedStake(fixture.taker.address)).to.eq(0);
     });
 

--- a/test/staking/riskManager.coverage.spec.ts
+++ b/test/staking/riskManager.coverage.spec.ts
@@ -553,8 +553,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       await setRiskIntent(fixture, intentHash, { settlementHook: fixture.orchestrator.address });
 
       await expect(fixture.orchestrator.createPosition(fixture.manager.address, intentHash))
-        .to.be.revertedWithCustomError(fixture.manager, "InsufficientCollateral")
-        .withArgs(fixture.taker.address, usdc(1), usdc(50));
+        .to.be.revertedWithCustomError(fixture.manager, "InsufficientCollateral");
       expect(await fixture.vault.reservedStake(fixture.taker.address)).to.eq(0);
     });
 

--- a/test/staking/riskManager.coverage.spec.ts
+++ b/test/staking/riskManager.coverage.spec.ts
@@ -20,7 +20,7 @@ function chargebackConfig(overrides: Record<string, unknown> = {}) {
     enabled: true,
     chargeback: {
       chargebackable: true,
-      deferredPayoutEnabled: false,
+      deferredPayoutEnabled: true,
       reserveBps: 10_000,
       riskWindow: DAY,
       ...((overrides.chargeback as Record<string, unknown>) ?? {}),
@@ -311,11 +311,11 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       }))).to.be.revertedWithCustomError(manager, "InvalidPlatformConfig");
     });
 
-    it("rejects deferred payout on a chargebackable platform in v1", async () => {
+    it("accepts deferred payout on a chargebackable platform", async () => {
       const { manager } = await loadFixture(deployHarnessFixture);
       await expect(manager.setPlatformRiskConfig(OTHER_METHOD, chargebackConfig({
         chargeback: { deferredPayoutEnabled: true },
-      }))).to.be.revertedWithCustomError(manager, "InvalidPlatformConfig");
+      }))).to.emit(manager, "PlatformRiskConfigUpdated");
     });
 
     it("stores a disabled platform for future admission policy", async () => {
@@ -508,6 +508,55 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       await setRiskIntent(fixture, intentHash, { paymentMethod: OTHER_METHOD });
       await expect(fixture.orchestrator.createPosition(fixture.manager.address, intentHash))
         .to.be.revertedWithCustomError(fixture.manager, "InsufficientCollateral");
+    });
+
+    it("requires the canonical hook for deferred payout admission", async () => {
+      const fixture = await loadFixture(deployHarnessFixture);
+      const intentHash = ethers.utils.id("deferred-hook-required");
+      await fixture.vault.setTakerState(
+        fixture.taker.address,
+        fixture.taker.address,
+        usdc(1),
+        usdc(1),
+        false,
+      );
+      await setRiskIntent(fixture, intentHash);
+      await expect(fixture.orchestrator.createPosition(fixture.manager.address, intentHash))
+        .to.be.revertedWithCustomError(fixture.manager, "DeferredPayoutHookRequired");
+    });
+
+    it("rejects an infeasible deferred payout fee mix before reserving stake", async () => {
+      const fixture = await loadFixture(deployHarnessFixture);
+      const intentHash = ethers.utils.id("deferred-fees-infeasible");
+      await fixture.vault.setTakerState(
+        fixture.taker.address,
+        fixture.taker.address,
+        usdc(1),
+        usdc(1),
+        false,
+      );
+      await fixture.orchestrator.setIntentTotalFeeRate(intentHash, 1);
+      await setRiskIntent(fixture, intentHash, { settlementHook: fixture.orchestrator.address });
+
+      await expect(fixture.orchestrator.createPosition(fixture.manager.address, intentHash))
+        .to.be.revertedWithCustomError(fixture.manager, "DeferredPayoutFeesExceedCapacity");
+      expect(await fixture.vault.reservedStake(fixture.taker.address)).to.eq(0);
+    });
+
+    it("requires a configured canonical hook for deferred payout admission", async () => {
+      const fixture = await loadFixture(deployHarnessFixture);
+      const intentHash = ethers.utils.id("deferred-hook-unconfigured");
+      await fixture.manager.setDeferredPayoutHook(ZERO);
+      await fixture.vault.setTakerState(
+        fixture.taker.address,
+        fixture.taker.address,
+        usdc(1),
+        usdc(1),
+        false,
+      );
+      await setRiskIntent(fixture, intentHash);
+      await expect(fixture.orchestrator.createPosition(fixture.manager.address, intentHash))
+        .to.be.revertedWithCustomError(fixture.manager, "DeferredPayoutHookRequired");
     });
 
     it("rejects a bonded position for an exiting stake owner", async () => {

--- a/test/staking/riskManager.coverage.spec.ts
+++ b/test/staking/riskManager.coverage.spec.ts
@@ -167,7 +167,21 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       const { owner, other, orchestrator, vault } = await loadFixture(deployHarnessFixture);
       await expect((await ethers.getContractFactory("RiskManager")).deploy(
         owner.address, orchestrator.address, vault.address, other.address,
-      )).to.be.reverted;
+      )).to.be.revertedWithCustomError(await ethers.getContractFactory("RiskManager"), "InvalidContract");
+    });
+
+    it("rejects an EOA orchestrator", async () => {
+      const { owner, other, vault, verifier } = await loadFixture(deployHarnessFixture);
+      await expect((await ethers.getContractFactory("RiskManager")).deploy(
+        owner.address, other.address, vault.address, verifier.address,
+      )).to.be.revertedWithCustomError(await ethers.getContractFactory("RiskManager"), "InvalidContract");
+    });
+
+    it("rejects an EOA stake vault", async () => {
+      const { owner, other, orchestrator, verifier } = await loadFixture(deployHarnessFixture);
+      await expect((await ethers.getContractFactory("RiskManager")).deploy(
+        owner.address, orchestrator.address, other.address, verifier.address,
+      )).to.be.revertedWithCustomError(await ethers.getContractFactory("RiskManager"), "InvalidContract");
     });
 
     it("updates the attestation verifier", async () => {
@@ -185,7 +199,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
 
     it("rejects an EOA attestation verifier update", async () => {
       const { manager, other } = await loadFixture(deployHarnessFixture);
-      await expect(manager.setAttestationVerifier(other.address)).to.be.revertedWithCustomError(manager, "ZeroAddress");
+      await expect(manager.setAttestationVerifier(other.address)).to.be.revertedWithCustomError(manager, "InvalidContract");
     });
 
     it("clears the deferred payout hook", async () => {
@@ -196,7 +210,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
 
     it("rejects an EOA deferred payout hook", async () => {
       const { manager, other } = await loadFixture(deployHarnessFixture);
-      await expect(manager.setDeferredPayoutHook(other.address)).to.be.revertedWithCustomError(manager, "ZeroAddress");
+      await expect(manager.setDeferredPayoutHook(other.address)).to.be.revertedWithCustomError(manager, "InvalidContract");
     });
 
     it("pauses and unpauses admission", async () => {

--- a/test/staking/riskManager.coverage.spec.ts
+++ b/test/staking/riskManager.coverage.spec.ts
@@ -582,12 +582,15 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
         .to.be.revertedWithCustomError(fixture.manager, "StakeOwnerExiting");
     });
 
-    it("rejects the deferred hook for a fully stake-backed position", async () => {
+    it("uses the canonical deferred hook as the mode selector with excess stake", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
       const intentHash = ethers.utils.id("deferred-hook-with-stake");
       await setRiskIntent(fixture, intentHash, { settlementHook: fixture.orchestrator.address });
-      await expect(fixture.orchestrator.createPosition(fixture.manager.address, intentHash))
-        .to.be.revertedWithCustomError(fixture.manager, "DeferredPayoutHookNotAllowed");
+      await fixture.orchestrator.createPosition(fixture.manager.address, intentHash);
+
+      const position = await fixture.manager.getRiskPosition(intentHash);
+      expect(position.mode).to.eq(3);
+      expect(position.initialReservation).to.eq(usdc("0.575"));
     });
 
     it("rejects the deferred hook for a free position", async () => {

--- a/test/staking/riskManager.spec.ts
+++ b/test/staking/riskManager.spec.ts
@@ -1267,9 +1267,29 @@ describe("RiskManager and OrchestratorV3", () => {
         .to.be.revertedWithCustomError(orchestrator, "RiskHookAdmissionFailed");
     });
 
-    it("keeps explicit deferred mode stable when a permissionless maturity release raises free stake", async () => {
-      const { taker, other, escrow, orchestrator, vault, manager, deferredHook } =
+    it("keeps a signed deferred authorization stable when permissionless maturity raises free stake", async () => {
+      const { maker, taker, other, witness, token, escrow, orchestrator, vault, manager, deferredHook } =
         await loadFixture(deployFixture);
+      await escrow.connect(maker).createDeposit({
+        token: token.address,
+        amount: usdc(50_000),
+        intentAmountRange: { min: usdc(1), max: usdc(10_000) },
+        paymentMethods: [PAYPAL],
+        paymentMethodData: [{
+          intentGatingService: witness.address,
+          payeeDetails: PAYEE,
+          data: "0x",
+        }],
+        currencies: [[{
+          code: USD,
+          minConversionRate: precise(1),
+          oracleRateConfig: { adapter: ZERO, adapterConfig: "0x", spreadBps: 0, maxStaleness: 0 },
+        }]],
+        delegate: ZERO,
+        intentGuardian: ZERO,
+        retainOnEmpty: true,
+      });
+      await orchestrator.connect(maker).setDepositRiskHook(escrow.address, 1, manager.address);
       await vault.connect(taker).depositStake(usdc("704.025"));
 
       const previousIntent = await signalIntent(orchestrator, escrow, taker, usdc(700), PAYPAL);
@@ -1278,21 +1298,35 @@ describe("RiskManager and OrchestratorV3", () => {
       await time.increaseTo(deadline);
       expect(await vault.freeStake(taker.address)).to.eq(usdc("4.025"));
 
+      const unsignedParams = {
+        ...signalParams(escrow, taker.address, usdc(700), PAYPAL, deferredHook.address),
+        depositId: 1,
+        signatureExpiration: (await time.latest()) + DAY,
+      };
+      const nonceBefore = await orchestrator.getIntentGatingNonce(taker.address, escrow.address, 1, PAYPAL);
+      const gatingHashBefore = await orchestrator.getIntentGatingMessageHash(unsignedParams, taker.address);
+      const params = {
+        ...unsignedParams,
+        gatingServiceSignature: await witness.signMessage(ethers.utils.arrayify(gatingHashBefore)),
+      };
+      await orchestrator.connect(taker).callStatic.signalIntent(params);
+
       await manager.connect(other).releaseMaturedPosition(previousIntent);
       expect(await vault.freeStake(taker.address)).to.eq(usdc("704.025"));
+      expect(await orchestrator.getIntentGatingNonce(taker.address, escrow.address, 1, PAYPAL))
+        .to.eq(nonceBefore);
+      expect(await orchestrator.getIntentGatingMessageHash(params, taker.address)).to.eq(gatingHashBefore);
 
-      const intentHash = await signalIntent(
-        orchestrator,
-        escrow,
-        taker,
-        usdc(700),
-        PAYPAL,
-        deferredHook.address,
-      );
+      const signalTx = await orchestrator.connect(taker).signalIntent(params);
+      await expect(signalTx).to.emit(orchestrator, "IntentGatingAuthorizationConsumed")
+        .withArgs(taker.address, escrow.address, 1, PAYPAL, nonceBefore);
+      const intentHash = intentHashFrom(await signalTx.wait());
       const position = await manager.getRiskPosition(intentHash);
       expect(position.mode).to.eq(3);
       expect(position.initialReservation).to.eq(usdc("4.025"));
       expect(await vault.reservedStake(taker.address)).to.eq(usdc("4.025"));
+      expect(await orchestrator.getIntentGatingNonce(taker.address, escrow.address, 1, PAYPAL))
+        .to.eq(nonceBefore.add(1));
     });
 
     it("slashes deferred proceeds without reducing membership stake", async () => {

--- a/test/staking/riskManager.spec.ts
+++ b/test/staking/riskManager.spec.ts
@@ -50,6 +50,7 @@ describe("RiskManager and OrchestratorV3", () => {
     );
     const boundedCall = await (await ethers.getContractFactory("BoundedCall")).deploy();
     const postIntentHookExecutor = await (await ethers.getContractFactory("PostIntentHookExecutor")).deploy();
+    const orchestratorV3Validation = await (await ethers.getContractFactory("OrchestratorV3Validation")).deploy();
     const orchestratorV3FeeLib = await (await ethers.getContractFactory("OrchestratorV3FeeLib")).deploy();
     const riskCallbackRecorder = await (await ethers.getContractFactory("RiskCallbackRecorder")).deploy();
     const orchestratorV3RiskLib = await (await ethers.getContractFactory("OrchestratorV3RiskLib", {
@@ -62,6 +63,7 @@ describe("RiskManager and OrchestratorV3", () => {
       libraries: {
         BoundedCall: boundedCall.address,
         PostIntentHookExecutor: postIntentHookExecutor.address,
+        OrchestratorV3Validation: orchestratorV3Validation.address,
         OrchestratorV3FeeLib: orchestratorV3FeeLib.address,
         OrchestratorV3RiskLib: orchestratorV3RiskLib.address,
       },
@@ -78,7 +80,7 @@ describe("RiskManager and OrchestratorV3", () => {
     const vault = await (await ethers.getContractFactory("StakeVault")).deploy(
       owner.address,
       token.address,
-      owner.address,
+      ZERO,
       30 * DAY,
       DAY,
     );
@@ -263,6 +265,73 @@ describe("RiskManager and OrchestratorV3", () => {
   }
 
   describe("configuration and exact formulas", () => {
+    it("rejects a deferred hook with a zero dependency", async () => {
+      const { vault, manager, deferredHook, orchestratorRegistry } = await loadFixture(deployFixture);
+      await expect((await ethers.getContractFactory("DeferredPayoutHook")).deploy(
+        ZERO,
+        vault.address,
+        manager.address,
+        orchestratorRegistry.address,
+      )).to.be.revertedWithCustomError(deferredHook, "ZeroAddress");
+    });
+
+    it("rejects a deferred hook payout token without deployed code", async () => {
+      const { other, vault, manager, deferredHook, orchestratorRegistry } = await loadFixture(deployFixture);
+      await expect((await ethers.getContractFactory("DeferredPayoutHook")).deploy(
+        other.address,
+        vault.address,
+        manager.address,
+        orchestratorRegistry.address,
+      )).to.be.revertedWithCustomError(deferredHook, "InvalidContract");
+    });
+
+    it("rejects a deferred hook stake vault without deployed code", async () => {
+      const { other, token, manager, deferredHook, orchestratorRegistry } = await loadFixture(deployFixture);
+      await expect((await ethers.getContractFactory("DeferredPayoutHook")).deploy(
+        token.address,
+        other.address,
+        manager.address,
+        orchestratorRegistry.address,
+      )).to.be.revertedWithCustomError(deferredHook, "InvalidContract");
+    });
+
+    it("rejects a deferred hook risk manager without deployed code", async () => {
+      const { other, token, vault, deferredHook, orchestratorRegistry } = await loadFixture(deployFixture);
+      await expect((await ethers.getContractFactory("DeferredPayoutHook")).deploy(
+        token.address,
+        vault.address,
+        other.address,
+        orchestratorRegistry.address,
+      )).to.be.revertedWithCustomError(deferredHook, "InvalidContract");
+    });
+
+    it("rejects a deferred hook orchestrator registry without deployed code", async () => {
+      const { other, token, vault, manager, deferredHook } = await loadFixture(deployFixture);
+      await expect((await ethers.getContractFactory("DeferredPayoutHook")).deploy(
+        token.address,
+        vault.address,
+        manager.address,
+        other.address,
+      )).to.be.revertedWithCustomError(deferredHook, "InvalidContract");
+    });
+
+    it("rejects a deferred hook wired to another manager vault", async () => {
+      const { owner, token, manager, deferredHook, orchestratorRegistry, vault } = await loadFixture(deployFixture);
+      const otherVault = await (await ethers.getContractFactory("StakeVault")).deploy(
+        owner.address,
+        token.address,
+        ZERO,
+        30 * DAY,
+        DAY,
+      );
+      await expect((await ethers.getContractFactory("DeferredPayoutHook")).deploy(
+        token.address,
+        otherVault.address,
+        manager.address,
+        orchestratorRegistry.address,
+      )).to.be.revertedWithCustomError(deferredHook, "RiskManagerStakeVaultMismatch");
+    });
+
     it("rejects a deferred hook token that differs from the vault token", async () => {
       const { vault, manager, deferredHook, orchestratorRegistry } = await loadFixture(deployFixture);
       const otherToken = await (await ethers.getContractFactory("USDCMock"))
@@ -334,6 +403,48 @@ describe("RiskManager and OrchestratorV3", () => {
       expect(result.maxGriefingBond).to.eq(usdc("5.75"));
       expect(result.chargebackReserve).to.eq(usdc(1_000));
       expect(result.requiredReservation).to.eq(usdc(1_000));
+    });
+
+    it("rejects a risk-hook update for an escrow address without deployed code", async () => {
+      const { maker, other, orchestrator } = await loadFixture(deployFixture);
+      await expect(orchestrator.connect(maker).setDepositRiskHook(other.address, 0, ZERO))
+        .to.be.revertedWithCustomError(orchestrator, "InvalidContract");
+    });
+
+    it("rejects a risk-hook address without deployed code", async () => {
+      const { maker, other, escrow, orchestrator } = await loadFixture(deployFixture);
+      await expect(orchestrator.connect(maker).setDepositRiskHook(escrow.address, 0, other.address))
+        .to.be.revertedWithCustomError(orchestrator, "InvalidRiskHook");
+    });
+
+    it("rejects a risk-hook update from someone other than the depositor or delegate", async () => {
+      const { other, escrow, orchestrator } = await loadFixture(deployFixture);
+      await expect(orchestrator.connect(other).setDepositRiskHook(escrow.address, 0, ZERO))
+        .to.be.revertedWithCustomError(orchestrator, "UnauthorizedCallerOrDelegate");
+    });
+
+    it("rejects deferred-hook execution from an unregistered caller", async () => {
+      const { other, token, escrow, deferredHook } = await loadFixture(deployFixture);
+      const hookContext = {
+        intentHash: ethers.utils.id("unauthorized-deferred-hook"),
+        token: token.address,
+        executableAmount: 1,
+        intent: {
+          owner: other.address,
+          to: other.address,
+          escrow: escrow.address,
+          depositId: 0,
+          amount: 1,
+          timestamp: await time.latest(),
+          paymentMethod: PAYPAL,
+          fiatCurrency: USD,
+          conversionRate: precise(1),
+          payeeId: PAYEE,
+          signalHookData: "0x",
+        },
+      };
+      await expect(deferredHook.connect(other).execute(hookContext, "0x"))
+        .to.be.revertedWithCustomError(deferredHook, "UnauthorizedOrchestrator");
     });
   });
 

--- a/test/staking/riskManager.spec.ts
+++ b/test/staking/riskManager.spec.ts
@@ -1267,11 +1267,32 @@ describe("RiskManager and OrchestratorV3", () => {
         .to.be.revertedWithCustomError(orchestrator, "RiskHookAdmissionFailed");
     });
 
-    it("rejects the deferred hook when stake already covers the full reservation", async () => {
-      const { taker, escrow, orchestrator, vault, manager, deferredHook } = await loadFixture(deployFixture);
-      await vault.connect(taker).depositStake(usdc(700));
-      await expect(signalIntent(orchestrator, escrow, taker, usdc(700), PAYPAL, deferredHook.address))
-        .to.be.revertedWithCustomError(orchestrator, "RiskHookAdmissionFailed");
+    it("keeps explicit deferred mode stable when a permissionless maturity release raises free stake", async () => {
+      const { taker, other, escrow, orchestrator, vault, manager, deferredHook } =
+        await loadFixture(deployFixture);
+      await vault.connect(taker).depositStake(usdc("704.025"));
+
+      const previousIntent = await signalIntent(orchestrator, escrow, taker, usdc(700), PAYPAL);
+      await fulfillIntent(orchestrator, previousIntent, usdc(700));
+      const deadline = (await manager.getRiskPosition(previousIntent)).coverageDeadline.toNumber();
+      await time.increaseTo(deadline);
+      expect(await vault.freeStake(taker.address)).to.eq(usdc("4.025"));
+
+      await manager.connect(other).releaseMaturedPosition(previousIntent);
+      expect(await vault.freeStake(taker.address)).to.eq(usdc("704.025"));
+
+      const intentHash = await signalIntent(
+        orchestrator,
+        escrow,
+        taker,
+        usdc(700),
+        PAYPAL,
+        deferredHook.address,
+      );
+      const position = await manager.getRiskPosition(intentHash);
+      expect(position.mode).to.eq(3);
+      expect(position.initialReservation).to.eq(usdc("4.025"));
+      expect(await vault.reservedStake(taker.address)).to.eq(usdc("4.025"));
     });
 
     it("slashes deferred proceeds without reducing membership stake", async () => {

--- a/test/staking/riskManager.spec.ts
+++ b/test/staking/riskManager.spec.ts
@@ -264,6 +264,21 @@ describe("RiskManager and OrchestratorV3", () => {
     };
   }
 
+  async function configureManagerFee(
+    maker: any,
+    recipient: any,
+    escrow: Contract,
+    feeRate: BigNumber,
+    label: string,
+  ) {
+    const rateManager = await (await ethers.getContractFactory("RateManagerMock")).deploy();
+    const rateManagerId = ethers.utils.id(label);
+    await rateManager.setManager(rateManagerId, true);
+    await rateManager.setFee(rateManagerId, recipient.address, feeRate);
+    await rateManager.setRate(rateManagerId, escrow.address, 0, PAYPAL, USD, precise(1));
+    await escrow.connect(maker).setRateManager(0, rateManager.address, rateManagerId);
+  }
+
   describe("configuration and exact formulas", () => {
     it("rejects a deferred hook with a zero dependency", async () => {
       const { vault, manager, deferredHook, orchestratorRegistry } = await loadFixture(deployFixture);
@@ -920,7 +935,7 @@ describe("RiskManager and OrchestratorV3", () => {
       expect(await vault.reservedStake(taker.address)).to.eq(usdc("4.025"));
     });
 
-    it("holds settled proceeds as chargeback coverage and releases griefing stake", async () => {
+    it("holds zero-fee net proceeds as complete coverage and releases griefing stake", async () => {
       const { taker, escrow, orchestrator, vault, manager, deferredHook } = await loadFixture(deployFixture);
       await vault.connect(taker).depositStake(usdc(10));
       const intentHash = await signalIntent(
@@ -934,7 +949,9 @@ describe("RiskManager and OrchestratorV3", () => {
       await fulfillIntent(orchestrator, intentHash, usdc(700));
       expect(await vault.reservedStake(taker.address)).to.eq(0);
       expect((await vault.getDeferredPayout(intentHash)).amount).to.eq(usdc(700));
-      expect((await manager.getRiskPosition(intentHash)).reservedAmount).to.eq(usdc(700));
+      const position = await manager.getRiskPosition(intentHash);
+      expect(position.deferredPayoutAmount).to.eq(usdc(700));
+      expect(position.reservedAmount).to.eq(0);
     });
 
     it("rejects at admission when a self-referral would reduce deferred proceeds below coverage", async () => {
@@ -953,21 +970,24 @@ describe("RiskManager and OrchestratorV3", () => {
       expect(await orchestrator.getAccountIntentCount(taker.address)).to.eq(0);
     });
 
-    it("rejects any nonzero fee when deferred coverage reserves 100 percent", async () => {
-      const { owner, taker, escrow, orchestrator, vault, deferredHook } = await loadFixture(deployFixture);
+    it("admits a sub-unit fee rate whose exact token fee rounds to zero", async () => {
+      const { owner, taker, escrow, orchestrator, vault, manager, deferredHook } =
+        await loadFixture(deployFixture);
       await vault.connect(taker).depositStake(usdc(10));
       await orchestrator.connect(owner).setProtocolFee(1);
 
-      await expect(signalIntent(
+      const intentHash = await signalIntent(
         orchestrator,
         escrow,
         taker,
         usdc(700),
         PAYPAL,
         deferredHook.address,
-      )).to.be.revertedWithCustomError(orchestrator, "RiskHookAdmissionFailed");
+      );
+      await fulfillIntent(orchestrator, intentHash, usdc(700));
 
-      expect(await vault.reservedStake(taker.address)).to.eq(0);
+      expect((await vault.getDeferredPayout(intentHash)).amount).to.eq(usdc(700));
+      expect((await manager.getRiskPosition(intentHash)).reservedAmount).to.eq(0);
     });
 
     it("uses the zero fee snapshot when governance raises the protocol fee after admission", async () => {
@@ -995,9 +1015,10 @@ describe("RiskManager and OrchestratorV3", () => {
       expect(await orchestrator.getIntentTotalFeeRate(intentHash)).to.eq(0);
     });
 
-    it("pays the taker directly and releases deferred coverage on maker manual release", async () => {
-      const { maker, taker, escrow, orchestrator, token, vault, manager, deferredHook } =
+    it("pays snapshotted fees immediately and bypasses deferred capture on maker manual release", async () => {
+      const { owner, maker, taker, escrow, orchestrator, token, vault, manager, deferredHook } =
         await loadFixture(deployFixture);
+      await orchestrator.connect(owner).setProtocolFee(precise("0.01"));
       await vault.connect(taker).depositStake(usdc(10));
       const intentHash = await signalIntent(
         orchestrator,
@@ -1008,12 +1029,14 @@ describe("RiskManager and OrchestratorV3", () => {
         deferredHook.address,
       );
       const balanceBefore = await token.balanceOf(taker.address);
+      const protocolBalanceBefore = await token.balanceOf(owner.address);
 
       await orchestrator.connect(maker).releaseFundsToPayer(intentHash);
 
       const position = await manager.getRiskPosition(intentHash);
       const deferredPayout = await vault.getDeferredPayout(intentHash);
-      expect(await token.balanceOf(taker.address)).to.eq(balanceBefore.add(usdc(700)));
+      expect(await token.balanceOf(taker.address)).to.eq(balanceBefore.add(usdc(693)));
+      expect((await token.balanceOf(owner.address)).sub(protocolBalanceBefore)).to.eq(usdc(7));
       expect(position.status).to.eq(4);
       expect(position.paymentId).to.eq(ethers.constants.HashZero);
       expect(position.coverageDeadline).to.eq(0);
@@ -1026,7 +1049,7 @@ describe("RiskManager and OrchestratorV3", () => {
         .to.be.revertedWithCustomError(manager, "PositionNotSettled");
     });
 
-    it("rejects aggregate protocol, manager, and referral fees at full reserve", async () => {
+    it("conserves funds for a partial release and unlocks the exact rounded fee gap at maturity", async () => {
       const {
         owner,
         maker,
@@ -1035,27 +1058,157 @@ describe("RiskManager and OrchestratorV3", () => {
         other,
         escrow,
         orchestrator,
+        token,
         vault,
+        manager,
         deferredHook,
       } = await loadFixture(deployFixture);
       const feeRate = precise("0.01");
-      const rateManagerId = ethers.utils.id("v3-fee-manager");
-      const rateManager = await (await ethers.getContractFactory("RateManagerMock")).deploy();
-      await rateManager.setManager(rateManagerId, true);
-      await rateManager.setFee(rateManagerId, recipient.address, feeRate);
-      await rateManager.setRate(rateManagerId, escrow.address, 0, PAYPAL, USD, precise(1));
-      await escrow.connect(maker).setRateManager(0, rateManager.address, rateManagerId);
+      const intentAmount = usdc(700);
+      const releaseAmount = usdc("100.000001");
+      const exactFee = usdc(1);
+      const exactStakeGap = exactFee.mul(3);
+      const exactDeferredProceeds = releaseAmount.sub(exactStakeGap);
+      await configureManagerFee(maker, recipient, escrow, feeRate, "v3-hybrid-fee-manager");
       await orchestrator.connect(owner).setProtocolFee(feeRate);
-      await vault.connect(taker).depositStake(usdc(10));
+      await vault.connect(taker).depositStake(usdc(25));
 
-      await expect(orchestrator.connect(taker).signalIntent(signalParams(
+      const protocolBalanceBefore = await token.balanceOf(owner.address);
+      const managerBalanceBefore = await token.balanceOf(recipient.address);
+      const referralBalanceBefore = await token.balanceOf(other.address);
+      const intentHash = intentHashFrom(await (
+        await orchestrator.connect(taker).signalIntent(signalParams(
+          escrow,
+          taker.address,
+          intentAmount,
+          PAYPAL,
+          deferredHook.address,
+          [{ recipient: other.address, fee: feeRate }],
+        ))
+      ).wait());
+
+      expect((await manager.getRiskPosition(intentHash)).initialReservation).to.eq(usdc(21));
+      await vault.connect(taker).requestStakeWithdrawal(usdc(4));
+
+      await fulfillIntent(orchestrator, intentHash, releaseAmount);
+
+      const position = await manager.getRiskPosition(intentHash);
+      expect((await token.balanceOf(owner.address)).sub(protocolBalanceBefore)).to.eq(exactFee);
+      expect((await token.balanceOf(recipient.address)).sub(managerBalanceBefore)).to.eq(exactFee);
+      expect((await token.balanceOf(other.address)).sub(referralBalanceBefore)).to.eq(exactFee);
+      expect(position.deferredPayoutAmount).to.eq(exactDeferredProceeds);
+      expect(position.reservedAmount).to.eq(exactStakeGap);
+      expect(position.deferredPayoutAmount.add(position.reservedAmount)).to.eq(releaseAmount);
+      expect(await vault.reservedStake(taker.address)).to.eq(exactStakeGap);
+      expect(await token.balanceOf(orchestrator.address)).to.eq(0);
+      expect(await token.balanceOf(vault.address)).to.eq(await vault.totalLiabilities());
+
+      await time.increaseTo(position.coverageDeadline.toNumber());
+      await manager.releaseMaturedPosition(intentHash);
+      expect(await vault.reservedStake(taker.address)).to.eq(0);
+
+      const takerBalanceBefore = await token.balanceOf(taker.address);
+      await vault.connect(taker).withdrawDeferredPayout(intentHash, taker.address);
+      await vault.connect(taker).withdrawRequestedStake(taker.address);
+      expect((await token.balanceOf(taker.address)).sub(takerBalanceBefore)).to.eq(
+        exactDeferredProceeds.add(usdc(4)),
+      );
+
+      await vault.connect(taker).requestExit();
+      await time.increase(30 * DAY);
+      await vault.connect(taker).withdrawStake(taker.address);
+      expect(await vault.stakeBalance(taker.address)).to.eq(0);
+      expect(await token.balanceOf(vault.address)).to.eq(await vault.totalLiabilities());
+    });
+
+    it("slashes deferred proceeds plus the exact fee gap for gross maker compensation", async () => {
+      const {
+        owner,
+        maker,
+        taker,
+        recipient,
+        other,
         escrow,
-        taker.address,
-        usdc(700),
-        PAYPAL,
-        deferredHook.address,
-        [{ recipient: other.address, fee: feeRate }],
-      ))).to.be.revertedWithCustomError(orchestrator, "RiskHookAdmissionFailed");
+        orchestrator,
+        token,
+        vault,
+        manager,
+        deferredHook,
+      } = await loadFixture(deployFixture);
+      const feeRate = precise("0.01");
+      const releaseAmount = usdc(700);
+      const exactFee = usdc(7);
+      const exactStakeGap = exactFee.mul(3);
+      const exactDeferredProceeds = releaseAmount.sub(exactStakeGap);
+      await configureManagerFee(maker, recipient, escrow, feeRate, "v3-hybrid-chargeback-manager");
+      await orchestrator.connect(owner).setProtocolFee(feeRate);
+      await vault.connect(taker).depositStake(usdc(25));
+
+      const protocolBalanceBefore = await token.balanceOf(owner.address);
+      const managerBalanceBefore = await token.balanceOf(recipient.address);
+      const referralBalanceBefore = await token.balanceOf(other.address);
+      const intentHash = intentHashFrom(await (
+        await orchestrator.connect(taker).signalIntent(signalParams(
+          escrow,
+          taker.address,
+          releaseAmount,
+          PAYPAL,
+          deferredHook.address,
+          [{ recipient: other.address, fee: feeRate }],
+        ))
+      ).wait());
+      await fulfillIntent(orchestrator, intentHash, releaseAmount);
+
+      await expect(manager.submitChargeback(await chargebackAttestation(intentHash)))
+        .to.emit(manager, "HybridCoverageSlashed")
+        .withArgs(intentHash, exactDeferredProceeds, exactStakeGap, releaseAmount, 0);
+
+      const position = await manager.getRiskPosition(intentHash);
+      expect((await token.balanceOf(owner.address)).sub(protocolBalanceBefore)).to.eq(exactFee);
+      expect((await token.balanceOf(recipient.address)).sub(managerBalanceBefore)).to.eq(exactFee);
+      expect((await token.balanceOf(other.address)).sub(referralBalanceBefore)).to.eq(exactFee);
+      expect(await vault.claimableCompensation(maker.address)).to.eq(releaseAmount);
+      expect(await vault.stakeBalance(taker.address)).to.eq(usdc(25).sub(exactStakeGap));
+      expect(position.slashedAmount).to.eq(releaseAmount);
+      expect(position.deferredPayoutAmount).to.eq(0);
+      expect(position.reservedAmount).to.eq(0);
+      expect((await vault.getDeferredPayout(intentHash)).amount).to.eq(0);
+      expect(await token.balanceOf(vault.address)).to.eq(await vault.totalLiabilities());
+    });
+
+    it("charges only griefing on cancellation and pays no settlement fees", async () => {
+      const { owner, maker, taker, recipient, other, escrow, orchestrator, token, vault, manager, deferredHook } =
+        await loadFixture(deployFixture);
+      const feeRate = precise("0.01");
+      await configureManagerFee(maker, recipient, escrow, feeRate, "v3-hybrid-cancel-manager");
+      await orchestrator.connect(owner).setProtocolFee(feeRate);
+      await vault.connect(taker).depositStake(usdc(25));
+
+      const protocolBalanceBefore = await token.balanceOf(owner.address);
+      const managerBalanceBefore = await token.balanceOf(recipient.address);
+      const referralBalanceBefore = await token.balanceOf(other.address);
+      const intentHash = intentHashFrom(await (
+        await orchestrator.connect(taker).signalIntent(signalParams(
+          escrow,
+          taker.address,
+          usdc(700),
+          PAYPAL,
+          deferredHook.address,
+          [{ recipient: other.address, fee: feeRate }],
+        ))
+      ).wait());
+      const createdAt = (await manager.getRiskPosition(intentHash)).createdAt.toNumber();
+      await time.setNextBlockTimestamp(createdAt + 2 * HOUR);
+      await orchestrator.connect(taker).cancelIntent(intentHash);
+
+      expect(await vault.claimableCompensation(maker.address)).to.eq(usdc("1.225"));
+      expect(await vault.reservedStake(taker.address)).to.eq(0);
+      expect((await vault.getDeferredPayout(intentHash)).amount).to.eq(0);
+      expect((await manager.getRiskPosition(intentHash)).status).to.eq(2);
+      expect((await token.balanceOf(owner.address)).sub(protocolBalanceBefore)).to.eq(0);
+      expect((await token.balanceOf(recipient.address)).sub(managerBalanceBefore)).to.eq(0);
+      expect((await token.balanceOf(other.address)).sub(referralBalanceBefore)).to.eq(0);
+      expect(await token.balanceOf(vault.address)).to.eq(await vault.totalLiabilities());
     });
 
     it("distributes snapshotted protocol, manager, and referral fees for stake-backed settlement", async () => {

--- a/test/staking/riskManager.spec.ts
+++ b/test/staking/riskManager.spec.ts
@@ -684,7 +684,7 @@ describe("RiskManager and OrchestratorV3", () => {
       expect(await vault.reservedStake(taker.address)).to.eq(usdc(600));
     });
 
-    it("uses the verifier selected at fulfillment and stores its authenticated payment ID", async () => {
+    it("keeps a rotated verifier's authenticated payment ID slashable", async () => {
       const {
         taker,
         escrow,
@@ -704,6 +704,17 @@ describe("RiskManager and OrchestratorV3", () => {
 
       await fulfillIntent(orchestrator, intentHash, usdc(500));
       expect((await manager.getRiskPosition(intentHash)).paymentId).to.eq(replacementPaymentId);
+
+      await manager.submitChargeback(await chargebackAttestation(
+        intentHash,
+        undefined,
+        replacementPaymentId,
+      ));
+
+      const position = await manager.getRiskPosition(intentHash);
+      expect(position.status).to.eq(5);
+      expect(position.reservedAmount).to.eq(0);
+      expect(await vault.reservedStake(taker.address)).to.eq(0);
     });
 
     it("propagates a real UnifiedPaymentVerifierV3 result through OrchestratorV3", async () => {

--- a/test/staking/riskManager.spec.ts
+++ b/test/staking/riskManager.spec.ts
@@ -50,10 +50,20 @@ describe("RiskManager and OrchestratorV3", () => {
     );
     const boundedCall = await (await ethers.getContractFactory("BoundedCall")).deploy();
     const postIntentHookExecutor = await (await ethers.getContractFactory("PostIntentHookExecutor")).deploy();
+    const orchestratorV3FeeLib = await (await ethers.getContractFactory("OrchestratorV3FeeLib")).deploy();
+    const riskCallbackRecorder = await (await ethers.getContractFactory("RiskCallbackRecorder")).deploy();
+    const orchestratorV3RiskLib = await (await ethers.getContractFactory("OrchestratorV3RiskLib", {
+      libraries: {
+        BoundedCall: boundedCall.address,
+        RiskCallbackRecorder: riskCallbackRecorder.address,
+      },
+    })).deploy();
     const orchestrator = await (await ethers.getContractFactory("OrchestratorV3", {
       libraries: {
         BoundedCall: boundedCall.address,
         PostIntentHookExecutor: postIntentHookExecutor.address,
+        OrchestratorV3FeeLib: orchestratorV3FeeLib.address,
+        OrchestratorV3RiskLib: orchestratorV3RiskLib.address,
       },
     })).deploy(
       owner.address,
@@ -112,7 +122,7 @@ describe("RiskManager and OrchestratorV3", () => {
       enabled: true,
       chargeback: {
         chargebackable: true,
-        deferredPayoutEnabled: false,
+        deferredPayoutEnabled: true,
         reserveBps: 10_000,
         riskWindow: 30 * DAY,
       },
@@ -274,13 +284,14 @@ describe("RiskManager and OrchestratorV3", () => {
       })).to.be.revertedWithCustomError(manager, "InvalidPlatformConfig");
     });
 
-    it("rejects deferred payout for a chargebackable platform in v1", async () => {
+    it("accepts deferred payout for a chargebackable platform", async () => {
       const { manager } = await loadFixture(deployFixture);
-      await expect(manager.setPlatformRiskConfig(PAYPAL, {
+      await manager.setPlatformRiskConfig(PAYPAL, {
         enabled: true,
         chargeback: { chargebackable: true, deferredPayoutEnabled: true, reserveBps: 10_000, riskWindow: DAY },
         griefing: { griefingCliff: 1, griefingPenaltyBpsPerHour: 1, freeTakeCount: 0, freeTakeAmount: 0 },
-      })).to.be.revertedWithCustomError(manager, "InvalidPlatformConfig");
+      });
+      expect((await manager.getPlatformRiskConfig(PAYPAL)).chargeback.deferredPayoutEnabled).to.eq(true);
     });
 
     it("rejects free takes on a chargebackable platform", async () => {
@@ -493,6 +504,21 @@ describe("RiskManager and OrchestratorV3", () => {
       const cancelledAt = await orchestrator.getIntentCancellation(intentHash);
       expect(cancelledAt).to.be.gte(before);
       expect(cancelledAt).to.eq(await time.latest());
+    });
+
+    it("records released amount and time when a settlement callback fails", async () => {
+      const { maker, taker, escrow, orchestrator } = await loadFixture(deployFixture);
+      const mock = await (await ethers.getContractFactory("IntentRiskHookMock")).deploy();
+      await orchestrator.connect(maker).setDepositRiskHook(escrow.address, 0, mock.address);
+      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(10), ZELLE);
+      await mock.setRevertOnTerminal(true);
+      const before = await time.latest();
+      await fulfillIntent(orchestrator, intentHash, usdc(10));
+
+      const settlement = await orchestrator.getIntentSettlement(intentHash);
+      expect(settlement.releasedAmount).to.eq(usdc(10));
+      expect(settlement.settledAt).to.be.gte(before);
+      expect(settlement.settledAt).to.eq(await time.latest());
     });
   });
 
@@ -727,4 +753,211 @@ describe("RiskManager and OrchestratorV3", () => {
     });
   });
 
+  describe("deferred payout exception", () => {
+    it("reserves only the maximum griefing bond when stake cannot cover chargebacks", async () => {
+      const { taker, escrow, orchestrator, vault, manager, deferredHook } = await loadFixture(deployFixture);
+      await vault.connect(taker).depositStake(usdc(10));
+      const intentHash = await signalIntent(
+        orchestrator,
+        escrow,
+        taker,
+        usdc(700),
+        PAYPAL,
+        deferredHook.address,
+      );
+      const position = await manager.getRiskPosition(intentHash);
+      expect(position.mode).to.eq(3);
+      expect(position.initialReservation).to.eq(usdc("4.025"));
+      expect(await vault.reservedStake(taker.address)).to.eq(usdc("4.025"));
+    });
+
+    it("holds settled proceeds as chargeback coverage and releases griefing stake", async () => {
+      const { taker, escrow, orchestrator, vault, manager, deferredHook } = await loadFixture(deployFixture);
+      await vault.connect(taker).depositStake(usdc(10));
+      const intentHash = await signalIntent(
+        orchestrator,
+        escrow,
+        taker,
+        usdc(700),
+        PAYPAL,
+        deferredHook.address,
+      );
+      await fulfillIntent(orchestrator, intentHash, usdc(700));
+      expect(await vault.reservedStake(taker.address)).to.eq(0);
+      expect((await vault.getDeferredPayout(intentHash)).amount).to.eq(usdc(700));
+      expect((await manager.getRiskPosition(intentHash)).reservedAmount).to.eq(usdc(700));
+    });
+
+    it("rejects at admission when a self-referral would reduce deferred proceeds below coverage", async () => {
+      const { taker, escrow, orchestrator, vault, deferredHook } = await loadFixture(deployFixture);
+      await vault.connect(taker).depositStake(usdc(10));
+      await expect(orchestrator.connect(taker).signalIntent(signalParams(
+          escrow,
+          taker.address,
+          usdc(700),
+          PAYPAL,
+          deferredHook.address,
+          [{ recipient: taker.address, fee: precise("0.5") }],
+        )))
+        .to.be.revertedWithCustomError(orchestrator, "RiskHookAdmissionFailed");
+      expect(await vault.reservedStake(taker.address)).to.eq(0);
+      expect(await orchestrator.getAccountIntentCount(taker.address)).to.eq(0);
+    });
+
+    it("rejects any nonzero fee when deferred coverage reserves 100 percent", async () => {
+      const { owner, taker, escrow, orchestrator, vault, deferredHook } = await loadFixture(deployFixture);
+      await vault.connect(taker).depositStake(usdc(10));
+      await orchestrator.connect(owner).setProtocolFee(1);
+
+      await expect(signalIntent(
+        orchestrator,
+        escrow,
+        taker,
+        usdc(700),
+        PAYPAL,
+        deferredHook.address,
+      )).to.be.revertedWithCustomError(orchestrator, "RiskHookAdmissionFailed");
+
+      expect(await vault.reservedStake(taker.address)).to.eq(0);
+    });
+
+    it("uses the zero fee snapshot when governance raises the protocol fee after admission", async () => {
+      const { owner, taker, escrow, orchestrator, vault, deferredHook, token } =
+        await loadFixture(deployFixture);
+      await vault.connect(taker).depositStake(usdc(10));
+
+      const intentHash = await signalIntent(
+        orchestrator,
+        escrow,
+        taker,
+        usdc(700),
+        PAYPAL,
+        deferredHook.address,
+      );
+      expect(await orchestrator.getIntentTotalFeeRate(intentHash)).to.eq(0);
+
+      const releaseAmount = usdc("1.000001");
+      const protocolBalanceBefore = await token.balanceOf(owner.address);
+      await orchestrator.connect(owner).setProtocolFee(precise("0.05"));
+      await fulfillIntent(orchestrator, intentHash, releaseAmount);
+
+      expect((await vault.getDeferredPayout(intentHash)).amount).to.eq(releaseAmount);
+      expect((await token.balanceOf(owner.address)).sub(protocolBalanceBefore)).to.eq(0);
+      expect(await orchestrator.getIntentTotalFeeRate(intentHash)).to.eq(0);
+    });
+
+    it("rejects aggregate protocol, manager, and referral fees at full reserve", async () => {
+      const {
+        owner,
+        maker,
+        taker,
+        recipient,
+        other,
+        escrow,
+        orchestrator,
+        vault,
+        deferredHook,
+      } = await loadFixture(deployFixture);
+      const feeRate = precise("0.01");
+      const rateManagerId = ethers.utils.id("v3-fee-manager");
+      const rateManager = await (await ethers.getContractFactory("RateManagerMock")).deploy();
+      await rateManager.setManager(rateManagerId, true);
+      await rateManager.setFee(rateManagerId, recipient.address, feeRate);
+      await rateManager.setRate(rateManagerId, escrow.address, 0, PAYPAL, USD, precise(1));
+      await escrow.connect(maker).setRateManager(0, rateManager.address, rateManagerId);
+      await orchestrator.connect(owner).setProtocolFee(feeRate);
+      await vault.connect(taker).depositStake(usdc(10));
+
+      await expect(orchestrator.connect(taker).signalIntent(signalParams(
+        escrow,
+        taker.address,
+        usdc(700),
+        PAYPAL,
+        deferredHook.address,
+        [{ recipient: other.address, fee: feeRate }],
+      ))).to.be.revertedWithCustomError(orchestrator, "RiskHookAdmissionFailed");
+    });
+
+    it("distributes snapshotted protocol, manager, and referral fees for stake-backed settlement", async () => {
+      const {
+        owner,
+        maker,
+        taker,
+        recipient,
+        other,
+        escrow,
+        orchestrator,
+        token,
+        vault,
+      } = await loadFixture(deployFixture);
+      const feeRate = precise("0.01");
+      const releaseAmount = usdc(700);
+      const expectedFee = usdc(7);
+      const rateManagerId = ethers.utils.id("v3-fee-distribution-manager");
+      const rateManager = await (await ethers.getContractFactory("RateManagerMock")).deploy();
+      await rateManager.setManager(rateManagerId, true);
+      await rateManager.setFee(rateManagerId, recipient.address, feeRate);
+      await rateManager.setRate(rateManagerId, escrow.address, 0, PAYPAL, USD, precise(1));
+      await escrow.connect(maker).setRateManager(0, rateManager.address, rateManagerId);
+      await orchestrator.connect(owner).setProtocolFee(feeRate);
+      await vault.connect(taker).depositStake(releaseAmount);
+
+      const protocolBalanceBefore = await token.balanceOf(owner.address);
+      const managerBalanceBefore = await token.balanceOf(recipient.address);
+      const referralBalanceBefore = await token.balanceOf(other.address);
+      const takerBalanceBefore = await token.balanceOf(taker.address);
+      const intentHash = intentHashFrom(await (
+        await orchestrator.connect(taker).signalIntent(signalParams(
+          escrow,
+          taker.address,
+          releaseAmount,
+          PAYPAL,
+          ZERO,
+          [{ recipient: other.address, fee: feeRate }],
+        ))
+      ).wait());
+
+      await fulfillIntent(orchestrator, intentHash, releaseAmount);
+
+      expect((await token.balanceOf(owner.address)).sub(protocolBalanceBefore)).to.eq(expectedFee);
+      expect((await token.balanceOf(recipient.address)).sub(managerBalanceBefore)).to.eq(expectedFee);
+      expect((await token.balanceOf(other.address)).sub(referralBalanceBefore)).to.eq(expectedFee);
+      expect((await token.balanceOf(taker.address)).sub(takerBalanceBefore)).to.eq(
+        releaseAmount.sub(expectedFee.mul(3)),
+      );
+    });
+
+    it("requires the canonical deferred hook for the exception", async () => {
+      const { taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
+      await vault.connect(taker).depositStake(usdc(10));
+      await expect(signalIntent(orchestrator, escrow, taker, usdc(700), PAYPAL))
+        .to.be.revertedWithCustomError(orchestrator, "RiskHookAdmissionFailed");
+    });
+
+    it("rejects the deferred hook when stake already covers the full reservation", async () => {
+      const { taker, escrow, orchestrator, vault, manager, deferredHook } = await loadFixture(deployFixture);
+      await vault.connect(taker).depositStake(usdc(700));
+      await expect(signalIntent(orchestrator, escrow, taker, usdc(700), PAYPAL, deferredHook.address))
+        .to.be.revertedWithCustomError(orchestrator, "RiskHookAdmissionFailed");
+    });
+
+    it("slashes deferred proceeds without reducing membership stake", async () => {
+      const { maker, taker, escrow, orchestrator, vault, manager, deferredHook } =
+        await loadFixture(deployFixture);
+      await vault.connect(taker).depositStake(usdc(10));
+      const intentHash = await signalIntent(
+        orchestrator,
+        escrow,
+        taker,
+        usdc(700),
+        PAYPAL,
+        deferredHook.address,
+      );
+      await fulfillIntent(orchestrator, intentHash, usdc(700));
+      await manager.submitChargeback(await chargebackAttestation(intentHash));
+      expect(await vault.stakeBalance(taker.address)).to.eq(usdc(10));
+      expect(await vault.claimableCompensation(maker.address)).to.eq(usdc(700));
+      expect((await vault.getDeferredPayout(intentHash)).amount).to.eq(0);
+    });
+  });
 });

--- a/test/staking/riskManager.spec.ts
+++ b/test/staking/riskManager.spec.ts
@@ -510,6 +510,20 @@ describe("RiskManager and OrchestratorV3", () => {
   });
 
   describe("admission and portfolio reservations", () => {
+    it("fails closed when the admission callback exhausts its gas allowance", async () => {
+      const { maker, taker, escrow, orchestrator } = await loadFixture(deployFixture);
+      const mock = await (await ethers.getContractFactory("IntentRiskHookMock")).deploy();
+      await mock.setConsumeAllCreateGas(true);
+      await orchestrator.connect(maker).setDepositRiskHook(escrow.address, 0, mock.address);
+
+      await expect(orchestrator.connect(taker).signalIntent(
+        signalParams(escrow, taker.address, usdc(10), ZELLE),
+        { gasLimit: 2_500_000 },
+      )).to.be.revertedWithCustomError(orchestrator, "RiskHookAdmissionFailed");
+
+      expect(await orchestrator.getAccountIntentCount(taker.address)).to.eq(0);
+    });
+
     it("uses a delegated Safe as the shared stake owner", async () => {
       const { owner: safe, taker, escrow, orchestrator, token, vault, manager } = await loadFixture(deployFixture);
       await token.connect(safe).approve(vault.address, ethers.constants.MaxUint256);
@@ -630,6 +644,19 @@ describe("RiskManager and OrchestratorV3", () => {
       expect(settlement.releasedAmount).to.eq(usdc(10));
       expect(settlement.settledAt).to.be.gte(before);
       expect(settlement.settledAt).to.eq(await time.latest());
+    });
+
+    it("retains enough gas to record cancellation recovery after a callback exhausts its allowance", async () => {
+      const { maker, taker, escrow, orchestrator } = await loadFixture(deployFixture);
+      const mock = await (await ethers.getContractFactory("IntentRiskHookMock")).deploy();
+      await orchestrator.connect(maker).setDepositRiskHook(escrow.address, 0, mock.address);
+      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(10), ZELLE);
+      await mock.setConsumeAllTerminalGas(true);
+
+      await orchestrator.connect(taker).cancelIntent(intentHash, { gasLimit: 2_500_000 });
+
+      expect(await orchestrator.getIntentCancellation(intentHash)).to.eq(await time.latest());
+      expect(await orchestrator.getAccountIntentCount(taker.address)).to.eq(0);
     });
   });
 

--- a/test/staking/riskManager.spec.ts
+++ b/test/staking/riskManager.spec.ts
@@ -984,6 +984,37 @@ describe("RiskManager and OrchestratorV3", () => {
       expect(await orchestrator.getIntentTotalFeeRate(intentHash)).to.eq(0);
     });
 
+    it("pays the taker directly and releases deferred coverage on maker manual release", async () => {
+      const { maker, taker, escrow, orchestrator, token, vault, manager, deferredHook } =
+        await loadFixture(deployFixture);
+      await vault.connect(taker).depositStake(usdc(10));
+      const intentHash = await signalIntent(
+        orchestrator,
+        escrow,
+        taker,
+        usdc(700),
+        PAYPAL,
+        deferredHook.address,
+      );
+      const balanceBefore = await token.balanceOf(taker.address);
+
+      await orchestrator.connect(maker).releaseFundsToPayer(intentHash);
+
+      const position = await manager.getRiskPosition(intentHash);
+      const deferredPayout = await vault.getDeferredPayout(intentHash);
+      expect(await token.balanceOf(taker.address)).to.eq(balanceBefore.add(usdc(700)));
+      expect(position.status).to.eq(4);
+      expect(position.paymentId).to.eq(ethers.constants.HashZero);
+      expect(position.coverageDeadline).to.eq(0);
+      expect(position.reservedAmount).to.eq(0);
+      expect(position.deferredPayoutAmount).to.eq(0);
+      expect(await vault.reservedStake(taker.address)).to.eq(0);
+      expect(deferredPayout.beneficiary).to.eq(ZERO);
+      expect(deferredPayout.amount).to.eq(0);
+      await expect(manager.submitChargeback(await chargebackAttestation(intentHash)))
+        .to.be.revertedWithCustomError(manager, "PositionNotSettled");
+    });
+
     it("rejects aggregate protocol, manager, and referral fees at full reserve", async () => {
       const {
         owner,

--- a/test/staking/stakeVault.spec.ts
+++ b/test/staking/stakeVault.spec.ts
@@ -38,24 +38,26 @@ describe("StakeVault", () => {
   describe("contract dependency validation", () => {
     it("rejects a stake token without deployed code", async () => {
       const [owner, eoa] = await ethers.getSigners();
-      await expect((await ethers.getContractFactory("StakeVault")).deploy(
+      const vaultFactory = await ethers.getContractFactory("StakeVault");
+      await expect(vaultFactory.deploy(
         owner.address,
         eoa.address,
         ZERO_ADDRESS,
         30 * DAY,
         DAY,
-      )).to.be.revertedWithCustomError(await ethers.getContractFactory("StakeVault"), "InvalidContract");
+      )).to.be.revertedWithCustomError(vaultFactory, "InvalidContract");
     });
 
     it("rejects an initial controller without deployed code", async () => {
       const { owner, staker: eoa, token } = await deployFixture();
-      await expect((await ethers.getContractFactory("StakeVault")).deploy(
+      const vaultFactory = await ethers.getContractFactory("StakeVault");
+      await expect(vaultFactory.deploy(
         owner.address,
         token.address,
         eoa.address,
         30 * DAY,
         DAY,
-      )).to.be.revertedWithCustomError(await ethers.getContractFactory("StakeVault"), "InvalidContract");
+      )).to.be.revertedWithCustomError(vaultFactory, "InvalidContract");
     });
 
     it("rejects initializing a controller without deployed code", async () => {

--- a/test/staking/stakeVault.spec.ts
+++ b/test/staking/stakeVault.spec.ts
@@ -4,10 +4,20 @@ import { time } from "@nomicfoundation/hardhat-network-helpers";
 
 const usdc = (amount: string | number) => ethers.utils.parseUnits(String(amount), 6);
 const DAY = 24 * 60 * 60;
+const ZERO_ADDRESS = ethers.constants.AddressZero;
 
 describe("StakeVault", () => {
   async function deployFixture() {
-    const [owner, controller, nextController, staker, maker, recipient] = await ethers.getSigners();
+    const [owner, , , staker, maker, recipient] = await ethers.getSigners();
+
+    const controllerContract = await (await ethers.getContractFactory("RiskManagerOrchestratorHarness")).deploy();
+    const nextControllerContract = await (await ethers.getContractFactory("RiskManagerOrchestratorHarness")).deploy();
+    for (const controllerAddress of [controllerContract.address, nextControllerContract.address]) {
+      await ethers.provider.send("hardhat_impersonateAccount", [controllerAddress]);
+      await ethers.provider.send("hardhat_setBalance", [controllerAddress, "0x56BC75E2D63100000"]);
+    }
+    const controller = await ethers.getSigner(controllerContract.address);
+    const nextController = await ethers.getSigner(nextControllerContract.address);
 
     const token = await (await ethers.getContractFactory("USDCMock"))
       .deploy(usdc(1_000_000), "USD Coin", "USDC");
@@ -24,6 +34,59 @@ describe("StakeVault", () => {
 
     return { owner, controller, nextController, staker, maker, recipient, token, vault };
   }
+
+  describe("contract dependency validation", () => {
+    it("rejects a stake token without deployed code", async () => {
+      const [owner, eoa] = await ethers.getSigners();
+      await expect((await ethers.getContractFactory("StakeVault")).deploy(
+        owner.address,
+        eoa.address,
+        ZERO_ADDRESS,
+        30 * DAY,
+        DAY,
+      )).to.be.revertedWithCustomError(await ethers.getContractFactory("StakeVault"), "InvalidContract");
+    });
+
+    it("rejects an initial controller without deployed code", async () => {
+      const { owner, staker: eoa, token } = await deployFixture();
+      await expect((await ethers.getContractFactory("StakeVault")).deploy(
+        owner.address,
+        token.address,
+        eoa.address,
+        30 * DAY,
+        DAY,
+      )).to.be.revertedWithCustomError(await ethers.getContractFactory("StakeVault"), "InvalidContract");
+    });
+
+    it("rejects initializing a controller without deployed code", async () => {
+      const { owner, staker: eoa, token } = await deployFixture();
+      const vault = await (await ethers.getContractFactory("StakeVault")).deploy(
+        owner.address,
+        token.address,
+        ZERO_ADDRESS,
+        30 * DAY,
+        DAY,
+      );
+      await expect(vault.connect(owner).initializeController(eoa.address))
+        .to.be.revertedWithCustomError(vault, "InvalidContract");
+    });
+
+    it("rejects proposing a controller without deployed code", async () => {
+      const { owner, staker: eoa, vault } = await deployFixture();
+      await expect(vault.connect(owner).proposeController(eoa.address))
+        .to.be.revertedWithCustomError(vault, "InvalidContract");
+    });
+
+    it("rechecks controller code when a handover is accepted", async () => {
+      const { owner, nextController, vault } = await deployFixture();
+      await vault.connect(owner).proposeController(nextController.address);
+      await time.increase(DAY);
+      await ethers.provider.send("hardhat_setCode", [nextController.address, "0x"]);
+
+      await expect(vault.connect(nextController).acceptController())
+        .to.be.revertedWithCustomError(vault, "InvalidContract");
+    });
+  });
 
   describe("#depositStake", () => {
     it("records stake and emits the resulting balance", async () => {

--- a/utils/riskMath.ts
+++ b/utils/riskMath.ts
@@ -28,6 +28,7 @@ export interface GriefingPenalty {
 }
 
 export const RISK_BPS_DENOMINATOR = 10_000n;
+export const RISK_PRECISE_UNIT = 1_000_000_000_000_000_000n;
 export const RISK_SECONDS_PER_HOUR = 3_600n;
 export const RISK_GRIEFING_DENOMINATOR = RISK_BPS_DENOMINATOR * RISK_SECONDS_PER_HOUR;
 
@@ -76,6 +77,30 @@ export function calculateRequiredReservation(
   const griefingBond = calculateMaxGriefingBond(amount, terms);
   const chargebackReserve = calculateChargebackReserve(amount, reserveBps);
   return griefingBond > chargebackReserve ? griefingBond : chargebackReserve;
+}
+
+/** floor(A * aggregateFeeRate / 1e18), safely upper-bounding independently rounded fee components. */
+export function calculateDeferredFeeGapUpperBound(
+  amount: IntegerLike,
+  totalFeeRate: IntegerLike,
+): bigint {
+  const bondedAmount = integer(amount, "amount");
+  const aggregateFeeRate = integer(totalFeeRate, "totalFeeRate");
+  if (aggregateFeeRate > RISK_PRECISE_UNIT) {
+    throw new RangeError("totalFeeRate cannot exceed 1e18");
+  }
+  return (bondedAmount * aggregateFeeRate) / RISK_PRECISE_UNIT;
+}
+
+/** max(maxGriefingBond, feeGapUpperBound), never the sum of mutually exclusive liabilities. */
+export function calculateHybridDeferredReservation(
+  amount: IntegerLike,
+  terms: GriefingTerms,
+  totalFeeRate: IntegerLike,
+): bigint {
+  const griefingBond = calculateMaxGriefingBond(amount, terms);
+  const feeGapUpperBound = calculateDeferredFeeGapUpperBound(amount, totalFeeRate);
+  return griefingBond > feeGapUpperBound ? griefingBond : feeGapUpperBound;
 }
 
 /** Capped, upward-rounded time-linear penalty used for cancellation and reconciliation. */


### PR DESCRIPTION
# Summary

This PR completes the V3 risk hardening work on top of the payment-ID and settlement-hook architecture from #181. It keeps V1/V2 settlement behavior unchanged and introduces no deployment or package publication.

The final scope is deliberately narrow:

- guarantee gross maker compensation in deferred mode with a hybrid of deferred proceeds and retained stake;
- validate V3/staking contract dependencies;
- bound risk callbacks while preserving durable fail-open terminal reconciliation;
- make V3 gating authorizations single-use and bind all security-relevant intent fields;
- bypass deferred capture for maker manual release;
- preserve chargebackability across payment-verifier rotation by storing the authenticated payment ID.

## Hybrid deferred-payout guarantee

For gross release `R`, the exact snapshotted fee components total `F`. Deferred mode now records:

```text
D = R - F  (net deferred proceeds)
S = R - D  (exact retained stake gap)
D + S = R  (gross maker compensation)
```

Protocol, manager, and referral fees are still distributed immediately and exactly from the admission snapshot. Fees are not delayed and the 100% gross compensation policy is unchanged.

At admission, deferred mode reserves:

```text
max(maxGriefingBond, floor(intentAmount * aggregateSnapshottedFeeRate / 1e18))
```

The aggregate bound safely covers the sum of independently rounded fee components for any release up to the intent amount. The mutually exclusive pending griefing liability and post-settlement fee-gap liability are not added together. The canonical deferred hook is an explicit, stable mode selector, so permissionless maturity/reconciliation work cannot flip a quoted deferred intent into stake-backed mode before inclusion.

On a deferred-eligible platform, explicitly attaching the canonical `DeferredPayoutHook` always selects `DEFERRED_PAYOUT` whenever the hybrid bound is available, including when free stake also covers full stake-backed admission. Selection and the exact reservation are therefore monotone under free-stake increases between quote/signing and inclusion; admission does not perform balance-first stake-backed selection followed by hook rejection.

At verified settlement, the hook transfers the exact net proceeds `D` into StakeVault. Registration then shrinks the provisional reservation to the exact gap `S`; it never requests additional unreserved stake after fiat payment.

Terminal flows are explicit:

- **No chargeback:** fee recipients retain exact snapshotted fees; at maturity the beneficiary withdraws `D`, `S` unlocks, and the stake owner recovers all unslashed stake.
- **Valid chargeback:** StakeVault atomically slashes `D + S` and credits the LP/maker exactly `R`; fee recipients retain `F`; the beneficiary receives no deferred proceeds; the stake owner loses exactly `S`.
- **Cancellation:** only the snapshotted time-linear griefing penalty can be charged; the remainder unlocks; no deferred proceeds or fees exist.
- **Maker manual release:** deferred capture is bypassed; the taker receives the correct net amount, fee recipients receive exact fees, the reservation closes, and no payment ID or chargeback position remains.

Partial releases, component rounding, sub-unit/zero-fee cases, callback fail-open reconciliation, maturity batching, stake exits/partial withdrawals, mixed-source slashing, and replay behavior are covered by unit, fuzz, and invariant tests. StakeVault continues to require every liability to be token-backed, and successful registration checks the actual transferred amount.

## Callback and lifecycle hardening

OrchestratorV3 caps configured risk callbacks at 2,000,000 gas and reserves 250,000 gas after each bounded call, accounting for EIP-150 and call overhead.

Admission remains fail-closed. Settlement and cancellation remain fail-open, with the exact authenticated terminal state recorded for permissionless reconciliation. Revert data is bounded. Maker manual release closes the risk position immediately and never invokes the deferred hook.

The payment ID authenticated by the verifier that fulfilled the intent is stored on the position. A later verifier-registry rotation therefore cannot strand coverage or prevent a valid chargeback.

## Single-use V3 gating authorization

V3 gating signatures consume a monotonic nonce scoped by taker, escrow, deposit, and payment method. The signed authorization binds the chain and verifying orchestrator; taker, escrow, deposit, amount, and recipient; payment method, currency, conversion rate, and expiry; every referral fee; settlement hook/data; pre-intent-hook data; and the current nonce.

Signature producers must call `getIntentGatingMessageHash(params, taker)` on the target OrchestratorV3 and sign that 32-byte value using EIP-191 `personal_sign` / `signMessage`. This is an intentional hard cut: previous reusable V3 signatures are invalid. Deposits without a gating service do not consume a nonce, and any reverted signal rolls nonce consumption back atomically.

## ABI and event surface

Hybrid-specific ABI churn is minimal:

- no function selector or struct-layout change is needed for the hybrid accounting;
- new `HybridCoverageSlashed(intentHash, deferredCoverage, stakeCoverage, grossCompensation, remainingCoverage)` event;
- existing event parameter names are clarified without changing types, order, or topics:
  - `RiskPositionSettled.releasedAmount` -> `grossReleasedAmount`;
  - `RiskPositionSettled.chargebackCoverage` -> `stakeCoverage`;
  - `RiskPositionSettled.releasedReservation` -> `releasedStakeReservation`;
  - `DeferredPayoutRegistered.deferredAmount` -> `deferredCoverage`;
  - `DeferredPayoutRegistered.chargebackCoverage` -> `stakeCoverage`;
  - `RiskPositionReleased.releasedCoverage` -> `releasedStakeCoverage`;
  - `PayoutDeferred.amount` -> `deferredCoverage`.

The broader V3 hardening also adds `IntentProtocolFeeSnapshotted`, `IntentGatingAuthorizationConsumed`, `getIntentTotalFeeRate`, `getIntentGatingNonce`, and `getIntentGatingMessageHash`, plus the linked validation/fee/risk/callback libraries.

Indexer/client ABI coordinates: `HybridCoverageSlashed` topic0 is `0xf83750b0c6b6b4ed5e1f963356db2e03d05a9fc539e9caf1de7ca86d23b5a2e5`; `IntentProtocolFeeSnapshotted` topic0 is `0xf15f9e9d5976a5db4a21bca053551d63a44974dbe55ed0e86c08ae79bfc5db5a`; `IntentGatingAuthorizationConsumed` topic0 is `0x31e33868ce7f4c323ca4a51138363d3f0deafbf6d98ab5ee94c30465f351d104`. New getter selectors are `getIntentTotalFeeRate` `0xf037b2c2`, `getIntentGatingNonce` `0xc429459d`, and `getIntentGatingMessageHash` `0xf77fabb1`.

Error ABI additions are `RiskCallbackGasLimitTooHigh`, OrchestratorV3 `InvalidContract`/`InvalidChainId`, dependency-validation `InvalidContract` errors on RiskManager/StakeVault/DeferredPayoutHook, and the hook's explicit zero-value, authorization, token, and wiring errors. `InsufficientDeferredPayoutCoverage` is removed because hybrid coverage intentionally permits `D < R` when reserved `S` closes the exact gap; `registerDeferredPayout` itself keeps the same selector.

The contracts package adds `RISK_PRECISE_UNIT`, `calculateDeferredFeeGapUpperBound`, and `calculateHybridDeferredReservation` so off-chain capacity calculations can match admission exactly.

Acceptance coordination is pinned to `ORCHESTRATOR_V3_AFFINE_RISK_HYBRID_STAGING_ACCEPTANCE_SPEC.md` v1.4, SHA-256 `07b70af8e3df4e33773926c3b0e70ef10c3793cbb8371d64c95ee3dbb1327065` (the staging plan was reviewed but not executed):

- RB-1/RB-2 hybrid `D + S` accounting: `490ed91`;
- RB-8 canonical-hook selection and monotonicity implementation: `7fb66c1`;
- RB-8 at/above-full-capacity and sign -> maturity/reconciliation -> inclusion evidence: `60ce62a`.

## Verification

Local verification completed against this diff:

- Hardhat: 1,391 passing, 5 pending;
- Foundry non-fork unit/fuzz/invariant aggregate: 152 passing;
- Foundry Base fork: 3 passing;
- Foundry fuzz: 34 tests at 1,000 runs each;
- Foundry invariant: 22 properties at 256 runs and depth 64;
- package tests: 17 passing;
- coverage: 98.85% statements / 92.04% branches / 98.68% functions / 98.53% lines overall;
- clean TypeScript/package builds, local deployment plus idempotent rerun, 191 localhost deployment tests, contract-size gate, and relevant Forge lint checks.
- independent Claude Fable 5 max-effort full-diff rereview: `No actionable findings found.`

`OrchestratorV3` runtime size is 24,061 bytes (515-byte EIP-170 margin). No coverage output, audit artifact, deployment key, secret, or continuity file is committed.

## Deployment and downstream implications

This PR does **not** deploy contracts, publish `@zkp2p/contracts-v2`, change deployment artifacts or live addresses, or enable deferred mode. The deployment-script source links the new libraries, but nonlocal reuse of an existing named stake-risk lane is guarded; a future live rollout must use the versioned/fresh deployment lane and explicit governance approval.

Before enabling hybrid deferred mode on a new deployment:

1. publish the reviewed contracts package under separate authorization;
2. update `zkp2p-indexer` event configuration/schema/handlers to distinguish deferred coverage, stake coverage, gross compensation, and remaining coverage;
3. update Curator's vendored risk math/ABI and capacity presentation to use the hybrid fee-gap reservation;
4. migrate V3 gating-signature producers to the nonce-scoped message hash;
5. deploy and configure the new V3/RiskManager/StakeVault/DeferredPayoutHook set through a fresh versioned lane and new numbered deployment, then verify wiring before governance enables the platform.

Concrete downstream handoff baselines are the clean payment-ID indexer candidate `6075a0e70f736bd88258c1168c2790154676c869` and Curator `origin/main` `cbb2012be15aa2a17d302834d9aab3d98604f9d6`. The indexer follow-up must consume `HybridCoverageSlashed`, the clarified coverage fields, exact post-settlement reservation shrink, and admission-sourced `DEFERRED_PAYOUT` mode (never re-derived from free stake); Curator must consume the package hybrid-reservation helper for capacity/quote presentation. These are handoffs, not changes or deployments performed by this PR.

Attestation, clients, pay, mobile, relayer, notification, and PeerHQ have no direct hybrid accounting change found, but their package/address consumption must be verified as part of that deployment handoff. Because no hybrid contracts are live, no reindex or data migration is required now.

## Scope boundaries

- no lower reserve floor;
- no delayed fees;
- no compatibility alias, dual behavior, or fallback deployment path;
- no V1/V2 gating or settlement change;
- no deployment or package publication.
