### PR TITLE
feat: propagate verified payment IDs into chargeback risk

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ The payment-ID lane is deployed in parallel with the legacy lane. It has a separ
 unified verifiers use the same `NullifierRegistry`. Deployment mirrors the legacy registry's exact live
 method/currency set and leaves all legacy routes and writers intact. Although the payment-attestation
 input schema is unchanged, its EIP-712 domain binds each signature to the selected verifier address.
+Subsequent payment-method and currency governance changes must update both registries atomically.
 
 The witness/threshold configuration remains immediately mutable and open positions do not snapshot a
 witness epoch. Delayed two-step governance and epoch snapshotting, followed by real provider E2E, are

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ The diagrams above describe the v2 settlement base. V3 adds the risk path docume
 
 `OrchestratorV3` preserves the v2 intent lifecycle and snapshots the depositor-selected risk hook when
 an intent is admitted. Admission callbacks fail closed; terminal callbacks are gas-bounded and may fail
-open so escrow liquidity is not trapped. `RiskManager` retains durable recovery data so a failed terminal
-callback can be reconciled permissionlessly using the original lifecycle timestamp.
+open so escrow liquidity is not trapped. `OrchestratorV3` retains durable recovery data so `RiskManager`
+can reconcile a failed terminal callback permissionlessly using the original lifecycle timestamp.
 
 For intent amount `A`, hourly griefing slope `s`, intent period `T`, griefing cliff `C`, and chargeback
 reserve ratio `r`, admission reserves the greater pending liability:
@@ -130,22 +130,28 @@ The current merged chargeback path is deliberately narrow and fail closed:
 
 - Chargebackable platform configs require `reserveBps == 10_000` and
   `deferredPayoutEnabled == false`, so the full gross released amount is stake-backed at admission.
-- `UnifiedPaymentVerifier` stores a commitment scoped by `(orchestrator, intentHash)` over the payment
-  method, hashed provider payment ID, fiat amount, and fiat currency. `RiskManager` snapshots the
-  payment verifier at admission and requires that commitment during verified-settlement reconciliation.
-- A maker manual release records no payment commitment, releases the reservation, starts no coverage
+- `UnifiedPaymentVerifierV3` returns the provider payment ID already authenticated inside the signed
+  `PaymentDetails`. `OrchestratorV3` passes that value through its fulfillment callback and
+  `RiskManager` stores it with the settled position; no payment verifier is snapshotted at admission.
+- A maker manual release records no payment ID, releases the reservation, starts no coverage
   window, and cannot be charged back.
 - Chargeback evidence uses the EIP-712 domain `ZKP2P RiskManager`, version `1`, current chain ID, and
   the `RiskManager` address. The signed type is
-  `ChargebackAttestation(bytes32 intentHash,bytes32 dataHash)`.
-- `data` ABI-encodes `ChargebackDetails(paymentMethod, originalPaymentId, disputeId, paymentAmount,
-  paymentCurrency)`. Those details must exactly match the verifier-backed payment commitment, and
-  `disputeId` must be nonzero.
+  `ChargebackAttestation(bytes32 intentHash,bytes32 originalPaymentId,bytes32 disputeId)`.
+- `originalPaymentId` must exactly match the identifier stored from verified fulfillment, and
+  `disputeId` must be nonzero. The payment method and gross token amount come from the position rather
+  than witness-supplied chargeback fields.
 - A valid claim inside the half-open interval `settledAt <= now < coverageDeadline` compensates the LP
   for the full gross `releasedAmount`. Partial chargebacks are not supported by this v1 policy.
 - Replay protection consumes `keccak256(paymentMethod, disputeId)` globally.
 - Fresh deployments require a dedicated three-witness chargeback verifier with a 2-of-3 threshold and
   a witness set disjoint from payment-attestation witnesses.
+
+The payment-ID lane is deployed in parallel with the legacy lane. It has a separate
+`PaymentVerifierRegistryV3`, `UnifiedPaymentVerifierV3`, `OrchestratorV3`, and risk stack, while both
+unified verifiers use the same `NullifierRegistry`. Deployment mirrors the legacy registry's exact live
+method/currency set and leaves all legacy routes and writers intact. Although the payment-attestation
+input schema is unchanged, its EIP-712 domain binds each signature to the selected verifier address.
 
 The witness/threshold configuration remains immediately mutable and open positions do not snapshot a
 witness epoch. Delayed two-step governance and epoch snapshotting, followed by real provider E2E, are

--- a/contracts/OrchestratorV2.sol
+++ b/contracts/OrchestratorV2.sol
@@ -266,36 +266,35 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         address managerFeeRecipient = intentManagerFeeRecipient[_params.intentHash];
         uint256 managerFee = intentManagerFee[_params.intentHash];
         
-        address verifier = paymentVerifierRegistry.getVerifier(intent.paymentMethod);
-        if (verifier == address(0)) revert PaymentMethodDoesNotExist(intent.paymentMethod);
-        
-        IPaymentVerifier.PaymentVerificationResult memory verificationResult = IPaymentVerifier(verifier).verifyPayment(
-            IPaymentVerifier.VerifyPaymentData({
-                intentHash: _params.intentHash,
-                paymentProof: _params.paymentProof,
-                data: _params.verificationData
-            })
-        );
-        if (!verificationResult.success) revert PaymentVerificationFailed();
-        if (verificationResult.intentHash != _params.intentHash) revert HashMismatch(_params.intentHash, verificationResult.intentHash);
+        (uint256 releaseAmount, bytes32 paymentId) = _verifyPayment(_params, intent.paymentMethod);
 
         // Enforce snapshot min-at-signal to prevent sub-min partial fulfillments
         uint256 minAtSignal = intentMinAtSignal[_params.intentHash];
-        if (minAtSignal > 0 && verificationResult.releaseAmount < minAtSignal) {
-            revert AmountBelowMin(verificationResult.releaseAmount, minAtSignal);
+        if (minAtSignal > 0 && releaseAmount < minAtSignal) {
+            revert AmountBelowMin(releaseAmount, minAtSignal);
         }
 
         // Effects
-        _resolveIntent(_params.intentHash, IntentResolution.FULFILLED, verificationResult.releaseAmount);
+        _resolveIntentWithPaymentId(
+            _params.intentHash,
+            IntentResolution.FULFILLED,
+            releaseAmount,
+            paymentId
+        );
 
         // Interactions
-        IEscrow(intent.escrow).unlockAndTransferFunds(intent.depositId, _params.intentHash, verificationResult.releaseAmount, address(this));
+        IEscrow(intent.escrow).unlockAndTransferFunds(
+            intent.depositId,
+            _params.intentHash,
+            releaseAmount,
+            address(this)
+        );
 
         _collectFeesTransferFundsAndExecuteAction(
             deposit.token, 
             _params.intentHash, 
             intent, 
-            verificationResult.releaseAmount,
+            releaseAmount,
             _params.settlementHookData,
             managerFeeRecipient,
             managerFee,
@@ -532,6 +531,43 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         uint256
     ) internal virtual {
         _pruneIntent(_intentHash);
+    }
+
+    /**
+     * @notice Resolves a verified fulfillment with optional verifier-authenticated payment identity.
+     * @dev V2 ignores the identifier because its verifier ABI does not return one. V3 overrides this
+     *      extension point and transports the value to its risk hook and failed-callback record.
+     */
+    function _resolveIntentWithPaymentId(
+        bytes32 _intentHash,
+        IntentResolution _resolution,
+        uint256 _releasedAmount,
+        bytes32
+    ) internal virtual {
+        _resolveIntent(_intentHash, _resolution, _releasedAmount);
+    }
+
+    /** @dev Calls the legacy three-field verifier ABI. */
+    function _verifyPayment(
+        FulfillIntentParams calldata _params,
+        bytes32 _paymentMethod
+    ) internal virtual returns (uint256 releaseAmount, bytes32 paymentId) {
+        address verifier = paymentVerifierRegistry.getVerifier(_paymentMethod);
+        if (verifier == address(0)) revert PaymentMethodDoesNotExist(_paymentMethod);
+
+        IPaymentVerifier.PaymentVerificationResult memory result = IPaymentVerifier(verifier).verifyPayment(
+            IPaymentVerifier.VerifyPaymentData({
+                intentHash: _params.intentHash,
+                paymentProof: _params.paymentProof,
+                data: _params.verificationData
+            })
+        );
+        if (!result.success) revert PaymentVerificationFailed();
+        if (result.intentHash != _params.intentHash) {
+            revert HashMismatch(_params.intentHash, result.intentHash);
+        }
+
+        return (result.releaseAmount, bytes32(0));
     }
 
     /**

--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -197,15 +197,13 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
     ) external view override returns (
         uint256 releasedAmount,
         bytes32 paymentId,
-        uint64 settledAt,
-        bool isManualRelease
+        uint64 settledAt
     ) {
         IntentSettlement memory settlement = failedIntentSettlements[_intentHash];
         return (
             settlement.releasedAmount,
             settlement.paymentId,
-            settlement.settledAt,
-            settlement.isManualRelease
+            settlement.settledAt
         );
     }
 
@@ -285,8 +283,7 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
             failedIntentSettlements[_intentHash] = IntentSettlement({
                 releasedAmount: _releasedAmount,
                 paymentId: _paymentId,
-                settledAt: settledAt,
-                isManualRelease: _resolution == IntentResolution.RELEASED
+                settledAt: settledAt
             });
         } else if (!isSettlement && !callbackSucceeded) {
             failedIntentCancellations[_intentHash] = IntentCancellation({ cancelledAt: cancelledAt });

--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -194,9 +194,19 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
      */
     function getIntentSettlement(
         bytes32 _intentHash
-    ) external view override returns (uint256 releasedAmount, uint64 settledAt, bool isManualRelease) {
+    ) external view override returns (
+        uint256 releasedAmount,
+        bytes32 paymentId,
+        uint64 settledAt,
+        bool isManualRelease
+    ) {
         IntentSettlement memory settlement = failedIntentSettlements[_intentHash];
-        return (settlement.releasedAmount, settlement.settledAt, settlement.isManualRelease);
+        return (
+            settlement.releasedAmount,
+            settlement.paymentId,
+            settlement.settledAt,
+            settlement.isManualRelease
+        );
     }
 
     /**
@@ -235,6 +245,16 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
         IntentResolution _resolution,
         uint256 _releasedAmount
     ) internal override {
+        _resolveIntentWithPaymentId(_intentHash, _resolution, _releasedAmount, bytes32(0));
+    }
+
+    /** @dev Transports the authenticated payment identifier through terminal risk accounting. */
+    function _resolveIntentWithPaymentId(
+        bytes32 _intentHash,
+        IntentResolution _resolution,
+        uint256 _releasedAmount,
+        bytes32 _paymentId
+    ) internal override {
         bool isSettlement = _resolution != IntentResolution.CANCELLED;
         uint64 settledAt;
         uint64 cancelledAt;
@@ -257,12 +277,14 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
             _intentHash,
             uint8(_resolution),
             _releasedAmount,
+            _paymentId,
             riskCallbackGasLimit,
             MAX_RISK_CALLBACK_RETURN_DATA
         );
         if (isSettlement && !callbackSucceeded) {
             failedIntentSettlements[_intentHash] = IntentSettlement({
                 releasedAmount: _releasedAmount,
+                paymentId: _paymentId,
                 settledAt: settledAt,
                 isManualRelease: _resolution == IntentResolution.RELEASED
             });
@@ -270,6 +292,22 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
             failedIntentCancellations[_intentHash] = IntentCancellation({ cancelledAt: cancelledAt });
             emit IntentCancellationRecorded(_intentHash, cancelledAt);
         }
+    }
+
+    /** @dev Calls the payment-ID-aware verifier ABI used exclusively by the V3 lane. */
+    function _verifyPayment(
+        FulfillIntentParams calldata _params,
+        bytes32 _paymentMethod
+    ) internal override returns (uint256 releaseAmount, bytes32 paymentId) {
+        address verifier = paymentVerifierRegistry.getVerifier(_paymentMethod);
+        if (verifier == address(0)) revert PaymentMethodDoesNotExist(_paymentMethod);
+
+        return BoundedCall.verifyPaymentV3(
+            verifier,
+            _params.intentHash,
+            _params.paymentProof,
+            _params.verificationData
+        );
     }
 
     /**

--- a/contracts/RiskManager.sol
+++ b/contracts/RiskManager.sol
@@ -12,7 +12,7 @@ import { IAttestationVerifier } from "./interfaces/IAttestationVerifier.sol";
 import { IEscrowV2 } from "./interfaces/IEscrowV2.sol";
 import { IIntentRiskHook } from "./interfaces/IIntentRiskHook.sol";
 import { IOrchestratorV3 } from "./interfaces/IOrchestratorV3.sol";
-import { IRiskManager, IPaymentEvidenceVerifier, IOrchestratorPaymentVerifier } from "./interfaces/IRiskManager.sol";
+import { IRiskManager } from "./interfaces/IRiskManager.sol";
 import { IStakeVault } from "./interfaces/IStakeVault.sol";
 
 /**
@@ -92,7 +92,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
     /// @notice Minimal EIP-712 type hash; chain and manager binding live in the EIP-712 domain.
     bytes32 public constant CHARGEBACK_ATTESTATION_TYPEHASH = keccak256(
-        "ChargebackAttestation(bytes32 intentHash,bytes32 dataHash)"
+        "ChargebackAttestation(bytes32 intentHash,bytes32 originalPaymentId,bytes32 disputeId)"
     );
 
     /* ============ Immutable Dependencies ============ */
@@ -260,19 +260,6 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         position.status = PositionStatus.PENDING;
         position.consumedFreeTake = consumedFreeTake;
         position.deferredPayoutHook = mode == RiskMode.DEFERRED_PAYOUT ? deferredPayoutHook : address(0);
-        if (config.chargeback.chargebackable) {
-            address paymentVerifier = IOrchestratorPaymentVerifier(address(orchestrator))
-                .paymentVerifierRegistry()
-                .getVerifier(intent.paymentMethod);
-            (bool exposesEvidence, bytes memory response) = paymentVerifier.staticcall(
-                abi.encodeCall(
-                    IPaymentEvidenceVerifier.getPaymentDetailsHash,
-                    (address(orchestrator), bytes32(0))
-                )
-            );
-            if (!exposesEvidence || response.length != 32) revert InvalidPaymentEvidence(_intentHash);
-            position.paymentVerifier = paymentVerifier;
-        }
         position.payoutRecipient = intent.to;
         position.chargebackReserveBps = config.chargeback.reserveBps;
         position.griefingPenaltyBpsPerHour = config.griefing.griefingPenaltyBpsPerHour;
@@ -334,17 +321,17 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
      */
     function onIntentFulfilled(
         bytes32 _intentHash,
-        uint256 _releasedAmount
+        uint256 _releasedAmount,
+        bytes32 _paymentId
     ) external override onlyOrchestrator nonReentrant {
-        bytes32 paymentDetailsHash = _getPaymentDetailsHash(_intentHash);
         if (
             riskPositions[_intentHash].chargebackReserveBps != 0
-                && paymentDetailsHash == bytes32(0)
+                && _paymentId == bytes32(0)
         ) revert InvalidPaymentEvidence(_intentHash);
         _settlePosition(
             _intentHash,
             _releasedAmount,
-            paymentDetailsHash,
+            _paymentId,
             uint64(block.timestamp)
         );
     }
@@ -410,7 +397,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
     /** @dev Reads and applies one failed settlement record. */
     function _reconcileSettlement(bytes32 _intentHash) internal {
-        (uint256 releasedAmount, uint64 settledAt, bool isManualRelease) =
+        (uint256 releasedAmount, bytes32 paymentId, uint64 settledAt, bool isManualRelease) =
             orchestrator.getIntentSettlement(_intentHash);
         if (releasedAmount == 0 || settledAt == 0) revert SettlementNotRecorded(_intentHash);
         if (isManualRelease) {
@@ -418,11 +405,10 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             return;
         }
 
-        bytes32 paymentDetailsHash = _getPaymentDetailsHash(_intentHash);
-        if (riskPositions[_intentHash].chargebackReserveBps != 0 && paymentDetailsHash == bytes32(0)) {
+        if (riskPositions[_intentHash].chargebackReserveBps != 0 && paymentId == bytes32(0)) {
             revert InvalidPaymentEvidence(_intentHash);
         }
-        _settlePosition(_intentHash, releasedAmount, paymentDetailsHash, settledAt);
+        _settlePosition(_intentHash, releasedAmount, paymentId, settledAt);
     }
 
     /* ============ Deferred Payout ============ */
@@ -530,9 +516,9 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             revert PositionModeMismatch(_attestation.intentHash, position.mode);
         }
 
