### PR TITLE
fix: preserve historical hook deployment

### DIFF
--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -10,7 +10,7 @@ import { IIntentRiskHook } from "./interfaces/IIntentRiskHook.sol";
 import { IOrchestratorV2 } from "./interfaces/IOrchestratorV2.sol";
 import { IOrchestratorV3 } from "./interfaces/IOrchestratorV3.sol";
 import { BoundedCall } from "./lib/BoundedCall.sol";
-import { SettlementHookExecutor } from "./lib/SettlementHookExecutor.sol";
+import { PostIntentHookExecutor as SettlementHookExecutor } from "./lib/SettlementHookExecutor.sol";
 
 /**
  * @title OrchestratorV3
@@ -28,7 +28,8 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
 
     mapping(address => mapping(uint256 => IIntentRiskHook)) internal depositRiskHooks;
     mapping(bytes32 => IIntentRiskHook) internal intentRiskHooks;
-    mapping(bytes32 => bool) public override intentRequiresSettlementHook;
+    // Historical ABI name retained so existing V3 consumers keep the deployed getter selector.
+    mapping(bytes32 => bool) public override intentRequiresPostIntentHook;
     mapping(bytes32 => IntentSettlement) internal failedIntentSettlements;
     mapping(bytes32 => IntentCancellation) internal failedIntentCancellations;
 
@@ -174,7 +175,7 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
     function _shouldExecuteSettlementHookOnManualRelease(
         bytes32 _intentHash
     ) internal view override returns (bool) {
-        bool requiresSettlementHook = intentRequiresSettlementHook[_intentHash];
+        bool requiresSettlementHook = intentRequiresPostIntentHook[_intentHash];
         if (requiresSettlementHook && address(intents[_intentHash].settlementHook) == address(0)) {
             revert RequiredSettlementHookMissing(_intentHash);
         }
@@ -223,7 +224,7 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
             riskCallbackGasLimit,
             MAX_RISK_CALLBACK_RETURN_DATA
         );
-        intentRequiresSettlementHook[_intentHash] = requiresSettlementHook;
+        intentRequiresPostIntentHook[_intentHash] = requiresSettlementHook;
         emit IntentRiskHookSnapshotted(_intentHash, address(riskHook), requiresSettlementHook);
     }
 
@@ -250,7 +251,7 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
 
         super._resolveIntent(_intentHash, _resolution, _releasedAmount);
         delete intentRiskHooks[_intentHash];
-        delete intentRequiresSettlementHook[_intentHash];
+        delete intentRequiresPostIntentHook[_intentHash];
 
         bool callbackSucceeded = BoundedCall.executeTerminalRiskCallback(
             riskHook,

--- a/contracts/interfaces/IOrchestratorV3.sol
+++ b/contracts/interfaces/IOrchestratorV3.sol
@@ -65,7 +65,8 @@ interface IOrchestratorV3 is IOrchestratorV2 {
 
     function getDepositRiskHook(address _escrow, uint256 _depositId) external view returns (IIntentRiskHook);
     function getIntentRiskHook(bytes32 _intentHash) external view returns (IIntentRiskHook);
-    function intentRequiresSettlementHook(bytes32 _intentHash) external view returns (bool);
+    /// @dev Historical ABI name retained; the returned policy requires the intent settlement hook.
+    function intentRequiresPostIntentHook(bytes32 _intentHash) external view returns (bool);
     function getRiskIntent(bytes32 _intentHash) external view returns (RiskIntentData memory);
     function getAccountIntentCount(address _account) external view returns (uint256);
     /**

--- a/contracts/lib/SettlementHookExecutor.sol
+++ b/contracts/lib/SettlementHookExecutor.sol
@@ -9,10 +9,11 @@ import { IOrchestratorV2 } from "../interfaces/IOrchestratorV2.sol";
 import { ISettlementHook } from "../interfaces/ISettlementHook.sol";
 
 /**
- * @title SettlementHookExecutor
- * @notice Transfers settled funds directly or executes a settlement hook with an exact allowance.
+ * @title PostIntentHookExecutor
+ * @notice Historical linked-library coordinate that executes settlement hooks with an exact allowance.
+ * @dev The name is retained to preserve immutable deployment history; the public hook API is ISettlementHook.
  */