-        (ChargebackDetails memory details, bytes32 nullifier) = _validateAttestation(_attestation, position);
+        bytes32 nullifier = _validateAttestation(_attestation, position);
         bytes32 digest = _hashTypedDataV4(_hashChargebackAttestation(_attestation));
-        if (!attestationVerifier.verify(digest, _attestation.signatures, _attestation.data)) {
+        if (!attestationVerifier.verify(digest, _attestation.signatures, bytes(""))) {
             revert AttestationVerificationFailed();
         }
 
@@ -561,7 +547,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             compensatedAmount,
             position.slashedAmount,
             position.reservedAmount,
-            details.disputeId
+            _attestation.disputeId
         );
     }
 
@@ -804,7 +790,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
     function _settlePosition(
         bytes32 _intentHash,
         uint256 _releasedAmount,
-        bytes32 _paymentDetailsHash,
+        bytes32 _paymentId,
         uint64 _settledAt
     ) internal {
         if (_releasedAmount == 0) revert ZeroAmount();
@@ -815,7 +801,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
         uint256 pendingReservation = position.reservedAmount;
         position.releasedAmount = _releasedAmount;
-        position.paymentDetailsHash = _paymentDetailsHash;
+        position.paymentId = _paymentId;
         position.settledAt = _settledAt;
 
         if (position.chargebackReserveBps == 0) {
@@ -891,7 +877,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         uint256 releasedReservation = position.reservedAmount;
         position.status = PositionStatus.RELEASED;
         position.releasedAmount = _releasedAmount;
-        position.paymentDetailsHash = bytes32(0);
+        position.paymentId = bytes32(0);
         position.settledAt = _settledAt;
         position.coverageDeadline = 0;
         position.reservedAmount = 0;
@@ -916,7 +902,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
     /** @dev Applies a durable failed-settlement record only when the position remains pending. */
     function _synchronizeSettlement(bytes32 _intentHash) internal {
-        (uint256 releasedAmount, uint64 settledAt, bool isManualRelease) =
+        (uint256 releasedAmount, bytes32 paymentId, uint64 settledAt, bool isManualRelease) =
             orchestrator.getIntentSettlement(_intentHash);
         if (releasedAmount == 0) revert SettlementNotRecorded(_intentHash);
         if (settledAt == 0) revert SettlementNotRecorded(_intentHash);
@@ -925,21 +911,10 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             return;
         }
 
-        bytes32 paymentDetailsHash = _getPaymentDetailsHash(_intentHash);
-        if (riskPositions[_intentHash].chargebackReserveBps != 0 && paymentDetailsHash == bytes32(0)) {
+        if (riskPositions[_intentHash].chargebackReserveBps != 0 && paymentId == bytes32(0)) {
             revert InvalidPaymentEvidence(_intentHash);
         }
-        _settlePosition(_intentHash, releasedAmount, paymentDetailsHash, settledAt);
-    }
-
-    /** @dev Reads evidence from the payment verifier snapshotted before funds were locked. */
-    function _getPaymentDetailsHash(bytes32 _intentHash) internal view returns (bytes32) {
-        address paymentVerifier = riskPositions[_intentHash].paymentVerifier;
-        if (paymentVerifier == address(0)) return bytes32(0);
-        return IPaymentEvidenceVerifier(paymentVerifier).getPaymentDetailsHash(
-            address(orchestrator),
-            _intentHash
-        );
+        _settlePosition(_intentHash, releasedAmount, paymentId, settledAt);
     }
 
     /* ============ Internal Validation ============ */
@@ -1013,29 +988,20 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
     function _validateAttestation(
         ChargebackAttestation calldata _attestation,
         RiskPosition storage _position
-    ) internal view returns (ChargebackDetails memory details, bytes32 nullifier) {
+    ) internal view returns (bytes32 nullifier) {
         if (_attestation.intentHash == bytes32(0)) revert InvalidAttestation();
-        if (keccak256(_attestation.data) != _attestation.dataHash) revert InvalidAttestation();
-        if (_position.paymentDetailsHash == bytes32(0)) revert InvalidAttestation();
+        if (_position.paymentId == bytes32(0)) revert InvalidAttestation();
         if (block.timestamp >= _position.coverageDeadline) {
             revert ChargebackWindowClosed(_position.coverageDeadline, uint64(block.timestamp));
         }
 
-        details = abi.decode(_attestation.data, (ChargebackDetails));
-        if (details.paymentMethod != _position.paymentMethod) revert InvalidAttestation();
-        if (details.originalPaymentId == bytes32(0)) revert InvalidAttestation();
-        if (details.disputeId == bytes32(0)) revert InvalidAttestation();
-        if (details.paymentAmount == 0 || details.paymentCurrency == bytes32(0)) revert InvalidAttestation();
         if (
-            keccak256(abi.encode(
-                details.paymentMethod,
-                details.originalPaymentId,
-                details.paymentAmount,
-                details.paymentCurrency
-            )) != _position.paymentDetailsHash
+            _attestation.originalPaymentId == bytes32(0)
+                || _attestation.originalPaymentId != _position.paymentId
+                || _attestation.disputeId == bytes32(0)
         ) revert InvalidAttestation();
 
-        nullifier = keccak256(abi.encodePacked(details.paymentMethod, details.disputeId));
+        nullifier = keccak256(abi.encodePacked(_position.paymentMethod, _attestation.disputeId));
         if (usedChargebackNullifiers[nullifier]) revert ChargebackEvidenceUsed(nullifier);
     }
 
@@ -1107,7 +1073,8 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             abi.encode(
                 CHARGEBACK_ATTESTATION_TYPEHASH,
                 _attestation.intentHash,
-                _attestation.dataHash
+                _attestation.originalPaymentId,
+                _attestation.disputeId
             )
         );
     }