-library SettlementHookExecutor {
+library PostIntentHookExecutor {
     using SafeERC20 for IERC20;
 
     /**

--- a/deploy/26_deploy_stake_risk_system.ts
+++ b/deploy/26_deploy_stake_risk_system.ts
@@ -33,7 +33,6 @@ const LOCAL_CHARGEBACK_WITNESSES = [
 const STAKE_RISK_DEPLOYMENT_NAMES = [
   "BoundedCall",
   "PostIntentHookExecutor",
-  "SettlementHookExecutor",
   "OrchestratorV3",
   "StakeVault",
   "ChargebackAttestationVerifier",
@@ -144,15 +143,15 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log("BoundedCall deployed at", boundedCall.address);
   if (boundedCall.newlyDeployed) await waitForDeploymentDelay(hre);
 
-  const settlementHookExecutor = await deploy("SettlementHookExecutor", { from: deployer, args: [] });
-  console.log("SettlementHookExecutor deployed at", settlementHookExecutor.address);
-  if (settlementHookExecutor.newlyDeployed) await waitForDeploymentDelay(hre);
+  const postIntentHookExecutor = await deploy("PostIntentHookExecutor", { from: deployer, args: [] });
+  console.log("PostIntentHookExecutor deployed at", postIntentHookExecutor.address);
+  if (postIntentHookExecutor.newlyDeployed) await waitForDeploymentDelay(hre);
 
   const orchestratorV3 = await deploy("OrchestratorV3", {
     from: deployer,
     libraries: {
       BoundedCall: boundedCall.address,
-      SettlementHookExecutor: settlementHookExecutor.address,
+      PostIntentHookExecutor: postIntentHookExecutor.address,
     },
     args: [
       deployer,

--- a/deploy/deploy_summary.ts
+++ b/deploy/deploy_summary.ts
@@ -60,8 +60,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     ----------------------------------------------------------------------
     Stake Risk Contracts:
     BoundedCall:                        ${tryGetAddress(network, "BoundedCall")}
-    PostIntentHookExecutor (historical): ${tryGetAddress(network, "PostIntentHookExecutor")}
-    SettlementHookExecutor (source):    ${tryGetAddress(network, "SettlementHookExecutor")}
+    PostIntentHookExecutor:             ${tryGetAddress(network, "PostIntentHookExecutor")}
     OrchestratorV3:                     ${tryGetAddress(network, "OrchestratorV3")}
     StakeVault:                         ${tryGetAddress(network, "StakeVault")}
     RiskManager:                        ${tryGetAddress(network, "RiskManager")}

--- a/test/deploy/26_stakeRiskSystem.spec.ts
+++ b/test/deploy/26_stakeRiskSystem.spec.ts
@@ -47,7 +47,7 @@ describe("Affine stake risk system deployment", () => {
 
   it("deploys the linked orchestrator components", async () => {
     expect(deployedAddress("BoundedCall")).to.properAddress;
-    expect(deployedAddress("SettlementHookExecutor")).to.properAddress;
+    expect(deployedAddress("PostIntentHookExecutor")).to.properAddress;
     expect(deployedAddress("OrchestratorV3")).to.properAddress;
   });
 
@@ -147,15 +147,13 @@ describe("Affine stake risk system deployment", () => {
       .to.throw("chargeback witnesses must be disjoint from payment witnesses");
   });
 
-  it("fails before either historical or current executor coordinates can be overwritten", async () => {
-    for (const executorName of ["PostIntentHookExecutor", "SettlementHookExecutor"]) {
-      const lookedUp: string[] = [];
-      await expect(assertFreshNonLocalStakeRiskDeployment("base_staging", async (name) => {
-        lookedUp.push(name);
-        return name === executorName ? { address: ethers.constants.AddressZero } : null;
-      })).to.be.rejectedWith("use a separately named, governance-reviewed migration");
-      expect(lookedUp).to.include(executorName);
-    }
+  it("fails before a nonlocal canonical deployment can be overwritten", async () => {
+    const lookedUp: string[] = [];
+    await expect(assertFreshNonLocalStakeRiskDeployment("base_staging", async (name) => {
+      lookedUp.push(name);
+      return name === "OrchestratorV3" ? { address: ethers.constants.AddressZero } : null;
+    })).to.be.rejectedWith("use a separately named, governance-reviewed migration");
+    expect(lookedUp).to.include("OrchestratorV3");
   });
 
   it("uses the deployed modular attestation verifier and RiskManager EIP-712 domain", async () => {

--- a/test/staking/riskManager.spec.ts
+++ b/test/staking/riskManager.spec.ts
@@ -45,11 +45,11 @@ describe("RiskManager and OrchestratorV3", () => {
       MAX_INTENT_PERIOD,
     );
     const boundedCall = await (await ethers.getContractFactory("BoundedCall")).deploy();
-    const settlementHookExecutor = await (await ethers.getContractFactory("SettlementHookExecutor")).deploy();
+    const postIntentHookExecutor = await (await ethers.getContractFactory("PostIntentHookExecutor")).deploy();
     const orchestrator = await (await ethers.getContractFactory("OrchestratorV3", {
       libraries: {
         BoundedCall: boundedCall.address,
-        SettlementHookExecutor: settlementHookExecutor.address,
+        PostIntentHookExecutor: postIntentHookExecutor.address,
       },
     })).deploy(
       owner.address,


### PR DESCRIPTION
## Summary

Follow-up to #179 and its late deployment-history review:

- restore `deploy/26_deploy_stake_risk_system.ts`, its summary, and deployment test byte-for-byte to the pre-rename version;
- retain `PostIntentHookExecutor` as the sole historical linked-library/deployment coordinate while importing it locally as `SettlementHookExecutor` for source readability;
- restore the deployed V3 getter `intentRequiresPostIntentHook(bytes32)` and selector `0x4953e792` as the sole getter—no compatibility alias or duplicate runtime path;
- keep the public V2/V3 signal/fulfill structs, hook interface, settlement data, and errors on the new `settlementHook` terminology.

No deployment or package publication is performed. Existing Base/Base-staging ABI/address artifacts remain untouched.

## Why

Repository policy makes numbered live deployment scripts immutable. PR #179 incorrectly repurposed script 26 for a new linker coordinate even though nonlocal preflight prevented mutation. This follow-up fully restores that history instead of adding a new live migration.

The historical getter is also retained because it is already deployed. Its name is now explicitly documented as a historical ABI exception; its value still means that the intent settlement hook is required.

## Security review

Independent re-review found no security or correctness issues and confirmed:

- script 26/history equality against pre-#179 main;
- one executor artifact/link path only;
- deployed getter selector, event topics, and physical storage layout preserved;
- no deployment or package artifact changes;
- the late P2 is fully resolved.

Informational constraint: clean V3 runtime bytecode is 24,526 bytes, 50 bytes below EIP-170. Future live-deployment changes must recheck size.

## Validation

- clean compile: 117 Solidity files; 262 typings; V3 runtime 24,526 bytes
- focused RiskManager/OrchestratorV3: 30 passing
- localhost deployment: passed using `PostIntentHookExecutor`
- deployment suite: 180 passing
- `yarn pkg:build`: passed
- `yarn pkg:test`: 14 passing
- `git diff --check`: passed
- historical deploy script/summary/test comparison: exact

Remote CI will rerun the complete Hardhat, package, deployment, Foundry unit, fuzz, and invariant gates.