--- a/contracts/RiskManager.sol
+++ b/contracts/RiskManager.sol
@@ -397,17 +397,14 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
     /** @dev Reads and applies one failed settlement record. */
     function _reconcileSettlement(bytes32 _intentHash) internal {
-        (uint256 releasedAmount, bytes32 paymentId, uint64 settledAt, bool isManualRelease) =
+        (uint256 releasedAmount, bytes32 paymentId, uint64 settledAt) =
             orchestrator.getIntentSettlement(_intentHash);
         if (releasedAmount == 0 || settledAt == 0) revert SettlementNotRecorded(_intentHash);
-        if (isManualRelease) {
+        if (paymentId == bytes32(0)) {
             _releaseManualPosition(_intentHash, releasedAmount, settledAt);
             return;
         }
 
-        if (riskPositions[_intentHash].chargebackReserveBps != 0 && paymentId == bytes32(0)) {
-            revert InvalidPaymentEvidence(_intentHash);
-        }
         _settlePosition(_intentHash, releasedAmount, paymentId, settledAt);
     }
 
@@ -902,18 +899,15 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
     /** @dev Applies a durable failed-settlement record only when the position remains pending. */
     function _synchronizeSettlement(bytes32 _intentHash) internal {
-        (uint256 releasedAmount, bytes32 paymentId, uint64 settledAt, bool isManualRelease) =
+        (uint256 releasedAmount, bytes32 paymentId, uint64 settledAt) =
             orchestrator.getIntentSettlement(_intentHash);
         if (releasedAmount == 0) revert SettlementNotRecorded(_intentHash);
         if (settledAt == 0) revert SettlementNotRecorded(_intentHash);
-        if (isManualRelease) {
+        if (paymentId == bytes32(0)) {
             _releaseManualPosition(_intentHash, releasedAmount, settledAt);
             return;
         }
 
-        if (riskPositions[_intentHash].chargebackReserveBps != 0 && paymentId == bytes32(0)) {
-            revert InvalidPaymentEvidence(_intentHash);
-        }
         _settlePosition(_intentHash, releasedAmount, paymentId, settledAt);
     }
 

--- a/contracts/interfaces/IIntentRiskHook.sol
+++ b/contracts/interfaces/IIntentRiskHook.sol
@@ -27,8 +27,9 @@ interface IIntentRiskHook {
      * @notice Resolves risk accounting after proof verification succeeds.
      * @param _intentHash Identifier of the intent being fulfilled.
      * @param _releasedAmount Gross escrow amount released for the verified payment.
+     * @param _paymentId Provider payment identifier authenticated by the payment verifier.
      */
-    function onIntentFulfilled(bytes32 _intentHash, uint256 _releasedAmount) external;
+    function onIntentFulfilled(bytes32 _intentHash, uint256 _releasedAmount, bytes32 _paymentId) external;
 
     /**
      * @notice Resolves risk accounting after a maker authorizes manual release.

--- a/contracts/interfaces/IOrchestratorV3.sol
+++ b/contracts/interfaces/IOrchestratorV3.sol
@@ -25,6 +25,8 @@ interface IOrchestratorV3 is IOrchestratorV2 {
 
     struct IntentSettlement {
         uint256 releasedAmount;
+        /// @notice Payment identifier returned by the verifier; zero for maker manual release.
+        bytes32 paymentId;
         uint64 settledAt;
         /// @notice Distinguishes an evidence-free maker release from verified fulfillment recovery.
         bool isManualRelease;
@@ -74,7 +76,12 @@ interface IOrchestratorV3 is IOrchestratorV2 {
      */
     function getIntentSettlement(
         bytes32 _intentHash
-    ) external view returns (uint256 releasedAmount, uint64 settledAt, bool isManualRelease);
+    ) external view returns (
+        uint256 releasedAmount,
+        bytes32 paymentId,
+        uint64 settledAt,
+        bool isManualRelease
+    );
     /**
      * @notice Returns the liquidity-unlock timestamp when a cancellation callback failed open.
      * @dev The risk hook must use this timestamp during reconciliation rather than the later transaction time.

--- a/contracts/interfaces/IOrchestratorV3.sol
+++ b/contracts/interfaces/IOrchestratorV3.sol
@@ -28,8 +28,6 @@ interface IOrchestratorV3 is IOrchestratorV2 {
         /// @notice Payment identifier returned by the verifier; zero for maker manual release.
         bytes32 paymentId;
         uint64 settledAt;
-        /// @notice Distinguishes an evidence-free maker release from verified fulfillment recovery.
-        bool isManualRelease;
     }
 
     struct IntentCancellation {
@@ -79,8 +77,7 @@ interface IOrchestratorV3 is IOrchestratorV2 {
     ) external view returns (
         uint256 releasedAmount,
         bytes32 paymentId,
-        uint64 settledAt,
-        bool isManualRelease
+        uint64 settledAt
     );
     /**
      * @notice Returns the liquidity-unlock timestamp when a cancellation callback failed open.

--- a/contracts/interfaces/IPaymentVerifierV3.sol
+++ b/contracts/interfaces/IPaymentVerifierV3.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { IPaymentVerifier } from "./IPaymentVerifier.sol";
+
+/**
+ * @title IPaymentVerifierV3
+ * @notice Payment verifier result that returns the authenticated provider payment identifier.
+ * @dev The input tuple and function selector intentionally match IPaymentVerifier. The additional
+ *      return field requires callers to opt into this interface and leaves existing verifier lanes
+ *      ABI-compatible with the three-field result.
+ */
+interface IPaymentVerifierV3 {
+    struct PaymentVerificationResult {
+        bool success;
+        bytes32 intentHash;
+        uint256 releaseAmount;
+        bytes32 paymentId;
+    }
+
+    function verifyPayment(
+        IPaymentVerifier.VerifyPaymentData calldata _verifyPaymentData
+    ) external returns (PaymentVerificationResult memory result);
+}

--- a/contracts/interfaces/IRiskManager.sol
+++ b/contracts/interfaces/IRiskManager.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.18;
 
 import { IIntentRiskHook } from "./IIntentRiskHook.sol";
 import { IOrchestratorV3 } from "./IOrchestratorV3.sol";
-import { IPaymentVerifierRegistry } from "./IPaymentVerifierRegistry.sol";
 import { IStakeVault } from "./IStakeVault.sol";
 
 /**
@@ -91,8 +90,6 @@ interface IRiskManager is IIntentRiskHook {
         bool consumedFreeTake;
         /// @notice Canonical deferred hook snapshotted only for a deferred-payout position.
         address deferredPayoutHook;
-        /// @notice Payment verifier snapshotted at admission as the immutable source of payment evidence.
-        address paymentVerifier;
         /// @notice Original intent recipient entitled to unslashed deferred proceeds.
         address payoutRecipient;
         /// @notice Snapshotted chargeback reserve ratio applied to the exact released amount.
@@ -123,9 +120,9 @@ interface IRiskManager is IIntentRiskHook {
         uint256 reservedAmount;
         /// @notice Exact amount released from Escrow at settlement before post-hook fees.
         uint256 releasedAmount;
-        /// @notice Commitment to the verifier-backed method, payment ID, fiat amount, and currency.
+        /// @notice Provider payment identifier authenticated and returned by the payment verifier.
         /// @dev Zero means the position came from maker manual release rather than verified fulfillment.
-        bytes32 paymentDetailsHash;
+        bytes32 paymentId;
         /// @notice Total net proceeds recorded in StakeVault for a deferred payout.
         uint256 deferredPayoutAmount;
         /// @notice Cumulative compensation already charged against this position.
@@ -136,28 +133,12 @@ interface IRiskManager is IIntentRiskHook {
     struct ChargebackAttestation {
         /// @notice Position whose full released amount may be consumed.
         bytes32 intentHash;
-        /// @notice Hash of `data`, binding all chargeback details to the witness signatures.
-        bytes32 dataHash;
-        /// @notice Signatures from the dedicated chargeback witness set.
-        bytes[] signatures;
-        /// @notice ABI-encoded `ChargebackDetails` authenticated by `dataHash`.
-        bytes data;
-        /// @notice Optional unsigned metadata for off-chain correlation.
-        bytes metadata;
-    }
-
-    /** @notice Verifier-derived dispute details bound to the original fulfilled payment. */
-    struct ChargebackDetails {
-        /// @notice Payment-method hash recorded by the payment verifier.
-        bytes32 paymentMethod;
-        /// @notice Hashed provider payment identifier recorded by the payment verifier.
+        /// @notice Original provider payment identifier stored from verified fulfillment.
         bytes32 originalPaymentId;
         /// @notice Nonzero provider dispute identifier used for global replay protection.
         bytes32 disputeId;
-        /// @notice Original fiat amount in the payment method's minor unit (for example, cents).
-        uint256 paymentAmount;
-        /// @notice Fiat-currency hash recorded by the payment verifier.
-        bytes32 paymentCurrency;
+        /// @notice Signatures from the dedicated chargeback witness set.
+        bytes[] signatures;
     }
 
     /* ============ Events ============ */
@@ -364,21 +345,4 @@ interface IRiskManager is IIntentRiskHook {
     function orchestrator() external view returns (IOrchestratorV3);
     /** @notice Returns the immutable policy-agnostic custody and reservation vault. */
     function stakeVault() external view returns (IStakeVault);
-}
-
-/**
- * @title IPaymentEvidenceVerifier
- * @notice Exposes the immutable evidence commitment produced while verifying an intent payment.
- */
-interface IPaymentEvidenceVerifier {
-    /** @notice Returns payment details committed while the named orchestrator verified the intent. */
-    function getPaymentDetailsHash(
-        address _orchestrator,
-        bytes32 _intentHash
-    ) external view returns (bytes32);
-}
-
-/** @notice Narrow Orchestrator surface used to snapshot a payment verifier at admission. */
-interface IOrchestratorPaymentVerifier {
-    function paymentVerifierRegistry() external view returns (IPaymentVerifierRegistry);
 }

--- a/contracts/lib/BoundedCall.sol
+++ b/contracts/lib/BoundedCall.sol
@@ -3,6 +3,8 @@
 pragma solidity ^0.8.18;
 
 import { IIntentRiskHook } from "../interfaces/IIntentRiskHook.sol";
+import { IPaymentVerifier } from "../interfaces/IPaymentVerifier.sol";
+import { IPaymentVerifierV3 } from "../interfaces/IPaymentVerifierV3.sol";
 
 /**
  * @title BoundedCall
@@ -21,6 +23,32 @@ library BoundedCall {
     error RiskHookAdmissionFailed(bytes32 intentHash, address hook, bytes revertData);
     error InvalidRiskHookResponse(address hook, bytes response);
     error RequiredSettlementHookMissing(bytes32 intentHash);
+    error PaymentVerificationFailed();
+    error HashMismatch(bytes32 expected, bytes32 actual);
+
+    /**
+     * @notice Calls the payment-ID-aware verifier without expanding the already size-constrained
+     *         OrchestratorV3 runtime.
+     * @dev Public library execution uses DELEGATECALL, so the verifier still observes the
+     *      orchestrator as msg.sender.
+     */
+    function verifyPaymentV3(
+        address _verifier,
+        bytes32 _intentHash,
+        bytes memory _paymentProof,
+        bytes memory _verificationData
+    ) public returns (uint256 releaseAmount, bytes32 paymentId) {
+        IPaymentVerifierV3.PaymentVerificationResult memory result = IPaymentVerifierV3(_verifier).verifyPayment(
+            IPaymentVerifier.VerifyPaymentData({
+                intentHash: _intentHash,
+                paymentProof: _paymentProof,
+                data: _verificationData
+            })
+        );
+        if (!result.success || result.paymentId == bytes32(0)) revert PaymentVerificationFailed();
+        if (result.intentHash != _intentHash) revert HashMismatch(_intentHash, result.intentHash);
+        return (result.releaseAmount, result.paymentId);
+    }
 
     /**
      * @notice Executes a fail-closed risk admission callback.
@@ -60,6 +88,7 @@ library BoundedCall {
         bytes32 _intentHash,
         uint8 _resolution,
         uint256 _releasedAmount,
+        bytes32 _paymentId,
         uint256 _gasLimit,
         uint256 _maxReturnDataSize
     ) public returns (bool success) {
@@ -72,7 +101,10 @@ library BoundedCall {
             callData = abi.encodeCall(IIntentRiskHook.onIntentCancelled, (_intentHash));
         } else if (_resolution == 1) {
             callbackSelector = IIntentRiskHook.onIntentFulfilled.selector;
-            callData = abi.encodeCall(IIntentRiskHook.onIntentFulfilled, (_intentHash, _releasedAmount));
+            callData = abi.encodeCall(
+                IIntentRiskHook.onIntentFulfilled,
+                (_intentHash, _releasedAmount, _paymentId)
+            );
         } else {
             callbackSelector = IIntentRiskHook.onIntentReleased.selector;
             callData = abi.encodeCall(IIntentRiskHook.onIntentReleased, (_intentHash, _releasedAmount));

--- a/contracts/mocks/IntentRiskHookMock.sol
+++ b/contracts/mocks/IntentRiskHookMock.sol
@@ -14,6 +14,7 @@ contract IntentRiskHookMock is IIntentRiskHook {
     bool public revertOnTerminal;
     uint256 public terminalRevertDataSize;
     bytes32 public lastIntentHash;
+    bytes32 public lastPaymentId;
     uint256 public lastReleasedAmount;
     uint256 public createdCalls;
     uint256 public cancelledCalls;
@@ -50,11 +51,16 @@ contract IntentRiskHookMock is IIntentRiskHook {
         cancelledCalls++;
     }
 
-    function onIntentFulfilled(bytes32 _intentHash, uint256 _releasedAmount) external override {
+    function onIntentFulfilled(
+        bytes32 _intentHash,
+        uint256 _releasedAmount,
+        bytes32 _paymentId
+    ) external override {
         _revertWithConfiguredData();
         if (revertOnTerminal) revert("risk fulfillment failed");
         lastIntentHash = _intentHash;
         lastReleasedAmount = _releasedAmount;
+        lastPaymentId = _paymentId;
         fulfilledCalls++;
     }
 

--- a/contracts/mocks/PaymentVerifierMock.sol
+++ b/contracts/mocks/PaymentVerifierMock.sol
@@ -2,12 +2,11 @@
 pragma solidity ^0.8.18;
 
 import { IPaymentVerifier } from "../interfaces/IPaymentVerifier.sol";
-import { IPaymentEvidenceVerifier } from "../interfaces/IRiskManager.sol";
 import { IOrchestrator } from "../interfaces/IOrchestrator.sol";
 import { IOrchestratorV2 } from "../interfaces/IOrchestratorV2.sol";
 import { IEscrow } from "../interfaces/IEscrow.sol";
 
-contract PaymentVerifierMock is IPaymentVerifier, IPaymentEvidenceVerifier {
+contract PaymentVerifierMock is IPaymentVerifier {
 
     struct PaymentDetails {
         uint256 amount;
@@ -32,7 +31,6 @@ contract PaymentVerifierMock is IPaymentVerifier, IPaymentEvidenceVerifier {
     bool public shouldReturnFalse;
     address public orchestratorAddress;
     address public escrowAddress;
-    mapping(address => mapping(bytes32 => bytes32)) internal verifiedPaymentDetailsHashes;
 
     function setShouldVerifyPayment(bool _shouldVerifyPayment) external {
         shouldVerifyPayment = _shouldVerifyPayment;
@@ -54,7 +52,7 @@ contract PaymentVerifierMock is IPaymentVerifier, IPaymentEvidenceVerifier {
 
     function verifyPayment(
         IPaymentVerifier.VerifyPaymentData calldata _verifyPaymentData
-    ) external override returns (PaymentVerificationResult memory) {
+    ) external view override returns (PaymentVerificationResult memory) {
         PaymentDetails memory paymentDetails = _extractPaymentDetails(_verifyPaymentData.paymentProof);
 
         Snapshot memory snapshot = _fetchSnapshot(paymentDetails.intentHash);
@@ -91,25 +89,11 @@ contract PaymentVerifierMock is IPaymentVerifier, IPaymentEvidenceVerifier {
             releaseAmount = snapshot.amount;
         }
 
-        bytes32 paymentId = keccak256(abi.encodePacked("payment", paymentDetails.intentHash));
-        verifiedPaymentDetailsHashes[msg.sender][paymentDetails.intentHash] = keccak256(abi.encode(
-            snapshot.paymentMethod,
-            paymentId,
-            paymentDetails.amount,
-            paymentDetails.fiatCurrency
-        ));
         return PaymentVerificationResult({
             success: true,
             intentHash: paymentDetails.intentHash,
             releaseAmount: releaseAmount
         });
-    }
-
-    function getPaymentDetailsHash(
-        address _orchestrator,
-        bytes32 _intentHash
-    ) external view override returns (bytes32) {
-        return verifiedPaymentDetailsHashes[_orchestrator][_intentHash];
     }
 
     function _fetchSnapshot(bytes32 intentHash) internal view returns (Snapshot memory snapshot) {

--- a/contracts/mocks/PaymentVerifierV3Mock.sol
+++ b/contracts/mocks/PaymentVerifierV3Mock.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { IPaymentVerifier } from "../interfaces/IPaymentVerifier.sol";
+import { IPaymentVerifierV3 } from "../interfaces/IPaymentVerifierV3.sol";
+
+/** @notice Configurable payment-ID-aware verifier used by OrchestratorV3 tests. */
+contract PaymentVerifierV3Mock is IPaymentVerifierV3 {
+    bool public shouldReturnFalse;
+    bytes32 public paymentId;
+    bool public useConfiguredPaymentId;
+
+    function setShouldReturnFalse(bool _shouldReturnFalse) external {
+        shouldReturnFalse = _shouldReturnFalse;
+    }
+
+    function setPaymentId(bytes32 _paymentId) external {
+        paymentId = _paymentId;
+        useConfiguredPaymentId = true;
+    }
+
+    function clearPaymentId() external {
+        paymentId = bytes32(0);
+        useConfiguredPaymentId = false;
+    }
+
+    function verifyPayment(
+        IPaymentVerifier.VerifyPaymentData calldata _verifyPaymentData
+    ) external view override returns (PaymentVerificationResult memory) {
+        (uint256 releaseAmount, , , , bytes32 intentHash) = abi.decode(
+            _verifyPaymentData.paymentProof,
+            (uint256, uint256, bytes32, bytes32, bytes32)
+        );
+        if (shouldReturnFalse) {
+            return PaymentVerificationResult(false, bytes32(0), 0, bytes32(0));
+        }
+        bytes32 resultPaymentId = useConfiguredPaymentId
+            ? paymentId
+            : keccak256(abi.encodePacked("payment", intentHash));
+        return PaymentVerificationResult(true, intentHash, releaseAmount, resultPaymentId);
+    }
+}

--- a/contracts/mocks/RiskManagerHarnessMocks.sol
+++ b/contracts/mocks/RiskManagerHarnessMocks.sol
@@ -85,23 +85,7 @@ contract RiskManagerOrchestratorHarness {
         settlements[_intentHash] = IOrchestratorV3.IntentSettlement(
             _releasedAmount,
             paymentId,
-            _settledAt,
-            _isManualRelease
-        );
-    }
-
-    function setIntentSettlementWithPaymentId(
-        bytes32 _intentHash,
-        uint256 _releasedAmount,
-        bytes32 _paymentId,
-        uint64 _settledAt,
-        bool _isManualRelease
-    ) external {
-        settlements[_intentHash] = IOrchestratorV3.IntentSettlement(
-            _releasedAmount,
-            _paymentId,
-            _settledAt,
-            _isManualRelease
+            _settledAt
         );
     }
 
@@ -113,13 +97,12 @@ contract RiskManagerOrchestratorHarness {
         return cancellationTimes[_intentHash];
     }
 
-    function getIntentSettlement(bytes32 _intentHash) external view returns (uint256, bytes32, uint64, bool) {
+    function getIntentSettlement(bytes32 _intentHash) external view returns (uint256, bytes32, uint64) {
         IOrchestratorV3.IntentSettlement memory settlement = settlements[_intentHash];
         return (
             settlement.releasedAmount,
             settlement.paymentId,
-            settlement.settledAt,
-            settlement.isManualRelease
+            settlement.settledAt
         );
     }
 

--- a/contracts/mocks/RiskManagerHarnessMocks.sol
+++ b/contracts/mocks/RiskManagerHarnessMocks.sol
@@ -8,7 +8,6 @@ import { IEscrowV2 } from "../interfaces/IEscrowV2.sol";
 import { IAttestationVerifier } from "../interfaces/IAttestationVerifier.sol";
 import { IIntentRiskHook } from "../interfaces/IIntentRiskHook.sol";
 import { IOrchestratorV3 } from "../interfaces/IOrchestratorV3.sol";
-import { IPaymentVerifierRegistry } from "../interfaces/IPaymentVerifierRegistry.sol";
 import { IRiskManager } from "../interfaces/IRiskManager.sol";
 import { IStakeVault } from "../interfaces/IStakeVault.sol";
 import { RiskManager } from "../RiskManager.sol";
@@ -65,23 +64,6 @@ contract RiskManagerOrchestratorHarness {
     mapping(bytes32 => IOrchestratorV3.RiskIntentData) internal riskIntents;
     mapping(bytes32 => uint64) internal cancellationTimes;
     mapping(bytes32 => IOrchestratorV3.IntentSettlement) internal settlements;
-    mapping(bytes32 => bytes32) internal paymentEvidence;
-
-    function paymentVerifierRegistry() external view returns (IPaymentVerifierRegistry) {
-        return IPaymentVerifierRegistry(address(this));
-    }
-
-    function getVerifier(bytes32) external view returns (address) {
-        return address(this);
-    }
-
-    function getPaymentDetailsHash(address, bytes32 _intentHash) external view returns (bytes32) {
-        return paymentEvidence[_intentHash];
-    }
-
-    function setPaymentEvidence(bytes32 _intentHash, bytes32 _evidence) external {
-        paymentEvidence[_intentHash] = _evidence;
-    }
 
     function setRiskIntent(bytes32 _intentHash, IOrchestratorV3.RiskIntentData calldata _intent) external {
         riskIntents[_intentHash] = _intent;
@@ -97,14 +79,30 @@ contract RiskManagerOrchestratorHarness {
         uint64 _settledAt,
         bool _isManualRelease
     ) external {
-        bytes32 paymentId = keccak256(abi.encodePacked("payment", _intentHash));
-        paymentEvidence[_intentHash] = keccak256(abi.encode(
-            riskIntents[_intentHash].paymentMethod,
-            paymentId,
+        bytes32 paymentId = _isManualRelease
+            ? bytes32(0)
+            : keccak256(abi.encodePacked("payment", _intentHash));
+        settlements[_intentHash] = IOrchestratorV3.IntentSettlement(
             _releasedAmount,
-            keccak256("USD")
-        ));
-        settlements[_intentHash] = IOrchestratorV3.IntentSettlement(_releasedAmount, _settledAt, _isManualRelease);
+            paymentId,
+            _settledAt,
+            _isManualRelease
+        );
+    }
+
+    function setIntentSettlementWithPaymentId(
+        bytes32 _intentHash,
+        uint256 _releasedAmount,
+        bytes32 _paymentId,
+        uint64 _settledAt,
+        bool _isManualRelease
+    ) external {
+        settlements[_intentHash] = IOrchestratorV3.IntentSettlement(
+            _releasedAmount,
+            _paymentId,
+            _settledAt,
+            _isManualRelease
+        );
     }
 
     function getRiskIntent(bytes32 _intentHash) external view returns (IOrchestratorV3.RiskIntentData memory) {
@@ -115,9 +113,14 @@ contract RiskManagerOrchestratorHarness {
         return cancellationTimes[_intentHash];
     }
 
-    function getIntentSettlement(bytes32 _intentHash) external view returns (uint256, uint64, bool) {
+    function getIntentSettlement(bytes32 _intentHash) external view returns (uint256, bytes32, uint64, bool) {
         IOrchestratorV3.IntentSettlement memory settlement = settlements[_intentHash];
-        return (settlement.releasedAmount, settlement.settledAt, settlement.isManualRelease);
+        return (
+            settlement.releasedAmount,
+            settlement.paymentId,
+            settlement.settledAt,
+            settlement.isManualRelease
+        );
     }
 
     function createPosition(IIntentRiskHook _hook, bytes32 _intentHash) external returns (bool) {
@@ -130,13 +133,7 @@ contract RiskManagerOrchestratorHarness {
 
     function fulfillPosition(IIntentRiskHook _hook, bytes32 _intentHash, uint256 _releasedAmount) external {
         bytes32 paymentId = keccak256(abi.encodePacked("payment", _intentHash));
-        paymentEvidence[_intentHash] = keccak256(abi.encode(
-            riskIntents[_intentHash].paymentMethod,
-            paymentId,
-            _releasedAmount,
-            keccak256("USD")
-        ));
-        _hook.onIntentFulfilled(_intentHash, _releasedAmount);
+        _hook.onIntentFulfilled(_intentHash, _releasedAmount, paymentId);
     }
 
     function releasePosition(IIntentRiskHook _hook, bytes32 _intentHash, uint256 _releasedAmount) external {

--- a/contracts/unifiedVerifier/BaseUnifiedPaymentVerifier.sol
+++ b/contracts/unifiedVerifier/BaseUnifiedPaymentVerifier.sol
@@ -4,8 +4,12 @@ pragma solidity ^0.8.18;
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { Bytes32ArrayUtils } from "../external/Bytes32ArrayUtils.sol";
 import { IAttestationVerifier } from "../interfaces/IAttestationVerifier.sol";
+import { IEscrow } from "../interfaces/IEscrow.sol";
 import { INullifierRegistry } from "../interfaces/INullifierRegistry.sol";
+import { IOrchestrator } from "../interfaces/IOrchestrator.sol";
+import { IOrchestratorV2 } from "../interfaces/IOrchestratorV2.sol";
 import { IOrchestratorRegistry } from "../interfaces/IOrchestratorRegistry.sol";
+import { IPaymentVerifier } from "../interfaces/IPaymentVerifier.sol";
 
 /**
  * @title BaseUnifiedPaymentVerifier
@@ -26,15 +30,70 @@ abstract contract BaseUnifiedPaymentVerifier is Ownable {
 
     uint256 internal constant PRECISE_UNIT = 1e18;
 
+    uint256 private constant MAX_TIMESTAMP_BUFFER = 48 * 60 * 60 * 1000;
+
+    bytes32 private constant DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
+
+    bytes32 private constant PAYMENT_ATTESTATION_TYPEHASH = keccak256(
+        "PaymentAttestation(bytes32 intentHash,uint256 releaseAmount,bytes32 dataHash)"
+    );
+
+    bytes4 private constant GET_DEPOSIT_PRE_INTENT_HOOK_SELECTOR =
+        bytes4(keccak256("getDepositPreIntentHook(address,uint256)"));
+
     /* ============ Events ============ */
 
     event PaymentMethodAdded(bytes32 indexed paymentMethod);
     event PaymentMethodRemoved(bytes32 indexed paymentMethod);
     event AttestationVerifierUpdated(address indexed oldVerifier, address indexed newVerifier);
+    event PaymentVerified(
+        bytes32 indexed intentHash,
+        bytes32 indexed method,
+        bytes32 indexed currency,
+        uint256 amount,
+        uint256 timestamp,
+        bytes32 paymentId,
+        bytes32 payeeId
+    );
+
+    /* ============ Structs ============ */
+
+    struct PaymentDetails {
+        bytes32 method;
+        bytes32 payeeId;
+        uint256 amount;
+        bytes32 currency;
+        uint256 timestamp;
+        bytes32 paymentId;
+    }
+
+    struct IntentSnapshot {
+        bytes32 intentHash;
+        uint256 amount;
+        bytes32 paymentMethod;
+        bytes32 fiatCurrency;
+        bytes32 payeeDetails;
+        uint256 conversionRate;
+        uint256 signalTimestamp;
+        uint256 timestampBuffer;
+    }
+
+    struct PaymentAttestation {
+        bytes32 intentHash;
+        uint256 releaseAmount;
+        bytes32 dataHash;
+        bytes[] signatures;
+        bytes data;
+        bytes metadata;
+    }
+
     /* ============ State Variables ============ */
 
     IOrchestratorRegistry public immutable orchestratorRegistry;
     INullifierRegistry public immutable nullifierRegistry;
+    bytes32 public immutable DOMAIN_SEPARATOR;
     IAttestationVerifier public attestationVerifier;
 
     bytes32[] public paymentMethods;
@@ -67,6 +126,15 @@ abstract contract BaseUnifiedPaymentVerifier is Ownable {
         orchestratorRegistry = _orchestratorRegistry;
         nullifierRegistry = _nullifierRegistry;
         attestationVerifier = _attestationVerifier;
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                DOMAIN_TYPEHASH,
+                keccak256(bytes("UnifiedPaymentVerifier")),
+                keccak256(bytes("1")),
+                block.chainid,
+                address(this)
+            )
+        );
     }
 
     /* ============ External Functions ============ */
@@ -125,5 +193,134 @@ abstract contract BaseUnifiedPaymentVerifier is Ownable {
     function _validateAndAddNullifier(bytes32 _nullifier) internal {
         require(!nullifierRegistry.isNullified(_nullifier), "Nullifier has already been used");
         nullifierRegistry.addNullifier(_nullifier);
+    }
+
+    /**
+     * @dev Verifies one payment attestation and returns only values authenticated by that attestation.
+     *      Thin ABI wrappers decide whether to expose the payment identifier to their caller.
+     */
+    function _verifyPayment(
+        IPaymentVerifier.VerifyPaymentData calldata _verifyPaymentData
+    ) internal returns (bytes32 intentHash, uint256 releaseAmount, bytes32 paymentId) {
+        PaymentAttestation memory attestation = abi.decode(
+            _verifyPaymentData.paymentProof,
+            (PaymentAttestation)
+        );
+        (PaymentDetails memory paymentDetails, IntentSnapshot memory intentSnapshot) =
+            abi.decode(attestation.data, (PaymentDetails, IntentSnapshot));
+
+        require(isPaymentMethod[paymentDetails.method], "UPV: Invalid payment method");
+        require(paymentDetails.amount != 0, "UPV: Invalid payment amount");
+        require(paymentDetails.currency != bytes32(0), "UPV: Invalid payment currency");
+
+        _validateIntentSnapshot(_verifyPaymentData.intentHash, intentSnapshot);
+        require(_verifyAttestation(attestation), "UPV: Invalid attestation");
+
+        _nullifyPayment(paymentDetails.method, paymentDetails.paymentId);
+        _emitPaymentDetails(attestation.intentHash, paymentDetails);
+
+        return (
+            attestation.intentHash,
+            _calculateReleaseAmount(attestation.releaseAmount, intentSnapshot.amount),
+            paymentDetails.paymentId
+        );
+    }
+
+    function _verifyAttestation(PaymentAttestation memory _attestation) internal view returns (bool) {
+        bytes32 structHash = keccak256(
+            abi.encode(
+                PAYMENT_ATTESTATION_TYPEHASH,
+                _attestation.intentHash,
+                _attestation.releaseAmount,
+                _attestation.dataHash
+            )
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash));
+
+        require(keccak256(_attestation.data) == _attestation.dataHash, "UPV: Data hash mismatch");
+        return attestationVerifier.verify(digest, _attestation.signatures, _attestation.data);
+    }
+
+    function _validateIntentSnapshot(
+        bytes32 _intentHash,
+        IntentSnapshot memory _snapshot
+    ) internal view {
+        require(_snapshot.intentHash == _intentHash, "UPV: Snapshot hash mismatch");
+
+        if (_isV2Orchestrator(msg.sender)) {
+            IOrchestratorV2.Intent memory intentV2 = IOrchestratorV2(msg.sender).getIntent(_intentHash);
+            _validateSnapshotAgainstIntent(
+                _snapshot,
+                intentV2.payeeId,
+                intentV2.amount,
+                intentV2.paymentMethod,
+                intentV2.fiatCurrency,
+                intentV2.conversionRate,
+                intentV2.timestamp
+            );
+        } else {
+            IOrchestrator.Intent memory intent = IOrchestrator(msg.sender).getIntent(_intentHash);
+            _validateSnapshotAgainstIntent(
+                _snapshot,
+                intent.payeeId,
+                intent.amount,
+                intent.paymentMethod,
+                intent.fiatCurrency,
+                intent.conversionRate,
+                intent.timestamp
+            );
+        }
+
+        require(
+            _snapshot.timestampBuffer <= MAX_TIMESTAMP_BUFFER,
+            "UPV: Snapshot timestamp buffer exceeds maximum"
+        );
+    }
+
+    function _validateSnapshotAgainstIntent(
+        IntentSnapshot memory _snapshot,
+        bytes32 _payeeId,
+        uint256 _amount,
+        bytes32 _paymentMethod,
+        bytes32 _fiatCurrency,
+        uint256 _conversionRate,
+        uint256 _signalTimestamp
+    ) internal pure {
+        require(_snapshot.payeeDetails == _payeeId, "UPV: Snapshot payee mismatch");
+        require(_snapshot.amount == _amount, "UPV: Snapshot amount mismatch");
+        require(_snapshot.paymentMethod == _paymentMethod, "UPV: Snapshot method mismatch");
+        require(_snapshot.fiatCurrency == _fiatCurrency, "UPV: Snapshot currency mismatch");
+        require(_snapshot.conversionRate == _conversionRate, "UPV: Snapshot rate mismatch");
+        require(_snapshot.signalTimestamp == _signalTimestamp, "UPV: Snapshot timestamp mismatch");
+    }
+
+    function _isV2Orchestrator(address _orchestrator) internal view returns (bool isV2Orchestrator) {
+        (isV2Orchestrator, ) = _orchestrator.staticcall(
+            abi.encodeWithSelector(GET_DEPOSIT_PRE_INTENT_HOOK_SELECTOR, address(0), 0)
+        );
+    }
+
+    function _nullifyPayment(bytes32 _paymentMethod, bytes32 _paymentId) internal {
+        require(_paymentId != bytes32(0), "UPV: Invalid payment ID");
+        _validateAndAddNullifier(keccak256(abi.encodePacked(_paymentMethod, _paymentId)));
+    }
+
+    function _calculateReleaseAmount(
+        uint256 _releaseAmount,
+        uint256 _intentAmount
+    ) internal pure returns (uint256) {
+        return _releaseAmount > _intentAmount ? _intentAmount : _releaseAmount;
+    }
+
+    function _emitPaymentDetails(bytes32 _intentHash, PaymentDetails memory _paymentDetails) internal {
+        emit PaymentVerified(
+            _intentHash,
+            _paymentDetails.method,
+            _paymentDetails.currency,
+            _paymentDetails.amount,
+            _paymentDetails.timestamp,
+            _paymentDetails.paymentId,
+            _paymentDetails.payeeId
+        );
     }
 }

--- a/contracts/unifiedVerifier/UnifiedPaymentVerifierV3.sol
+++ b/contracts/unifiedVerifier/UnifiedPaymentVerifierV3.sol
@@ -7,14 +7,15 @@ import { IAttestationVerifier } from "../interfaces/IAttestationVerifier.sol";
 import { INullifierRegistry } from "../interfaces/INullifierRegistry.sol";
 import { IOrchestratorRegistry } from "../interfaces/IOrchestratorRegistry.sol";
 import { IPaymentVerifier } from "../interfaces/IPaymentVerifier.sol";
+import { IPaymentVerifierV3 } from "../interfaces/IPaymentVerifierV3.sol";
 
 /**
- * @title UnifiedPaymentVerifier
- * @notice Legacy three-field payment-verification ABI.
- * @dev New payment-ID-aware orchestrators use UnifiedPaymentVerifierV3. This wrapper remains so
- *      existing orchestrators and deployments keep their exact return format.
+ * @title UnifiedPaymentVerifierV3
+ * @notice Returns the payment identifier already authenticated inside signed PaymentDetails.
+ * @dev The payment-attestation type is unchanged. EIP-712 chain and verifier-address binding remains
+ *      in the domain separator; only the verification result gains `paymentId`.
  */
-contract UnifiedPaymentVerifier is IPaymentVerifier, BaseUnifiedPaymentVerifier {
+contract UnifiedPaymentVerifierV3 is IPaymentVerifierV3, BaseUnifiedPaymentVerifier {
     constructor(
         IOrchestratorRegistry _orchestratorRegistry,
         INullifierRegistry _nullifierRegistry,
@@ -22,13 +23,14 @@ contract UnifiedPaymentVerifier is IPaymentVerifier, BaseUnifiedPaymentVerifier 
     ) BaseUnifiedPaymentVerifier(_orchestratorRegistry, _nullifierRegistry, _attestationVerifier) { }
 
     function verifyPayment(
-        VerifyPaymentData calldata _verifyPaymentData
+        IPaymentVerifier.VerifyPaymentData calldata _verifyPaymentData
     ) external override onlyOrchestrator returns (PaymentVerificationResult memory result) {
-        (bytes32 intentHash, uint256 releaseAmount, ) = _verifyPayment(_verifyPaymentData);
+        (bytes32 intentHash, uint256 releaseAmount, bytes32 paymentId) = _verifyPayment(_verifyPaymentData);
         return PaymentVerificationResult({
             success: true,
             intentHash: intentHash,
-            releaseAmount: releaseAmount
+            releaseAmount: releaseAmount,
+            paymentId: paymentId
         });
     }
 }

--- a/deploy/28_deploy_payment_id_risk_system.ts
+++ b/deploy/28_deploy_payment_id_risk_system.ts
@@ -174,7 +174,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const relayerRegistryAddress = getDeployedContractAddress(network, "RelayerRegistry");
   const orchestratorRegistryAddress = getDeployedContractAddress(network, "OrchestratorRegistry");
   const nullifierRegistryAddress = getDeployedContractAddress(network, "NullifierRegistry");
-  const settlementHookExecutorAddress = getDeployedContractAddress(network, "SettlementHookExecutor");
+  const postIntentHookExecutorAddress = getDeployedContractAddress(network, "PostIntentHookExecutor");
   const stakeTokenAddress = USDC[network] || getDeployedContractAddress(network, "USDCMock");
 
   const paymentVerifierRegistryV3 = await deploy("PaymentVerifierRegistryV3", {
@@ -208,7 +208,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     from: deployer,
     libraries: {
       BoundedCall: boundedCall.address,
-      SettlementHookExecutor: settlementHookExecutorAddress,
+      PostIntentHookExecutor: postIntentHookExecutorAddress,
     },
     args: [
       deployer,

--- a/deploy/28_deploy_payment_id_risk_system.ts
+++ b/deploy/28_deploy_payment_id_risk_system.ts
@@ -1,0 +1,309 @@
+import "module-alias/register";
+
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { ethers } from "hardhat";
+
+import {
+  MULTI_SIG,
+  ORCHESTRATOR_V2_PROTOCOL_FEE,
+  ORCHESTRATOR_V2_PROTOCOL_FEE_RECIPIENT,
+  RISK_CALLBACK_GAS_LIMIT,
+  STAKE_VAULT_BASE_EXIT_DELAY,
+  STAKE_VAULT_CONTROLLER_CHANGE_DELAY,
+  USDC,
+} from "../deployments/parameters";
+import {
+  addOrchestratorToRegistry,
+  addPaymentMethodToRegistry,
+  addPaymentMethodToUnifiedVerifier,
+  addWritePermission,
+  getDeployedContractAddress,
+  setNewOwner,
+  waitForDeploymentDelay,
+} from "../deployments/helpers";
+import {
+  chargebackWitnessConfigForNetwork,
+  stakeRiskPlatformPolicyForNetwork,
+} from "./26_deploy_stake_risk_system";
+
+const PAYPAL = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("paypal"));
+const VENMO = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("venmo"));
+const ZELLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("zelle"));
+
+export const PAYMENT_ID_RISK_DEPLOYMENT_NAMES = [
+  "PaymentVerifierRegistryV3",
+  "UnifiedPaymentVerifierV3",
+  "BoundedCallPaymentId",
+  "OrchestratorV3PaymentId",
+  "StakeVaultPaymentId",
+  "ChargebackAttestationVerifierPaymentId",
+  "RiskManagerPaymentId",
+  "DeferredPayoutHookPaymentId",
+] as const;
+
+export async function assertFreshNonLocalPaymentIdRiskDeployment(
+  network: string,
+  getDeployment: (name: string) => Promise<unknown | null>,
+) {
+  if (network === "localhost" || network === "hardhat") return;
+  const existing: string[] = [];
+  for (const name of PAYMENT_ID_RISK_DEPLOYMENT_NAMES) {
+    if (await getDeployment(name)) existing.push(name);
+  }
+  if (existing.length !== 0) {
+    throw new Error(
+      `${network} already has payment-ID risk deployment records (${existing.join(", ")}); `
+      + "use a new governance-reviewed version",
+    );
+  }
+}
+
+function normalize(values: string[]): string[] {
+  return values.map((value) => value.toLowerCase()).sort();
+}
+
+function equalValues(left: string[], right: string[]): boolean {
+  const normalizedLeft = normalize(left);
+  const normalizedRight = normalize(right);
+  return normalizedLeft.length === normalizedRight.length
+    && normalizedLeft.every((value, index) => value === normalizedRight[index]);
+}
+
+function platformRiskConfigMatches(actual: any, expected: any): boolean {
+  return actual.enabled === expected.enabled
+    && actual.chargeback.chargebackable === expected.chargeback.chargebackable
+    && actual.chargeback.deferredPayoutEnabled === expected.chargeback.deferredPayoutEnabled
+    && ethers.BigNumber.from(actual.chargeback.reserveBps).eq(expected.chargeback.reserveBps)
+    && ethers.BigNumber.from(actual.chargeback.riskWindow).eq(expected.chargeback.riskWindow)
+    && ethers.BigNumber.from(actual.griefing.griefingCliff).eq(expected.griefing.griefingCliff)
+    && ethers.BigNumber.from(actual.griefing.griefingPenaltyBpsPerHour)
+      .eq(expected.griefing.griefingPenaltyBpsPerHour)
+    && ethers.BigNumber.from(actual.griefing.freeTakeCount).eq(expected.griefing.freeTakeCount)
+    && ethers.BigNumber.from(actual.griefing.freeTakeAmount).eq(expected.griefing.freeTakeAmount);
+}
+
+async function loadLegacyPaymentConfiguration(network: string) {
+  const registryAddress = getDeployedContractAddress(network, "PaymentVerifierRegistry");
+  const legacyVerifierAddress = getDeployedContractAddress(network, "UnifiedPaymentVerifierV2");
+  const registry = await ethers.getContractAt("PaymentVerifierRegistry", registryAddress);
+  const legacyVerifier = await ethers.getContractAt("UnifiedPaymentVerifier", legacyVerifierAddress);
+  const methods: string[] = await registry.getPaymentMethods();
+  if (methods.length === 0 || new Set(normalize(methods)).size !== methods.length) {
+    throw new Error("Legacy payment verifier registry must have a nonempty unique method set");
+  }
+
+  const configurations: Array<{ method: string; currencies: string[] }> = [];
+  for (const method of methods) {
+    const verifier = await registry.getVerifier(method);
+    if (verifier.toLowerCase() !== legacyVerifierAddress.toLowerCase()) {
+      throw new Error(`Legacy payment method ${method} is not routed to UnifiedPaymentVerifierV2`);
+    }
+    const currencies: string[] = await registry.getCurrencies(method);
+    if (
+      currencies.length === 0
+      || new Set(normalize(currencies)).size !== currencies.length
+      || currencies.some((currency) => currency === ethers.constants.HashZero)
+    ) {
+      throw new Error(`Legacy payment method ${method} has invalid currencies`);
+    }
+    configurations.push({ method, currencies });
+  }
+
+  const paymentAttestationVerifierAddress = await legacyVerifier.attestationVerifier();
+  const paymentAttestationVerifier = await ethers.getContractAt(
+    "MultiAttestationVerifier",
+    paymentAttestationVerifierAddress,
+  );
+  const paymentWitnesses: string[] = await paymentAttestationVerifier.witnesses();
+  if (paymentWitnesses.length === 0) {
+    throw new Error("Live payment attestation witness set must be nonempty");
+  }
+
+  return {
+    registry,
+    legacyVerifier,
+    legacyVerifierAddress,
+    configurations,
+    paymentAttestationVerifierAddress,
+    paymentWitnesses,
+  };
+}
+
+async function assertRegistryParity(
+  legacyConfigurations: Array<{ method: string; currencies: string[] }>,
+  newRegistry: any,
+  newVerifier: any,
+) {
+  const expectedMethods = legacyConfigurations.map(({ method }) => method);
+  const actualRegistryMethods: string[] = await newRegistry.getPaymentMethods();
+  const actualVerifierMethods: string[] = await newVerifier.getPaymentMethods();
+  if (!equalValues(actualRegistryMethods, expectedMethods) || !equalValues(actualVerifierMethods, expectedMethods)) {
+    throw new Error("Payment-ID lane method set does not match the legacy lane");
+  }
+  for (const { method, currencies } of legacyConfigurations) {
+    if ((await newRegistry.getVerifier(method)).toLowerCase() !== newVerifier.address.toLowerCase()) {
+      throw new Error(`Payment-ID lane verifier mismatch for ${method}`);
+    }
+    if (!equalValues(await newRegistry.getCurrencies(method), currencies)) {
+      throw new Error(`Payment-ID lane currency mismatch for ${method}`);
+    }
+  }
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deploy } = hre.deployments;
+  const network = hre.deployments.getNetworkName();
+  await assertFreshNonLocalPaymentIdRiskDeployment(
+    network,
+    hre.deployments.getOrNull.bind(hre.deployments),
+  );
+  const { reversible: reversibleConfig, nonChargebackable: nonChargebackableConfig } =
+    stakeRiskPlatformPolicyForNetwork(network);
+  const legacy = await loadLegacyPaymentConfiguration(network);
+  const chargebackWitnessConfig = chargebackWitnessConfigForNetwork(
+    network,
+    process.env.CHARGEBACK_WITNESS_ADDRESSES,
+    legacy.paymentWitnesses,
+  );
+  const [deployer] = await hre.getUnnamedAccounts();
+  const multiSig = MULTI_SIG[network] || deployer;
+  const chainId = (await ethers.provider.getNetwork()).chainId;
+
+  const escrowRegistryAddress = getDeployedContractAddress(network, "EscrowRegistry");
+  const relayerRegistryAddress = getDeployedContractAddress(network, "RelayerRegistry");
+  const orchestratorRegistryAddress = getDeployedContractAddress(network, "OrchestratorRegistry");
+  const nullifierRegistryAddress = getDeployedContractAddress(network, "NullifierRegistry");
+  const settlementHookExecutorAddress = getDeployedContractAddress(network, "SettlementHookExecutor");
+  const stakeTokenAddress = USDC[network] || getDeployedContractAddress(network, "USDCMock");
+
+  const paymentVerifierRegistryV3 = await deploy("PaymentVerifierRegistryV3", {
+    contract: "PaymentVerifierRegistry",
+    from: deployer,
+    args: [],
+  });
+  const unifiedPaymentVerifierV3 = await deploy("UnifiedPaymentVerifierV3", {
+    from: deployer,
+    args: [
+      orchestratorRegistryAddress,
+      nullifierRegistryAddress,
+      legacy.paymentAttestationVerifierAddress,
+    ],
+  });
+  const newRegistry = await ethers.getContractAt("PaymentVerifierRegistry", paymentVerifierRegistryV3.address);
+  const newVerifier = await ethers.getContractAt("UnifiedPaymentVerifierV3", unifiedPaymentVerifierV3.address);
+  for (const { method, currencies } of legacy.configurations) {
+    await addPaymentMethodToUnifiedVerifier(hre, newVerifier, method);
+    await addPaymentMethodToRegistry(hre, newRegistry, method, newVerifier.address, currencies);
+  }
+  await assertRegistryParity(legacy.configurations, newRegistry, newVerifier);
+
+  const boundedCall = await deploy("BoundedCallPaymentId", {
+    contract: "BoundedCall",
+    from: deployer,
+    args: [],
+  });
+  const orchestratorV3 = await deploy("OrchestratorV3PaymentId", {
+    contract: "OrchestratorV3",
+    from: deployer,
+    libraries: {
+      BoundedCall: boundedCall.address,
+      SettlementHookExecutor: settlementHookExecutorAddress,
+    },
+    args: [
+      deployer,
+      chainId,
+      escrowRegistryAddress,
+      paymentVerifierRegistryV3.address,
+      relayerRegistryAddress,
+      ORCHESTRATOR_V2_PROTOCOL_FEE[network],
+      ORCHESTRATOR_V2_PROTOCOL_FEE_RECIPIENT[network] || deployer,
+      RISK_CALLBACK_GAS_LIMIT,
+    ],
+  });
+  const stakeVault = await deploy("StakeVaultPaymentId", {
+    contract: "StakeVault",
+    from: deployer,
+    args: [
+      deployer,
+      stakeTokenAddress,
+      ethers.constants.AddressZero,
+      STAKE_VAULT_BASE_EXIT_DELAY,
+      STAKE_VAULT_CONTROLLER_CHANGE_DELAY,
+    ],
+  });
+  const chargebackAttestationVerifier = await deploy("ChargebackAttestationVerifierPaymentId", {
+    contract: "MultiAttestationVerifier",
+    from: deployer,
+    args: [chargebackWitnessConfig.witnesses, chargebackWitnessConfig.threshold],
+  });
+  const riskManager = await deploy("RiskManagerPaymentId", {
+    contract: "RiskManager",
+    from: deployer,
+    args: [deployer, orchestratorV3.address, stakeVault.address, chargebackAttestationVerifier.address],
+  });
+  const deferredPayoutHook = await deploy("DeferredPayoutHookPaymentId", {
+    contract: "DeferredPayoutHook",
+    from: deployer,
+    args: [stakeTokenAddress, stakeVault.address, riskManager.address, orchestratorRegistryAddress],
+  });
+
+  const vault = await ethers.getContractAt("StakeVault", stakeVault.address);
+  const manager = await ethers.getContractAt("RiskManager", riskManager.address);
+  const orchestrator = await ethers.getContractAt("OrchestratorV3", orchestratorV3.address);
+  const chargebackVerifier = await ethers.getContractAt(
+    "MultiAttestationVerifier",
+    chargebackAttestationVerifier.address,
+  );
+  if ((await vault.controller()) === ethers.constants.AddressZero) {
+    await (await vault.initializeController(manager.address)).wait();
+    await waitForDeploymentDelay(hre);
+  } else if ((await vault.controller()).toLowerCase() !== manager.address.toLowerCase()) {
+    throw new Error("Payment-ID StakeVault controller mismatch");
+  }
+  if ((await manager.deferredPayoutHook()).toLowerCase() !== deferredPayoutHook.address.toLowerCase()) {
+    await (await manager.setDeferredPayoutHook(deferredPayoutHook.address)).wait();
+  }
+  if (!(await orchestrator.allowMultipleIntents())) {
+    await (await orchestrator.setAllowMultipleIntents(true)).wait();
+  }
+  for (const paymentMethod of [PAYPAL, VENMO]) {
+    if (!platformRiskConfigMatches(await manager.getPlatformRiskConfig(paymentMethod), reversibleConfig)) {
+      await (await manager.setPlatformRiskConfig(paymentMethod, reversibleConfig)).wait();
+    }
+  }
+  if (!platformRiskConfigMatches(await manager.getPlatformRiskConfig(ZELLE), nonChargebackableConfig)) {
+    await (await manager.setPlatformRiskConfig(ZELLE, nonChargebackableConfig)).wait();
+  }
+
+  const orchestratorRegistry = await ethers.getContractAt("OrchestratorRegistry", orchestratorRegistryAddress);
+  const nullifierRegistry = await ethers.getContractAt("NullifierRegistry", nullifierRegistryAddress);
+  await addOrchestratorToRegistry(hre, orchestratorRegistry, orchestrator.address);
+  await addWritePermission(hre, nullifierRegistry, newVerifier.address);
+  if (!(await nullifierRegistry.isWriter(legacy.legacyVerifierAddress))) {
+    throw new Error("Legacy UnifiedPaymentVerifierV2 must remain a shared nullifier writer");
+  }
+
+  await setNewOwner(hre, newRegistry, multiSig);
+  await setNewOwner(hre, newVerifier, multiSig);
+  await setNewOwner(hre, orchestrator, multiSig);
+  await setNewOwner(hre, vault, multiSig);
+  await setNewOwner(hre, manager, multiSig);
+  await setNewOwner(hre, chargebackVerifier, multiSig);
+};
+
+func.tags = ["PaymentIdRiskSystem"];
+func.dependencies = ["27_remove_legacy_zelle_payment_methods"];
+func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> => {
+  const network = hre.deployments.getNetworkName();
+  if (network === "localhost" || network === "hardhat") return false;
+  if (process.env.DEPLOY_PAYMENT_ID_RISK_SYSTEM !== "true") return true;
+  stakeRiskPlatformPolicyForNetwork(network);
+  await assertFreshNonLocalPaymentIdRiskDeployment(
+    network,
+    hre.deployments.getOrNull.bind(hre.deployments),
+  );
+  return false;
+};
+
+export default func;

--- a/deploy/28_deploy_payment_id_risk_system.ts
+++ b/deploy/28_deploy_payment_id_risk_system.ts
@@ -59,6 +59,19 @@ export async function assertFreshNonLocalPaymentIdRiskDeployment(
   }
 }
 
+export async function requireHistoricalPostIntentHookExecutor(
+  network: string,
+  getDeployment: (name: string) => Promise<{ address: string } | null>,
+): Promise<string> {
+  const deployment = await getDeployment("PostIntentHookExecutor");
+  if (!deployment) {
+    throw new Error(
+      `${network} requires the historical PostIntentHookExecutor deployment before the payment-ID risk lane`,
+    );
+  }
+  return deployment.address;
+}
+
 function normalize(values: string[]): string[] {
   return values.map((value) => value.toLowerCase()).sort();
 }
@@ -174,7 +187,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const relayerRegistryAddress = getDeployedContractAddress(network, "RelayerRegistry");
   const orchestratorRegistryAddress = getDeployedContractAddress(network, "OrchestratorRegistry");
   const nullifierRegistryAddress = getDeployedContractAddress(network, "NullifierRegistry");
-  const postIntentHookExecutorAddress = getDeployedContractAddress(network, "PostIntentHookExecutor");
+  const postIntentHookExecutorAddress = await requireHistoricalPostIntentHookExecutor(
+    network,
+    hre.deployments.getOrNull.bind(hre.deployments),
+  );
   const stakeTokenAddress = USDC[network] || getDeployedContractAddress(network, "USDCMock");
 
   const paymentVerifierRegistryV3 = await deploy("PaymentVerifierRegistryV3", {

--- a/deploy/deploy_summary.ts
+++ b/deploy/deploy_summary.ts
@@ -66,6 +66,16 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     StakeVault:                         ${tryGetAddress(network, "StakeVault")}
     RiskManager:                        ${tryGetAddress(network, "RiskManager")}
     DeferredPayoutHook:                 ${tryGetAddress(network, "DeferredPayoutHook")}
+    ----------------------------------------------------------------------
+    Payment-ID Risk Contracts:
+    PaymentVerifierRegistryV3:          ${tryGetAddress(network, "PaymentVerifierRegistryV3")}
+    UnifiedPaymentVerifierV3:           ${tryGetAddress(network, "UnifiedPaymentVerifierV3")}
+    BoundedCallPaymentId:               ${tryGetAddress(network, "BoundedCallPaymentId")}
+    OrchestratorV3PaymentId:            ${tryGetAddress(network, "OrchestratorV3PaymentId")}
+    StakeVaultPaymentId:                ${tryGetAddress(network, "StakeVaultPaymentId")}
+    ChargebackVerifierPaymentId:        ${tryGetAddress(network, "ChargebackAttestationVerifierPaymentId")}
+    RiskManagerPaymentId:               ${tryGetAddress(network, "RiskManagerPaymentId")}
+    DeferredPayoutHookPaymentId:        ${tryGetAddress(network, "DeferredPayoutHookPaymentId")}
     `
   );
 

--- a/test-foundry/invariant/RiskManagerInvariant.t.sol
+++ b/test-foundry/invariant/RiskManagerInvariant.t.sol
@@ -10,7 +10,6 @@ import { RiskManager } from "../../contracts/RiskManager.sol";
 import { StakeVault } from "../../contracts/StakeVault.sol";
 import { IEscrowV2 } from "../../contracts/interfaces/IEscrowV2.sol";
 import { IOrchestratorV3 } from "../../contracts/interfaces/IOrchestratorV3.sol";
-import { IPaymentVerifierRegistry } from "../../contracts/interfaces/IPaymentVerifierRegistry.sol";
 import { IRiskManager } from "../../contracts/interfaces/IRiskManager.sol";
 import { IStakeVault } from "../../contracts/interfaces/IStakeVault.sol";
 import { AttestationVerifierMock } from "../../contracts/mocks/AttestationVerifierMock.sol";
@@ -43,7 +42,6 @@ contract RiskManagerInvariantHandler is Test {
     uint256 public nonce;
 
     mapping(bytes32 => IOrchestratorV3.RiskIntentData) internal intents;
-    mapping(bytes32 => bytes32) internal paymentEvidence;
     bytes32[] internal intentHashes;
 
     constructor(RiskInvariantEscrow _escrow, address _stakeOwner) {
@@ -93,13 +91,7 @@ contract RiskManagerInvariantHandler is Test {
         if (position.status != IRiskManager.PositionStatus.PENDING) return;
         uint256 releasedAmount = bound(uint256(rawReleasedAmount), 1, position.intentAmount);
         bytes32 paymentId = keccak256(abi.encodePacked("payment", intentHash));
-        paymentEvidence[intentHash] = keccak256(abi.encode(
-            position.paymentMethod,
-            paymentId,
-            releasedAmount,
-            keccak256("USD")
-        ));
-        manager.onIntentFulfilled(intentHash, releasedAmount);
+        manager.onIntentFulfilled(intentHash, releasedAmount, paymentId);
         delete intents[intentHash];
     }
 
@@ -107,20 +99,8 @@ contract RiskManagerInvariantHandler is Test {
         return intents[_intentHash];
     }
 
-    function paymentVerifierRegistry() external view returns (IPaymentVerifierRegistry) {
-        return IPaymentVerifierRegistry(address(this));
-    }
-
-    function getVerifier(bytes32) external view returns (address) {
-        return address(this);
-    }
-
-    function getPaymentDetailsHash(address, bytes32 _intentHash) external view returns (bytes32) {
-        return paymentEvidence[_intentHash];
-    }
-
-    function getIntentSettlement(bytes32) external pure returns (uint256, uint64, bool) {
-        return (0, 0, false);
+    function getIntentSettlement(bytes32) external pure returns (uint256, bytes32, uint64, bool) {
+        return (0, bytes32(0), 0, false);
     }
 
     function getIntentCancellation(bytes32) external pure returns (uint64) {

--- a/test-foundry/invariant/RiskManagerInvariant.t.sol
+++ b/test-foundry/invariant/RiskManagerInvariant.t.sol
@@ -99,8 +99,8 @@ contract RiskManagerInvariantHandler is Test {
         return intents[_intentHash];
     }
 
-    function getIntentSettlement(bytes32) external pure returns (uint256, bytes32, uint64, bool) {
-        return (0, bytes32(0), 0, false);
+    function getIntentSettlement(bytes32) external pure returns (uint256, bytes32, uint64) {
+        return (0, bytes32(0), 0);
     }
 
     function getIntentCancellation(bytes32) external pure returns (uint64) {

--- a/test-foundry/unit/RiskManager.t.sol
+++ b/test-foundry/unit/RiskManager.t.sol
@@ -10,7 +10,6 @@ import { StakeVault } from "../../contracts/StakeVault.sol";
 import { IEscrowV2 } from "../../contracts/interfaces/IEscrowV2.sol";
 import { IIntentRiskHook } from "../../contracts/interfaces/IIntentRiskHook.sol";
 import { IOrchestratorV3 } from "../../contracts/interfaces/IOrchestratorV3.sol";
-import { IPaymentVerifierRegistry } from "../../contracts/interfaces/IPaymentVerifierRegistry.sol";
 import { ISettlementHook } from "../../contracts/interfaces/ISettlementHook.sol";
 import { IRiskManager } from "../../contracts/interfaces/IRiskManager.sol";
 import { IStakeVault } from "../../contracts/interfaces/IStakeVault.sol";
@@ -43,20 +42,6 @@ contract RiskOrchestratorHarness {
     mapping(bytes32 => IOrchestratorV3.RiskIntentData) internal intents;
     mapping(bytes32 => IOrchestratorV3.IntentSettlement) internal settlements;
     mapping(bytes32 => IOrchestratorV3.IntentCancellation) internal cancellations;
-    mapping(bytes32 => bytes32) internal paymentEvidence;
-
-    function paymentVerifierRegistry() external view returns (IPaymentVerifierRegistry) {
-        return IPaymentVerifierRegistry(address(this));
-    }
-
-    function getVerifier(bytes32) external view returns (address) {
-        return address(this);
-    }
-
-    function getPaymentDetailsHash(address, bytes32 _intentHash) external view returns (bytes32) {
-        return paymentEvidence[_intentHash];
-    }
-
     function setIntent(
         bytes32 _intentHash,
         address _taker,
@@ -81,9 +66,14 @@ contract RiskOrchestratorHarness {
         return intents[_intentHash];
     }
 
-    function getIntentSettlement(bytes32 _intentHash) external view returns (uint256, uint64, bool) {
+    function getIntentSettlement(bytes32 _intentHash) external view returns (uint256, bytes32, uint64, bool) {
         IOrchestratorV3.IntentSettlement memory settlement = settlements[_intentHash];
-        return (settlement.releasedAmount, settlement.settledAt, settlement.isManualRelease);
+        return (
+            settlement.releasedAmount,
+            settlement.paymentId,
+            settlement.settledAt,
+            settlement.isManualRelease
+        );
     }
 
     function getIntentCancellation(bytes32 _intentHash) external view returns (uint64) {
@@ -101,13 +91,7 @@ contract RiskOrchestratorHarness {
 
     function fulfillPosition(IIntentRiskHook _manager, bytes32 _intentHash, uint256 _amount) external {
         bytes32 paymentId = keccak256(abi.encodePacked("payment", _intentHash));
-        paymentEvidence[_intentHash] = keccak256(abi.encode(
-            intents[_intentHash].paymentMethod,
-            paymentId,
-            _amount,
-            keccak256("USD")
-        ));
-        _manager.onIntentFulfilled(_intentHash, _amount);
+        _manager.onIntentFulfilled(_intentHash, _amount, paymentId);
         delete intents[_intentHash];
     }
 
@@ -118,14 +102,9 @@ contract RiskOrchestratorHarness {
 
     function recordSettlementWithoutCallback(bytes32 _intentHash, uint256 _amount, uint64 _settledAt) external {
         bytes32 paymentId = keccak256(abi.encodePacked("payment", _intentHash));
-        paymentEvidence[_intentHash] = keccak256(abi.encode(
-            intents[_intentHash].paymentMethod,
-            paymentId,
-            _amount,
-            keccak256("USD")
-        ));
         settlements[_intentHash] = IOrchestratorV3.IntentSettlement({
             releasedAmount: _amount,
+            paymentId: paymentId,
             settledAt: _settledAt,
             isManualRelease: false
         });
@@ -258,22 +237,13 @@ contract RiskManagerTest is Test {
 
     function _chargeback(
         bytes32 _intentHash,
-        uint256 _paymentAmount,
         uint256 _disputeNonce
     ) internal view returns (IRiskManager.ChargebackAttestation memory) {
-        bytes memory data = abi.encode(IRiskManager.ChargebackDetails({
-            paymentMethod: PAYPAL,
-            originalPaymentId: keccak256(abi.encodePacked("payment", _intentHash)),
-            disputeId: keccak256(abi.encode(_intentHash, _disputeNonce)),
-            paymentAmount: _paymentAmount,
-            paymentCurrency: keccak256("USD")
-        }));
         return IRiskManager.ChargebackAttestation({
             intentHash: _intentHash,
-            dataHash: keccak256(data),
-            signatures: new bytes[](0),
-            data: data,
-            metadata: ""
+            originalPaymentId: keccak256(abi.encodePacked("payment", _intentHash)),
+            disputeId: keccak256(abi.encode(_intentHash, _disputeNonce)),
+            signatures: new bytes[](0)
         });
     }
 
@@ -491,22 +461,24 @@ contract RiskManagerTest is Test {
         _createPosition(intentHash);
         orchestrator.fulfillPosition(manager, intentHash, 500e6);
 
-        manager.submitChargeback(_chargeback(intentHash, 500e6, 1));
+        manager.submitChargeback(_chargeback(intentHash, 1));
 
         assertEq(vault.claimableCompensation(maker), 500e6);
         assertEq(vault.reservedStake(taker), 0);
         assertEq(manager.getRiskPosition(intentHash).reservedAmount, 0);
     }
 
-    function test_ChargebackRejectsMismatchedFiatAmount() public {
+    function test_ChargebackRejectsMismatchedPaymentId() public {
         _stake(taker, 500e6);
         bytes32 intentHash = keccak256("capped-chargeback");
         _setIntent(intentHash, taker, 500e6, PAYPAL, address(0));
         _createPosition(intentHash);
         orchestrator.fulfillPosition(manager, intentHash, 500e6);
 
+        IRiskManager.ChargebackAttestation memory attestation = _chargeback(intentHash, 1);
+        attestation.originalPaymentId = keccak256("wrong-payment-id");
         vm.expectRevert(IRiskManager.InvalidAttestation.selector);
-        manager.submitChargeback(_chargeback(intentHash, 499e6, 1));
+        manager.submitChargeback(attestation);
 
         assertEq(vault.claimableCompensation(maker), 0);
         assertEq(uint256(manager.getRiskPosition(intentHash).status), uint256(IRiskManager.PositionStatus.SETTLED));

--- a/test-foundry/unit/RiskManager.t.sol
+++ b/test-foundry/unit/RiskManager.t.sol
@@ -66,13 +66,12 @@ contract RiskOrchestratorHarness {
         return intents[_intentHash];
     }
 
-    function getIntentSettlement(bytes32 _intentHash) external view returns (uint256, bytes32, uint64, bool) {
+    function getIntentSettlement(bytes32 _intentHash) external view returns (uint256, bytes32, uint64) {
         IOrchestratorV3.IntentSettlement memory settlement = settlements[_intentHash];
         return (
             settlement.releasedAmount,
             settlement.paymentId,
-            settlement.settledAt,
-            settlement.isManualRelease
+            settlement.settledAt
         );
     }
 
@@ -105,8 +104,7 @@ contract RiskOrchestratorHarness {
         settlements[_intentHash] = IOrchestratorV3.IntentSettlement({
             releasedAmount: _amount,
             paymentId: paymentId,
-            settledAt: _settledAt,
-            isManualRelease: false
+            settledAt: _settledAt
         });
         delete intents[_intentHash];
     }

--- a/test/deploy/26_stakeRiskSystem.spec.ts
+++ b/test/deploy/26_stakeRiskSystem.spec.ts
@@ -175,16 +175,16 @@ describe("Affine stake risk system deployment", () => {
     const { chainId } = await ethers.provider.getNetwork();
     const chargeback = {
       intentHash: ethers.utils.id("affine-risk-deployment-test"),
-      dataHash: ethers.utils.id("deployment-evidence"),
+      originalPaymentId: ethers.utils.id("deployment-payment"),
+      disputeId: ethers.utils.id("deployment-dispute"),
       signatures: [],
-      data: "0x",
-      metadata: "0x",
     };
     const domain = { name: "ZKP2P RiskManager", version: "1", chainId, verifyingContract: manager.address };
     const types = {
       ChargebackAttestation: [
         { name: "intentHash", type: "bytes32" },
-        { name: "dataHash", type: "bytes32" },
+        { name: "originalPaymentId", type: "bytes32" },
+        { name: "disputeId", type: "bytes32" },
       ],
     };
     const digest = await manager.hashChargebackAttestation(chargeback);
@@ -194,7 +194,11 @@ describe("Affine stake risk system deployment", () => {
       const signers = await ethers.getSigners();
       const localWitnesses = signers.filter((signer) => witnessConfig.witnesses
         .map((address) => address.toLowerCase()).includes(signer.address.toLowerCase()));
-      const value = { intentHash: chargeback.intentHash, dataHash: chargeback.dataHash };
+      const value = {
+        intentHash: chargeback.intentHash,
+        originalPaymentId: chargeback.originalPaymentId,
+        disputeId: chargeback.disputeId,
+      };
       const signatures = [
         await localWitnesses[0]._signTypedData(domain, types, value),
         await localWitnesses[1]._signTypedData(domain, types, value),

--- a/test/deploy/28_paymentIdRiskSystem.spec.ts
+++ b/test/deploy/28_paymentIdRiskSystem.spec.ts
@@ -1,0 +1,181 @@
+import "module-alias/register";
+
+import { expect } from "chai";
+import hre, { deployments, ethers } from "hardhat";
+
+import deployPaymentIdRiskSystem, {
+  assertFreshNonLocalPaymentIdRiskDeployment,
+  PAYMENT_ID_RISK_DEPLOYMENT_NAMES,
+} from "../../deploy/28_deploy_payment_id_risk_system";
+import {
+  MULTI_SIG,
+  RISK_CALLBACK_GAS_LIMIT,
+} from "../../deployments/parameters";
+import { stakeRiskPlatformPolicyForNetwork } from "../../deploy/26_deploy_stake_risk_system";
+
+const PAYPAL = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("paypal"));
+const VENMO = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("venmo"));
+const ZELLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("zelle"));
+
+describe("Payment-ID-aware parallel risk system deployment", () => {
+  const network = deployments.getNetworkName();
+  const policy = stakeRiskPlatformPolicyForNetwork(network);
+
+  function deployedAddress(name: string): string {
+    return require(`../../deployments/${network}/${name}.json`).address;
+  }
+
+  async function contracts() {
+    return {
+      legacyRegistry: await ethers.getContractAt(
+        "PaymentVerifierRegistry",
+        deployedAddress("PaymentVerifierRegistry"),
+      ),
+      newRegistry: await ethers.getContractAt(
+        "PaymentVerifierRegistry",
+        deployedAddress("PaymentVerifierRegistryV3"),
+      ),
+      legacyVerifier: await ethers.getContractAt(
+        "UnifiedPaymentVerifier",
+        deployedAddress("UnifiedPaymentVerifierV2"),
+      ),
+      newVerifier: await ethers.getContractAt(
+        "UnifiedPaymentVerifierV3",
+        deployedAddress("UnifiedPaymentVerifierV3"),
+      ),
+      orchestrator: await ethers.getContractAt(
+        "OrchestratorV3",
+        deployedAddress("OrchestratorV3PaymentId"),
+      ),
+      vault: await ethers.getContractAt("StakeVault", deployedAddress("StakeVaultPaymentId")),
+      manager: await ethers.getContractAt("RiskManager", deployedAddress("RiskManagerPaymentId")),
+      deferredHook: await ethers.getContractAt(
+        "DeferredPayoutHook",
+        deployedAddress("DeferredPayoutHookPaymentId"),
+      ),
+      chargebackVerifier: await ethers.getContractAt(
+        "MultiAttestationVerifier",
+        deployedAddress("ChargebackAttestationVerifierPaymentId"),
+      ),
+      nullifierRegistry: await ethers.getContractAt(
+        "NullifierRegistry",
+        deployedAddress("NullifierRegistry"),
+      ),
+      orchestratorRegistry: await ethers.getContractAt(
+        "OrchestratorRegistry",
+        deployedAddress("OrchestratorRegistry"),
+      ),
+    };
+  }
+
+  it("deploys every versioned coordinate without replacing the legacy lane", async () => {
+    for (const name of PAYMENT_ID_RISK_DEPLOYMENT_NAMES) {
+      expect(deployedAddress(name)).to.properAddress;
+    }
+    expect(deployedAddress("PaymentVerifierRegistryV3"))
+      .not.to.eq(deployedAddress("PaymentVerifierRegistry"));
+    expect(deployedAddress("UnifiedPaymentVerifierV3"))
+      .not.to.eq(deployedAddress("UnifiedPaymentVerifierV2"));
+  });
+
+  it("mirrors exact live payment methods and currencies into the new registry", async () => {
+    const { legacyRegistry, newRegistry, legacyVerifier, newVerifier } = await contracts();
+    const legacyMethods: string[] = await legacyRegistry.getPaymentMethods();
+    const newMethods: string[] = await newRegistry.getPaymentMethods();
+    const verifierMethods: string[] = await newVerifier.getPaymentMethods();
+    expect(newMethods.map((value) => value.toLowerCase())).to.have.members(
+      legacyMethods.map((value) => value.toLowerCase()),
+    );
+    expect(verifierMethods.map((value) => value.toLowerCase())).to.have.members(
+      legacyMethods.map((value) => value.toLowerCase()),
+    );
+    for (const method of legacyMethods) {
+      expect(await legacyRegistry.getVerifier(method)).to.eq(legacyVerifier.address);
+      expect(await newRegistry.getVerifier(method)).to.eq(newVerifier.address);
+      expect((await newRegistry.getCurrencies(method)).map((value: string) => value.toLowerCase()))
+        .to.have.members((await legacyRegistry.getCurrencies(method)).map((value: string) => value.toLowerCase()));
+    }
+  });
+
+  it("shares replay protection while keeping independent registry routing", async () => {
+    const {
+      legacyVerifier,
+      newVerifier,
+      orchestrator,
+      nullifierRegistry,
+      orchestratorRegistry,
+    } = await contracts();
+    expect(await nullifierRegistry.isWriter(legacyVerifier.address)).to.eq(true);
+    expect(await nullifierRegistry.isWriter(newVerifier.address)).to.eq(true);
+    expect(await newVerifier.nullifierRegistry()).to.eq(nullifierRegistry.address);
+    expect(await newVerifier.orchestratorRegistry()).to.eq(orchestratorRegistry.address);
+    expect(await orchestratorRegistry.isOrchestrator(orchestrator.address)).to.eq(true);
+    expect(await orchestrator.paymentVerifierRegistry()).to.eq(deployedAddress("PaymentVerifierRegistryV3"));
+  });
+
+  it("wires and owns the versioned risk components", async () => {
+    const [deployer] = await ethers.getSigners();
+    const { newRegistry, newVerifier, orchestrator, vault, manager, deferredHook, chargebackVerifier } =
+      await contracts();
+    const expectedOwner = MULTI_SIG[network] || deployer.address;
+    for (const owned of [newRegistry, newVerifier, orchestrator, vault, manager, chargebackVerifier]) {
+      expect(await owned.owner()).to.eq(expectedOwner);
+    }
+    expect(await orchestrator.riskCallbackGasLimit()).to.eq(RISK_CALLBACK_GAS_LIMIT);
+    expect(await orchestrator.allowMultipleIntents()).to.eq(true);
+    expect(await vault.controller()).to.eq(manager.address);
+    expect(await manager.orchestrator()).to.eq(orchestrator.address);
+    expect(await manager.stakeVault()).to.eq(vault.address);
+    expect(await manager.deferredPayoutHook()).to.eq(deferredHook.address);
+    expect(await deferredHook.riskManager()).to.eq(manager.address);
+  });
+
+  it("uses a dedicated 2-of-3 chargeback witness set disjoint from live payment witnesses", async () => {
+    const { legacyVerifier, chargebackVerifier } = await contracts();
+    const paymentVerifier = await ethers.getContractAt(
+      "MultiAttestationVerifier",
+      await legacyVerifier.attestationVerifier(),
+    );
+    const paymentWitnesses = new Set(
+      (await paymentVerifier.witnesses()).map((value: string) => value.toLowerCase()),
+    );
+    const chargebackWitnesses: string[] = await chargebackVerifier.witnesses();
+    expect(chargebackWitnesses).to.have.length(3);
+    expect(await chargebackVerifier.requiredSignatures()).to.eq(2);
+    expect(chargebackWitnesses.some((value) => paymentWitnesses.has(value.toLowerCase()))).to.eq(false);
+  });
+
+  for (const [label, method] of [["PayPal", PAYPAL], ["Venmo", VENMO]] as const) {
+    it(`configures ${label} as full-reserve chargebackable`, async () => {
+      const { manager } = await contracts();
+      const config = await manager.getPlatformRiskConfig(method);
+      expect(config.enabled).to.eq(true);
+      expect(config.chargeback.chargebackable).to.eq(true);
+      expect(config.chargeback.reserveBps).to.eq(policy.reversible.chargeback.reserveBps);
+      expect(config.chargeback.riskWindow).to.eq(policy.reversible.chargeback.riskWindow);
+    });
+  }
+
+  it("keeps Zelle non-chargebackable", async () => {
+    const { manager } = await contracts();
+    const config = await manager.getPlatformRiskConfig(ZELLE);
+    expect(config.enabled).to.eq(true);
+    expect(config.chargeback.chargebackable).to.eq(false);
+    expect(config.chargeback.reserveBps).to.eq(0);
+  });
+
+  it("rejects any existing versioned coordinate before a nonlocal deployment", async () => {
+    await expect(assertFreshNonLocalPaymentIdRiskDeployment("base_staging", async (name) => (
+      name === "UnifiedPaymentVerifierV3" ? { address: ethers.constants.AddressZero } : null
+    ))).to.be.rejectedWith("use a new governance-reviewed version");
+  });
+
+  it("reruns locally without changing versioned addresses or wiring", async function () {
+    this.timeout(180_000);
+    const before = PAYMENT_ID_RISK_DEPLOYMENT_NAMES.map(deployedAddress);
+    const { vault, manager } = await contracts();
+    await deployPaymentIdRiskSystem(hre);
+    expect(PAYMENT_ID_RISK_DEPLOYMENT_NAMES.map(deployedAddress)).to.deep.eq(before);
+    expect(await vault.controller()).to.eq(manager.address);
+  });
+});

--- a/test/deploy/28_paymentIdRiskSystem.spec.ts
+++ b/test/deploy/28_paymentIdRiskSystem.spec.ts
@@ -6,6 +6,7 @@ import hre, { deployments, ethers } from "hardhat";
 import deployPaymentIdRiskSystem, {
   assertFreshNonLocalPaymentIdRiskDeployment,
   PAYMENT_ID_RISK_DEPLOYMENT_NAMES,
+  requireHistoricalPostIntentHookExecutor,
 } from "../../deploy/28_deploy_payment_id_risk_system";
 import {
   MULTI_SIG,
@@ -168,6 +169,11 @@ describe("Payment-ID-aware parallel risk system deployment", () => {
     await expect(assertFreshNonLocalPaymentIdRiskDeployment("base_staging", async (name) => (
       name === "UnifiedPaymentVerifierV3" ? { address: ethers.constants.AddressZero } : null
     ))).to.be.rejectedWith("use a new governance-reviewed version");
+  });
+
+  it("fails descriptively when the historical settlement executor prerequisite is absent", async () => {
+    await expect(requireHistoricalPostIntentHookExecutor("base", async () => null))
+      .to.be.rejectedWith("base requires the historical PostIntentHookExecutor deployment");
   });
 
   it("reruns locally without changing versioned addresses or wiring", async function () {

--- a/test/staking/riskManager.coverage.spec.ts
+++ b/test/staking/riskManager.coverage.spec.ts
@@ -119,34 +119,18 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
     fixture: Awaited<ReturnType<typeof deployHarnessFixture>>,
     intentHash: string,
     options: {
-      paymentMethod?: string;
       originalPaymentId?: string;
       disputeId?: string;
-      paymentAmount?: BigNumber;
-      paymentCurrency?: string;
-      data?: string;
-      dataHash?: string;
     } = {},
   ) {
     const paymentId = options.originalPaymentId ?? ethers.utils.keccak256(
       ethers.utils.solidityPack(["string", "bytes32"], ["payment", intentHash]),
     );
-    const data = options.data ?? ethers.utils.defaultAbiCoder.encode(
-      ["tuple(bytes32 paymentMethod,bytes32 originalPaymentId,bytes32 disputeId,uint256 paymentAmount,bytes32 paymentCurrency)"],
-      [{
-        paymentMethod: options.paymentMethod ?? PAYPAL,
-        originalPaymentId: paymentId,
-        disputeId: options.disputeId ?? ethers.utils.id(`evidence-${intentHash}`),
-        paymentAmount: options.paymentAmount ?? usdc(50),
-        paymentCurrency: options.paymentCurrency ?? ethers.utils.id("USD"),
-      }],
-    );
     return {
       intentHash,
-      dataHash: options.dataHash ?? ethers.utils.keccak256(data),
+      originalPaymentId: paymentId,
+      disputeId: options.disputeId ?? ethers.utils.id(`evidence-${intentHash}`),
       signatures: [],
-      data,
-      metadata: "0x",
     };
   }
 
@@ -404,7 +388,11 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
 
     it("rejects direct fulfillment callbacks outside the orchestrator", async () => {
       const { manager } = await loadFixture(deployHarnessFixture);
-      await expect(manager.onIntentFulfilled(ethers.utils.id("unauthorized-fulfill"), 1))
+      await expect(manager.onIntentFulfilled(
+        ethers.utils.id("unauthorized-fulfill"),
+        1,
+        ethers.utils.id("payment-id"),
+      ))
         .to.be.revertedWithCustomError(manager, "UnauthorizedOrchestrator");
     });
 
@@ -674,7 +662,11 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       await createPosition(fixture, intentHash);
       await fixture.orchestrator.setIntentSettlement(intentHash, usdc(50), await time.latest(), false);
       await fixture.manager.reconcileSettlement(intentHash);
-      expect((await fixture.manager.getRiskPosition(intentHash)).releasedAmount).to.eq(usdc(50));
+      const position = await fixture.manager.getRiskPosition(intentHash);
+      expect(position.releasedAmount).to.eq(usdc(50));
+      expect(position.paymentId).to.eq(ethers.utils.keccak256(
+        ethers.utils.solidityPack(["string", "bytes32"], ["payment", intentHash]),
+      ));
     });
 
     it("reconciles a failed manual release by releasing stake immediately", async () => {
@@ -686,7 +678,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
 
       const position = await fixture.manager.getRiskPosition(intentHash);
       expect(position.status).to.eq(4);
-      expect(position.paymentDetailsHash).to.eq(ethers.constants.HashZero);
+      expect(position.paymentId).to.eq(ethers.constants.HashZero);
       expect(position.coverageDeadline).to.eq(0);
       expect(position.reservedAmount).to.eq(0);
       expect(await fixture.vault.reservedStake(fixture.taker.address)).to.eq(0);
@@ -697,8 +689,13 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       const intentHash = ethers.utils.id("failed-verified-without-evidence");
       await createPosition(fixture, intentHash);
       const reservedBefore = (await fixture.manager.getRiskPosition(intentHash)).reservedAmount;
-      await fixture.orchestrator.setIntentSettlement(intentHash, usdc(50), await time.latest(), false);
-      await fixture.orchestrator.setPaymentEvidence(intentHash, ethers.constants.HashZero);
+      await fixture.orchestrator.setIntentSettlementWithPaymentId(
+        intentHash,
+        usdc(50),
+        ethers.constants.HashZero,
+        await time.latest(),
+        false,
+      );
 
       await expect(fixture.manager.reconcileSettlement(intentHash))
         .to.be.revertedWithCustomError(fixture.manager, "InvalidPaymentEvidence");
@@ -844,13 +841,6 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
         .to.be.revertedWithCustomError(fixture.manager, "PositionNotSettled");
     });
 
-    it("rejects a mismatched payment method", async () => {
-      const fixture = await loadFixture(settledFixture);
-      await expect(fixture.manager.submitChargeback(
-        await validAttestation(fixture, fixture.intentHash, { paymentMethod: OTHER_METHOD }),
-      )).to.be.revertedWithCustomError(fixture.manager, "InvalidAttestation");
-    });
-
     it("rejects a mismatched original payment identifier", async () => {
       const fixture = await loadFixture(settledFixture);
       await expect(fixture.manager.submitChargeback(
@@ -858,23 +848,10 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       )).to.be.revertedWithCustomError(fixture.manager, "InvalidAttestation");
     });
 
-    it("rejects mismatched fiat amount or currency", async () => {
-      const fixture = await loadFixture(settledFixture);
-      await expect(fixture.manager.submitChargeback(
-        await validAttestation(fixture, fixture.intentHash, { paymentAmount: usdc(49) }),
-      )).to.be.revertedWithCustomError(fixture.manager, "InvalidAttestation");
-      await expect(fixture.manager.submitChargeback(
-        await validAttestation(fixture, fixture.intentHash, { paymentCurrency: ethers.utils.id("EUR") }),
-      )).to.be.revertedWithCustomError(fixture.manager, "InvalidAttestation");
-    });
-
-    it("rejects a zero dispute identifier and a data hash mismatch", async () => {
+    it("rejects a zero dispute identifier", async () => {
       const fixture = await loadFixture(settledFixture);
       await expect(fixture.manager.submitChargeback(
         await validAttestation(fixture, fixture.intentHash, { disputeId: ethers.constants.HashZero }),
-      )).to.be.revertedWithCustomError(fixture.manager, "InvalidAttestation");
-      await expect(fixture.manager.submitChargeback(
-        await validAttestation(fixture, fixture.intentHash, { dataHash: ethers.utils.id("wrong-data") }),
       )).to.be.revertedWithCustomError(fixture.manager, "InvalidAttestation");
     });
 
@@ -1057,7 +1034,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       const intentHash = ethers.utils.id("forced-settlement-mode");
       await fixture.manager.forcePosition(intentHash, 1, 1, ZERO, PAYPAL, 1, 0);
       await expect(fixture.orchestrator.fulfillPosition(fixture.manager.address, intentHash, 1))
-        .to.be.revertedWithCustomError(fixture.manager, "InvalidPaymentEvidence");
+        .to.be.revertedWithCustomError(fixture.manager, "PositionModeMismatch");
     });
 
     it("rejects chargeback evidence for an impossible settled free position", async () => {

--- a/test/staking/riskManager.coverage.spec.ts
+++ b/test/staking/riskManager.coverage.spec.ts
@@ -684,26 +684,6 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       expect(await fixture.vault.reservedStake(fixture.taker.address)).to.eq(0);
     });
 
-    it("keeps a failed verified fulfillment pending when payment evidence is unavailable", async () => {
-      const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("failed-verified-without-evidence");
-      await createPosition(fixture, intentHash);
-      const reservedBefore = (await fixture.manager.getRiskPosition(intentHash)).reservedAmount;
-      await fixture.orchestrator.setIntentSettlementWithPaymentId(
-        intentHash,
-        usdc(50),
-        ethers.constants.HashZero,
-        await time.latest(),
-        false,
-      );
-
-      await expect(fixture.manager.reconcileSettlement(intentHash))
-        .to.be.revertedWithCustomError(fixture.manager, "InvalidPaymentEvidence");
-      const position = await fixture.manager.getRiskPosition(intentHash);
-      expect(position.status).to.eq(1);
-      expect(position.reservedAmount).to.eq(reservedBefore);
-    });
-
     it("rejects an empty settlement reconciliation batch", async () => {
       const { manager } = await loadFixture(deployHarnessFixture);
       await expect(manager.reconcileSettlements([])).to.be.revertedWithCustomError(manager, "EmptyBatch");

--- a/test/staking/riskManager.spec.ts
+++ b/test/staking/riskManager.spec.ts
@@ -628,7 +628,6 @@ describe("RiskManager and OrchestratorV3", () => {
       expect(settlement.paymentId).to.eq(ethers.utils.keccak256(
         ethers.utils.solidityPack(["string", "bytes32"], ["payment", intentHash]),
       ));
-      expect(settlement.isManualRelease).to.eq(false);
     });
 
     it("makes a maker manual release immediately non-chargebackable and releases its reservation", async () => {

--- a/test/staking/riskManager.spec.ts
+++ b/test/staking/riskManager.spec.ts
@@ -1,7 +1,10 @@
+import "module-alias/register";
+
 import { expect } from "chai";
 import { BigNumber, Contract, ContractReceipt } from "ethers";
 import { ethers } from "hardhat";
 import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
+import { buildUnifiedPaymentProof } from "@utils/unifiedVerifierUtils";
 
 const usdc = (amount: string | number) => ethers.utils.parseUnits(String(amount), 6);
 const precise = (amount: string | number) => ethers.utils.parseEther(String(amount));
@@ -19,7 +22,8 @@ const ZERO = ethers.constants.AddressZero;
 
 describe("RiskManager and OrchestratorV3", () => {
   async function deployFixture() {
-    const [owner, maker, makerDelegate, taker, secondTaker, recipient, other] = await ethers.getSigners();
+    const [owner, maker, makerDelegate, taker, secondTaker, recipient, other, witness] =
+      await ethers.getSigners();
     const network = await ethers.provider.getNetwork();
 
     const token = await (await ethers.getContractFactory("USDCMock"))
@@ -28,7 +32,7 @@ describe("RiskManager and OrchestratorV3", () => {
     const escrowRegistry = await (await ethers.getContractFactory("EscrowRegistry")).deploy();
     const relayerRegistry = await (await ethers.getContractFactory("RelayerRegistry")).deploy();
     const orchestratorRegistry = await (await ethers.getContractFactory("OrchestratorRegistry")).deploy();
-    const verifier = await (await ethers.getContractFactory("PaymentVerifierMock")).deploy();
+    const verifier = await (await ethers.getContractFactory("PaymentVerifierV3Mock")).deploy();
     const attestationVerifier = await (await ethers.getContractFactory("AttestationVerifierMock")).deploy();
 
     await paymentVerifierRegistry.addPaymentMethod(PAYPAL, verifier.address, [USD]);
@@ -89,9 +93,6 @@ describe("RiskManager and OrchestratorV3", () => {
     await escrowRegistry.addEscrow(escrow.address);
     await orchestratorRegistry.addOrchestrator(orchestrator.address);
     await orchestrator.setAllowMultipleIntents(true);
-    await verifier.setShouldVerifyPayment(true);
-    await verifier.setVerificationContext(orchestrator.address, escrow.address);
-
     await manager.setPlatformRiskConfig(ZELLE, {
       enabled: true,
       chargeback: {
@@ -161,6 +162,7 @@ describe("RiskManager and OrchestratorV3", () => {
       secondTaker,
       recipient,
       other,
+      witness,
       network,
       token,
       escrow,
@@ -169,7 +171,9 @@ describe("RiskManager and OrchestratorV3", () => {
       manager,
       deferredHook,
       orchestratorRegistry,
+      paymentVerifierRegistry,
       verifier,
+      boundedCall,
       attestationVerifier,
     };
   }
@@ -234,32 +238,17 @@ describe("RiskManager and OrchestratorV3", () => {
   }
 
   async function chargebackAttestation(
-    manager: Contract,
     intentHash: string,
-    paymentAmount: BigNumber,
     disputeId = ethers.utils.id(`dispute-${intentHash}`),
-    detailsOverrides: Record<string, unknown> = {},
+    originalPaymentId = ethers.utils.keccak256(
+      ethers.utils.solidityPack(["string", "bytes32"], ["payment", intentHash]),
+    ),
   ) {
-    const details = {
-      paymentMethod: PAYPAL,
-      originalPaymentId: ethers.utils.keccak256(
-        ethers.utils.solidityPack(["string", "bytes32"], ["payment", intentHash]),
-      ),
-      disputeId,
-      paymentAmount,
-      paymentCurrency: USD,
-      ...detailsOverrides,
-    };
-    const data = ethers.utils.defaultAbiCoder.encode(
-      ["tuple(bytes32 paymentMethod,bytes32 originalPaymentId,bytes32 disputeId,uint256 paymentAmount,bytes32 paymentCurrency)"],
-      [details],
-    );
     return {
       intentHash,
-      dataHash: ethers.utils.keccak256(data),
+      originalPaymentId,
+      disputeId,
       signatures: [],
-      data,
-      metadata: "0x",
     };
   }
 
@@ -525,7 +514,121 @@ describe("RiskManager and OrchestratorV3", () => {
       const position = await manager.getRiskPosition(intentHash);
       expect(position.status).to.eq(3);
       expect(position.reservedAmount).to.eq(usdc(600));
+      expect(position.paymentId).to.eq(ethers.utils.keccak256(
+        ethers.utils.solidityPack(["string", "bytes32"], ["payment", intentHash]),
+      ));
       expect(await vault.reservedStake(taker.address)).to.eq(usdc(600));
+    });
+
+    it("uses the verifier selected at fulfillment and stores its authenticated payment ID", async () => {
+      const {
+        taker,
+        escrow,
+        orchestrator,
+        vault,
+        manager,
+        paymentVerifierRegistry,
+      } = await loadFixture(deployFixture);
+      await vault.connect(taker).depositStake(usdc(500));
+      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(500), PAYPAL);
+
+      const replacement = await (await ethers.getContractFactory("PaymentVerifierV3Mock")).deploy();
+      const replacementPaymentId = ethers.utils.id("replacement-verifier-payment");
+      await replacement.setPaymentId(replacementPaymentId);
+      await paymentVerifierRegistry.removePaymentMethod(PAYPAL);
+      await paymentVerifierRegistry.addPaymentMethod(PAYPAL, replacement.address, [USD]);
+
+      await fulfillIntent(orchestrator, intentHash, usdc(500));
+      expect((await manager.getRiskPosition(intentHash)).paymentId).to.eq(replacementPaymentId);
+    });
+
+    it("propagates a real UnifiedPaymentVerifierV3 result through OrchestratorV3", async () => {
+      const {
+        owner,
+        witness,
+        taker,
+        escrow,
+        orchestrator,
+        vault,
+        manager,
+        orchestratorRegistry,
+        paymentVerifierRegistry,
+      } = await loadFixture(deployFixture);
+      const nullifierRegistry = await (await ethers.getContractFactory("NullifierRegistry")).deploy();
+      const paymentAttestationVerifier = await (
+        await ethers.getContractFactory("SimpleAttestationVerifier")
+      ).deploy(witness.address);
+      const unifiedVerifier = await (
+        await ethers.getContractFactory("UnifiedPaymentVerifierV3")
+      ).deploy(orchestratorRegistry.address, nullifierRegistry.address, paymentAttestationVerifier.address);
+      await nullifierRegistry.addWritePermission(unifiedVerifier.address);
+      await unifiedVerifier.addPaymentMethod(PAYPAL);
+      await paymentVerifierRegistry.removePaymentMethod(PAYPAL);
+      await paymentVerifierRegistry.addPaymentMethod(PAYPAL, unifiedVerifier.address, [USD]);
+
+      await vault.connect(taker).depositStake(usdc(500));
+      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(500), PAYPAL);
+      const intent = await orchestrator.getIntent(intentHash);
+      const paymentId = ethers.utils.id("real-unified-verifier-payment");
+      const proof = await buildUnifiedPaymentProof({
+        verifier: unifiedVerifier.address,
+        witness: { address: witness.address, wallet: witness } as any,
+        chainId: (await ethers.provider.getNetwork()).chainId,
+        paymentPaymentMethod: PAYPAL,
+        paymentPayeeId: PAYEE,
+        paymentAmount: usdc(500),
+        paymentCurrency: USD,
+        paymentTimestamp: BigNumber.from(intent.timestamp).mul(1000),
+        paymentPaymentId: paymentId,
+        attestationIntentHash: intentHash,
+        attestationReleaseAmount: usdc(500),
+        snapshotIntentHash: intentHash,
+        snapshotIntentAmount: intent.amount,
+        snapshotIntentPaymentMethod: PAYPAL,
+        snapshotIntentFiatCurrency: USD,
+        snapshotIntentPayeeDetails: PAYEE,
+        snapshotIntentConversionRate: intent.conversionRate,
+        snapshotIntentSignalTimestamp: intent.timestamp,
+        snapshotIntentTimestampBuffer: BigNumber.from(0),
+        intentDepositId: intent.depositId,
+        intentEscrow: escrow.address,
+        intentTo: taker.address,
+      });
+
+      await orchestrator.connect(owner).fulfillIntent({
+        paymentProof: proof.paymentProof,
+        intentHash,
+        verificationData: "0x",
+        settlementHookData: "0x",
+      });
+      expect((await manager.getRiskPosition(intentHash)).paymentId).to.eq(paymentId);
+    });
+
+    it("rejects a zero verifier payment ID before resolving the intent", async () => {
+      const { taker, escrow, orchestrator, vault, manager, verifier } = await loadFixture(deployFixture);
+      await vault.connect(taker).depositStake(usdc(500));
+      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(500), PAYPAL);
+      await verifier.setPaymentId(ethers.constants.HashZero);
+
+      await expect(fulfillIntent(orchestrator, intentHash, usdc(500))).to.be.reverted;
+      expect((await orchestrator.getIntent(intentHash)).owner).to.eq(taker.address);
+      expect((await manager.getRiskPosition(intentHash)).status).to.eq(1);
+    });
+
+    it("records the authenticated payment ID when a terminal risk callback fails open", async () => {
+      const { maker, taker, escrow, orchestrator } = await loadFixture(deployFixture);
+      const mock = await (await ethers.getContractFactory("IntentRiskHookMock")).deploy();
+      await orchestrator.connect(maker).setDepositRiskHook(escrow.address, 0, mock.address);
+      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(10), ZELLE);
+      await mock.setRevertOnTerminal(true);
+
+      await fulfillIntent(orchestrator, intentHash, usdc(10));
+      const settlement = await orchestrator.getIntentSettlement(intentHash);
+      expect(settlement.releasedAmount).to.eq(usdc(10));
+      expect(settlement.paymentId).to.eq(ethers.utils.keccak256(
+        ethers.utils.solidityPack(["string", "bytes32"], ["payment", intentHash]),
+      ));
+      expect(settlement.isManualRelease).to.eq(false);
     });
 
     it("makes a maker manual release immediately non-chargebackable and releases its reservation", async () => {
@@ -536,7 +639,7 @@ describe("RiskManager and OrchestratorV3", () => {
       await orchestrator.connect(maker).releaseFundsToPayer(intentHash);
       const position = await manager.getRiskPosition(intentHash);
       expect(position.status).to.eq(4);
-      expect(position.paymentDetailsHash).to.eq(ethers.constants.HashZero);
+      expect(position.paymentId).to.eq(ethers.constants.HashZero);
       expect(position.coverageDeadline).to.eq(0);
       expect(position.reservedAmount).to.eq(0);
       expect(await vault.reservedStake(taker.address)).to.eq(0);
@@ -548,15 +651,20 @@ describe("RiskManager and OrchestratorV3", () => {
       await vault.connect(taker).depositStake(usdc(500));
       const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(500), PAYPAL);
       await fulfillIntent(orchestrator, intentHash, usdc(500));
-      const claim = await chargebackAttestation(manager, intentHash, usdc(500));
+      const claim = await chargebackAttestation(intentHash);
       const { chainId } = await ethers.provider.getNetwork();
       expect(await manager.hashChargebackAttestation(claim)).to.eq(ethers.utils._TypedDataEncoder.hash(
         { name: "ZKP2P RiskManager", version: "1", chainId, verifyingContract: manager.address },
         { ChargebackAttestation: [
           { name: "intentHash", type: "bytes32" },
-          { name: "dataHash", type: "bytes32" },
+          { name: "originalPaymentId", type: "bytes32" },
+          { name: "disputeId", type: "bytes32" },
         ] },
-        { intentHash: claim.intentHash, dataHash: claim.dataHash },
+        {
+          intentHash: claim.intentHash,
+          originalPaymentId: claim.originalPaymentId,
+          disputeId: claim.disputeId,
+        },
       ));
       await manager.submitChargeback(claim);
       expect(await vault.claimableCompensation(maker.address)).to.eq(usdc(500));
@@ -571,9 +679,9 @@ describe("RiskManager and OrchestratorV3", () => {
       await fulfillIntent(orchestrator, firstHash, usdc(500));
       await fulfillIntent(orchestrator, secondHash, usdc(500));
       const disputeId = ethers.utils.id("shared-dispute");
-      await manager.submitChargeback(await chargebackAttestation(manager, firstHash, usdc(500), disputeId));
+      await manager.submitChargeback(await chargebackAttestation(firstHash, disputeId));
       await expect(manager.submitChargeback(
-        await chargebackAttestation(manager, secondHash, usdc(500), disputeId),
+        await chargebackAttestation(secondHash, disputeId),
       )).to.be.revertedWithCustomError(manager, "ChargebackEvidenceUsed");
     });
 
@@ -583,15 +691,15 @@ describe("RiskManager and OrchestratorV3", () => {
       const manualHash = await signalIntent(orchestrator, escrow, taker, usdc(500), PAYPAL);
       await orchestrator.connect(maker).releaseFundsToPayer(manualHash);
       await expect(manager.submitChargeback(
-        await chargebackAttestation(manager, manualHash, usdc(500)),
+        await chargebackAttestation(manualHash),
       )).to.be.revertedWithCustomError(manager, "PositionNotSettled");
 
       const verifiedHash = await signalIntent(orchestrator, escrow, taker, usdc(500), PAYPAL);
       await fulfillIntent(orchestrator, verifiedHash, usdc(500));
       await expect(manager.submitChargeback(await chargebackAttestation(
-        manager,
         verifiedHash,
-        usdc(499),
+        undefined,
+        ethers.utils.id("wrong-payment-id"),
       ))).to.be.revertedWithCustomError(manager, "InvalidAttestation");
     });
 
@@ -614,7 +722,7 @@ describe("RiskManager and OrchestratorV3", () => {
       await fulfillIntent(orchestrator, intentHash, usdc(500));
       const deadline = (await manager.getRiskPosition(intentHash)).coverageDeadline.toNumber();
       await time.increaseTo(deadline);
-      const claim = await chargebackAttestation(manager, intentHash, usdc(500));
+      const claim = await chargebackAttestation(intentHash);
       await expect(manager.submitChargeback(claim))
         .to.be.revertedWithCustomError(manager, "ChargebackWindowClosed");
     });

--- a/test/unifiedVerifier/unifiedPaymentVerifier.spec.ts
+++ b/test/unifiedVerifier/unifiedPaymentVerifier.spec.ts
@@ -230,9 +230,12 @@ describe("UnifiedPaymentVerifier", () => {
     builtProof = await buildProof();
   });
 
-  const buildProof = async (overrides: BuildPaymentProofOverrides = {}) => {
+  const buildProof = async (
+    overrides: BuildPaymentProofOverrides = {},
+    targetVerifier = verifier.address,
+  ) => {
     return buildUnifiedPaymentProof({
-      verifier: verifier.address,
+      verifier: targetVerifier,
       witness,
       chainId,
       paymentPaymentMethod: overrides.paymentPaymentMethod ?? venmoPaymentMethodHash,
@@ -335,6 +338,66 @@ describe("UnifiedPaymentVerifier", () => {
       expect(result.success).to.be.true;
       expect(result.intentHash).to.eq(intentHash);
       expect(result.releaseAmount).to.eq(builtProof.attestation.releaseAmount);
+      expect((result as { paymentId?: string }).paymentId).to.eq(undefined);
+    });
+
+    it("returns the signed payment ID through the V3 result without changing the payment attestation", async () => {
+      const verifierV3 = await (await ethers.getContractFactory("UnifiedPaymentVerifierV3", owner.wallet)).deploy(
+        orchestratorRegistry.address,
+        nullifierRegistry.address,
+        attestationVerifier.address,
+      );
+      await nullifierRegistry.addWritePermission(verifierV3.address);
+      await verifierV3.addPaymentMethod(venmoPaymentMethodHash);
+      const proofV3 = await buildProof({}, verifierV3.address);
+      const verificationData = await buildVerificationDataForIntent(intentHash);
+      const encodedCall = verifierV3.interface.encodeFunctionData("verifyPayment", [{
+        intentHash,
+        paymentProof: proofV3.paymentProof,
+        data: verificationData,
+      }]);
+      const raw = await ethers.provider.call({
+        to: verifierV3.address,
+        data: encodedCall,
+        from: orchestrator.address,
+      });
+      const [result] = verifierV3.interface.decodeFunctionResult("verifyPayment", raw);
+
+      expect(verifierV3.interface.getSighash("verifyPayment")).to.eq(
+        verifier.interface.getSighash("verifyPayment"),
+      );
+      expect(result.success).to.eq(true);
+      expect(result.intentHash).to.eq(intentHash);
+      expect(result.releaseAmount).to.eq(proofV3.attestation.releaseAmount);
+      expect(result.paymentId).to.eq(proofV3.paymentDetails.paymentId);
+    });
+
+    it("rejects payment replay across legacy and V3 lanes sharing one nullifier registry", async () => {
+      const verifierV3 = await (await ethers.getContractFactory("UnifiedPaymentVerifierV3", owner.wallet)).deploy(
+        orchestratorRegistry.address,
+        nullifierRegistry.address,
+        attestationVerifier.address,
+      );
+      await nullifierRegistry.addWritePermission(verifierV3.address);
+      await verifierV3.addPaymentMethod(venmoPaymentMethodHash);
+      const proofV3 = await buildProof({}, verifierV3.address);
+      const verificationData = await buildVerificationDataForIntent(intentHash);
+
+      await ethers.provider.send("hardhat_impersonateAccount", [orchestrator.address]);
+      await ethers.provider.send("hardhat_setBalance", [orchestrator.address, "0x1000000000000000000"]);
+      const orchestratorSigner = await ethers.getSigner(orchestrator.address);
+      await verifier.connect(orchestratorSigner).verifyPayment({
+        intentHash,
+        paymentProof: builtProof.paymentProof,
+        data: verificationData,
+      });
+
+      await expect(verifierV3.connect(orchestratorSigner).verifyPayment({
+        intentHash,
+        paymentProof: proofV3.paymentProof,
+        data: verificationData,
+      })).to.be.revertedWith("Nullifier has already been used");
+      await ethers.provider.send("hardhat_stopImpersonatingAccount", [orchestrator.address]);
     });
 
     it("emits PaymentVerified event", async () => {
@@ -351,40 +414,22 @@ describe("UnifiedPaymentVerifier", () => {
         );
     });
 
-    it("persists the verifier-backed chargeback evidence commitment", async () => {
-      await subject();
-      const expectedDetailsHash = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(
-        ["bytes32", "bytes32", "uint256", "bytes32"],
-        [
-          builtProof.paymentDetails.method,
-          builtProof.paymentDetails.paymentId,
-          builtProof.paymentDetails.amount,
-          builtProof.paymentDetails.currency,
-        ],
-      ));
-      expect(await verifier.getPaymentDetailsHash(orchestrator.address, intentHash)).to.eq(expectedDetailsHash);
-      expect(await verifier.getPaymentDetailsHash(attacker.address, intentHash)).to.eq(ethers.constants.HashZero);
-    });
-
-    it("rejects a zero payment identifier before recording evidence", async () => {
+    it("rejects a zero payment identifier", async () => {
       builtProof = await buildProof({ paymentPaymentId: ethers.constants.HashZero });
       subjectProof = builtProof.paymentProof;
       await expect(subject()).to.be.revertedWith("UPV: Invalid payment ID");
-      expect(await verifier.getPaymentDetailsHash(orchestrator.address, intentHash)).to.eq(ethers.constants.HashZero);
     });
 
-    it("rejects a zero fiat amount before recording evidence", async () => {
+    it("rejects a zero fiat amount", async () => {
       builtProof = await buildProof({ paymentAmount: BigNumber.from(0) });
       subjectProof = builtProof.paymentProof;
       await expect(subject()).to.be.revertedWith("UPV: Invalid payment amount");
-      expect(await verifier.getPaymentDetailsHash(orchestrator.address, intentHash)).to.eq(ethers.constants.HashZero);
     });
 
-    it("rejects a zero fiat currency before recording evidence", async () => {
+    it("rejects a zero fiat currency", async () => {
       builtProof = await buildProof({ paymentCurrency: ethers.constants.HashZero });
       subjectProof = builtProof.paymentProof;
       await expect(subject()).to.be.revertedWith("UPV: Invalid payment currency");
-      expect(await verifier.getPaymentDetailsHash(orchestrator.address, intentHash)).to.eq(ethers.constants.HashZero);
     });
 
     it("should nullify the payment with correct collision-resistant nullifier", async () => {


### PR DESCRIPTION
## Summary

- add UnifiedPaymentVerifierV3 with a four-field PaymentVerificationResult that returns the payment ID authenticated by the existing payment attestation
- pass the verified payment ID through OrchestratorV3 and persist it in RiskManager for exact later chargeback matching
- remove RiskManager verifier and payment-details-hash snapshots, plus the now-redundant manual-release recovery flag
- use a direct intent/payment/dispute EIP-712 chargeback payload
- add an opt-in parallel deployment lane that preserves the legacy verifier/orchestrator and shares replay protection

## Compatibility

- the legacy UnifiedPaymentVerifier ABI and payment-attestation schema remain unchanged
- the V3 verifier has a distinct address/domain and registry, so old and new lanes can run concurrently
- payment methods and currencies are mirrored exactly at deployment; both lanes share NullifierRegistry
- later method/currency governance updates must apply to both registries atomically
- the new lane reuses the immutable historical PostIntentHookExecutor deployment coordinate and fails descriptively when that prerequisite is absent

## Validation

- Hardhat: 1,331 passing, 5 pending
- Foundry non-fork: 133 passing
- Foundry Base fork: 3 passing
- deploy assertions: 191 passing
- TypeScript transpile and contracts package build: passing
- package tests: 14 passing
- local full reset deployment: passing
- Fable 5 xhigh: no actionable findings after the single P3 deployment prerequisite fix
- remote Hardhat and Foundry CI: passing

## Rollout note

No staging or production deployment is included. Public chargeback rollout remains gated on attestation-service integration and delayed, epoch-aware witness governance; this PR initializes a separate 2-of-3 chargeback witness set but does not claim to solve mutable witness governance.