### PR TITLE
feat: replace cancellation penalties with paid intent extensions

### DIFF
--- a/STAKE_RISK_POLICY_SPEC.md
+++ b/STAKE_RISK_POLICY_SPEC.md
@@ -1,275 +1,157 @@
-# Stake Risk Curves and Reusable Base-Unbonded Capacity
+# Paid Intent Expiry Extensions
 
 ## Status
 
-Hard-cut contract specification. The contract implementation follows this model; deployment and downstream consumers must migrate to the new ABI without compatibility aliases.
+Hard-cut contract specification. Cancellation penalties and griefing bonds are removed from the active ABI. Historical deployment scripts and artifacts remain immutable.
 
-## Summary
+## Policy
 
-The protocol uses stake for two independent risks:
+- The initial intent period is free. The proposed deployment value is one hour.
+- An active intent's owner may buy more time through `OrchestratorV3`.
+- Total intent lifetime is capped at five days by the orchestrator and may be capped lower by the payment method's risk configuration.
+- The proposed extension price is 20% APR on the complete locked intent amount.
+- Extension fees come from the stake owner's free stake and compensate the affected liquidity provider.
+- Cancellation and expiry cleanup do not slash stake.
+- Paid extension fees are final even if the intent is later cancelled, expired, or fulfilled.
+- Chargeback coverage remains a separate post-settlement risk policy.
 
-1. A griefing bond compensates an LP when a taker locks liquidity and later cancels or lets the intent expire.
-2. Chargeback coverage protects an LP for a configured period after a chargebackable payment settles.
+## Architecture
 
-For non-chargebackable payment methods, every intent receives a reusable base-unbonded tranche. Only the amount above that base enters the griefing curve. The base is stateless: there is no lifetime count, usage mapping, or consumed allowance.
+```text
+intent owner
+    |
+    | extendIntentExpiry(intentHash, extensionSeconds)
+    v
+OrchestratorV3
+    |
+    | bounded, fail-closed extension callback
+    v
+deposit-selected risk hook (RiskManager)
+    |
+    | spend free stake; credit LP compensation
+    v
+StakeVault
+    |
+    | fee charged successfully
+    v
+EscrowV2 extends the intent expiry
+```
 
-For chargebackable payment methods, the base must be zero and the full intent amount remains subject to the existing chargeback policy.
+The orchestrator owns the generic extension flow. `RiskManager` is only one implementation of the optional extension hook, so a depositor can select a different risk mechanism through the existing deposit risk-hook setting.
 
-## Security Boundary
+The fee is charged before Escrow mutates the expiry. Any hook or Escrow failure reverts the entire transaction.
 
-The reusable base is economic policy, not identity or Sybil protection. The contract intentionally does not approximate account identity with wallet-local counters.
-
-If admission must be limited to one stable platform account, that constraint belongs in the platform-account gating or proof layer. Once an intent reaches `RiskManager`, the contract applies the configured base to every eligible intent, including concurrent intents.
-
-The model therefore accepts that base-only capacity can be reused without contract state. LPs and admission systems must price or gate that exposure explicitly.
-
-## Terminology
-
-- `A`: complete intent amount.
-- `U`: reusable base-unbonded amount configured for the payment method.
-- `B`: bonded amount, `max(A - U, 0)`.
-- `S`: currently free stake for the selected stake owner.
-- `T`: snapshotted maximum intent period.
-- `C`: snapshotted griefing cliff.
-- `s`: griefing penalty slope in basis points per hour.
-- `r`: chargeback reserve ratio in basis points.
-
-## Platform Configuration
+## Configuration
 
 ```solidity
-struct ChargebackConfig {
-    bool chargebackable;
-    bool deferredPayoutEnabled;
-    uint16 reserveBps;
-    uint64 riskWindow;
-}
-
-struct GriefingConfig {
-    uint64 griefingCliff;
-    uint32 griefingPenaltyBpsPerHour;
-    uint256 baseUnbondedAmount;
+struct IntentExtensionConfig {
+    uint16 feeBps;
+    uint64 maxIntentLifetime;
 }
 
 struct PlatformRiskConfig {
     bool enabled;
     ChargebackConfig chargeback;
-    GriefingConfig griefing;
+    IntentExtensionConfig extension;
 }
 ```
 
 Configuration rules:
 
-- `chargeback.reserveBps` is between `0` and `10_000`.
-- A chargebackable method requires a nonzero reserve ratio, a nonzero bounded risk window, and `griefing.baseUnbondedAmount == 0`.
-- A non-chargebackable method requires `reserveBps == 0` and disables deferred payout.
-- The griefing cliff must be shorter than the Escrow intent period.
-- The maximum griefing rate cannot exceed 100% of the bonded amount.
-- A zero griefing slope disables the griefing curve.
+- `feeBps` is an annual rate from zero to 10,000 basis points.
+- A nonzero rate requires a maximum lifetime longer than Escrow's initial intent period.
+- A zero rate requires a zero maximum lifetime and disables paid extensions for the payment method.
+- The effective lifetime cap is the lower of the orchestrator's five-day cap and the risk hook's snapshotted cap.
+- Configuration changes affect only newly admitted intents.
 
-## Bonded Amount
+## Fee Math
 
-For every admission:
-
-```text
-B = max(A - U, 0)
-```
-
-Because chargebackable methods require `U = 0`, their bonded amount is the full intent amount.
-
-The position snapshots both `intentAmount` and `bondedAmount`. Later policy changes cannot alter the amount used for cancellation accounting.
-
-## Griefing Curve
-
-The maximum griefing bond is:
+For intent amount `A`, annual rate `r`, and total purchased extension time `t`:
 
 ```text
-chargeableMaximum = max(T - C, 0)
-
-Gmax = ceil(
-    B * s * chargeableMaximum
-    / (10_000 * 1 hour)
-)
+cumulativeFee(t) = ceil(A * r * t / (10,000 * 365 days))
+feeForThisExtension = cumulativeFee(newT) - feesAlreadyPaid
 ```
 
-At cancellation:
+Charging the cumulative difference makes splitting one extension into many transactions cost exactly the same as buying it once. All division rounds upward.
+
+At 20% APR, a 1,000 USDC intent costs approximately:
 
 ```text
-effectiveElapsed = min(cancelledAt - createdAt, T)
-chargeableElapsed = max(effectiveElapsed - C, 0)
-
-Gcancel = ceil(
-    B * s * chargeableElapsed
-    / (10_000 * 1 hour)
-)
+1 hour:  0.022832 USDC
+24 hours: 0.547946 USDC
 ```
 
-Rounding is upward. If `B == 0`, both values are zero at every timestamp.
+The fee uses the complete intent amount. It does not depend on whether the payment method is chargebackable or on any historical base-cap policy.
 
-## Chargeback Curve
+## Stake Rules
 
-For a chargebackable method:
+The extension fee may use only free stake:
 
 ```text
-Q = ceil(A * r / 10_000)
+free stake = active stake
+           - reserved stake
+           - pending withdrawal amount
 ```
 
-Chargeback coverage is calculated from the complete intent amount. The base-unbonded policy never reduces post-settlement chargeback coverage.
+Stake already exiting, reserved for chargeback coverage, or pending withdrawal cannot fund an extension.
 
-## Admission Reservation
+When the intent owner and stake owner differ, the stake owner must explicitly authorize that intent owner to spend free stake on extension fees. Self-funded intents require no delegation.
 
-For an ordinary position:
-
-```text
-requiredReservation = max(Gmax, Q)
-```
-
-Cancellation and settlement are mutually exclusive outcomes, so the liabilities are not added.
-
-For deferred payout, the existing chargeback policy remains unchanged. Because chargebackable methods require `U = 0`, the reusable base does not alter deferred admission or settlement accounting.
-
-## Modes
-
-- `UNBONDED`: `B == 0`; reserves and slashes no stake.
-- `STAKE_BACKED`: `B > 0` and ordinary stake backs the position.
-- `DEFERRED_PAYOUT`: the configured deferred hook backs settlement while pending stake covers the griefing exposure.
-
-There is no count-based or lifetime-subsidy mode.
-
-## Capacity Math
-
-For a non-chargebackable method with a nonzero griefing rate:
-
-```text
-griefingRateNumerator = s * (T - C)
-
-bondedTakingCapacity(S) = floor(
-    S * 10_000 * 1 hour
-    / griefingRateNumerator
-)
-
-maximumIntentAmount(S) = U + bondedTakingCapacity(S)
-```
-
-For a chargebackable method, `U = 0` and the existing chargeback capacity also constrains admission:
-
-```text
-chargebackCapacity(S) = floor(S * 10_000 / r)
-
-maximumIntentAmount(S) = min(
-    griefingCapacity(S),
-    chargebackCapacity(S)
-)
-```
-
-A disabled curve does not constrain capacity. If every applicable curve is disabled, capacity is unbounded by `RiskManager`; other protocol and LP limits still apply.
-
-Across multiple active positions, admission remains subject to the shared portfolio invariant:
-
-```text
-sum(active stake reservations) <= eligible stake
-```
-
-The reusable base itself is not reserved and does not create a portfolio counter. Multiple base-only intents can be open concurrently.
+An extension does not resize or create a stake reservation. The fee is spent immediately and credited to LP compensation.
 
 ## Lifecycle
 
-### Base-only non-chargebackable intent
+### Admission
 
-- Snapshots `bondedAmount = 0` and mode `UNBONDED`.
-- Reserves no stake.
-- Cancellation or expiry charges zero.
-- Settlement creates no chargeback position.
-- A later intent receives the same configured base.
+- The intent receives the initial free expiry from Escrow.
+- A non-chargebackable intent reserves no stake.
+- A chargebackable intent reserves only its configured chargeback coverage.
+- Deferred payout admission does not add a cancellation bond.
+- The position snapshots the extension rate, lifetime cap, and initial intent period.
 
-### Partially bonded non-chargebackable intent
+### Extension
 
-- Snapshots `bondedAmount = A - U`.
-- Reserves `Gmax` calculated only from that excess.
-- Cancellation slashes the accrued excess-only penalty and releases the remainder.
-- Settlement releases the complete pending reservation.
+1. The intent owner asks `OrchestratorV3` for additional time.
+2. The orchestrator rejects zero-duration, expired, non-owner, or over-cap requests.
+3. The selected extension hook calculates the cumulative fee.
+4. `RiskManager` verifies authorization, exit state, and sufficient free stake.
+5. `StakeVault` spends the fee and credits the LP.
+6. Escrow updates the expiry.
 
-### Chargebackable intent
+### Cancellation or expiry
 
-- Requires `U = 0`, so `B = A`.
-- Uses the existing stake-backed or deferred-payout lifecycle.
-- Cancellation charges only accrued griefing exposure.
-- Settlement transitions to the configured chargeback coverage.
+- The pending position closes and releases its complete reservation.
+- No cancellation penalty is calculated or slashed.
+- Previously paid extension fees are not refunded.
 
-## Position and Event Surface
+### Fulfillment
 
-The hard-cut ABI:
+- Non-chargebackable positions close without a stake reservation.
+- Ordinary chargebackable positions retain the configured post-settlement coverage.
+- Deferred payout positions continue through the existing deferred lifecycle.
 
-- replaces risk mode `FREE` with `UNBONDED`;
-- replaces `freeTakeCount` and `freeTakeAmount` with `baseUnbondedAmount`;
-- removes `freeTakesUsed` and the consumption event;
-- removes the consumed-allowance flag from positions;
-- adds snapshotted `bondedAmount` to positions and `RiskPositionCreated`;
-- emits `baseUnbondedAmount` in platform configuration updates.
+## No-Chargeback Base-Cap Edge Case
 
-Indexers must derive unbonded versus bonded exposure from the position mode and `bondedAmount`. They must not reconstruct removed usage counters.
+The former 500 USDC base-unbonded tranche is not part of this model. A non-chargebackable intent of any size gets the same free initial period and reserves zero stake during that period.
+
+If its owner wants more time, the fee is charged on the full locked amount. For example, extending a 500 USDC intent for one hour at 20% APR costs approximately 0.011416 USDC. Without sufficient opted-in free stake, the extension fails and the original expiry remains unchanged.
+
+This removes the wallet-reusable subsidy boundary and directly prices only the extra liquidity-lock time requested by the buyer.
 
 ## Core Invariants
 
-1. Chargebackable methods configure a zero base-unbonded amount.
-2. `bondedAmount == max(intentAmount - baseUnbondedAmount, 0)` at admission.
-3. An unbonded position reserves and slashes zero stake.
-4. A pending ordinary position reserves exactly `max(Gmax, Q)`.
-5. Cancellation penalty never exceeds the snapshotted maximum griefing bond.
-6. Cancellation uses the snapshotted bonded amount and maximum intent period.
-7. Fulfillment never charges a griefing penalty.
-8. A chargeback never consumes more than the remaining position coverage.
-9. Governance changes affect only future positions.
-10. All stake-backed positions share the same stake-owner portfolio balance.
+1. Cancellation and expiry never slash stake.
+2. Only the intent owner can request an extension.
+3. An expired intent cannot be revived.
+4. Total intent lifetime never exceeds either configured cap.
+5. Split extensions cost the same as one combined extension.
+6. Extension fees cannot use reserved, exiting, or pending-withdrawal stake.
+7. A delegated buyer cannot spend another depositor's stake without explicit authorization.
+8. Escrow expiry changes only after the extension fee succeeds.
+9. Extension fees do not reduce chargeback reservations or coverage.
+10. Depositors retain control of which risk hook applies to their deposits.
 
-## Illustrative Non-Chargebackable Policy
+## Deployment
 
-```text
-chargeback:
-  chargebackable:                false
-  deferredPayoutEnabled:         false
-  reserveBps:                    0
-  riskWindow:                    0
-griefing:
-  griefingCliff:                 15 minutes
-  griefingPenaltyBpsPerHour:     10
-  baseUnbondedAmount:            500 USDC
-Escrow maximum intent period:    6 hours
-```
-
-Examples:
-
-```text
-A = 500 USDC  => B =   0 USDC => Gmax = 0
-A = 700 USDC  => B = 200 USDC => Gmax = 1.15 USDC
-A = 1,000 USDC => B = 500 USDC => Gmax = 2.875 USDC
-```
-
-The 500 USDC base is reusable for every admitted intent. It is not a one-time allowance and is not Sybil resistance.
-
-## Illustrative Chargebackable Policy
-
-```text
-chargeback:
-  chargebackable:                true
-  deferredPayoutEnabled:         true
-  reserveBps:                    10,000
-  riskWindow:                    30 days
-griefing:
-  griefingCliff:                 15 minutes
-  griefingPenaltyBpsPerHour:     10
-  baseUnbondedAmount:            0
-Escrow maximum intent period:    6 hours
-```
-
-For a 1,000 USDC intent, the maximum griefing bond is 5.75 USDC and ordinary chargeback coverage is 1,000 USDC, so ordinary admission reserves 1,000 USDC.
-
-## Rollout
-
-This ABI is a hard cut. A release requires:
-
-1. A fresh `RiskManager` deployment and explicit platform configuration.
-2. A contracts package release containing the new ABI and risk math.
-3. Indexer migration to the new config and position event shapes.
-4. Curator and client migration from usage-based capacity to `base + bonded capacity`.
-
-Historical deployment artifacts remain immutable. No legacy fields, aliases, or dual event decoding are added to the active contract.
+The ABI change requires fresh immutable contract deployments. Historical scripts and deployment artifacts must not be edited to simulate compatibility. A live rollout should use a new numbered deployment script and migrate package, indexer, curator, and client consumers as a coordinated hard cut.

--- a/contracts/EscrowV2.sol
+++ b/contracts/EscrowV2.sol
@@ -41,7 +41,6 @@ contract EscrowV2 is Ownable, Pausable, ReentrancyGuard, IEscrowV2 {
     uint256 internal constant BPS = 10_000;
     int256 internal constant SIGNED_BPS = 10_000;
     uint256 internal constant MAX_DUST_THRESHOLD = 1e6;            // 1 USDC
-    uint256 internal constant MAX_TOTAL_INTENT_EXPIRATION_PERIOD = 86400 * 5; // 5 days
     uint256 internal constant PRUNE_ALL_EXPIRED_INTENTS = type(uint256).max;
     uint256 internal constant MAX_ADAPTER_CONFIG_BYTES = 256;
     
@@ -865,12 +864,11 @@ contract EscrowV2 is Ownable, Pausable, ReentrancyGuard, IEscrowV2 {
         token.safeTransfer(_to, _transferAmount);
     }
 
-    /* ============ Intent Guardian Only (External Functions) ============ */
+    /* ============ Orchestrator Only (Expiry Extension) ============ */
 
     /**
-     * @notice INTENT GUARDIAN ONLY: Extends the expiry time of an existing intent. Only callable by intent guardian.
-     * This function reverts if the total intent expiry period is greater than the maximum allowed to prevent griefing
-     * by extending the intent expiry period indefinitely.
+     * @notice Extends an active intent after its owning orchestrator applies extension policy.
+     * @dev The same registered orchestrator that created the lock must call this function.
      * 
      * @param _depositId The deposit ID containing the intent
      * @param _intentHash The intent hash to extend expiry for
@@ -881,7 +879,8 @@ contract EscrowV2 is Ownable, Pausable, ReentrancyGuard, IEscrowV2 {
         bytes32 _intentHash,
         uint256 _additionalTime
     ) 
-        external 
+        external
+        onlyOrchestrator
     {
         // Checks
         Deposit storage deposit = deposits[_depositId];
@@ -889,10 +888,11 @@ contract EscrowV2 is Ownable, Pausable, ReentrancyGuard, IEscrowV2 {
         
         if (deposit.depositor == address(0)) revert DepositNotFound(_depositId);
         if (intent.intentHash == bytes32(0)) revert IntentNotFound(_intentHash);
-        if (deposit.intentGuardian != msg.sender) revert UnauthorizedCaller(msg.sender, deposit.intentGuardian);
+        address intentOwnerOrchestrator = intentOrchestrator[_intentHash];
+        if (intentOwnerOrchestrator != msg.sender) revert UnauthorizedCaller(msg.sender, intentOwnerOrchestrator);
         if (_additionalTime == 0) revert ZeroValue();
-        if (intent.expiryTime + _additionalTime > intent.timestamp + MAX_TOTAL_INTENT_EXPIRATION_PERIOD) {
-            revert AmountAboveMax(_additionalTime, MAX_TOTAL_INTENT_EXPIRATION_PERIOD);
+        if (intent.expiryTime <= block.timestamp) {
+            revert IntentAlreadyExpired(_intentHash, intent.expiryTime, block.timestamp);
         }
         
         // Effects

--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.18;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { OrchestratorV2 } from "./OrchestratorV2.sol";
-import { IEscrow } from "./interfaces/IEscrow.sol";
 import { IIntentRiskHook } from "./interfaces/IIntentRiskHook.sol";
 import { IOrchestratorV2 } from "./interfaces/IOrchestratorV2.sol";
 import { IOrchestratorV3 } from "./interfaces/IOrchestratorV3.sol";
@@ -23,6 +22,7 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
 
     uint256 public constant MIN_RISK_CALLBACK_GAS_LIMIT = 750_000;
     uint256 public constant MAX_RISK_CALLBACK_RETURN_DATA = 2_048;
+    uint256 public constant MAX_INTENT_LIFETIME = 5 days;
 
     /* ============ State Variables ============ */
 
@@ -103,22 +103,29 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
         uint256 _depositId,
         IIntentRiskHook _hook
     ) external override nonReentrant {
-        if (_escrow == address(0)) revert ZeroAddress();
+        BoundedCall.setDepositRiskHook(depositRiskHooks, _escrow, _depositId, _hook);
+    }
 
-        address hookAddress = address(_hook);
-        if (hookAddress != address(0) && hookAddress.code.length == 0) {
-            revert InvalidRiskHook(hookAddress);
-        }
+    /* ============ Intent Owner Functions ============ */
 
-        IEscrow.Deposit memory deposit = IEscrow(_escrow).getDeposit(_depositId);
-        bool isDepositorOrDelegate = msg.sender == deposit.depositor
-            || (deposit.delegate != address(0) && msg.sender == deposit.delegate);
-        if (!isDepositorOrDelegate) {
-            revert UnauthorizedCallerOrDelegate(msg.sender, deposit.depositor, deposit.delegate);
-        }
-
-        depositRiskHooks[_escrow][_depositId] = _hook;
-        emit DepositRiskHookSet(_escrow, _depositId, hookAddress, msg.sender);
+    /**
+     * @inheritdoc IOrchestratorV3
+     * @dev The snapshotted hook charges before Escrow mutates the expiry. Any later failure rolls
+     *      the charge back with the transaction.
+     */
+    function extendIntentExpiry(
+        bytes32 _intentHash,
+        uint256 _extensionSeconds
+    ) external override nonReentrant whenNotPaused {
+        BoundedCall.extendIntentExpiry(
+            intents,
+            intentRiskHooks,
+            _intentHash,
+            _extensionSeconds,
+            MAX_INTENT_LIFETIME,
+            riskCallbackGasLimit,
+            MAX_RISK_CALLBACK_RETURN_DATA
+        );
     }
 
     /* ============ Governance Functions ============ */
@@ -153,17 +160,7 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
      * @notice Returns the scalar intent fields required by a risk hook without copying dynamic intent data.
      */
     function getRiskIntent(bytes32 _intentHash) external view override returns (RiskIntentData memory riskIntent) {
-        Intent storage intent = intents[_intentHash];
-        riskIntent = RiskIntentData({
-            owner: intent.owner,
-            to: intent.to,
-            escrow: intent.escrow,
-            depositId: intent.depositId,
-            amount: intent.amount,
-            paymentMethod: intent.paymentMethod,
-            postIntentHook: address(intent.postIntentHook),
-            createdAt: uint64(intent.timestamp)
-        });
+        return BoundedCall.getRiskIntent(intents, _intentHash);
     }
 
     /**
@@ -197,19 +194,15 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
      * @notice Snapshots and executes risk admission after V2 stores the intent.
      */
     function _afterIntentSignaled(bytes32 _intentHash) internal override {
-        Intent storage intent = intents[_intentHash];
-        IIntentRiskHook riskHook = depositRiskHooks[intent.escrow][intent.depositId];
-        intentRiskHooks[_intentHash] = riskHook;
-
-        bool requiresPostIntentHook = BoundedCall.executeRiskAdmission(
-            riskHook,
+        BoundedCall.snapshotAndAdmit(
+            depositRiskHooks,
+            intentRiskHooks,
+            intentRequiresPostIntentHook,
+            intents,
             _intentHash,
-            address(intent.postIntentHook),
             riskCallbackGasLimit,
             MAX_RISK_CALLBACK_RETURN_DATA
         );
-        intentRequiresPostIntentHook[_intentHash] = requiresPostIntentHook;
-        emit IntentRiskHookSnapshotted(_intentHash, address(riskHook), requiresPostIntentHook);
     }
 
     /**

--- a/contracts/RiskManager.sol
+++ b/contracts/RiskManager.sol
@@ -10,6 +10,7 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import { IAttestationVerifier } from "./interfaces/IAttestationVerifier.sol";
 import { IEscrowV2 } from "./interfaces/IEscrowV2.sol";
+import { IIntentExtensionHook } from "./interfaces/IIntentExtensionHook.sol";
 import { IIntentRiskHook } from "./interfaces/IIntentRiskHook.sol";
 import { IOrchestratorV3 } from "./interfaces/IOrchestratorV3.sol";
 import { IRiskManager } from "./interfaces/IRiskManager.sol";
@@ -17,75 +18,19 @@ import { IStakeVault } from "./interfaces/IStakeVault.sol";
 
 /**
  * @title RiskManager
- * @notice Enforces continuous, stake-backed taker risk without tiers, amount caps, cooldowns, or
- *         stake-derived intent-count limits.
- *
- * @dev ECONOMIC MODEL
- *      A pending bonded intent can end in exactly one of two mutually exclusive ways: cancellation,
- *      which may owe the LP a griefing penalty, or settlement, which may create chargeback exposure.
- *      Admission therefore reserves the maximum of those liabilities instead of their sum:
- *
- *        B = max(A - U, 0)
- *        maxGriefingBond = ceil(B * s * (T - C) / (10_000 * 1 hour))
- *        chargebackReserve = ceil(A * r / 10_000)
- *        initialReservation = max(maxGriefingBond, chargebackReserve)
- *
- *      where A is intent amount, U is the platform's reusable unbonded base, B is the bonded amount,
- *      s is penalty basis points per hour, T is the Escrow's snapshotted maximum intent period, C is
- *      the griefing cliff, and r is the chargeback reserve ratio. Chargebackable platforms require U=0.
- *
- * @dev CANCELLATION CURVE
- *      At cancellation, elapsed time is capped at T so an intent-guardian extension cannot increase
- *      taker liability. The charged penalty is:
- *
- *        effectiveElapsed = min(cancelledAt - createdAt, T)
- *        chargeableTime = max(effectiveElapsed - C, 0)
- *        penalty = ceil(B * s * chargeableTime / (10_000 * 1 hour))
- *
- *      Rounding is always upward. Every cancellation strictly after the cliff therefore pays at
- *      least one smallest token unit whenever the slope and amount are nonzero.
- *
- * @dev LIFECYCLE
- *      - Non-chargebackable intents receive the reusable unbonded base on every admission.
- *      - Only the amount above that base enters the griefing curve and reserves stake.
- *      - Cancellation slashes only the accrued griefing penalty and releases every unused unit.
- *      - Non-chargebackable settlement releases the full pending reservation immediately.
- *      - Chargebackable settlement resizes stake coverage to the exact released amount and starts the
- *        snapshotted coverage window.
- *      - Deferred payout is an explicit exception: pending stake covers only griefing, while settled
- *        proceeds held in StakeVault replace chargeback stake coverage.
- *      - Maturity releases remaining stake coverage; valid chargebacks can consume coverage partially.
- *
- * @dev SECURITY INVARIANTS AND RATIONALE
- *      1. Mutable platform and Escrow policy is snapshotted at admission; governance cannot rewrite
- *         existing liabilities.
- *      2. All positions for one stake owner share StakeVault.freeStake, so reservations compose across
- *         takers and platforms without a protocol-wide exposure gate.
- *      3. The base unbonded amount is stateless contract policy. Sybil-resistant account gating is a
- *         separate admission concern and is not approximated with wallet-local usage state.
- *      4. Terminal callbacks are intentionally fail-open in OrchestratorV3 for liquidity liveness.
- *         Failed cancellations retain the full reservation and use the orchestrator-recorded unlock
- *         timestamp during permissionless reconciliation, preventing delay-based overcharging and
- *         callback failure from escaping liability.
- *      5. Chargeback compensation cannot exceed remaining snapshotted coverage. Uncovered losses and
- *         claims after maturity remain the LP's risk by design.
- *      6. This contract never holds tokens. StakeVault is the sole accounting and custody boundary.
- *      7. Escrow intent amounts and StakeVault liabilities must use the same immutable token, otherwise
- *         raw units, griefing penalties, base limits, and chargeback ratios would have no shared meaning.
- *      8. Deferred proceeds must cover the complete configured reserve after fees. A shortfall fails
- *         settlement rather than silently advertising less protection than governance configured.
+ * @notice Enforces prepaid intent extensions and post-settlement chargeback coverage.
+ * @dev Cancellation is free and releases all pending reservation. Extensions are owner-initiated,
+ *      charged from free stake, and credited to the affected LP before Escrow changes the expiry.
+ *      Chargeback policy remains independent and is snapshotted at admission.
  */
 contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
     /* ============ Constants ============ */
 
-    /// @notice Basis-point denominator shared by both affine curves.
+    /// @notice Basis-point denominator shared by chargeback and extension rates.
     uint256 public constant BPS_DENOMINATOR = 10_000;
 
-    /// @notice Seconds per hour used to convert the configured hourly griefing slope.
-    uint256 public constant SECONDS_PER_HOUR = 1 hours;
-
-    /// @notice Combined denominator for the time-linear griefing formula.
-    uint256 public constant GRIEFING_DENOMINATOR = BPS_DENOMINATOR * SECONDS_PER_HOUR;
+    /// @notice Denominator for annualized paid-extension pricing.
+    uint256 internal constant EXTENSION_FEE_DENOMINATOR = BPS_DENOMINATOR * 365 days;
 
     /// @notice Operational ceiling preventing a governance value that cannot fit in uint64 deadlines.
     /// @dev One year is deliberately far above the approved illustrative 30-day window while keeping
@@ -170,9 +115,8 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
     /**
      * @inheritdoc IIntentRiskHook
-     * @dev Admission is fail-closed. This function resolves delegation, validates the current platform
-     *      against the intent's Escrow period, snapshots every liability input, applies the configured
-     *      base tranche, and reserves shared portfolio stake before returning.
+     * @dev Admission is fail-closed. It snapshots extension and chargeback terms, then reserves only
+     *      chargeback coverage when the platform requires it.
      */
     function onIntentCreated(bytes32 _intentHash)
         external
@@ -190,40 +134,32 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         PlatformRiskConfig memory config = platformRiskConfigs[intent.paymentMethod];
         if (!config.enabled) revert PlatformDisabled(intent.paymentMethod);
 
-        uint64 maxIntentPeriod = _toUint64(IEscrowV2(intent.escrow).intentExpirationPeriod());
-        _validatePositionPolicy(intent.paymentMethod, maxIntentPeriod, config.griefing);
+        uint64 initialIntentPeriod = _toUint64(IEscrowV2(intent.escrow).intentExpirationPeriod());
+        _validateIntentExtensionPolicy(intent.paymentMethod, initialIntentPeriod, config.extension);
 
         IEscrowV2.Deposit memory deposit = IEscrowV2(intent.escrow).getDeposit(intent.depositId);
         _validateIntentToken(deposit.token);
         address stakeOwner = stakeVault.stakeOwnerOf(intent.owner);
-        uint256 bondedAmount = _calculateBondedAmount(intent.amount, config.griefing.baseUnbondedAmount);
-
-        (uint256 maxGriefingBond, uint256 chargebackReserve, uint256 requiredReservation) =
-            _calculateRequiredReservation(intent.amount, maxIntentPeriod, config);
+        uint256 chargebackReserve = _calculateChargebackReserve(intent.amount, config.chargeback.reserveBps);
 
         RiskMode mode;
         uint256 initialReservation;
 
-        if (bondedAmount == 0) {
+        if (!config.chargeback.chargebackable) {
             mode = RiskMode.UNBONDED;
         } else {
             uint256 available = stakeVault.freeStake(stakeOwner);
-            if (available >= requiredReservation) {
+            if (available >= chargebackReserve) {
                 mode = RiskMode.STAKE_BACKED;
-                initialReservation = requiredReservation;
-            } else if (
-                config.chargeback.chargebackable
-                    && config.chargeback.deferredPayoutEnabled
-                    && available >= maxGriefingBond
-            ) {
+                initialReservation = chargebackReserve;
+            } else if (config.chargeback.deferredPayoutEnabled) {
                 if (deferredPayoutHook == address(0) || intent.postIntentHook != deferredPayoutHook) {
                     revert DeferredPayoutHookRequired(deferredPayoutHook, intent.postIntentHook);
                 }
                 mode = RiskMode.DEFERRED_PAYOUT;
-                initialReservation = maxGriefingBond;
                 requiresPostIntentHook = true;
             } else {
-                revert InsufficientCollateral(stakeOwner, available, requiredReservation);
+                revert InsufficientCollateral(stakeOwner, available, chargebackReserve);
             }
 
             if (initialReservation != 0 && stakeVault.isExiting(stakeOwner)) {
@@ -249,14 +185,11 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         position.deferredPayoutHook = mode == RiskMode.DEFERRED_PAYOUT ? deferredPayoutHook : address(0);
         position.payoutRecipient = intent.to;
         position.chargebackReserveBps = config.chargeback.reserveBps;
-        position.griefingPenaltyBpsPerHour = config.griefing.griefingPenaltyBpsPerHour;
+        position.extensionFeeBps = config.extension.feeBps;
         position.riskWindow = config.chargeback.riskWindow;
         position.createdAt = intent.createdAt;
-        position.maxIntentPeriod = maxIntentPeriod;
-        position.griefingCliff = config.griefing.griefingCliff;
+        position.maxIntentLifetime = config.extension.maxIntentLifetime;
         position.intentAmount = intent.amount;
-        position.bondedAmount = bondedAmount;
-        position.maxGriefingBond = maxGriefingBond;
         position.initialReservation = initialReservation;
         position.reservedAmount = initialReservation;
 
@@ -284,16 +217,74 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             _position.paymentMethod,
             _position.mode,
             _position.intentAmount,
-            _position.bondedAmount,
             _position.createdAt,
-            _position.maxIntentPeriod,
-            _position.griefingCliff,
-            _position.griefingPenaltyBpsPerHour,
             _position.chargebackReserveBps,
             _position.riskWindow,
-            _position.maxGriefingBond,
+            _position.extensionFeeBps,
+            _position.maxIntentLifetime,
             _chargebackReserve,
             _position.initialReservation
+        );
+    }
+
+    /**
+     * @inheritdoc IIntentExtensionHook
+     * @dev The cumulative formula prevents a buyer from reducing fees by splitting one extension into
+     *      many rounding-sized calls. Delegated stake requires a separate spend authorization.
+     */
+    function onIntentExpiryExtension(
+        bytes32 _intentHash,
+        uint256 _extensionSeconds,
+        uint256 _newExpiry
+    ) external override onlyOrchestrator nonReentrant returns (uint256 fee) {
+        RiskPosition storage position = riskPositions[_intentHash];
+        if (position.status != PositionStatus.PENDING) {
+            revert PositionNotPending(_intentHash, position.status);
+        }
+        if (position.extensionFeeBps == 0 || position.maxIntentLifetime == 0) {
+            revert IntentExtensionsDisabled(_intentHash);
+        }
+
+        uint256 maximumExpiry = uint256(position.createdAt) + position.maxIntentLifetime;
+        if (_newExpiry > maximumExpiry) {
+            revert IntentExtensionLifetimeExceeded(_intentHash, _newExpiry, maximumExpiry);
+        }
+        if (stakeVault.isExiting(position.stakeOwner)) {
+            revert StakeOwnerExiting(position.taker, position.stakeOwner);
+        }
+        if (
+            position.stakeOwner != position.taker
+                && !stakeVault.isExtensionFeeAuthorized(position.stakeOwner, position.taker)
+        ) {
+            revert ExtensionFeeAuthorizationRequired(_intentHash, position.stakeOwner, position.taker);
+        }
+
+        uint256 purchasedExtensionSeconds = uint256(position.purchasedExtensionSeconds) + _extensionSeconds;
+        uint256 cumulativeFees = calculateIntentExtensionFee(
+            position.intentAmount,
+            position.extensionFeeBps,
+            purchasedExtensionSeconds
+        );
+        fee = cumulativeFees - position.extensionFeesPaid;
+        uint256 available = stakeVault.freeStake(position.stakeOwner);
+        if (fee > available) {
+            revert InsufficientExtensionFeeStake(position.stakeOwner, available, fee);
+        }
+
+        position.purchasedExtensionSeconds = _toUint64(purchasedExtensionSeconds);
+        position.extensionFeesPaid = cumulativeFees;
+        if (fee != 0) {
+            stakeVault.spendFreeStake(_intentHash, position.stakeOwner, position.lp, fee);
+        }
+
+        emit IntentExtensionFeeCharged(
+            _intentHash,
+            position.stakeOwner,
+            position.lp,
+            _extensionSeconds,
+            fee,
+            _newExpiry,
+            cumulativeFees
         );
     }
 
@@ -540,9 +531,8 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             _config.chargeback.deferredPayoutEnabled,
             _config.chargeback.reserveBps,
             _config.chargeback.riskWindow,
-            _config.griefing.griefingCliff,
-            _config.griefing.griefingPenaltyBpsPerHour,
-            _config.griefing.baseUnbondedAmount
+            _config.extension.feeBps,
+            _config.extension.maxIntentLifetime
         );
     }
 
@@ -621,56 +611,6 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
     /**
      * @inheritdoc IRiskManager
      */
-    function calculateBondedAmount(
-        uint256 _amount,
-        uint256 _baseUnbondedAmount
-    ) external pure override returns (uint256) {
-        return _calculateBondedAmount(_amount, _baseUnbondedAmount);
-    }
-
-    /**
-     * @inheritdoc IRiskManager
-     * @dev Uses full-precision multiplication and upward rounding. Invalid `cliff >= period` inputs
-     *      return zero here; platform admission separately rejects such a configuration.
-     */
-    function calculateMaxGriefingBond(
-        uint256 _intentAmount,
-        uint64 _maxIntentPeriod,
-        GriefingConfig calldata _config
-    ) external pure override returns (uint256) {
-        return _calculateMaxGriefingBond(
-            _calculateBondedAmount(_intentAmount, _config.baseUnbondedAmount),
-            _maxIntentPeriod,
-            _config.griefingCliff,
-            _config.griefingPenaltyBpsPerHour
-        );
-    }
-
-    /**
-     * @inheritdoc IRiskManager
-     * @dev `effectiveElapsed` is elapsed wall time capped by the snapshotted maximum intent period.
-     */
-    function calculateGriefingPenalty(
-        uint256 _bondedAmount,
-        uint64 _createdAt,
-        uint64 _cancelledAt,
-        uint64 _maxIntentPeriod,
-        uint64 _griefingCliff,
-        uint32 _griefingPenaltyBpsPerHour
-    ) external pure override returns (uint256 penalty, uint256 effectiveElapsed) {
-        return _calculateGriefingPenalty(
-            _bondedAmount,
-            _createdAt,
-            _cancelledAt,
-            _maxIntentPeriod,
-            _griefingCliff,
-            _griefingPenaltyBpsPerHour
-        );
-    }
-
-    /**
-     * @inheritdoc IRiskManager
-     */
     function calculateChargebackReserve(
         uint256 _amount,
         uint16 _reserveBps
@@ -681,16 +621,15 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
     /**
      * @inheritdoc IRiskManager
      */
-    function calculateRequiredReservation(
-        uint256 _intentAmount,
-        uint64 _maxIntentPeriod,
-        PlatformRiskConfig calldata _config
-    ) external pure override returns (
-        uint256 maxGriefingBond,
-        uint256 chargebackReserve,
-        uint256 requiredReservation
-    ) {
-        return _calculateRequiredReservation(_intentAmount, _maxIntentPeriod, _config);
+    function calculateIntentExtensionFee(
+        uint256 _amount,
+        uint16 _annualFeeBps,
+        uint256 _extensionSeconds
+    ) public pure override returns (uint256) {
+        if (_amount == 0 || _annualFeeBps == 0 || _extensionSeconds == 0) return 0;
+        if (_extensionSeconds > type(uint64).max) revert TimestampOverflow(_extensionSeconds);
+        uint256 annualizedTime = uint256(_annualFeeBps) * _extensionSeconds;
+        return Math.mulDiv(_amount, annualizedTime, EXTENSION_FEE_DENOMINATOR, Math.Rounding.Up);
     }
 
     /**
@@ -705,7 +644,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
     /* ============ Internal Lifecycle Accounting ============ */
 
     /**
-     * @dev Applies one cancellation using a trustworthy liquidity-unlock timestamp. Effects are written
+     * @dev Applies one free cancellation using a trustworthy liquidity-unlock timestamp. Effects are written
      *      before vault interactions; any vault failure reverts the complete callback and leaves the
      *      orchestrator's reconciliation record as the recovery path.
      */
@@ -715,51 +654,29 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             revert PositionNotPending(_intentHash, position.status);
         }
 
-        uint256 penalty;
-        uint256 effectiveElapsed;
-        (penalty, effectiveElapsed) = _calculateGriefingPenalty(
-            position.bondedAmount,
-            position.createdAt,
-            _cancelledAt,
-            position.maxIntentPeriod,
-            position.griefingCliff,
-            position.griefingPenaltyBpsPerHour
-        );
-        uint256 releasedReservation = position.reservedAmount - penalty;
+        uint256 releasedReservation = position.reservedAmount;
 
         position.status = PositionStatus.CANCELLED;
         position.cancelledAt = _cancelledAt;
         position.reservedAmount = 0;
-        position.slashedAmount = penalty;
 
-        if (position.initialReservation != 0) {
-            if (penalty != 0) stakeVault.slashReservation(_intentHash, position.lp, penalty);
-            if (releasedReservation != 0) stakeVault.releaseReservation(_intentHash);
-        }
+        if (releasedReservation != 0) stakeVault.releaseReservation(_intentHash);
         if (position.mode == RiskMode.DEFERRED_PAYOUT) {
             stakeVault.releaseDeferredPayoutAuthorization(_intentHash);
         }
 
-        emit GriefingPenaltyCharged(
-            _intentHash,
-            position.stakeOwner,
-            position.lp,
-            penalty,
-            effectiveElapsed
-        );
         emit RiskPositionCancelled(
             _intentHash,
             position.stakeOwner,
             position.lp,
             _cancelledAt,
-            penalty,
             releasedReservation
         );
     }
 
     /**
-     * @dev Transitions a pending position at settlement. Griefing liability disappears without penalty.
-     *      Stake-backed coverage is resized to the exact released amount; deferred coverage remains zero
+     * @dev Transitions a pending position at settlement. Stake-backed coverage is resized to the exact
+     *      released amount; deferred coverage remains zero
      *      until the mandatory hook atomically registers transferred proceeds.
      */
     function _settlePosition(bytes32 _intentHash, uint256 _releasedAmount, uint64 _settledAt) internal {
@@ -850,29 +767,27 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             ) {
                 revert InvalidPlatformConfig(_paymentMethod);
             }
-            if (_config.griefing.baseUnbondedAmount != 0) revert InvalidPlatformConfig(_paymentMethod);
         } else if (_config.chargeback.reserveBps != 0 || _config.chargeback.deferredPayoutEnabled) {
             revert InvalidPlatformConfig(_paymentMethod);
         }
+
+        bool extensionDisabled = _config.extension.feeBps == 0 && _config.extension.maxIntentLifetime == 0;
+        bool extensionEnabled =
+            _config.extension.feeBps != 0 && _config.extension.maxIntentLifetime != 0;
+        if ((!extensionDisabled && !extensionEnabled) || _config.extension.feeBps > BPS_DENOMINATOR) {
+            revert InvalidIntentExtensionConfig(_paymentMethod);
+        }
     }
 
-    /**
-     * @dev Enforces cliff and maximum-liability constraints against the exact Escrow period that will
-     *      be snapshotted. The rate check is amount-independent because the bonded amount never exceeds
-     *      the complete intent amount.
-     */
-    function _validatePositionPolicy(
+    /** @dev An enabled extension policy must add time beyond the Escrow's initial free period. */
+    function _validateIntentExtensionPolicy(
         bytes32 _paymentMethod,
-        uint64 _maxIntentPeriod,
-        GriefingConfig memory _config
+        uint64 _initialIntentPeriod,
+        IntentExtensionConfig memory _config
     ) internal pure {
-        if (_maxIntentPeriod == 0 || _config.griefingCliff >= _maxIntentPeriod) {
-            revert InvalidPositionPolicy(_paymentMethod, _config.griefingCliff, _maxIntentPeriod);
-        }
-        uint256 maximumRateNumerator =
-            uint256(_config.griefingPenaltyBpsPerHour) * (_maxIntentPeriod - _config.griefingCliff);
-        if (maximumRateNumerator > GRIEFING_DENOMINATOR) {
-            revert GriefingPenaltyExceedsIntentAmount(_paymentMethod);
+        if (_config.feeBps == 0 && _config.maxIntentLifetime == 0) return;
+        if (_initialIntentPeriod == 0 || _config.maxIntentLifetime <= _initialIntentPeriod) {
+            revert InvalidIntentExtensionConfig(_paymentMethod);
         }
     }
 
@@ -909,70 +824,10 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
     /* ============ Internal Formula Helpers ============ */
 
-    /** @dev Returns the reusable base-subtracted amount exposed to the griefing curve. */
-    function _calculateBondedAmount(
-        uint256 _amount,
-        uint256 _baseUnbondedAmount
-    ) internal pure returns (uint256) {
-        return _amount > _baseUnbondedAmount ? _amount - _baseUnbondedAmount : 0;
-    }
-
-    /** @dev Implements ceil(B * s * (T - C) / (10_000 * 1 hour)) without intermediate overflow. */
-    function _calculateMaxGriefingBond(
-        uint256 _bondedAmount,
-        uint64 _maxIntentPeriod,
-        uint64 _griefingCliff,
-        uint32 _griefingPenaltyBpsPerHour
-    ) internal pure returns (uint256) {
-        if (_griefingPenaltyBpsPerHour == 0 || _maxIntentPeriod <= _griefingCliff) return 0;
-        uint256 rateNumerator =
-            uint256(_griefingPenaltyBpsPerHour) * (_maxIntentPeriod - _griefingCliff);
-        return Math.mulDiv(_bondedAmount, rateNumerator, GRIEFING_DENOMINATOR, Math.Rounding.Up);
-    }
-
-    /** @dev Implements the capped time-linear cancellation formula with exact upward rounding. */
-    function _calculateGriefingPenalty(
-        uint256 _bondedAmount,
-        uint64 _createdAt,
-        uint64 _cancelledAt,
-        uint64 _maxIntentPeriod,
-        uint64 _griefingCliff,
-        uint32 _griefingPenaltyBpsPerHour
-    ) internal pure returns (uint256 penalty, uint256 effectiveElapsed) {
-        if (_cancelledAt <= _createdAt) return (0, 0);
-        effectiveElapsed = _min(uint256(_cancelledAt - _createdAt), _maxIntentPeriod);
-        if (_griefingPenaltyBpsPerHour == 0 || effectiveElapsed <= _griefingCliff) {
-            return (0, effectiveElapsed);
-        }
-        uint256 chargeableTime = effectiveElapsed - _griefingCliff;
-        uint256 rateNumerator = uint256(_griefingPenaltyBpsPerHour) * chargeableTime;
-        penalty = Math.mulDiv(_bondedAmount, rateNumerator, GRIEFING_DENOMINATOR, Math.Rounding.Up);
-    }
-
     /** @dev Implements ceil(A * r / 10_000) with full-precision multiplication. */
     function _calculateChargebackReserve(uint256 _amount, uint16 _reserveBps) internal pure returns (uint256) {
         if (_reserveBps == 0) return 0;
         return Math.mulDiv(_amount, _reserveBps, BPS_DENOMINATOR, Math.Rounding.Up);
-    }
-
-    /** @dev Computes both mutually exclusive liabilities and reserves their maximum. */
-    function _calculateRequiredReservation(
-        uint256 _intentAmount,
-        uint64 _maxIntentPeriod,
-        PlatformRiskConfig memory _config
-    ) internal pure returns (
-        uint256 maxGriefingBond,
-        uint256 chargebackReserve,
-        uint256 requiredReservation
-    ) {
-        maxGriefingBond = _calculateMaxGriefingBond(
-            _calculateBondedAmount(_intentAmount, _config.griefing.baseUnbondedAmount),
-            _maxIntentPeriod,
-            _config.griefing.griefingCliff,
-            _config.griefing.griefingPenaltyBpsPerHour
-        );
-        chargebackReserve = _calculateChargebackReserve(_intentAmount, _config.chargeback.reserveBps);
-        requiredReservation = _max(maxGriefingBond, chargebackReserve);
     }
 
     /** @dev Produces the EIP-712 struct hash for a chargeback attestation. */
@@ -1013,8 +868,4 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         return _left < _right ? _left : _right;
     }
 
-    /** @dev Small branch helpers keep formula code explicit and auditable. */
-    function _max(uint256 _left, uint256 _right) internal pure returns (uint256) {
-        return _left > _right ? _left : _right;
-    }
 }

--- a/contracts/StakeVault.sol
+++ b/contracts/StakeVault.sol
@@ -39,6 +39,7 @@ contract StakeVault is IStakeVault, Ownable, ReentrancyGuard {
     mapping(address => uint256) public override stakeBalance;
     mapping(address => uint256) public override reservedStake;
     mapping(address => address) internal delegatedStakeOwners;
+    mapping(address => mapping(address => bool)) public override isExtensionFeeAuthorized;
     mapping(address => bool) internal stakeDelegationDisabled;
     mapping(address => address) internal allowedStakeOwners;
     mapping(address => ExitRequest) internal exitRequests;
@@ -171,6 +172,16 @@ contract StakeVault is IStakeVault, Ownable, ReentrancyGuard {
         for (uint256 takerIndex = 0; takerIndex < _takers.length; takerIndex++) {
             _setTakerAuthorization(msg.sender, _takers[takerIndex], _authorized);
         }
+    }
+
+    /**
+     * @notice Separately authorizes a delegated taker to spend the caller's free stake on extensions.
+     * @dev Ordinary reservation delegation does not imply permission to consume stake.
+     */
+    function setExtensionFeeAuthorization(address _taker, bool _authorized) external override {
+        if (_taker == address(0) || _taker == msg.sender) revert InvalidTaker(_taker);
+        isExtensionFeeAuthorized[msg.sender][_taker] = _authorized;
+        emit ExtensionFeeAuthorizationUpdated(msg.sender, _taker, _authorized);
     }
 
     /**
@@ -548,6 +559,30 @@ contract StakeVault is IStakeVault, Ownable, ReentrancyGuard {
             stakeBalance[staker],
             remainingReservation
         );
+    }
+
+    /**
+     * @notice Spends unreserved stake and credits a beneficiary without changing a reservation.
+     * @dev Pending withdrawals, active reservations, and exiting stake are excluded.
+     */
+    function spendFreeStake(
+        bytes32 _intentHash,
+        address _staker,
+        address _beneficiary,
+        uint256 _amount
+    ) external override onlyController {
+        if (_staker == address(0) || _beneficiary == address(0)) revert ZeroAddress();
+        if (_amount == 0) revert ZeroAmount();
+        if (exitRequests[_staker].exiting) revert AlreadyExiting(_staker);
+
+        uint256 available = freeStake(_staker);
+        if (_amount > available) revert InsufficientFreeStake(_staker, available, _amount);
+
+        stakeBalance[_staker] -= _amount;
+        totalStaked -= _amount;
+        _creditCompensation(_intentHash, _beneficiary, _amount);
+
+        emit FreeStakeSpent(_intentHash, _staker, _beneficiary, _amount, available - _amount);
     }
 
     /**

--- a/contracts/interfaces/IEscrowV2.sol
+++ b/contracts/interfaces/IEscrowV2.sol
@@ -181,6 +181,7 @@ interface IEscrowV2 {
     // Not found errors
     error DepositNotFound(uint256 depositId);
     error IntentNotFound(bytes32 intentHash);
+    error IntentAlreadyExpired(bytes32 intentHash, uint256 expiry, uint256 currentTime);
     error PaymentMethodNotActive(uint256 depositId, bytes32 paymentMethod);
     error PaymentMethodNotListed(uint256 depositId, bytes32 paymentMethod);
     error CurrencyNotFound(bytes32 paymentMethod, bytes32 currency);

--- a/contracts/interfaces/IIntentExtensionHook.sol
+++ b/contracts/interfaces/IIntentExtensionHook.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+/**
+ * @title IIntentExtensionHook
+ * @notice Optional paid-extension capability for a snapshotted V3 risk hook.
+ */
+interface IIntentExtensionHook {
+    /**
+     * @notice Authorizes and charges for an extension before Escrow mutates the expiry.
+     * @return fee Non-refundable stake fee credited to the depositor.
+     */
+    function onIntentExpiryExtension(
+        bytes32 _intentHash,
+        uint256 _extensionSeconds,
+        uint256 _newExpiry
+    ) external returns (uint256 fee);
+}

--- a/contracts/interfaces/IOrchestratorV3.sol
+++ b/contracts/interfaces/IOrchestratorV3.sol
@@ -45,6 +45,15 @@ interface IOrchestratorV3 is IOrchestratorV2 {
     event RiskCallbackGasLimitUpdated(uint256 gasLimit);
     event IntentSettlementRecorded(bytes32 indexed intentHash, uint256 releasedAmount, uint64 settledAt);
     event IntentCancellationRecorded(bytes32 indexed intentHash, uint64 cancelledAt);
+    event IntentExpiryExtended(
+        bytes32 indexed intentHash,
+        address indexed owner,
+        address indexed riskHook,
+        uint256 extensionSeconds,
+        uint256 fee,
+        uint256 previousExpiry,
+        uint256 newExpiry
+    );
 
     /* ============ Errors ============ */
 
@@ -53,11 +62,17 @@ interface IOrchestratorV3 is IOrchestratorV2 {
     error InvalidRiskHookResponse(address hook, bytes response);
     error RequiredPostIntentHookMissing(bytes32 intentHash);
     error RiskCallbackGasLimitTooLow(uint256 gasLimit, uint256 minimum);
+    error InvalidIntentExtensionDuration(uint256 extensionSeconds);
+    error IntentAlreadyExpired(bytes32 intentHash, uint256 expiry, uint256 currentTime);
+    error IntentExtensionCapExceeded(bytes32 intentHash, uint256 requestedExpiry, uint256 maximumExpiry);
+    error IntentExtensionRiskHookMissing(bytes32 intentHash);
+    error RiskHookExtensionFailed(bytes32 intentHash, address hook, bytes revertData);
 
     /* ============ External Functions ============ */
 
     function setDepositRiskHook(address _escrow, uint256 _depositId, IIntentRiskHook _hook) external;
     function setRiskCallbackGasLimit(uint256 _gasLimit) external;
+    function extendIntentExpiry(bytes32 _intentHash, uint256 _extensionSeconds) external;
 
     /* ============ View Functions ============ */
 

--- a/contracts/interfaces/IRiskManager.sol
+++ b/contracts/interfaces/IRiskManager.sol
@@ -2,19 +2,19 @@
 
 pragma solidity ^0.8.18;
 
+import { IIntentExtensionHook } from "./IIntentExtensionHook.sol";
 import { IIntentRiskHook } from "./IIntentRiskHook.sol";
 import { IOrchestratorV3 } from "./IOrchestratorV3.sol";
 import { IStakeVault } from "./IStakeVault.sol";
 
 /**
  * @title IRiskManager
- * @notice Continuous stake-risk policy for pending-intent griefing and post-settlement chargebacks.
- * @dev Implementations must snapshot mutable platform and Escrow terms when an intent is admitted.
+ * @notice Stake policy for paid intent extensions and post-settlement chargebacks.
+ * @dev Implementations snapshot mutable platform terms when an intent is admitted.
  */
-interface IRiskManager is IIntentRiskHook {
+interface IRiskManager is IIntentRiskHook, IIntentExtensionHook {
     /* ============ Enums ============ */
 
-    /** @notice Economic source backing a position. */
     enum RiskMode {
         NONE,
         UNBONDED,
@@ -22,7 +22,6 @@ interface IRiskManager is IIntentRiskHook {
         DEFERRED_PAYOUT
     }
 
-    /** @notice Lifecycle state of a snapshotted risk position. */
     enum PositionStatus {
         NONE,
         PENDING,
@@ -34,117 +33,63 @@ interface IRiskManager is IIntentRiskHook {
 
     /* ============ Structs ============ */
 
-    /// @notice Controls post-settlement chargeback protection for a payment platform.
     struct ChargebackConfig {
-        /// @notice Whether a fulfilled payment can later reverse and create LP loss.
         bool chargebackable;
-        /// @notice Whether held settlement proceeds may replace membership stake as post-settlement coverage.
         bool deferredPayoutEnabled;
-        /// @notice Upward-rounded portion of the exact released amount retained as coverage, in basis points.
         uint16 reserveBps;
-        /// @notice Half-open period after settlement during which authenticated chargebacks may slash coverage.
         uint64 riskWindow;
     }
 
-    /// @notice Controls pending-intent liquidity-lock penalties and the reusable unbonded base tranche.
-    struct GriefingConfig {
-        /// @notice Cancellation grace period after signaling during which the accrued penalty is zero.
-        uint64 griefingCliff;
-        /// @notice Time-linear penalty slope applied after the cliff, in basis points per hour.
-        uint32 griefingPenaltyBpsPerHour;
-        /// @notice Reusable per-intent amount excluded from the griefing bond on non-chargebackable platforms.
-        uint256 baseUnbondedAmount;
+    struct IntentExtensionConfig {
+        /// @notice Annualized extension price in basis points. Zero disables extensions.
+        uint16 feeBps;
+        /// @notice Maximum total lifetime from creation. Zero disables extensions.
+        uint64 maxIntentLifetime;
     }
 
-    /// @notice Combines admission status with the independent chargeback and griefing policies for a platform.
     struct PlatformRiskConfig {
-        /// @notice Whether new positions may snapshot this policy; disabling never mutates existing positions.
         bool enabled;
-        /// @notice Post-settlement reversal policy, independent of pending-intent griefing exposure.
         ChargebackConfig chargeback;
-        /// @notice Pending cancellation and reusable base-unbonded policy.
-        GriefingConfig griefing;
+        IntentExtensionConfig extension;
     }
 
-    /**
-     * @notice Immutable admission terms plus mutable lifecycle accounting for one intent.
-     * @dev Fields through `initialReservation` are snapshots. Later governance and Escrow changes cannot
-     *      alter the position's liability. `reservedAmount` is the remaining slashable amount.
-     */
     struct RiskPosition {
-        /// @notice Intent owner whose action created the position.
         address taker;
-        /// @notice Portfolio owner whose shared stake backs any amount above the unbonded base.
         address stakeOwner;
-        /// @notice Escrow depositor compensated by griefing penalties and valid chargebacks.
         address lp;
-        /// @notice Payment platform whose policy was snapshotted at admission.
         bytes32 paymentMethod;
-        /// @notice Economic backing source selected once at admission.
         RiskMode mode;
-        /// @notice Current lifecycle state; terminal transitions never return to pending.
         PositionStatus status;
-        /// @notice Canonical deferred hook snapshotted only for a deferred-payout position.
         address deferredPayoutHook;
-        /// @notice Original intent recipient entitled to unslashed deferred proceeds.
         address payoutRecipient;
-        /// @notice Snapshotted chargeback reserve ratio applied to the exact released amount.
         uint16 chargebackReserveBps;
-        /// @notice Snapshotted hourly slope used by the time-linear cancellation formula.
-        uint32 griefingPenaltyBpsPerHour;
-        /// @notice Snapshotted duration of post-settlement chargeback coverage.
+        uint16 extensionFeeBps;
         uint64 riskWindow;
-        /// @notice Canonical Orchestrator intent-creation timestamp.
         uint64 createdAt;
-        /// @notice Escrow intent period at admission, which caps griefing liability.
-        uint64 maxIntentPeriod;
-        /// @notice Snapshotted zero-penalty cancellation interval.
-        uint64 griefingCliff;
-        /// @notice Liquidity-unlock timestamp used for cancellation accounting.
+        uint64 maxIntentLifetime;
+        uint64 purchasedExtensionSeconds;
         uint64 cancelledAt;
-        /// @notice Fulfillment or manual-release timestamp that starts coverage.
         uint64 settledAt;
-        /// @notice First timestamp excluded from the half-open chargeback window.
         uint64 coverageDeadline;
-        /// @notice Original locked amount on which maximum pending liabilities were calculated.
         uint256 intentAmount;
-        /// @notice Portion of the intent amount exposed to the griefing curve after subtracting the base tranche.
-        uint256 bondedAmount;
-        /// @notice Maximum time-capped griefing penalty at admission.
-        uint256 maxGriefingBond;
-        /// @notice Stake reserved at admission before terminal resizing or release.
         uint256 initialReservation;
-        /// @notice Remaining slashable stake or deferred proceeds for this position.
         uint256 reservedAmount;
-        /// @notice Exact amount released from Escrow at settlement before post-hook fees.
         uint256 releasedAmount;
-        /// @notice Total net proceeds recorded in StakeVault for a deferred payout.
         uint256 deferredPayoutAmount;
-        /// @notice Cumulative compensation already charged against this position.
         uint256 slashedAmount;
+        uint256 extensionFeesPaid;
     }
 
-    /** @notice Signed evidence authorizing compensation from an active chargeback position. */
     struct ChargebackAttestation {
-        /// @notice Chain domain preventing cross-chain replay.
         uint256 chainId;
-        /// @notice RiskManager domain preventing replay across manager replacements.
         address riskManager;
-        /// @notice Orchestrator domain preventing replay across intent namespaces.
         address orchestrator;
-        /// @notice Position whose remaining coverage may be consumed.
         bytes32 intentHash;
-        /// @notice Payment platform bound to the position snapshot.
         bytes32 paymentMethod;
-        /// @notice LP loss requested; compensation is capped at remaining coverage.
         uint256 chargebackAmount;
-        /// @notice Nonzero off-chain evidence identifier emitted for audit correlation.
         bytes32 evidenceId;
-        /// @notice Manager-wide one-time nonce preventing attestation replay.
         uint256 nonce;
-        /// @notice First timestamp at which the attestation is valid.
         uint64 validAfter;
-        /// @notice Last timestamp at which the attestation itself is valid.
         uint64 validUntil;
     }
 
@@ -157,9 +102,8 @@ interface IRiskManager is IIntentRiskHook {
         bool deferredPayoutEnabled,
         uint16 reserveBps,
         uint64 riskWindow,
-        uint64 griefingCliff,
-        uint32 griefingPenaltyBpsPerHour,
-        uint256 baseUnbondedAmount
+        uint16 extensionFeeBps,
+        uint64 maxIntentLifetime
     );
     event RiskPositionCreated(
         bytes32 indexed intentHash,
@@ -169,30 +113,28 @@ interface IRiskManager is IIntentRiskHook {
         bytes32 paymentMethod,
         RiskMode mode,
         uint256 intentAmount,
-        uint256 bondedAmount,
         uint64 createdAt,
-        uint64 maxIntentPeriod,
-        uint64 griefingCliff,
-        uint32 griefingPenaltyBpsPerHour,
         uint16 chargebackReserveBps,
         uint64 riskWindow,
-        uint256 maxGriefingBond,
+        uint16 extensionFeeBps,
+        uint64 maxIntentLifetime,
         uint256 chargebackReserve,
         uint256 initialReservation
     );
-    event GriefingPenaltyCharged(
+    event IntentExtensionFeeCharged(
         bytes32 indexed intentHash,
         address indexed stakeOwner,
         address indexed lp,
-        uint256 penalty,
-        uint256 elapsedTime
+        uint256 extensionSeconds,
+        uint256 fee,
+        uint256 newExpiry,
+        uint256 cumulativeFees
     );
     event RiskPositionCancelled(
         bytes32 indexed intentHash,
         address indexed stakeOwner,
         address indexed lp,
         uint64 cancelledAt,
-        uint256 penalty,
         uint256 releasedReservation
     );
     event RiskPositionSettled(
@@ -244,8 +186,11 @@ interface IRiskManager is IIntentRiskHook {
     error AdmissionPaused();
     error InvalidPlatformConfig(bytes32 paymentMethod);
     error PlatformDisabled(bytes32 paymentMethod);
-    error InvalidPositionPolicy(bytes32 paymentMethod, uint64 griefingCliff, uint64 maxIntentPeriod);
-    error GriefingPenaltyExceedsIntentAmount(bytes32 paymentMethod);
+    error InvalidIntentExtensionConfig(bytes32 paymentMethod);
+    error IntentExtensionsDisabled(bytes32 intentHash);
+    error IntentExtensionLifetimeExceeded(bytes32 intentHash, uint256 requestedExpiry, uint256 maximumExpiry);
+    error ExtensionFeeAuthorizationRequired(bytes32 intentHash, address stakeOwner, address taker);
+    error InsufficientExtensionFeeStake(address stakeOwner, uint256 available, uint256 required);
     error StakeOwnerExiting(address taker, address stakeOwner);
     error InsufficientCollateral(address stakeOwner, uint256 available, uint256 required);
     error DeferredPayoutHookRequired(address expectedHook, address actualHook);
@@ -272,34 +217,21 @@ interface IRiskManager is IIntentRiskHook {
 
     /* ============ Governance Functions ============ */
 
-    /** @notice Sets policy for future positions on a payment method without rewriting existing snapshots. */
     function setPlatformRiskConfig(bytes32 _paymentMethod, PlatformRiskConfig calldata _config) external;
-    /** @notice Replaces the evidence verifier used for subsequently submitted chargeback attestations. */
     function setAttestationVerifier(address _verifier) external;
-    /** @notice Sets the canonical deferred hook snapshotted by future deferred-payout positions. */
     function setDeferredPayoutHook(address _hook) external;
-    /** @notice Pauses or resumes new admission while leaving terminal accounting and withdrawals available. */
     function setAdmissionPaused(bool _paused) external;
-    /** @notice Accepts a previously proposed delayed StakeVault controller handover on behalf of this manager. */
     function acceptVaultController() external;
 
     /* ============ Lifecycle Functions ============ */
 
-    /** @notice Records net proceeds already transferred to StakeVault by the snapshotted canonical hook. */
     function registerDeferredPayout(bytes32 _intentHash, address _beneficiary, uint256 _amount) external;
-    /** @notice Permissionlessly applies one durable failed-cancellation record using its original timestamp. */
     function reconcileCancellation(bytes32 _intentHash) external;
-    /** @notice Atomically reconciles several durable failed-cancellation records. */
     function reconcileCancellations(bytes32[] calldata _intentHashes) external;
-    /** @notice Permissionlessly applies one durable failed-settlement record. */
     function reconcileSettlement(bytes32 _intentHash) external;
-    /** @notice Atomically reconciles several durable failed-settlement records. */
     function reconcileSettlements(bytes32[] calldata _intentHashes) external;
-    /** @notice Ends slashability and releases remaining stake coverage at or after its deadline. */
     function releaseMaturedPosition(bytes32 _intentHash) external;
-    /** @notice Atomically matures several settled positions. */
     function releaseMaturedPositions(bytes32[] calldata _intentHashes) external;
-    /** @notice Authenticates chargeback evidence and compensates the LP up to remaining coverage. */
     function submitChargeback(
         ChargebackAttestation calldata _attestation,
         bytes[] calldata _signatures,
@@ -308,44 +240,19 @@ interface IRiskManager is IIntentRiskHook {
 
     /* ============ View and Math Functions ============ */
 
-    /** @notice Returns policy used only by future admissions for a payment method. */
     function getPlatformRiskConfig(bytes32 _paymentMethod) external view returns (PlatformRiskConfig memory);
-    /** @notice Returns the complete immutable snapshot and mutable lifecycle accounting for an intent. */
     function getRiskPosition(bytes32 _intentHash) external view returns (RiskPosition memory);
-    /** @notice Returns the delegated portfolio owner and current aggregate stake capacity for a taker. */
     function getTakerState(address _taker)
         external
         view
         returns (address stakeOwner, uint256 totalStake, uint256 reserved, uint256 free, bool exiting);
-    /** @notice Returns max(intent amount - base unbonded amount, 0). */
-    function calculateBondedAmount(uint256 _amount, uint256 _baseUnbondedAmount) external pure returns (uint256);
-    /** @notice Returns ceil(bonded amount * slope * (period - cliff) / (10_000 * 1 hour)). */
-    function calculateMaxGriefingBond(
-        uint256 _intentAmount,
-        uint64 _maxIntentPeriod,
-        GriefingConfig calldata _config
-    ) external pure returns (uint256);
-    /** @notice Returns the time-capped penalty for a bonded amount and effective elapsed time at cancellation. */
-    function calculateGriefingPenalty(
-        uint256 _bondedAmount,
-        uint64 _createdAt,
-        uint64 _cancelledAt,
-        uint64 _maxIntentPeriod,
-        uint64 _griefingCliff,
-        uint32 _griefingPenaltyBpsPerHour
-    ) external pure returns (uint256 penalty, uint256 effectiveElapsed);
-    /** @notice Returns ceil(amount * reserveBps / 10_000). */
     function calculateChargebackReserve(uint256 _amount, uint16 _reserveBps) external pure returns (uint256);
-    /** @notice Returns both mutually exclusive liabilities and their maximum admission reservation. */
-    function calculateRequiredReservation(
-        uint256 _intentAmount,
-        uint64 _maxIntentPeriod,
-        PlatformRiskConfig calldata _config
-    ) external pure returns (uint256 maxGriefingBond, uint256 chargebackReserve, uint256 requiredReservation);
-    /** @notice Returns the complete EIP-712 digest that an attestation verifier authenticates. */
+    function calculateIntentExtensionFee(
+        uint256 _amount,
+        uint16 _annualFeeBps,
+        uint256 _extensionSeconds
+    ) external pure returns (uint256);
     function hashChargebackAttestation(ChargebackAttestation calldata _attestation) external view returns (bytes32);
-    /** @notice Returns the immutable canonical lifecycle source authorized to call position callbacks. */
     function orchestrator() external view returns (IOrchestratorV3);
-    /** @notice Returns the immutable policy-agnostic custody and reservation vault. */
     function stakeVault() external view returns (IStakeVault);
 }

--- a/contracts/interfaces/IStakeVault.sol
+++ b/contracts/interfaces/IStakeVault.sol
@@ -71,6 +71,13 @@ interface IStakeVault {
         uint256 remainingStake,
         uint256 remainingReservation
     );
+    event FreeStakeSpent(
+        bytes32 indexed intentHash,
+        address indexed staker,
+        address indexed beneficiary,
+        uint256 amount,
+        uint256 remainingFreeStake
+    );
     event ExitRequested(address indexed staker, uint64 requestedAt, uint64 availableAt);
     event ExitCancelled(address indexed staker);
     event StakeWithdrawalRequested(
@@ -119,6 +126,7 @@ interface IStakeVault {
         uint256 amount
     );
     event TakerAuthorizationUpdated(address indexed stakeOwner, address indexed taker, bool authorized);
+    event ExtensionFeeAuthorizationUpdated(address indexed stakeOwner, address indexed taker, bool authorized);
     event StakeDelegationEnabledUpdated(address indexed taker, bool enabled);
     event AllowedStakeOwnerUpdated(address indexed taker, address indexed allowedStakeOwner);
     event ControllerProposed(address indexed currentController, address indexed pendingController, uint64 validAt);
@@ -132,6 +140,7 @@ interface IStakeVault {
     function depositStakeFor(address _taker, uint256 _amount) external;
     function setTakerAuthorization(address _taker, bool _authorized) external;
     function setTakerAuthorizations(address[] calldata _takers, bool _authorized) external;
+    function setExtensionFeeAuthorization(address _taker, bool _authorized) external;
     function clearStakeOwner() external;
     function setStakeDelegationEnabled(bool _enabled) external;
     function setAllowedStakeOwner(address _stakeOwner) external;
@@ -154,6 +163,7 @@ interface IStakeVault {
     function updateReservation(bytes32 _intentHash, uint256 _newAmount, uint64 _releaseTime) external;
     function releaseReservation(bytes32 _intentHash) external;
     function slashReservation(bytes32 _intentHash, address _maker, uint256 _amount) external;
+    function spendFreeStake(bytes32 _intentHash, address _staker, address _beneficiary, uint256 _amount) external;
     function authorizeDeferredPayout(bytes32 _intentHash, address _beneficiary, uint64 _releaseTime) external;
     function releaseDeferredPayoutAuthorization(bytes32 _intentHash) external;
     function recordDeferredPayout(bytes32 _intentHash, address _beneficiary, uint256 _amount, uint64 _releaseTime) external;
@@ -175,6 +185,7 @@ interface IStakeVault {
     function eligibleStake(address _staker) external view returns (uint256);
     function freeStake(address _staker) external view returns (uint256);
     function stakeOwnerOf(address _taker) external view returns (address);
+    function isExtensionFeeAuthorized(address _stakeOwner, address _taker) external view returns (bool);
     function stakeDelegationEnabled(address _taker) external view returns (bool);
     function allowedStakeOwner(address _taker) external view returns (address);
     function isExiting(address _staker) external view returns (bool);

--- a/contracts/lib/BoundedCall.sol
+++ b/contracts/lib/BoundedCall.sol
@@ -2,15 +2,31 @@
 
 pragma solidity ^0.8.18;
 
+import { IEscrow } from "../interfaces/IEscrow.sol";
+import { IEscrowV2 } from "../interfaces/IEscrowV2.sol";
 import { IIntentRiskHook } from "../interfaces/IIntentRiskHook.sol";
+import { IIntentExtensionHook } from "../interfaces/IIntentExtensionHook.sol";
+import { IOrchestratorV2 } from "../interfaces/IOrchestratorV2.sol";
+import { IOrchestratorV3 } from "../interfaces/IOrchestratorV3.sol";
 
 /**
  * @title BoundedCall
- * @notice Performs gas-limited calls while bounding copied return data.
+ * @notice Executes V3 risk-hook routing with gas-limited, bounded-return-data calls.
  * @dev This follows the excessively-safe-call pattern: the callee cannot force the caller to
  *      copy unbounded return data and exhaust gas during memory expansion.
  */
 library BoundedCall {
+    event DepositRiskHookSet(address indexed escrow, uint256 indexed depositId, address indexed hook, address setter);
+    event IntentRiskHookSnapshotted(bytes32 indexed intentHash, address indexed riskHook, bool requiresPostIntentHook);
+    event IntentExpiryExtended(
+        bytes32 indexed intentHash,
+        address indexed owner,
+        address indexed riskHook,
+        uint256 extensionSeconds,
+        uint256 fee,
+        uint256 previousExpiry,
+        uint256 newExpiry
+    );
     event RiskHookCallbackFailed(
         bytes32 indexed intentHash,
         address indexed riskHook,
@@ -19,8 +35,136 @@ library BoundedCall {
     );
 
     error RiskHookAdmissionFailed(bytes32 intentHash, address hook, bytes revertData);
+    error RiskHookExtensionFailed(bytes32 intentHash, address hook, bytes revertData);
     error InvalidRiskHookResponse(address hook, bytes response);
     error RequiredPostIntentHookMissing(bytes32 intentHash);
+    error ZeroAddress();
+    error InvalidRiskHook(address hook);
+    error UnauthorizedCallerOrDelegate(address caller, address depositor, address delegate);
+    error IntentNotFound(bytes32 intentHash);
+    error UnauthorizedCaller(address caller, address authorizedCaller);
+    error InvalidIntentExtensionDuration(uint256 extensionSeconds);
+    error IntentAlreadyExpired(bytes32 intentHash, uint256 expiry, uint256 currentTime);
+    error IntentExtensionCapExceeded(bytes32 intentHash, uint256 requestedExpiry, uint256 maximumExpiry);
+    error IntentExtensionRiskHookMissing(bytes32 intentHash);
+
+    function setDepositRiskHook(
+        mapping(address => mapping(uint256 => IIntentRiskHook)) storage _depositRiskHooks,
+        address _escrow,
+        uint256 _depositId,
+        IIntentRiskHook _hook
+    ) external {
+        if (_escrow == address(0)) revert ZeroAddress();
+
+        address hookAddress = address(_hook);
+        if (hookAddress != address(0) && hookAddress.code.length == 0) {
+            revert InvalidRiskHook(hookAddress);
+        }
+
+        IEscrow.Deposit memory deposit = IEscrow(_escrow).getDeposit(_depositId);
+        bool isDepositorOrDelegate = msg.sender == deposit.depositor
+            || (deposit.delegate != address(0) && msg.sender == deposit.delegate);
+        if (!isDepositorOrDelegate) {
+            revert UnauthorizedCallerOrDelegate(msg.sender, deposit.depositor, deposit.delegate);
+        }
+
+        _depositRiskHooks[_escrow][_depositId] = _hook;
+        emit DepositRiskHookSet(_escrow, _depositId, hookAddress, msg.sender);
+    }
+
+    function getRiskIntent(
+        mapping(bytes32 => IOrchestratorV2.Intent) storage _intents,
+        bytes32 _intentHash
+    ) external view returns (IOrchestratorV3.RiskIntentData memory riskIntent) {
+        IOrchestratorV2.Intent storage intent = _intents[_intentHash];
+        riskIntent = IOrchestratorV3.RiskIntentData({
+            owner: intent.owner,
+            to: intent.to,
+            escrow: intent.escrow,
+            depositId: intent.depositId,
+            amount: intent.amount,
+            paymentMethod: intent.paymentMethod,
+            postIntentHook: address(intent.postIntentHook),
+            createdAt: uint64(intent.timestamp)
+        });
+    }
+
+    function snapshotAndAdmit(
+        mapping(address => mapping(uint256 => IIntentRiskHook)) storage _depositRiskHooks,
+        mapping(bytes32 => IIntentRiskHook) storage _intentRiskHooks,
+        mapping(bytes32 => bool) storage _intentRequiresPostIntentHook,
+        mapping(bytes32 => IOrchestratorV2.Intent) storage _intents,
+        bytes32 _intentHash,
+        uint256 _callbackGasLimit,
+        uint256 _maxReturnDataSize
+    ) external {
+        IOrchestratorV2.Intent storage intent = _intents[_intentHash];
+        IIntentRiskHook riskHook = _depositRiskHooks[intent.escrow][intent.depositId];
+        _intentRiskHooks[_intentHash] = riskHook;
+
+        bool requiresPostIntentHook = executeRiskAdmission(
+            riskHook,
+            _intentHash,
+            address(intent.postIntentHook),
+            _callbackGasLimit,
+            _maxReturnDataSize
+        );
+        _intentRequiresPostIntentHook[_intentHash] = requiresPostIntentHook;
+        emit IntentRiskHookSnapshotted(_intentHash, address(riskHook), requiresPostIntentHook);
+    }
+
+    function extendIntentExpiry(
+        mapping(bytes32 => IOrchestratorV2.Intent) storage _intents,
+        mapping(bytes32 => IIntentRiskHook) storage _intentRiskHooks,
+        bytes32 _intentHash,
+        uint256 _extensionSeconds,
+        uint256 _maximumLifetime,
+        uint256 _callbackGasLimit,
+        uint256 _maxReturnDataSize
+    ) external {
+        IOrchestratorV2.Intent storage intent = _intents[_intentHash];
+        if (intent.timestamp == 0) revert IntentNotFound(_intentHash);
+        if (intent.owner != msg.sender) revert UnauthorizedCaller(msg.sender, intent.owner);
+        if (_extensionSeconds == 0) revert InvalidIntentExtensionDuration(_extensionSeconds);
+
+        IEscrowV2 escrow = IEscrowV2(intent.escrow);
+        IEscrowV2.Intent memory escrowIntent = escrow.getDepositIntent(intent.depositId, _intentHash);
+        if (escrowIntent.intentHash == bytes32(0)) revert IntentNotFound(_intentHash);
+        if (escrowIntent.expiryTime <= block.timestamp) {
+            revert IntentAlreadyExpired(_intentHash, escrowIntent.expiryTime, block.timestamp);
+        }
+        if (_extensionSeconds > type(uint256).max - escrowIntent.expiryTime) {
+            revert InvalidIntentExtensionDuration(_extensionSeconds);
+        }
+
+        uint256 newExpiry = escrowIntent.expiryTime + _extensionSeconds;
+        uint256 maximumExpiry = intent.timestamp + _maximumLifetime;
+        if (newExpiry > maximumExpiry) {
+            revert IntentExtensionCapExceeded(_intentHash, newExpiry, maximumExpiry);
+        }
+
+        IIntentRiskHook riskHook = _intentRiskHooks[_intentHash];
+        if (address(riskHook) == address(0)) revert IntentExtensionRiskHookMissing(_intentHash);
+        uint256 fee = executeRiskExtension(
+            IIntentExtensionHook(address(riskHook)),
+            _intentHash,
+            _extensionSeconds,
+            newExpiry,
+            _callbackGasLimit,
+            _maxReturnDataSize
+        );
+
+        escrow.extendIntentExpiry(intent.depositId, _intentHash, _extensionSeconds);
+        emit IntentExpiryExtended(
+            _intentHash,
+            intent.owner,
+            address(riskHook),
+            _extensionSeconds,
+            fee,
+            escrowIntent.expiryTime,
+            newExpiry
+        );
+    }
 
     /**
      * @notice Executes a fail-closed risk admission callback.
@@ -32,7 +176,7 @@ library BoundedCall {
         address _postIntentHook,
         uint256 _gasLimit,
         uint256 _maxReturnDataSize
-    ) public returns (bool requiresPostIntentHook) {
+    ) internal returns (bool requiresPostIntentHook) {
         if (address(_riskHook) == address(0)) return false;
 
         (bool success, bytes memory response) = callWithBoundedReturnData(
@@ -88,6 +232,31 @@ library BoundedCall {
         if (!success) {
             emit RiskHookCallbackFailed(_intentHash, address(_riskHook), callbackSelector, revertData);
         }
+    }
+
+    /**
+     * @notice Executes a fail-closed paid-extension callback with bounded return data.
+     */
+    function executeRiskExtension(
+        IIntentExtensionHook _riskHook,
+        bytes32 _intentHash,
+        uint256 _extensionSeconds,
+        uint256 _newExpiry,
+        uint256 _gasLimit,
+        uint256 _maxReturnDataSize
+    ) internal returns (uint256 fee) {
+        (bool success, bytes memory response) = callWithBoundedReturnData(
+            address(_riskHook),
+            _gasLimit,
+            _maxReturnDataSize,
+            abi.encodeCall(
+                IIntentExtensionHook.onIntentExpiryExtension,
+                (_intentHash, _extensionSeconds, _newExpiry)
+            )
+        );
+        if (!success) revert RiskHookExtensionFailed(_intentHash, address(_riskHook), response);
+        if (response.length != 32) revert InvalidRiskHookResponse(address(_riskHook), response);
+        fee = abi.decode(response, (uint256));
     }
 
     /**

--- a/contracts/mocks/OrchestratorMock.sol
+++ b/contracts/mocks/OrchestratorMock.sol
@@ -57,6 +57,14 @@ contract OrchestratorMock {
     ) external {
         escrow.unlockAndTransferFunds(_depositId, _intentHash, _transferAmount, _to);
     }
+
+    function extendIntentExpiry(
+        uint256 _depositId,
+        bytes32 _intentHash,
+        uint256 _additionalTime
+    ) external {
+        escrow.extendIntentExpiry(_depositId, _intentHash, _additionalTime);
+    }
     
     // Getter for testing
     function getLastPrunedIntents() external view returns (bytes32[] memory) {

--- a/deploy/28_deploy_paid_extension_stake_risk_system.ts
+++ b/deploy/28_deploy_paid_extension_stake_risk_system.ts
@@ -9,7 +9,6 @@ import {
   ORCHESTRATOR_V2_PROTOCOL_FEE,
   ORCHESTRATOR_V2_PROTOCOL_FEE_RECIPIENT,
   RISK_CALLBACK_GAS_LIMIT,
-  STAKE_RISK_PLATFORM_POLICY,
   STAKE_VAULT_BASE_EXIT_DELAY,
   STAKE_VAULT_CONTROLLER_CHANGE_DELAY,
   USDC,
@@ -25,55 +24,82 @@ const PAYPAL = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("paypal"));
 const VENMO = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("venmo"));
 const ZELLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("zelle"));
 
+const FIVE_DAYS = 5 * 24 * 60 * 60;
+const TWENTY_PERCENT_APR_BPS = 2_000;
+
+const INITIAL_PAID_EXTENSION_POLICY = {
+  reversible: {
+    enabled: true,
+    chargeback: {
+      chargebackable: true,
+      deferredPayoutEnabled: true,
+      reserveBps: 10_000,
+      riskWindow: 30 * 24 * 60 * 60,
+    },
+    extension: {
+      feeBps: TWENTY_PERCENT_APR_BPS,
+      maxIntentLifetime: FIVE_DAYS,
+    },
+  },
+  nonChargebackable: {
+    enabled: true,
+    chargeback: {
+      chargebackable: false,
+      deferredPayoutEnabled: false,
+      reserveBps: 0,
+      riskWindow: 0,
+    },
+    extension: {
+      feeBps: TWENTY_PERCENT_APR_BPS,
+      maxIntentLifetime: FIVE_DAYS,
+    },
+  },
+};
+
+const PAID_EXTENSION_POLICY: Record<string, typeof INITIAL_PAID_EXTENSION_POLICY> = {
+  localhost: INITIAL_PAID_EXTENSION_POLICY,
+  hardhat: INITIAL_PAID_EXTENSION_POLICY,
+  base_staging: INITIAL_PAID_EXTENSION_POLICY,
+};
+
 function platformRiskConfigMatches(actual: any, expected: any): boolean {
   return actual.enabled === expected.enabled
     && actual.chargeback.chargebackable === expected.chargeback.chargebackable
     && actual.chargeback.deferredPayoutEnabled === expected.chargeback.deferredPayoutEnabled
     && ethers.BigNumber.from(actual.chargeback.reserveBps).eq(expected.chargeback.reserveBps)
     && ethers.BigNumber.from(actual.chargeback.riskWindow).eq(expected.chargeback.riskWindow)
-    && ethers.BigNumber.from(actual.griefing.griefingCliff).eq(expected.griefing.griefingCliff)
-    && ethers.BigNumber.from(actual.griefing.griefingPenaltyBpsPerHour)
-      .eq(expected.griefing.griefingPenaltyBpsPerHour)
-    && ethers.BigNumber.from(actual.griefing.freeTakeCount).eq(expected.griefing.freeTakeCount)
-    && ethers.BigNumber.from(actual.griefing.freeTakeAmount).eq(expected.griefing.freeTakeAmount);
+    && ethers.BigNumber.from(actual.extension.feeBps).eq(expected.extension.feeBps)
+    && ethers.BigNumber.from(actual.extension.maxIntentLifetime).eq(expected.extension.maxIntentLifetime);
 }
 
-export function stakeRiskPlatformPolicyForNetwork(network: string): any {
-  const policy = STAKE_RISK_PLATFORM_POLICY[network];
+export function paidExtensionPolicyForNetwork(network: string): typeof INITIAL_PAID_EXTENSION_POLICY {
+  const policy = PAID_EXTENSION_POLICY[network];
   if (!policy) {
-    throw new Error(`No governance-ratified stake risk platform policy for network: ${network}`);
+    throw new Error(`No governance-ratified paid-extension policy for network: ${network}`);
   }
   return policy;
 }
 
-/**
- * Deploys the continuous stake-risk system against the existing EscrowV2 and registries.
- * Non-local execution requires both an explicit opt-in and a network-keyed, governance-ratified policy.
- */
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deploy } = hre.deployments;
   const network = hre.deployments.getNetworkName();
   const { reversible: reversibleConfig, nonChargebackable: nonChargebackableConfig } =
-    stakeRiskPlatformPolicyForNetwork(network);
+    paidExtensionPolicyForNetwork(network);
   const chainId = (await ethers.provider.getNetwork()).chainId;
   const [deployer] = await hre.getUnnamedAccounts();
-  const multiSig = MULTI_SIG[network] ? MULTI_SIG[network] : deployer;
+  const multiSig = MULTI_SIG[network] || deployer;
 
   const escrowRegistryAddress = getDeployedContractAddress(network, "EscrowRegistry");
   const paymentVerifierRegistryAddress = getDeployedContractAddress(network, "PaymentVerifierRegistry");
   const relayerRegistryAddress = getDeployedContractAddress(network, "RelayerRegistry");
   const orchestratorRegistryAddress = getDeployedContractAddress(network, "OrchestratorRegistry");
   const attestationVerifierAddress = getDeployedContractAddress(network, "MultiAttestationVerifier");
-  const stakeTokenAddress = USDC[network]
-    ? USDC[network]
-    : getDeployedContractAddress(network, "USDCMock");
+  const stakeTokenAddress = USDC[network] || getDeployedContractAddress(network, "USDCMock");
 
   const boundedCall = await deploy("BoundedCall", { from: deployer, args: [] });
-  console.log("BoundedCall deployed at", boundedCall.address);
   if (boundedCall.newlyDeployed) await waitForDeploymentDelay(hre);
 
   const postIntentHookExecutor = await deploy("PostIntentHookExecutor", { from: deployer, args: [] });
-  console.log("PostIntentHookExecutor deployed at", postIntentHookExecutor.address);
   if (postIntentHookExecutor.newlyDeployed) await waitForDeploymentDelay(hre);
 
   const orchestratorV3 = await deploy("OrchestratorV3", {
@@ -93,7 +119,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       RISK_CALLBACK_GAS_LIMIT,
     ],
   });
-  console.log("OrchestratorV3 deployed at", orchestratorV3.address);
   if (orchestratorV3.newlyDeployed) await waitForDeploymentDelay(hre);
 
   const stakeVault = await deploy("StakeVault", {
@@ -106,21 +131,18 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       STAKE_VAULT_CONTROLLER_CHANGE_DELAY,
     ],
   });
-  console.log("StakeVault deployed at", stakeVault.address);
   if (stakeVault.newlyDeployed) await waitForDeploymentDelay(hre);
 
   const riskManager = await deploy("RiskManager", {
     from: deployer,
     args: [deployer, orchestratorV3.address, stakeVault.address, attestationVerifierAddress],
   });
-  console.log("RiskManager deployed at", riskManager.address);
   if (riskManager.newlyDeployed) await waitForDeploymentDelay(hre);
 
   const deferredPayoutHook = await deploy("DeferredPayoutHook", {
     from: deployer,
     args: [stakeTokenAddress, stakeVault.address, riskManager.address, orchestratorRegistryAddress],
   });
-  console.log("DeferredPayoutHook deployed at", deferredPayoutHook.address);
   if (deferredPayoutHook.newlyDeployed) await waitForDeploymentDelay(hre);
 
   const stakeVaultContract = await ethers.getContractAt("StakeVault", stakeVault.address);
@@ -147,8 +169,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   }
 
   for (const paymentMethod of [PAYPAL, VENMO]) {
-    const actual = await riskManagerContract.getPlatformRiskConfig(paymentMethod);
-    if (!platformRiskConfigMatches(actual, reversibleConfig)) {
+    if (!platformRiskConfigMatches(await riskManagerContract.getPlatformRiskConfig(paymentMethod), reversibleConfig)) {
       await (await riskManagerContract.setPlatformRiskConfig(paymentMethod, reversibleConfig)).wait();
       await waitForDeploymentDelay(hre);
     }
@@ -160,18 +181,19 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   }
 
   await addOrchestratorToRegistry(hre, orchestratorRegistry, orchestratorV3.address);
-  console.log("OrchestratorV3 added to OrchestratorRegistry");
-
   await setNewOwner(hre, orchestratorV3Contract, multiSig);
   await setNewOwner(hre, riskManagerContract, multiSig);
   await setNewOwner(hre, stakeVaultContract, multiSig);
-  console.log("Stake risk system ownership transferred to", multiSig);
 };
 
-func.tags = ["StakeRiskSystem"];
+func.tags = ["PaidExtensionStakeRiskSystem"];
 func.dependencies = ["16_configure_v2_payment_methods", "MultiAttestationVerifier"];
-// This deployment targets the removed griefing ABI. It remains as immutable deployment history,
-// while deploy/28 is the only executable stake-risk deployment after the paid-extension cutover.
-func.skip = async (): Promise<boolean> => true;
+func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> => {
+  const network = hre.deployments.getNetworkName();
+  if (network === "localhost" || network === "hardhat") return false;
+  if (process.env.DEPLOY_PAID_EXTENSION_STAKE_RISK_SYSTEM !== "true") return true;
+  paidExtensionPolicyForNetwork(network);
+  return false;
+};
 
 export default func;

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -35,7 +35,7 @@ import { getKeccak256Hash, calculateIntentHash } from "@zkp2p/contracts-v2/utils
 
 // Import the stable, not-yet-deployed risk-system ABI and exact bigint math helpers
 import { RiskManager } from "@zkp2p/contracts-v2/abis/contracts"
-import { calculateRequiredReservation } from "@zkp2p/contracts-v2/utils/riskMath"
+import { calculateIntentExtensionFee } from "@zkp2p/contracts-v2/utils/riskMath"
 
 // Example: Create contract instance with ethers
 import { ethers } from 'ethers';
@@ -169,7 +169,7 @@ All modules are directly accessible via subpath exports:
 - `@zkp2p/contracts-v2/constants/<network>` - Constants per network
 - `@zkp2p/contracts-v2/paymentMethods` - Payment method configs
 - `@zkp2p/contracts-v2/utils/protocolUtils` - Protocol utilities
-- `@zkp2p/contracts-v2/utils/riskMath` - Exact bigint capacity, reservation, and penalty formulas
+- `@zkp2p/contracts-v2/utils/riskMath` - Exact bigint chargeback-capacity and extension-fee formulas
 - `@zkp2p/contracts-v2/types` - TypeScript types
 
 ### Export Format Details

--- a/packages/contracts/test/riskMath.spec.ts
+++ b/packages/contracts/test/riskMath.spec.ts
@@ -1,35 +1,13 @@
 import {
-  calculateBondedTakingCapacity,
-  calculateBondedAmount,
   calculateChargebackReserve,
-  calculateGriefingPenalty,
-  calculateMaxGriefingBond,
-  calculateRequiredReservation,
-  calculateTotalTakingCapacity,
-} from "../utils/riskMath";
+  calculateChargebackTakingCapacity,
+  calculateIntentExtensionFee,
+  calculateIntentExtensionFeeDelta,
+} from "../../../utils/riskMath";
 
 const HOUR = 3_600n;
-const terms = {
-  maxIntentPeriod: 6n * HOUR,
-  griefingCliff: 15n * 60n,
-  griefingPenaltyBpsPerHour: 10n,
-};
 
 describe("riskMath", () => {
-  it("subtracts the reusable base without underflow", () => {
-    expect(calculateBondedAmount(700_000_000n, 500_000_000n)).toBe(200_000_000n);
-    expect(calculateBondedAmount(500_000_000n, 500_000_000n)).toBe(0n);
-    expect(calculateBondedAmount(400_000_000n, 500_000_000n)).toBe(0n);
-  });
-
-  it("rounds the maximum griefing bond upward", () => {
-    expect(calculateMaxGriefingBond(1_000_000_001n, terms)).toBe(5_750_001n);
-  });
-
-  it("returns zero maximum griefing bond for a disabled slope", () => {
-    expect(calculateMaxGriefingBond(1_000_000n, { ...terms, griefingPenaltyBpsPerHour: 0 })).toBe(0n);
-  });
-
   it("rounds chargeback coverage upward", () => {
     expect(calculateChargebackReserve(101n, 5_000)).toBe(51n);
   });
@@ -38,55 +16,31 @@ describe("riskMath", () => {
     expect(() => calculateChargebackReserve(100n, 10_001)).toThrow("reserveBps");
   });
 
-  it("takes the maximum of griefing and chargeback requirements", () => {
-    expect(calculateRequiredReservation(1_000_000_000n, terms, 10_000, 0)).toBe(1_000_000_000n);
+  it("calculates chargeback taking capacity", () => {
+    expect(calculateChargebackTakingCapacity(1_000_000_000n, 10_000)).toBe(1_000_000_000n);
+    expect(calculateChargebackTakingCapacity(1_000_000_000n, 0)).toBeNull();
   });
 
-  it("charges nothing at the griefing cliff", () => {
-    expect(calculateGriefingPenalty(1_000_000_000n, 1_000, 1_000n + 15n * 60n, terms)).toEqual({
-      penalty: 0n,
-      effectiveElapsed: 15n * 60n,
-    });
+  it("calculates the 119-hour extension at 20 percent APR", () => {
+    expect(calculateIntentExtensionFee(1_000_000_000n, 2_000, 119n * HOUR)).toBe(2_716_895n);
   });
 
-  it("charges one smallest unit immediately after the cliff when division has a remainder", () => {
-    expect(calculateGriefingPenalty(1n, 1_000, 1_000n + 15n * 60n + 1n, terms).penalty).toBe(1n);
+  it("makes cumulative pricing independent of call splitting", () => {
+    const firstDuration = 48n * HOUR;
+    const firstFee = calculateIntentExtensionFeeDelta(1_000_000_000n, 2_000, 0, 0, firstDuration);
+    const secondFee = calculateIntentExtensionFeeDelta(
+      1_000_000_000n,
+      2_000,
+      firstDuration,
+      firstFee,
+      71n * HOUR,
+    );
+    expect(firstFee + secondFee).toBe(2_716_895n);
   });
 
-  it("caps grievance accrual at the maximum intent period", () => {
-    const late = calculateGriefingPenalty(1_000_000_000n, 1_000, 1_000n + 30n * HOUR, terms);
-    expect(late.effectiveElapsed).toBe(6n * HOUR);
-    expect(late.penalty).toBe(5_750_000n);
-  });
-
-  it("returns zero for a cancellation timestamp before creation", () => {
-    expect(calculateGriefingPenalty(1_000n, 2_000, 1_000, terms)).toEqual({
-      penalty: 0n,
-      effectiveElapsed: 0n,
-    });
-  });
-
-  it("uses the constraining chargeback curve for bonded capacity", () => {
-    const capacity = calculateBondedTakingCapacity(1_000_000_000n, terms, 10_000);
-    expect(capacity.chargebackCapacity).toBe(1_000_000_000n);
-    expect(capacity.bondedTakingCapacity).toBe(1_000_000_000n);
-  });
-
-  it("treats disabled curves as unbounded", () => {
-    const capacity = calculateBondedTakingCapacity(1_000n, {
-      ...terms,
-      griefingPenaltyBpsPerHour: 0,
-    }, 0);
-    expect(capacity).toEqual({
-      griefingCapacity: null,
-      chargebackCapacity: null,
-      bondedTakingCapacity: null,
-    });
-  });
-
-  it("adds the reusable base to finite bonded capacity", () => {
-    expect(calculateTotalTakingCapacity(200_000_000n, 500_000_000n)).toBe(700_000_000n);
-    expect(calculateTotalTakingCapacity(null, 500_000_000n)).toBeNull();
+  it("allows a rounding-only zero marginal fee", () => {
+    const firstFee = calculateIntentExtensionFee(1n, 10_000, 1n);
+    expect(calculateIntentExtensionFeeDelta(1n, 10_000, 1n, firstFee, 1n)).toBe(0n);
   });
 
   it("rejects unsafe number inputs", () => {

--- a/test-foundry/fuzz/RiskManagerMathFuzz.t.sol
+++ b/test-foundry/fuzz/RiskManagerMathFuzz.t.sol
@@ -7,7 +7,6 @@ import { Test } from "forge-std/Test.sol";
 import { RiskManager } from "../../contracts/RiskManager.sol";
 import { IAttestationVerifier } from "../../contracts/interfaces/IAttestationVerifier.sol";
 import { IOrchestratorV3 } from "../../contracts/interfaces/IOrchestratorV3.sol";
-import { IRiskManager } from "../../contracts/interfaces/IRiskManager.sol";
 import { IStakeVault } from "../../contracts/interfaces/IStakeVault.sol";
 
 contract RiskManagerMathFuzzTest is Test {
@@ -22,66 +21,21 @@ contract RiskManagerMathFuzzTest is Test {
         );
     }
 
-    function testFuzz_GriefingPenaltyNeverExceedsMaximumBond(
+    function testFuzz_ExtensionFeeIsTheSmallestUpwardRoundedCharge(
         uint96 rawAmount,
-        uint96 rawBaseUnbondedAmount,
-        uint32 rawMaxPeriod,
-        uint32 rawCliff,
-        uint16 rawSlope,
-        uint48 rawElapsed
-    ) public view {
-        uint256 amount = bound(uint256(rawAmount), 1, 1_000_000_000e6);
-        uint64 maxPeriod = uint64(bound(uint256(rawMaxPeriod), 2, 365 days));
-        uint64 cliff = uint64(bound(uint256(rawCliff), 0, maxPeriod - 1));
-        uint32 maxSlope = uint32((manager.GRIEFING_DENOMINATOR()) / (maxPeriod - cliff));
-        uint32 slope = uint32(bound(uint256(rawSlope), 0, maxSlope));
-        uint64 elapsed = uint64(bound(uint256(rawElapsed), 0, 2 * uint256(maxPeriod)));
-        uint64 createdAt = 1_000_000;
-        uint64 cancelledAt = createdAt + elapsed;
-        uint256 baseUnbondedAmount = uint256(rawBaseUnbondedAmount);
-        uint256 bondedAmount = manager.calculateBondedAmount(amount, baseUnbondedAmount);
-
-        uint256 maximumBond = manager.calculateMaxGriefingBond(
-            amount,
-            maxPeriod,
-            IRiskManager.GriefingConfig({
-                griefingCliff: cliff,
-                griefingPenaltyBpsPerHour: slope,
-                baseUnbondedAmount: baseUnbondedAmount
-            })
-        );
-        (uint256 penalty,) = manager.calculateGriefingPenalty(
-            bondedAmount,
-            createdAt,
-            cancelledAt,
-            maxPeriod,
-            cliff,
-            slope
-        );
-
-        assertEq(bondedAmount, amount > baseUnbondedAmount ? amount - baseUnbondedAmount : 0);
-        assertLe(penalty, maximumBond);
-    }
-
-    function testFuzz_AtOrBeforeCliffPenaltyIsZero(
-        uint96 rawAmount,
-        uint32 rawCliff,
-        uint16 rawSlope,
-        uint32 rawElapsed
+        uint16 rawAnnualFeeBps,
+        uint48 rawExtensionSeconds
     ) public view {
         uint256 amount = bound(uint256(rawAmount), 1, type(uint96).max);
-        uint64 cliff = uint64(bound(uint256(rawCliff), 1, 30 days));
-        uint64 elapsed = uint64(bound(uint256(rawElapsed), 0, cliff));
-        uint32 slope = uint32(bound(uint256(rawSlope), 0, 10_000));
-        (uint256 penalty,) = manager.calculateGriefingPenalty(
-            amount,
-            1_000_000,
-            uint64(1_000_000 + elapsed),
-            cliff + 1 days,
-            cliff,
-            slope
-        );
-        assertEq(penalty, 0);
+        uint16 annualFeeBps = uint16(bound(uint256(rawAnnualFeeBps), 1, 10_000));
+        uint256 extensionSeconds = bound(uint256(rawExtensionSeconds), 1, 365 days);
+
+        uint256 fee = manager.calculateIntentExtensionFee(amount, annualFeeBps, extensionSeconds);
+        uint256 numerator = amount * uint256(annualFeeBps) * extensionSeconds;
+        uint256 denominator = 10_000 * 365 days;
+
+        assertGe(fee * denominator, numerator);
+        if (fee > 0) assertLt((fee - 1) * denominator, numerator);
     }
 
     function testFuzz_ChargebackReserveIsTheSmallestUpwardRoundedCoverage(
@@ -95,39 +49,5 @@ contract RiskManagerMathFuzzTest is Test {
 
         assertGe(reserve * 10_000, amount * reserveBps);
         if (reserve > 0) assertLt((reserve - 1) * 10_000, amount * reserveBps);
-    }
-
-    function testFuzz_RequiredReservationEqualsMaximumCurve(
-        uint96 rawAmount,
-        uint96 rawBaseUnbondedAmount,
-        uint16 rawReserveBps,
-        uint16 rawSlope
-    ) public view {
-        uint256 amount = bound(uint256(rawAmount), 1, type(uint96).max);
-        uint16 reserveBps = uint16(bound(uint256(rawReserveBps), 0, 10_000));
-        uint32 slope = uint32(bound(uint256(rawSlope), 0, 1_000));
-        uint256 baseUnbondedAmount = reserveBps == 0 ? uint256(rawBaseUnbondedAmount) : 0;
-        uint256 bondedAmount = manager.calculateBondedAmount(amount, baseUnbondedAmount);
-        IRiskManager.PlatformRiskConfig memory config = IRiskManager.PlatformRiskConfig({
-            enabled: true,
-            chargeback: IRiskManager.ChargebackConfig({
-                chargebackable: reserveBps != 0,
-                deferredPayoutEnabled: false,
-                reserveBps: reserveBps,
-                riskWindow: 1 days
-            }),
-            griefing: IRiskManager.GriefingConfig({
-                griefingCliff: 15 minutes,
-                griefingPenaltyBpsPerHour: slope,
-                baseUnbondedAmount: baseUnbondedAmount
-            })
-        });
-
-        (uint256 griefing, uint256 chargeback, uint256 required) =
-            manager.calculateRequiredReservation(amount, 6 hours, config);
-
-        assertEq(required, griefing > chargeback ? griefing : chargeback);
-        assertLe(griefing, bondedAmount);
-        assertLe(chargeback, amount);
     }
 }

--- a/test-foundry/invariant/RiskManagerInvariant.t.sol
+++ b/test-foundry/invariant/RiskManagerInvariant.t.sol
@@ -143,10 +143,9 @@ contract RiskManagerInvariantTest is StdInvariant, Test {
         handler.setManager(manager);
         vault.initializeController(address(manager));
 
-        IRiskManager.GriefingConfig memory griefing = IRiskManager.GriefingConfig({
-            griefingCliff: 15 minutes,
-            griefingPenaltyBpsPerHour: 10,
-            baseUnbondedAmount: 0
+        IRiskManager.IntentExtensionConfig memory extension = IRiskManager.IntentExtensionConfig({
+            feeBps: 2_000,
+            maxIntentLifetime: 5 days
         });
         manager.setPlatformRiskConfig(PAYPAL, IRiskManager.PlatformRiskConfig({
             enabled: true,
@@ -156,9 +155,8 @@ contract RiskManagerInvariantTest is StdInvariant, Test {
                 reserveBps: 10_000,
                 riskWindow: 30 days
             }),
-            griefing: griefing
+            extension: extension
         }));
-        griefing.baseUnbondedAmount = 20e6;
         manager.setPlatformRiskConfig(ZELLE, IRiskManager.PlatformRiskConfig({
             enabled: true,
             chargeback: IRiskManager.ChargebackConfig({
@@ -167,7 +165,7 @@ contract RiskManagerInvariantTest is StdInvariant, Test {
                 reserveBps: 0,
                 riskWindow: 0
             }),
-            griefing: griefing
+            extension: extension
         }));
 
         deal(address(token), stakeOwner, 1_000_000e6);

--- a/test-foundry/unit/RiskManager.t.sol
+++ b/test-foundry/unit/RiskManager.t.sol
@@ -85,6 +85,15 @@ contract RiskOrchestratorHarness {
         delete intents[_intentHash];
     }
 
+    function extendPosition(
+        IRiskManager _manager,
+        bytes32 _intentHash,
+        uint256 _extensionSeconds,
+        uint256 _newExpiry
+    ) external returns (uint256) {
+        return _manager.onIntentExpiryExtension(_intentHash, _extensionSeconds, _newExpiry);
+    }
+
     function fulfillPosition(IIntentRiskHook _manager, bytes32 _intentHash, uint256 _amount) external {
         _manager.onIntentFulfilled(_intentHash, _amount);
         delete intents[_intentHash];
@@ -109,8 +118,8 @@ contract RiskManagerTest is Test {
     bytes32 internal constant ZELLE = keccak256("zelle");
     uint64 internal constant DAY = 1 days;
     uint64 internal constant MAX_INTENT_PERIOD = 6 hours;
-    uint64 internal constant GRIEFING_CLIFF = 15 minutes;
-    uint32 internal constant GRIEFING_SLOPE = 10;
+    uint16 internal constant EXTENSION_FEE_BPS = 2_000;
+    uint64 internal constant MAX_INTENT_LIFETIME = 5 days;
 
     address internal owner = makeAddr("owner");
     address internal taker = makeAddr("taker");
@@ -147,7 +156,7 @@ contract RiskManagerTest is Test {
 
         vm.startPrank(owner);
         manager.setPlatformRiskConfig(PAYPAL, _chargebackConfig(10_000, 30 days, true));
-        manager.setPlatformRiskConfig(ZELLE, _nonChargebackableConfig(20e6));
+        manager.setPlatformRiskConfig(ZELLE, _nonChargebackableConfig());
         manager.setDeferredPayoutHook(address(verifier));
         vm.stopPrank();
 
@@ -172,17 +181,14 @@ contract RiskManagerTest is Test {
                 reserveBps: _reserveBps,
                 riskWindow: _riskWindow
             }),
-            griefing: IRiskManager.GriefingConfig({
-                griefingCliff: GRIEFING_CLIFF,
-                griefingPenaltyBpsPerHour: GRIEFING_SLOPE,
-                baseUnbondedAmount: 0
+            extension: IRiskManager.IntentExtensionConfig({
+                feeBps: EXTENSION_FEE_BPS,
+                maxIntentLifetime: MAX_INTENT_LIFETIME
             })
         });
     }
 
-    function _nonChargebackableConfig(
-        uint256 _baseUnbondedAmount
-    ) internal pure returns (IRiskManager.PlatformRiskConfig memory) {
+    function _nonChargebackableConfig() internal pure returns (IRiskManager.PlatformRiskConfig memory) {
         return IRiskManager.PlatformRiskConfig({
             enabled: true,
             chargeback: IRiskManager.ChargebackConfig({
@@ -191,10 +197,9 @@ contract RiskManagerTest is Test {
                 reserveBps: 0,
                 riskWindow: 0
             }),
-            griefing: IRiskManager.GriefingConfig({
-                griefingCliff: GRIEFING_CLIFF,
-                griefingPenaltyBpsPerHour: GRIEFING_SLOPE,
-                baseUnbondedAmount: _baseUnbondedAmount
+            extension: IRiskManager.IntentExtensionConfig({
+                feeBps: EXTENSION_FEE_BPS,
+                maxIntentLifetime: MAX_INTENT_LIFETIME
             })
         });
     }
@@ -244,7 +249,7 @@ contract RiskManagerTest is Test {
         });
     }
 
-    function test_AdmissionReservesMaximumOfBothCurves() public {
+    function test_AdmissionReservesChargebackCoverageOnly() public {
         _stake(taker, 1_000e6);
         bytes32 intentHash = keccak256("max-reservation");
         _setIntent(intentHash, taker, 1_000e6, PAYPAL, address(0));
@@ -252,65 +257,19 @@ contract RiskManagerTest is Test {
         _createPosition(intentHash);
 
         IRiskManager.RiskPosition memory position = manager.getRiskPosition(intentHash);
-        assertEq(position.maxGriefingBond, 5.75e6);
         assertEq(position.initialReservation, 1_000e6);
         assertEq(vault.reservedStake(taker), 1_000e6);
     }
 
-    function test_BaseAmountIsUnbondedWithoutReservation() public {
-        bytes32 intentHash = keccak256("base-unbonded");
+    function test_NonChargebackableIntentIsUnbondedWithoutReservation() public {
+        bytes32 intentHash = keccak256("non-chargebackable-unbonded");
         _setIntent(intentHash, taker, 20e6, ZELLE, address(0));
 
         _createPosition(intentHash);
 
         IRiskManager.RiskPosition memory position = manager.getRiskPosition(intentHash);
         assertEq(uint256(position.mode), uint256(IRiskManager.RiskMode.UNBONDED));
-        assertEq(position.bondedAmount, 0);
         assertEq(vault.reservedStake(taker), 0);
-    }
-
-    function test_BaseAmountIsReusableAfterCancellation() public {
-        bytes32 firstIntentHash = keccak256("cancelled-base");
-        _setIntent(firstIntentHash, taker, 20e6, ZELLE, address(0));
-        _createPosition(firstIntentHash);
-
-        orchestrator.cancelPosition(manager, firstIntentHash);
-
-        bytes32 secondIntentHash = keccak256("reused-base");
-        _setIntent(secondIntentHash, taker, 20e6, ZELLE, address(0));
-        _createPosition(secondIntentHash);
-        assertEq(uint256(manager.getRiskPosition(secondIntentHash).mode), uint256(IRiskManager.RiskMode.UNBONDED));
-        assertEq(vault.reservedStake(taker), 0);
-    }
-
-    function test_BaseAmountCancellationAfterCliffNeverChargesStake() public {
-        bytes32 intentHash = keccak256("cancelled-base-after-cliff");
-        _setIntent(intentHash, taker, 20e6, ZELLE, address(0));
-        _createPosition(intentHash);
-        uint64 createdAt = manager.getRiskPosition(intentHash).createdAt;
-        vm.warp(createdAt + 2 hours);
-
-        orchestrator.cancelPosition(manager, intentHash);
-
-        IRiskManager.RiskPosition memory position = manager.getRiskPosition(intentHash);
-        assertEq(uint256(position.status), uint256(IRiskManager.PositionStatus.CANCELLED));
-        assertEq(position.slashedAmount, 0);
-        assertEq(vault.claimableCompensation(maker), 0);
-    }
-
-    function test_BaseAmountCancellationReconciliationAfterCliffNeverChargesStake() public {
-        bytes32 intentHash = keccak256("reconciled-base-after-cliff");
-        _setIntent(intentHash, taker, 20e6, ZELLE, address(0));
-        _createPosition(intentHash);
-        uint64 createdAt = manager.getRiskPosition(intentHash).createdAt;
-        orchestrator.recordCancellationWithoutCallback(intentHash, createdAt + 2 hours);
-
-        manager.reconcileCancellation(intentHash);
-
-        IRiskManager.RiskPosition memory position = manager.getRiskPosition(intentHash);
-        assertEq(uint256(position.status), uint256(IRiskManager.PositionStatus.CANCELLED));
-        assertEq(position.slashedAmount, 0);
-        assertEq(vault.claimableCompensation(maker), 0);
     }
 
     function test_AdmissionRejectsIntentTokenUnitMismatch() public {
@@ -355,13 +314,13 @@ contract RiskManagerTest is Test {
         assertEq(vault.reservedStake(stakeOwner), 1_000e6);
     }
 
-    function test_CancellationAtCliffChargesZero() public {
+    function test_CancellationReleasesReservationWithoutChargingStake() public {
         _stake(taker, 1_000e6);
         bytes32 intentHash = keccak256("cliff");
         _setIntent(intentHash, taker, 1_000e6, PAYPAL, address(0));
         _createPosition(intentHash);
         uint64 createdAt = manager.getRiskPosition(intentHash).createdAt;
-        vm.warp(createdAt + GRIEFING_CLIFF);
+        vm.warp(createdAt + 2 hours);
 
         orchestrator.cancelPosition(manager, intentHash);
 
@@ -369,7 +328,7 @@ contract RiskManagerTest is Test {
         assertEq(vault.reservedStake(taker), 0);
     }
 
-    function test_CancellationAfterTwoHoursChargesLinearPenalty() public {
+    function test_CancellationAfterTwoHoursRemainsFree() public {
         _stake(taker, 1_000e6);
         bytes32 intentHash = keccak256("two-hours");
         _setIntent(intentHash, taker, 1_000e6, PAYPAL, address(0));
@@ -379,22 +338,27 @@ contract RiskManagerTest is Test {
 
         orchestrator.cancelPosition(manager, intentHash);
 
-        assertEq(vault.claimableCompensation(maker), 1.75e6);
-        assertEq(vault.stakeBalance(taker), 998.25e6);
-        assertEq(manager.getRiskPosition(intentHash).slashedAmount, 1.75e6);
+        assertEq(vault.claimableCompensation(maker), 0);
+        assertEq(vault.stakeBalance(taker), 1_000e6);
+        assertEq(manager.getRiskPosition(intentHash).slashedAmount, 0);
     }
 
-    function test_CancellationPenaltyCapsAtSnapshottedIntentPeriod() public {
+    function test_ExtensionChargesAnnualizedFeeFromFreeStake() public {
         _stake(taker, 10e6);
         bytes32 intentHash = keccak256("extended");
         _setIntent(intentHash, taker, 1_000e6, ZELLE, address(0));
         _createPosition(intentHash);
         uint64 createdAt = manager.getRiskPosition(intentHash).createdAt;
-        vm.warp(createdAt + 2 days);
 
-        orchestrator.cancelPosition(manager, intentHash);
+        uint256 fee = orchestrator.extendPosition(
+            manager,
+            intentHash,
+            1 hours,
+            createdAt + MAX_INTENT_PERIOD + 1 hours
+        );
 
-        assertEq(vault.claimableCompensation(maker), 5.635e6);
+        assertEq(fee, manager.calculateIntentExtensionFee(1_000e6, EXTENSION_FEE_BPS, 1 hours));
+        assertEq(vault.claimableCompensation(maker), fee);
     }
 
     function test_ReconcileCancellationUsesRecordedTimestamp() public {
@@ -408,7 +372,7 @@ contract RiskManagerTest is Test {
 
         manager.reconcileCancellation(intentHash);
 
-        assertEq(vault.claimableCompensation(maker), 1.75e6);
+        assertEq(vault.claimableCompensation(maker), 0);
         assertEq(manager.getRiskPosition(intentHash).cancelledAt, createdAt + 2 hours);
     }
 
@@ -424,7 +388,7 @@ contract RiskManagerTest is Test {
         assertEq(vault.reservedStake(taker), 600e6);
     }
 
-    function test_NonChargebackableSettlementReleasesBond() public {
+    function test_NonChargebackableSettlementReleasesPosition() public {
         _stake(taker, 10e6);
         bytes32 intentHash = keccak256("irreversible-settlement");
         _setIntent(intentHash, taker, 1_000e6, ZELLE, address(0));
@@ -494,7 +458,7 @@ contract RiskManagerTest is Test {
         assertEq(uint256(manager.getRiskPosition(intentHash).status), uint256(IRiskManager.PositionStatus.RELEASED));
     }
 
-    function test_DeferredAdmissionReservesOnlyGriefingBond() public {
+    function test_DeferredAdmissionDoesNotReserveCancellationBond() public {
         _stake(taker, 10e6);
         bytes32 intentHash = keccak256("deferred");
         _setIntent(intentHash, taker, 700e6, PAYPAL, address(verifier));
@@ -504,8 +468,8 @@ contract RiskManagerTest is Test {
         IRiskManager.RiskPosition memory position = manager.getRiskPosition(intentHash);
         assertTrue(requiresHook);
         assertEq(uint256(position.mode), uint256(IRiskManager.RiskMode.DEFERRED_PAYOUT));
-        assertEq(position.initialReservation, 4.025e6);
-        assertEq(vault.reservedStake(taker), 4.025e6);
+        assertEq(position.initialReservation, 0);
+        assertEq(vault.reservedStake(taker), 0);
     }
 
     function test_DeferredRegistrationRejectsCoverageBelowConfiguredReserve() public {
@@ -540,6 +504,8 @@ contract RiskManagerTest is Test {
         IRiskManager.RiskPosition memory position = manager.getRiskPosition(intentHash);
         assertEq(position.chargebackReserveBps, 5_000);
         assertEq(position.riskWindow, 10 days);
+        assertEq(position.extensionFeeBps, EXTENSION_FEE_BPS);
+        assertEq(position.maxIntentLifetime, MAX_INTENT_LIFETIME);
         assertEq(position.initialReservation, 250e6);
     }
 }

--- a/test/deploy/26_stakeRiskSystem.spec.ts
+++ b/test/deploy/26_stakeRiskSystem.spec.ts
@@ -3,182 +3,72 @@ import "module-alias/register";
 import { expect } from "chai";
 import { deployments, ethers } from "hardhat";
 
-import {
-  stakeRiskPlatformPolicyForNetwork,
-} from "../../deploy/26_deploy_stake_risk_system";
-import {
-  MULTI_SIG,
-  MULTI_WITNESS_ADDRESSES,
-  MULTI_WITNESS_THRESHOLD,
-  RISK_CALLBACK_GAS_LIMIT,
-  STAKE_VAULT_BASE_EXIT_DELAY,
-} from "../../deployments/parameters";
+import historicalStakeRiskDeployment from "../../deploy/26_deploy_stake_risk_system";
+import { paidExtensionPolicyForNetwork } from "../../deploy/28_deploy_paid_extension_stake_risk_system";
+import { MULTI_SIG, STAKE_RISK_PLATFORM_POLICY } from "../../deployments/parameters";
 
 const PAYPAL = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("paypal"));
-const VENMO = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("venmo"));
 const ZELLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("zelle"));
 
-describe("Affine stake risk system deployment", () => {
+describe("Stake risk deployment cutover", () => {
   const network = deployments.getNetworkName();
-  const platformPolicy = stakeRiskPlatformPolicyForNetwork(network);
+  const policy = paidExtensionPolicyForNetwork(network);
 
   function deployedAddress(contractName: string): string {
     return require(`../../deployments/${network}/${contractName}.json`).address;
   }
 
-  async function contracts() {
-    const [deployer] = await ethers.getSigners();
-    return {
-      deployer,
-      orchestrator: await ethers.getContractAt("OrchestratorV3", deployedAddress("OrchestratorV3")),
-      vault: await ethers.getContractAt("StakeVault", deployedAddress("StakeVault")),
-      manager: await ethers.getContractAt("RiskManager", deployedAddress("RiskManager")),
-      deferredHook: await ethers.getContractAt("DeferredPayoutHook", deployedAddress("DeferredPayoutHook")),
-      orchestratorRegistry: await ethers.getContractAt(
-        "OrchestratorRegistry",
-        deployedAddress("OrchestratorRegistry"),
-      ),
-    };
-  }
+  it("cannot execute the removed griefing deployment", async () => {
+    expect(historicalStakeRiskDeployment.skip).not.to.eq(undefined);
+    expect(await historicalStakeRiskDeployment.skip!({} as any)).to.eq(true);
+    expect(STAKE_RISK_PLATFORM_POLICY.base).to.eq(undefined);
+  });
 
-  it("deploys the linked orchestrator components", async () => {
+  it("deploys the current V3 risk components with only historical library links", async () => {
     expect(deployedAddress("BoundedCall")).to.properAddress;
     expect(deployedAddress("PostIntentHookExecutor")).to.properAddress;
     expect(deployedAddress("OrchestratorV3")).to.properAddress;
-  });
-
-  it("deploys the replacement risk components", async () => {
     expect(deployedAddress("StakeVault")).to.properAddress;
     expect(deployedAddress("RiskManager")).to.properAddress;
     expect(deployedAddress("DeferredPayoutHook")).to.properAddress;
   });
 
-  it("transfers every owned component to the configured multisig", async () => {
-    const { deployer, orchestrator, vault, manager } = await contracts();
+  it("wires the risk components and registers the orchestrator", async () => {
+    const vault = await ethers.getContractAt("StakeVault", deployedAddress("StakeVault"));
+    const manager = await ethers.getContractAt("RiskManager", deployedAddress("RiskManager"));
+    const registry = await ethers.getContractAt("OrchestratorRegistry", deployedAddress("OrchestratorRegistry"));
+
+    expect(await vault.controller()).to.eq(manager.address);
+    expect(await manager.orchestrator()).to.eq(deployedAddress("OrchestratorV3"));
+    expect(await manager.stakeVault()).to.eq(vault.address);
+    expect(await registry.isOrchestrator(deployedAddress("OrchestratorV3"))).to.eq(true);
+  });
+
+  it("sets the 20% APR and five-day cap without a non-chargeback base tranche", async () => {
+    const manager = await ethers.getContractAt("RiskManager", deployedAddress("RiskManager"));
+    const reversible = await manager.getPlatformRiskConfig(PAYPAL);
+    const nonChargebackable = await manager.getPlatformRiskConfig(ZELLE);
+
+    expect(reversible.extension.feeBps).to.eq(policy.reversible.extension.feeBps);
+    expect(reversible.extension.maxIntentLifetime).to.eq(policy.reversible.extension.maxIntentLifetime);
+    expect(nonChargebackable.chargeback.reserveBps).to.eq(0);
+    expect(nonChargebackable.extension.feeBps).to.eq(policy.nonChargebackable.extension.feeBps);
+    expect(nonChargebackable.extension.maxIntentLifetime)
+      .to.eq(policy.nonChargebackable.extension.maxIntentLifetime);
+  });
+
+  it("transfers ownership and keeps production policy disabled", async () => {
+    const [deployer] = await ethers.getSigners();
     const expectedOwner = MULTI_SIG[network] || deployer.address;
+    const orchestrator = await ethers.getContractAt("OrchestratorV3", deployedAddress("OrchestratorV3"));
+    const vault = await ethers.getContractAt("StakeVault", deployedAddress("StakeVault"));
+    const manager = await ethers.getContractAt("RiskManager", deployedAddress("RiskManager"));
+
     expect(await orchestrator.owner()).to.eq(expectedOwner);
     expect(await vault.owner()).to.eq(expectedOwner);
     expect(await manager.owner()).to.eq(expectedOwner);
-  });
-
-  it("wires RiskManager as the vault controller", async () => {
-    const { vault, manager } = await contracts();
-    expect(await vault.controller()).to.eq(manager.address);
-  });
-
-  it("wires the immutable orchestrator and vault into RiskManager", async () => {
-    const { orchestrator, vault, manager } = await contracts();
-    expect(await manager.orchestrator()).to.eq(orchestrator.address);
-    expect(await manager.stakeVault()).to.eq(vault.address);
-  });
-
-  it("wires the canonical deferred payout hook in both directions", async () => {
-    const { vault, manager, deferredHook } = await contracts();
-    expect(await manager.deferredPayoutHook()).to.eq(deferredHook.address);
-    expect(await deferredHook.stakeVault()).to.eq(vault.address);
-    expect(await deferredHook.riskManager()).to.eq(manager.address);
-  });
-
-  it("registers OrchestratorV3 for escrow and deferred-hook authorization", async () => {
-    const { orchestrator, orchestratorRegistry } = await contracts();
-    expect(await orchestratorRegistry.isOrchestrator(orchestrator.address)).to.eq(true);
-  });
-
-  it("enables multiple intents without a stake-derived concurrency policy", async () => {
-    const { orchestrator } = await contracts();
-    expect(await orchestrator.allowMultipleIntents()).to.eq(true);
-  });
-
-  it("sets the bounded risk callback gas allowance", async () => {
-    const { orchestrator } = await contracts();
-    expect(await orchestrator.riskCallbackGasLimit()).to.eq(RISK_CALLBACK_GAS_LIMIT);
-  });
-
-  it("sets the configured base full-exit delay", async () => {
-    const { vault } = await contracts();
-    expect(await vault.baseExitDelay()).to.eq(STAKE_VAULT_BASE_EXIT_DELAY);
-  });
-
-  for (const [label, paymentMethod] of [["PayPal", PAYPAL], ["Venmo", VENMO]] as const) {
-    it(`configures ${label} chargeback and griefing curves`, async () => {
-      const { manager } = await contracts();
-      const config = await manager.getPlatformRiskConfig(paymentMethod);
-      expect(config.enabled).to.eq(true);
-      expect(config.chargeback.chargebackable).to.eq(true);
-      expect(config.chargeback.deferredPayoutEnabled).to.eq(true);
-      expect(config.chargeback.reserveBps).to.eq(platformPolicy.reversible.chargeback.reserveBps);
-      expect(config.chargeback.riskWindow).to.eq(platformPolicy.reversible.chargeback.riskWindow);
-      expect(config.griefing.griefingCliff).to.eq(platformPolicy.reversible.griefing.griefingCliff);
-      expect(config.griefing.griefingPenaltyBpsPerHour)
-        .to.eq(platformPolicy.reversible.griefing.griefingPenaltyBpsPerHour);
-      expect(config.griefing.baseUnbondedAmount).to.eq(0);
-    });
-  }
-
-  it("configures a reusable Zelle base only on the non-chargebackable platform", async () => {
-    const { manager } = await contracts();
-    const config = await manager.getPlatformRiskConfig(ZELLE);
-    expect(config.enabled).to.eq(true);
-    expect(config.chargeback.chargebackable).to.eq(false);
-    expect(config.chargeback.reserveBps).to.eq(0);
-    expect(config.griefing.baseUnbondedAmount)
-      .to.eq(platformPolicy.nonChargebackable.griefing.baseUnbondedAmount);
-  });
-
-  it("refuses nonlocal deployment without governance-ratified platform policy", async () => {
-    expect(() => stakeRiskPlatformPolicyForNetwork("base")).to.throw(
-      "No governance-ratified stake risk platform policy for network: base",
+    expect(() => paidExtensionPolicyForNetwork("base")).to.throw(
+      "No governance-ratified paid-extension policy for network: base",
     );
-  });
-
-  it("uses the deployed modular attestation verifier and RiskManager EIP-712 domain", async () => {
-    const { deployer, manager } = await contracts();
-    const verifier = await ethers.getContractAt(
-      "MultiAttestationVerifier",
-      deployedAddress("MultiAttestationVerifier"),
-    );
-    expect(await manager.attestationVerifier()).to.eq(verifier.address);
-    expect((await verifier.requiredSignatures()).toNumber()).to.eq(MULTI_WITNESS_THRESHOLD[network]);
-    expect((await verifier.witnesses()).map((w) => w.toLowerCase())).to.have.members(
-      MULTI_WITNESS_ADDRESSES[network].map((w) => w.toLowerCase()),
-    );
-
-    const { chainId } = await ethers.provider.getNetwork();
-    const chargeback = {
-      chainId,
-      riskManager: manager.address,
-      orchestrator: await manager.orchestrator(),
-      intentHash: ethers.utils.id("affine-risk-deployment-test"),
-      paymentMethod: PAYPAL,
-      chargebackAmount: 1,
-      evidenceId: ethers.utils.id("deployment-evidence"),
-      nonce: 1,
-      validAfter: 1,
-      validUntil: 2,
-    };
-    const domain = { name: "ZKP2P RiskManager", version: "1", chainId, verifyingContract: manager.address };
-    const types = {
-      ChargebackAttestation: [
-        { name: "chainId", type: "uint256" },
-        { name: "riskManager", type: "address" },
-        { name: "orchestrator", type: "address" },
-        { name: "intentHash", type: "bytes32" },
-        { name: "paymentMethod", type: "bytes32" },
-        { name: "chargebackAmount", type: "uint256" },
-        { name: "evidenceId", type: "bytes32" },
-        { name: "nonce", type: "uint256" },
-        { name: "validAfter", type: "uint64" },
-        { name: "validUntil", type: "uint64" },
-      ],
-    };
-    const digest = await manager.hashChargebackAttestation(chargeback);
-    expect(digest).to.eq(ethers.utils._TypedDataEncoder.hash(domain, types, chargeback));
-
-    // Local deployments use the deployer as their witness, while live networks
-    // intentionally keep witness keys separate from the deployment key.
-    if (await verifier.isWitness(deployer.address)) {
-      const signature = await deployer._signTypedData(domain, types, chargeback);
-      expect(await verifier.verify(digest, [signature], "0x")).to.eq(true);
-    }
   });
 });

--- a/test/escrowV2/escrowV2.branchCoverage.spec.ts
+++ b/test/escrowV2/escrowV2.branchCoverage.spec.ts
@@ -1365,7 +1365,7 @@ describe("EscrowV2 -- Branch Coverage", () => {
     describe("when deposit does not exist", () => {
       async function subject() {
         const intentHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("phantom-extend"));
-        return escrow.connect(intentGuardian.wallet).extendIntentExpiry(BigNumber.from(999), intentHash, 120);
+        return orchestratorMock.connect(owner.wallet).extendIntentExpiry(BigNumber.from(999), intentHash, 120);
       }
 
       it("reverts with DepositNotFound", async () => {
@@ -1376,7 +1376,7 @@ describe("EscrowV2 -- Branch Coverage", () => {
     describe("when intent does not exist", () => {
       async function subject() {
         const intentHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("missing-extend-intent"));
-        return escrow.connect(intentGuardian.wallet).extendIntentExpiry(depositId, intentHash, 120);
+        return orchestratorMock.connect(owner.wallet).extendIntentExpiry(depositId, intentHash, 120);
       }
 
       it("reverts with IntentNotFound", async () => {
@@ -1384,7 +1384,7 @@ describe("EscrowV2 -- Branch Coverage", () => {
       });
     });
 
-    describe("when caller is not intentGuardian", () => {
+    describe("when caller is not a registered orchestrator", () => {
       let intentHash: BytesLike;
 
       async function subject() {
@@ -1404,7 +1404,7 @@ describe("EscrowV2 -- Branch Coverage", () => {
       let intentHash: BytesLike;
 
       async function subject() {
-        return escrow.connect(intentGuardian.wallet).extendIntentExpiry(depositId, intentHash, 0);
+        return orchestratorMock.connect(owner.wallet).extendIntentExpiry(depositId, intentHash, 0);
       }
 
       beforeEach(async () => {

--- a/test/escrowV2/escrowV2.legacyCoverage.spec.ts
+++ b/test/escrowV2/escrowV2.legacyCoverage.spec.ts
@@ -934,21 +934,21 @@ describe("EscrowV2", () => {
   });
 
   describe("#extendIntentExpiry", () => {
-    it("extends expiry when called by intent guardian", async () => {
+    it("extends expiry when called by the intent's owning orchestrator", async () => {
       const intentHash = await createIntentWith(orchestratorMock, usdc(20));
       const beforeIntent = await escrow.getDepositIntent(depositId, intentHash);
       await expect(
-        escrow.connect(intentGuardian.wallet).extendIntentExpiry(depositId, intentHash, 120)
+        orchestratorMock.connect(owner.wallet).extendIntentExpiry(depositId, intentHash, 120)
       ).to.emit(escrow, "IntentExpiryExtended");
       const afterIntent = await escrow.getDepositIntent(depositId, intentHash);
       expect(afterIntent.expiryTime.sub(beforeIntent.expiryTime)).to.eq(120);
     });
 
-    it("reverts when extension exceeds maximum horizon", async () => {
+    it("rejects a different allowlisted orchestrator", async () => {
       const intentHash = await createIntentWith(orchestratorMock, usdc(20));
       await expect(
-        escrow.connect(intentGuardian.wallet).extendIntentExpiry(depositId, intentHash, 86400 * 6)
-      ).to.be.revertedWithCustomError(escrow, "AmountAboveMax");
+        secondaryOrchestratorMock.connect(owner.wallet).extendIntentExpiry(depositId, intentHash, 120)
+      ).to.be.revertedWithCustomError(escrow, "UnauthorizedCaller");
     });
   });
 

--- a/test/staking/riskManager.coverage.spec.ts
+++ b/test/staking/riskManager.coverage.spec.ts
@@ -8,8 +8,8 @@ const MINUTE = 60;
 const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
 const MAX_INTENT_PERIOD = 6 * HOUR;
-const CLIFF = 15 * MINUTE;
-const SLOPE = 10;
+const EXTENSION_FEE_BPS = 2_000;
+const MAX_INTENT_LIFETIME = 5 * DAY;
 const PAYPAL = ethers.utils.id("coverage-paypal");
 const ZELLE = ethers.utils.id("coverage-zelle");
 const OTHER_METHOD = ethers.utils.id("coverage-other");
@@ -25,13 +25,12 @@ function chargebackConfig(overrides: Record<string, unknown> = {}) {
       riskWindow: DAY,
       ...((overrides.chargeback as Record<string, unknown>) ?? {}),
     },
-    griefing: {
-      griefingCliff: CLIFF,
-      griefingPenaltyBpsPerHour: SLOPE,
-      baseUnbondedAmount: 0,
-      ...((overrides.griefing as Record<string, unknown>) ?? {}),
+    extension: {
+      feeBps: EXTENSION_FEE_BPS,
+      maxIntentLifetime: MAX_INTENT_LIFETIME,
+      ...((overrides.extension as Record<string, unknown>) ?? {}),
     },
-    ...Object.fromEntries(Object.entries(overrides).filter(([key]) => key !== "chargeback" && key !== "griefing")),
+    ...Object.fromEntries(Object.entries(overrides).filter(([key]) => key !== "chargeback" && key !== "extension")),
   };
 }
 
@@ -45,13 +44,12 @@ function nonChargebackConfig(overrides: Record<string, unknown> = {}) {
       riskWindow: 0,
       ...((overrides.chargeback as Record<string, unknown>) ?? {}),
     },
-    griefing: {
-      griefingCliff: CLIFF,
-      griefingPenaltyBpsPerHour: SLOPE,
-      baseUnbondedAmount: 0,
-      ...((overrides.griefing as Record<string, unknown>) ?? {}),
+    extension: {
+      feeBps: EXTENSION_FEE_BPS,
+      maxIntentLifetime: MAX_INTENT_LIFETIME,
+      ...((overrides.extension as Record<string, unknown>) ?? {}),
     },
-    ...Object.fromEntries(Object.entries(overrides).filter(([key]) => key !== "chargeback" && key !== "griefing")),
+    ...Object.fromEntries(Object.entries(overrides).filter(([key]) => key !== "chargeback" && key !== "extension")),
   };
 }
 
@@ -72,9 +70,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
 
     await manager.setDeferredPayoutHook(orchestrator.address);
     await manager.setPlatformRiskConfig(PAYPAL, chargebackConfig());
-    await manager.setPlatformRiskConfig(ZELLE, nonChargebackConfig({
-      griefing: { baseUnbondedAmount: usdc(20) },
-    }));
+    await manager.setPlatformRiskConfig(ZELLE, nonChargebackConfig());
     await vault.setTakerState(taker.address, taker.address, usdc(100_000), usdc(100_000), false);
 
     return { owner, taker, maker, beneficiary, other, orchestrator, vault, escrow, verifier, manager };
@@ -274,11 +270,11 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
         .to.be.revertedWithCustomError(manager, "InvalidPlatformConfig");
     });
 
-    it("rejects a base unbonded amount on a chargebackable platform", async () => {
+    it("rejects a partially configured extension policy", async () => {
       const { manager } = await loadFixture(deployHarnessFixture);
       await expect(manager.setPlatformRiskConfig(OTHER_METHOD, chargebackConfig({
-        griefing: { baseUnbondedAmount: 1 },
-      }))).to.be.revertedWithCustomError(manager, "InvalidPlatformConfig");
+        extension: { feeBps: EXTENSION_FEE_BPS, maxIntentLifetime: 0 },
+      }))).to.be.revertedWithCustomError(manager, "InvalidIntentExtensionConfig");
     });
 
     it("rejects a chargebackable platform with a zero reserve", async () => {
@@ -333,44 +329,24 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
   });
 
   describe("public formula and hashing helpers", () => {
-    it("returns zero maximum griefing bond for a zero slope", async () => {
+    it("returns zero extension fee for a zero rate", async () => {
       const { manager } = await loadFixture(deployHarnessFixture);
-      expect(await manager.calculateMaxGriefingBond(100, MAX_INTENT_PERIOD, {
-        griefingCliff: CLIFF, griefingPenaltyBpsPerHour: 0, baseUnbondedAmount: 0,
-      })).to.eq(0);
+      expect(await manager.calculateIntentExtensionFee(100, 0, HOUR)).to.eq(0);
     });
 
-    it("returns zero maximum griefing bond when the cliff reaches the period", async () => {
+    it("returns zero extension fee for zero time", async () => {
       const { manager } = await loadFixture(deployHarnessFixture);
-      expect(await manager.calculateMaxGriefingBond(100, MAX_INTENT_PERIOD, {
-        griefingCliff: MAX_INTENT_PERIOD, griefingPenaltyBpsPerHour: SLOPE, baseUnbondedAmount: 0,
-      })).to.eq(0);
+      expect(await manager.calculateIntentExtensionFee(100, EXTENSION_FEE_BPS, 0)).to.eq(0);
     });
 
-    it("returns zero cancellation penalty at or before creation", async () => {
+    it("rounds a nonzero extension fee upward", async () => {
       const { manager } = await loadFixture(deployHarnessFixture);
-      const result = await manager.calculateGriefingPenalty(100, 10, 10, MAX_INTENT_PERIOD, CLIFF, SLOPE);
-      expect(result.penalty).to.eq(0);
-      expect(result.effectiveElapsed).to.eq(0);
-    });
-
-    it("returns elapsed time with zero penalty when the slope is zero", async () => {
-      const { manager } = await loadFixture(deployHarnessFixture);
-      const result = await manager.calculateGriefingPenalty(100, 10, 10 + HOUR, MAX_INTENT_PERIOD, CLIFF, 0);
-      expect(result.penalty).to.eq(0);
-      expect(result.effectiveElapsed).to.eq(HOUR);
+      expect(await manager.calculateIntentExtensionFee(1, 1, 1)).to.eq(1);
     });
 
     it("returns zero chargeback reserve for a zero ratio", async () => {
       const { manager } = await loadFixture(deployHarnessFixture);
       expect(await manager.calculateChargebackReserve(100, 0)).to.eq(0);
-    });
-
-    it("returns griefing coverage when it exceeds chargeback coverage", async () => {
-      const { manager } = await loadFixture(deployHarnessFixture);
-      const result = await manager.calculateRequiredReservation(1_000_000, MAX_INTENT_PERIOD, nonChargebackConfig());
-      expect(result.requiredReservation).to.eq(result.maxGriefingBond);
-      expect(result.requiredReservation).to.be.gt(0);
     });
 
     it("hashes a scoped EIP-712 chargeback attestation", async () => {
@@ -470,29 +446,29 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       await fixture.escrow.setIntentExpirationPeriod(0);
       await setRiskIntent(fixture, intentHash);
       await expect(fixture.orchestrator.createPosition(fixture.manager.address, intentHash))
-        .to.be.revertedWithCustomError(fixture.manager, "InvalidPositionPolicy");
+        .to.be.revertedWithCustomError(fixture.manager, "InvalidIntentExtensionConfig");
     });
 
-    it("rejects a griefing cliff equal to the Escrow period", async () => {
+    it("rejects an extension lifetime equal to the Escrow period", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("cliff-equals-period");
+      const intentHash = ethers.utils.id("extension-equals-period");
       await fixture.manager.setPlatformRiskConfig(OTHER_METHOD, nonChargebackConfig({
-        griefing: { griefingCliff: MAX_INTENT_PERIOD },
+        extension: { feeBps: EXTENSION_FEE_BPS, maxIntentLifetime: MAX_INTENT_PERIOD },
       }));
       await setRiskIntent(fixture, intentHash, { paymentMethod: OTHER_METHOD });
       await expect(fixture.orchestrator.createPosition(fixture.manager.address, intentHash))
-        .to.be.revertedWithCustomError(fixture.manager, "InvalidPositionPolicy");
+        .to.be.revertedWithCustomError(fixture.manager, "InvalidIntentExtensionConfig");
     });
 
-    it("rejects a maximum griefing penalty above the intent amount", async () => {
+    it("rejects an extension lifetime shorter than the Escrow period", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("penalty-too-high");
+      const intentHash = ethers.utils.id("extension-too-short");
       await fixture.manager.setPlatformRiskConfig(OTHER_METHOD, nonChargebackConfig({
-        griefing: { griefingCliff: 0, griefingPenaltyBpsPerHour: 10_000 },
+        extension: { feeBps: EXTENSION_FEE_BPS, maxIntentLifetime: MAX_INTENT_PERIOD - 1 },
       }));
       await setRiskIntent(fixture, intentHash, { paymentMethod: OTHER_METHOD });
       await expect(fixture.orchestrator.createPosition(fixture.manager.address, intentHash))
-        .to.be.revertedWithCustomError(fixture.manager, "GriefingPenaltyExceedsIntentAmount");
+        .to.be.revertedWithCustomError(fixture.manager, "InvalidIntentExtensionConfig");
     });
 
     it("rejects insufficient collateral when deferred payout is disabled", async () => {
@@ -571,23 +547,19 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
         .to.be.revertedWithCustomError(fixture.manager, "DeferredPayoutHookNotAllowed");
     });
 
-    it("admits a zero-reservation stake-backed position", async () => {
+    it("admits a zero-reservation non-chargebackable position", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
       const intentHash = ethers.utils.id("zero-stake-reservation");
-      await fixture.manager.setPlatformRiskConfig(OTHER_METHOD, nonChargebackConfig({
-        griefing: { griefingPenaltyBpsPerHour: 0 },
-      }));
+      await fixture.manager.setPlatformRiskConfig(OTHER_METHOD, nonChargebackConfig());
       await fixture.vault.setTakerState(fixture.taker.address, fixture.taker.address, 0, 0, true);
       await createPosition(fixture, intentHash, { paymentMethod: OTHER_METHOD });
       expect((await fixture.manager.getRiskPosition(intentHash)).initialReservation).to.eq(0);
     });
 
-    it("admits a zero-griefing deferred position", async () => {
+    it("admits a deferred position without a cancellation bond", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("zero-griefing-deferred");
-      await fixture.manager.setPlatformRiskConfig(OTHER_METHOD, chargebackConfig({
-        griefing: { griefingPenaltyBpsPerHour: 0 },
-      }));
+      const intentHash = ethers.utils.id("zero-cancellation-bond-deferred");
+      await fixture.manager.setPlatformRiskConfig(OTHER_METHOD, chargebackConfig());
       await fixture.vault.setTakerState(fixture.taker.address, fixture.taker.address, 0, 0, false);
       await createPosition(fixture, intentHash, {
         paymentMethod: OTHER_METHOD, postIntentHook: fixture.orchestrator.address,
@@ -597,12 +569,10 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       expect(position.initialReservation).to.eq(0);
     });
 
-    it("settles a zero-griefing deferred position without releasing stake", async () => {
+    it("settles a deferred position without releasing pending stake", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("zero-griefing-deferred-settlement");
-      await fixture.manager.setPlatformRiskConfig(OTHER_METHOD, chargebackConfig({
-        griefing: { griefingPenaltyBpsPerHour: 0 },
-      }));
+      const intentHash = ethers.utils.id("zero-cancellation-bond-deferred-settlement");
+      await fixture.manager.setPlatformRiskConfig(OTHER_METHOD, chargebackConfig());
       await fixture.vault.setTakerState(fixture.taker.address, fixture.taker.address, 0, 0, false);
       await createPosition(fixture, intentHash, {
         paymentMethod: OTHER_METHOD, postIntentHook: fixture.orchestrator.address,
@@ -671,19 +641,19 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       const intentHash = ethers.utils.id("single-cancellation");
       await createPosition(fixture, intentHash);
       const createdAt = (await fixture.manager.getRiskPosition(intentHash)).createdAt.toNumber();
-      await fixture.orchestrator.setIntentCancellation(intentHash, createdAt + CLIFF);
+      await fixture.orchestrator.setIntentCancellation(intentHash, createdAt + MINUTE);
       await fixture.manager.reconcileCancellation(intentHash);
       expect((await fixture.manager.getRiskPosition(intentHash)).status).to.eq(2);
     });
 
-    it("reconciles an unbonded cancellation after the cliff without a penalty", async () => {
+    it("reconciles an unbonded cancellation without a penalty", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
       const intentHash = ethers.utils.id("free-cancel-reconciliation");
       await createPosition(fixture, intentHash, { amount: usdc(20), paymentMethod: ZELLE });
       const position = await fixture.manager.getRiskPosition(intentHash);
       await fixture.orchestrator.setIntentCancellation(
         intentHash,
-        position.createdAt.toNumber() + CLIFF + 1,
+        position.createdAt.toNumber() + MINUTE,
       );
       await fixture.manager.reconcileCancellation(intentHash);
       const cancelled = await fixture.manager.getRiskPosition(intentHash);
@@ -704,8 +674,8 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       await createPosition(fixture, first);
       await createPosition(fixture, second);
       const createdAt = (await fixture.manager.getRiskPosition(first)).createdAt.toNumber();
-      await fixture.orchestrator.setIntentCancellation(first, createdAt + CLIFF);
-      await fixture.orchestrator.setIntentCancellation(second, createdAt + CLIFF);
+      await fixture.orchestrator.setIntentCancellation(first, createdAt + MINUTE);
+      await fixture.orchestrator.setIntentCancellation(second, createdAt + MINUTE);
       await fixture.manager.reconcileCancellations([first, second]);
       expect((await fixture.manager.getRiskPosition(second)).status).to.eq(2);
     });

--- a/test/staking/riskManager.spec.ts
+++ b/test/staking/riskManager.spec.ts
@@ -8,9 +8,9 @@ const precise = (amount: string | number) => ethers.utils.parseEther(String(amou
 const MINUTE = 60;
 const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
-const MAX_INTENT_PERIOD = 6 * HOUR;
-const GRIEFING_CLIFF = 15 * MINUTE;
-const GRIEFING_SLOPE = 10;
+const INITIAL_INTENT_PERIOD = HOUR;
+const EXTENSION_FEE_BPS = 2_000;
+const MAX_INTENT_LIFETIME = 5 * DAY;
 const PAYPAL = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("paypal"));
 const ZELLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("zelle"));
 const USD = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("USD"));
@@ -42,7 +42,7 @@ describe("RiskManager and OrchestratorV3", () => {
       owner.address,
       0,
       100,
-      MAX_INTENT_PERIOD,
+      INITIAL_INTENT_PERIOD,
     );
     const boundedCall = await (await ethers.getContractFactory("BoundedCall")).deploy();
     const postIntentHookExecutor = await (await ethers.getContractFactory("PostIntentHookExecutor")).deploy();
@@ -100,10 +100,9 @@ describe("RiskManager and OrchestratorV3", () => {
         reserveBps: 0,
         riskWindow: 0,
       },
-      griefing: {
-        griefingCliff: GRIEFING_CLIFF,
-        griefingPenaltyBpsPerHour: GRIEFING_SLOPE,
-        baseUnbondedAmount: usdc(20),
+      extension: {
+        feeBps: EXTENSION_FEE_BPS,
+        maxIntentLifetime: MAX_INTENT_LIFETIME,
       },
     });
     await manager.setPlatformRiskConfig(PAYPAL, {
@@ -114,10 +113,9 @@ describe("RiskManager and OrchestratorV3", () => {
         reserveBps: 10_000,
         riskWindow: 30 * DAY,
       },
-      griefing: {
-        griefingCliff: GRIEFING_CLIFF,
-        griefingPenaltyBpsPerHour: GRIEFING_SLOPE,
-        baseUnbondedAmount: 0,
+      extension: {
+        feeBps: EXTENSION_FEE_BPS,
+        maxIntentLifetime: MAX_INTENT_LIFETIME,
       },
     });
 
@@ -267,130 +265,54 @@ describe("RiskManager and OrchestratorV3", () => {
       )).to.be.revertedWithCustomError(deferredHook, "InvalidPayoutToken");
     });
 
-    it("rejects a chargeback reserve above 100 percent", async () => {
+    it("rejects invalid chargeback and extension rates", async () => {
       const { manager } = await loadFixture(deployFixture);
       await expect(manager.setPlatformRiskConfig(PAYPAL, {
         enabled: true,
         chargeback: { chargebackable: true, deferredPayoutEnabled: false, reserveBps: 10_001, riskWindow: DAY },
-        griefing: { griefingCliff: 1, griefingPenaltyBpsPerHour: 1, baseUnbondedAmount: 0 },
+        extension: { feeBps: EXTENSION_FEE_BPS, maxIntentLifetime: MAX_INTENT_LIFETIME },
       })).to.be.revertedWithCustomError(manager, "InvalidPlatformConfig");
-    });
-
-    it("rejects a base unbonded amount on a chargebackable platform", async () => {
-      const { manager } = await loadFixture(deployFixture);
-      await expect(manager.setPlatformRiskConfig(PAYPAL, {
-        enabled: true,
-        chargeback: { chargebackable: true, deferredPayoutEnabled: false, reserveBps: 10_000, riskWindow: DAY },
-        griefing: { griefingCliff: 1, griefingPenaltyBpsPerHour: 1, baseUnbondedAmount: 1 },
-      })).to.be.revertedWithCustomError(manager, "InvalidPlatformConfig");
-    });
-
-    it("accepts a reusable base unbonded amount on a non-chargebackable platform", async () => {
-      const { manager } = await loadFixture(deployFixture);
-      await manager.setPlatformRiskConfig(ZELLE, {
+      await expect(manager.setPlatformRiskConfig(ZELLE, {
         enabled: true,
         chargeback: { chargebackable: false, deferredPayoutEnabled: false, reserveBps: 0, riskWindow: 0 },
-        griefing: { griefingCliff: 1, griefingPenaltyBpsPerHour: 1, baseUnbondedAmount: usdc(500) },
-      });
-      expect((await manager.getPlatformRiskConfig(ZELLE)).griefing.baseUnbondedAmount).to.eq(usdc(500));
+        extension: { feeBps: 10_001, maxIntentLifetime: MAX_INTENT_LIFETIME },
+      })).to.be.revertedWithCustomError(manager, "InvalidIntentExtensionConfig");
+      await expect(manager.setPlatformRiskConfig(ZELLE, {
+        enabled: true,
+        chargeback: { chargebackable: false, deferredPayoutEnabled: false, reserveBps: 0, riskWindow: 0 },
+        extension: { feeBps: EXTENSION_FEE_BPS, maxIntentLifetime: 0 },
+      })).to.be.revertedWithCustomError(manager, "InvalidIntentExtensionConfig");
     });
 
-    it("calculates the illustrative 5.75 USDC maximum griefing bond", async () => {
+    it("prices extensions at the snapshotted annual rate with upward rounding", async () => {
       const { manager } = await loadFixture(deployFixture);
-      expect(await manager.calculateMaxGriefingBond(usdc(1_000), MAX_INTENT_PERIOD, {
-        griefingCliff: GRIEFING_CLIFF,
-        griefingPenaltyBpsPerHour: GRIEFING_SLOPE,
-        baseUnbondedAmount: 0,
-      })).to.eq(usdc("5.75"));
-    });
-
-    it("subtracts the reusable base before calculating the maximum griefing bond", async () => {
-      const { manager } = await loadFixture(deployFixture);
-      expect(await manager.calculateBondedAmount(usdc(700), usdc(500))).to.eq(usdc(200));
-      expect(await manager.calculateMaxGriefingBond(usdc(700), MAX_INTENT_PERIOD, {
-        griefingCliff: GRIEFING_CLIFF,
-        griefingPenaltyBpsPerHour: GRIEFING_SLOPE,
-        baseUnbondedAmount: usdc(500),
-      })).to.eq(usdc("1.15"));
-    });
-
-    it("rounds a chargeback reserve upward", async () => {
-      const { manager } = await loadFixture(deployFixture);
+      expect(await manager.calculateIntentExtensionFee(usdc(1_000), EXTENSION_FEE_BPS, DAY))
+        .to.eq(547_946);
+      expect(await manager.calculateIntentExtensionFee(1, 1, 1)).to.eq(1);
       expect(await manager.calculateChargebackReserve(101, 5_000)).to.eq(51);
-    });
-
-    it("uses the maximum rather than the sum of both reservations", async () => {
-      const { manager } = await loadFixture(deployFixture);
-      const config = await manager.getPlatformRiskConfig(PAYPAL);
-      const result = await manager.calculateRequiredReservation(usdc(1_000), MAX_INTENT_PERIOD, config);
-      expect(result.maxGriefingBond).to.eq(usdc("5.75"));
-      expect(result.chargebackReserve).to.eq(usdc(1_000));
-      expect(result.requiredReservation).to.eq(usdc(1_000));
     });
   });
 
-  describe("base unbonded tranche", () => {
-    it("admits an intent at the base without stake", async () => {
+  describe("free initial period", () => {
+    it("admits and cancels a non-chargebackable intent without stake or a penalty", async () => {
       const { taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
-      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE);
-      const position = await manager.getRiskPosition(intentHash);
-      expect(position.mode).to.eq(1);
-      expect(position.bondedAmount).to.eq(0);
-      expect(await vault.reservedStake(taker.address)).to.eq(0);
-    });
-
-    it("reuses the base after cancellation without counter state", async () => {
-      const { taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
-      const firstIntentHash = await signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE);
-      await orchestrator.connect(taker).cancelIntent(firstIntentHash);
-      const secondIntentHash = await signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE);
-      expect((await manager.getRiskPosition(secondIntentHash)).mode).to.eq(1);
-      expect(await vault.reservedStake(taker.address)).to.eq(0);
-    });
-
-    it("cancels an intent at the base after the griefing cliff without charging stake", async () => {
-      const { taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
-      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE);
-      await time.increase(GRIEFING_CLIFF + 1);
+      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(500), ZELLE);
+      await time.increase(INITIAL_INTENT_PERIOD - 1);
       await orchestrator.connect(taker).cancelIntent(intentHash);
       const position = await manager.getRiskPosition(intentHash);
+      expect(position.mode).to.eq(1);
       expect(position.status).to.eq(2);
       expect(position.slashedAmount).to.eq(0);
       expect(await vault.reservedStake(taker.address)).to.eq(0);
     });
 
-    it("expires an intent at the base after the griefing cliff without charging stake", async () => {
+    it("expires a non-chargebackable intent without charging stake", async () => {
       const { taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
-      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE);
-      await time.increase(MAX_INTENT_PERIOD + 1);
+      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(500), ZELLE);
+      await time.increase(INITIAL_INTENT_PERIOD + 1);
       await escrow.pruneExpiredIntents(0);
-      const position = await manager.getRiskPosition(intentHash);
-      expect(position.status).to.eq(2);
-      expect(position.slashedAmount).to.eq(0);
+      expect((await manager.getRiskPosition(intentHash)).slashedAmount).to.eq(0);
       expect(await vault.reservedStake(taker.address)).to.eq(0);
-    });
-
-    it("applies the base tranche to a larger intent and bonds only the excess", async () => {
-      const { taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
-      await vault.connect(taker).depositStake(usdc(1));
-      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(21), ZELLE);
-      const position = await manager.getRiskPosition(intentHash);
-      expect(position.mode).to.eq(2);
-      expect(position.intentAmount).to.eq(usdc(21));
-      expect(position.bondedAmount).to.eq(usdc(1));
-      expect(position.maxGriefingBond).to.eq(usdc("0.00575"));
-    });
-
-    it("reuses the base concurrently across delegated takers", async () => {
-      const { owner: safe, taker, secondTaker, escrow, orchestrator, vault, manager } =
-        await loadFixture(deployFixture);
-      await vault.connect(safe).setTakerAuthorization(taker.address, true);
-      await vault.connect(safe).setTakerAuthorization(secondTaker.address, true);
-      const first = await signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE);
-      const second = await signalIntent(orchestrator, escrow, secondTaker, usdc(20), ZELLE);
-      expect((await manager.getRiskPosition(first)).mode).to.eq(1);
-      expect((await manager.getRiskPosition(second)).mode).to.eq(1);
-      expect(await vault.reservedStake(safe.address)).to.eq(0);
     });
   });
 
@@ -428,63 +350,107 @@ describe("RiskManager and OrchestratorV3", () => {
       await manager.setPlatformRiskConfig(PAYPAL, {
         enabled: true,
         chargeback: { chargebackable: true, deferredPayoutEnabled: true, reserveBps: 5_000, riskWindow: DAY },
-        griefing: {
-          griefingCliff: GRIEFING_CLIFF,
-          griefingPenaltyBpsPerHour: GRIEFING_SLOPE,
-          baseUnbondedAmount: 0,
-        },
+        extension: { feeBps: EXTENSION_FEE_BPS, maxIntentLifetime: 4 * DAY },
       });
       await vault.connect(taker).depositStake(usdc(500));
       const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(500), PAYPAL);
       await manager.setPlatformRiskConfig(PAYPAL, {
         enabled: true,
         chargeback: { chargebackable: true, deferredPayoutEnabled: true, reserveBps: 10_000, riskWindow: 30 * DAY },
-        griefing: {
-          griefingCliff: 30 * MINUTE,
-          griefingPenaltyBpsPerHour: 20,
-          baseUnbondedAmount: 0,
-        },
+        extension: { feeBps: 1_000, maxIntentLifetime: MAX_INTENT_LIFETIME },
       });
       const position = await manager.getRiskPosition(intentHash);
       expect(position.chargebackReserveBps).to.eq(5_000);
       expect(position.riskWindow).to.eq(DAY);
-      expect(position.griefingCliff).to.eq(GRIEFING_CLIFF);
+      expect(position.extensionFeeBps).to.eq(EXTENSION_FEE_BPS);
+      expect(position.maxIntentLifetime).to.eq(4 * DAY);
     });
   });
 
-  describe("cancellation penalties", () => {
-    it("releases the complete reservation when cancelled at the cliff", async () => {
-      const { taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
-      await vault.connect(taker).depositStake(usdc(1_000));
-      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(1_000), PAYPAL);
-      const createdAt = (await manager.getRiskPosition(intentHash)).createdAt.toNumber();
-      await time.increaseTo(createdAt + GRIEFING_CLIFF);
-      await orchestrator.connect(taker).cancelIntent(intentHash);
-      expect(await vault.reservedStake(taker.address)).to.eq(0);
-      expect(await vault.claimableCompensation((await manager.getRiskPosition(intentHash)).lp)).to.eq(0);
-    });
-
-    it("charges the time-linear penalty after the cliff and releases the remainder", async () => {
+  describe("paid intent extensions", () => {
+    it("charges cumulative 20 percent APR from free stake without resizing reservations", async () => {
       const { maker, taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
-      await vault.connect(taker).depositStake(usdc(1_000));
-      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(1_000), PAYPAL);
-      const createdAt = (await manager.getRiskPosition(intentHash)).createdAt.toNumber();
-      await time.increaseTo(createdAt + 2 * HOUR);
-      await orchestrator.connect(taker).cancelIntent(intentHash);
-      expect(await vault.claimableCompensation(maker.address)).to.eq(usdc("1.75"));
-      expect(await vault.stakeBalance(taker.address)).to.eq(usdc("998.25"));
-      expect((await manager.getRiskPosition(intentHash)).slashedAmount).to.eq(usdc("1.75"));
+      await vault.connect(taker).depositStake(usdc(10));
+      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(1_000), ZELLE);
+      const before = await escrow.getDepositIntent(0, intentHash);
+      const firstFee = await manager.calculateIntentExtensionFee(usdc(1_000), EXTENSION_FEE_BPS, HOUR);
+
+      await expect(orchestrator.connect(taker).extendIntentExpiry(intentHash, HOUR))
+        .to.emit(orchestrator, "IntentExpiryExtended");
+      await orchestrator.connect(taker).extendIntentExpiry(intentHash, 2 * HOUR);
+
+      const cumulativeFee = await manager.calculateIntentExtensionFee(usdc(1_000), EXTENSION_FEE_BPS, 3 * HOUR);
+      const position = await manager.getRiskPosition(intentHash);
+      expect((await escrow.getDepositIntent(0, intentHash)).expiryTime).to.eq(before.expiryTime.add(3 * HOUR));
+      expect(position.extensionFeesPaid).to.eq(cumulativeFee);
+      expect(position.purchasedExtensionSeconds).to.eq(3 * HOUR);
+      expect(await vault.stakeBalance(taker.address)).to.eq(usdc(10).sub(cumulativeFee));
+      expect(await vault.claimableCompensation(maker.address)).to.eq(cumulativeFee);
+      expect(await vault.reservedStake(taker.address)).to.eq(0);
+      expect(firstFee).to.be.gt(0);
     });
 
-    it("caps a guardian-extended intent penalty at the snapshotted maximum period", async () => {
-      const { maker, makerDelegate, taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
-      await vault.connect(taker).depositStake(usdc(1_000));
+    it("requires the intent owner, an active intent, stake, and the five-day cap", async () => {
+      const { taker, other, escrow, orchestrator, vault } = await loadFixture(deployFixture);
       const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(1_000), ZELLE);
-      await escrow.connect(makerDelegate).extendIntentExpiry(0, intentHash, DAY);
-      const createdAt = (await manager.getRiskPosition(intentHash)).createdAt.toNumber();
-      await time.increaseTo(createdAt + DAY);
+      await expect(orchestrator.connect(other).extendIntentExpiry(intentHash, HOUR))
+        .to.be.revertedWithCustomError(orchestrator, "UnauthorizedCaller");
+      await expect(orchestrator.connect(taker).extendIntentExpiry(intentHash, 0))
+        .to.be.revertedWithCustomError(orchestrator, "InvalidIntentExtensionDuration");
+      await expect(orchestrator.connect(taker).extendIntentExpiry(intentHash, HOUR))
+        .to.be.revertedWithCustomError(orchestrator, "RiskHookExtensionFailed");
+
+      await vault.connect(taker).depositStake(usdc(10));
+      await expect(orchestrator.connect(taker).extendIntentExpiry(intentHash, MAX_INTENT_LIFETIME))
+        .to.be.revertedWithCustomError(orchestrator, "IntentExtensionCapExceeded");
+      const expiry = (await escrow.getDepositIntent(0, intentHash)).expiryTime;
+      await time.increaseTo(expiry);
+      await expect(orchestrator.connect(taker).extendIntentExpiry(intentHash, HOUR))
+        .to.be.revertedWithCustomError(orchestrator, "IntentAlreadyExpired");
+    });
+
+    it("requires separate authorization before delegated stake can pay extension fees", async () => {
+      const { owner: safe, taker, escrow, orchestrator, token, vault } = await loadFixture(deployFixture);
+      await token.connect(safe).approve(vault.address, ethers.constants.MaxUint256);
+      await vault.connect(safe).depositStakeFor(taker.address, usdc(10));
+      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(1_000), ZELLE);
+      await expect(orchestrator.connect(taker).extendIntentExpiry(intentHash, HOUR))
+        .to.be.revertedWithCustomError(orchestrator, "RiskHookExtensionFailed");
+      await vault.connect(safe).setExtensionFeeAuthorization(taker.address, true);
+      await orchestrator.connect(taker).extendIntentExpiry(intentHash, HOUR);
+      expect(await vault.stakeBalance(safe.address)).to.be.lt(usdc(10));
+    });
+
+    it("blocks exiting stake and enforces a lower snapshotted hook cap", async () => {
+      const { taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
+      await manager.setPlatformRiskConfig(ZELLE, {
+        enabled: true,
+        chargeback: { chargebackable: false, deferredPayoutEnabled: false, reserveBps: 0, riskWindow: 0 },
+        extension: { feeBps: EXTENSION_FEE_BPS, maxIntentLifetime: 2 * HOUR },
+      });
+      await vault.connect(taker).depositStake(usdc(10));
+      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(1_000), ZELLE);
+
+      await vault.connect(taker).requestExit();
+      await expect(orchestrator.connect(taker).extendIntentExpiry(intentHash, HOUR))
+        .to.be.revertedWithCustomError(orchestrator, "RiskHookExtensionFailed");
+      await vault.connect(taker).cancelExit();
+
+      await orchestrator.connect(taker).extendIntentExpiry(intentHash, HOUR);
+      await expect(orchestrator.connect(taker).extendIntentExpiry(intentHash, 1))
+        .to.be.revertedWithCustomError(orchestrator, "RiskHookExtensionFailed");
+    });
+
+    it("keeps paid extension fees but makes cancellation itself free", async () => {
+      const { maker, taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
+      await vault.connect(taker).depositStake(usdc(10));
+      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(1_000), ZELLE);
+      await orchestrator.connect(taker).extendIntentExpiry(intentHash, DAY);
+      const paid = (await manager.getRiskPosition(intentHash)).extensionFeesPaid;
       await orchestrator.connect(taker).cancelIntent(intentHash);
-      expect(await vault.claimableCompensation(maker.address)).to.eq(usdc("5.635"));
+      const position = await manager.getRiskPosition(intentHash);
+      expect(position.slashedAmount).to.eq(0);
+      expect(await vault.claimableCompensation(maker.address)).to.eq(paid);
     });
 
     it("records the original cancellation time when a terminal callback fails", async () => {
@@ -502,7 +468,7 @@ describe("RiskManager and OrchestratorV3", () => {
   });
 
   describe("settlement and chargeback coverage", () => {
-    it("releases a non-chargebackable griefing bond on fulfillment", async () => {
+    it("releases a non-chargebackable position on fulfillment", async () => {
       const { taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
       await vault.connect(taker).depositStake(usdc(10));
       const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(1_000), ZELLE);
@@ -592,7 +558,7 @@ describe("RiskManager and OrchestratorV3", () => {
   });
 
   describe("deferred payout exception", () => {
-    it("reserves only the maximum griefing bond when stake cannot cover chargebacks", async () => {
+    it("uses deferred payout without a pending cancellation bond", async () => {
       const { taker, escrow, orchestrator, vault, manager, deferredHook } = await loadFixture(deployFixture);
       await vault.connect(taker).depositStake(usdc(10));
       const intentHash = await signalIntent(
@@ -605,11 +571,11 @@ describe("RiskManager and OrchestratorV3", () => {
       );
       const position = await manager.getRiskPosition(intentHash);
       expect(position.mode).to.eq(3);
-      expect(position.initialReservation).to.eq(usdc("4.025"));
-      expect(await vault.reservedStake(taker.address)).to.eq(usdc("4.025"));
+      expect(position.initialReservation).to.eq(0);
+      expect(await vault.reservedStake(taker.address)).to.eq(0);
     });
 
-    it("holds settled proceeds as chargeback coverage and releases griefing stake", async () => {
+    it("holds settled proceeds as chargeback coverage", async () => {
       const { taker, escrow, orchestrator, vault, manager, deferredHook } = await loadFixture(deployFixture);
       await vault.connect(taker).depositStake(usdc(10));
       const intentHash = await signalIntent(
@@ -641,7 +607,7 @@ describe("RiskManager and OrchestratorV3", () => {
       await expect(fulfillIntent(orchestrator, intentHash, usdc(700)))
         .to.be.revertedWithCustomError(manager, "InsufficientDeferredPayoutCoverage");
       expect((await manager.getRiskPosition(intentHash)).status).to.eq(1);
-      expect(await vault.reservedStake(taker.address)).to.eq(usdc("4.025"));
+      expect(await vault.reservedStake(taker.address)).to.eq(0);
     });
 
     it("requires the canonical deferred hook for the exception", async () => {

--- a/test/staking/stakeVault.spec.ts
+++ b/test/staking/stakeVault.spec.ts
@@ -275,6 +275,36 @@ describe("StakeVault", () => {
   });
 
   describe("slashing and compensation", () => {
+    it("spends only free stake and leaves active reservations unchanged", async () => {
+      const { controller, staker, maker, vault } = await deployFixture();
+      const intentHash = ethers.utils.id("extension");
+      await vault.connect(staker).depositStake(usdc(1_000));
+      await vault.connect(controller).reserveStake(staker.address, intentHash, usdc(600), 0);
+
+      await expect(vault.connect(controller).spendFreeStake(intentHash, staker.address, maker.address, usdc(100)))
+        .to.emit(vault, "FreeStakeSpent")
+        .withArgs(intentHash, staker.address, maker.address, usdc(100), usdc(300));
+
+      expect(await vault.stakeBalance(staker.address)).to.eq(usdc(900));
+      expect(await vault.reservedStake(staker.address)).to.eq(usdc(600));
+      expect(await vault.claimableCompensation(maker.address)).to.eq(usdc(100));
+    });
+
+    it("does not spend stake isolated for a pending withdrawal", async () => {
+      const { controller, staker, maker, vault } = await deployFixture();
+      await vault.connect(staker).depositStake(usdc(1_000));
+      await vault.connect(staker).requestStakeWithdrawal(usdc(900));
+
+      await expect(
+        vault.connect(controller).spendFreeStake(
+          ethers.utils.id("extension"),
+          staker.address,
+          maker.address,
+          usdc(101),
+        ),
+      ).to.be.revertedWithCustomError(vault, "InsufficientFreeStake");
+    });
+
     it("slashes no more than requested and retains the remaining reservation", async () => {
       const { controller, staker, maker, vault } = await deployFixture();
       const intentHash = ethers.utils.id("intent");

--- a/utils/riskMath.ts
+++ b/utils/riskMath.ts
@@ -2,29 +2,9 @@
 
 export type IntegerLike = bigint | number | string | { toString(): string };
 
-export interface GriefingTerms {
-  maxIntentPeriod: IntegerLike;
-  griefingCliff: IntegerLike;
-  griefingPenaltyBpsPerHour: IntegerLike;
-}
-
-export interface RiskCapacity {
-  /** null means this disabled curve does not constrain capacity. */
-  griefingCapacity: bigint | null;
-  /** null means this disabled curve does not constrain capacity. */
-  chargebackCapacity: bigint | null;
-  /** null means both curves are disabled and bonded capacity is unbounded. */
-  bondedTakingCapacity: bigint | null;
-}
-
-export interface GriefingPenalty {
-  penalty: bigint;
-  effectiveElapsed: bigint;
-}
-
 export const RISK_BPS_DENOMINATOR = 10_000n;
-export const RISK_SECONDS_PER_HOUR = 3_600n;
-export const RISK_GRIEFING_DENOMINATOR = RISK_BPS_DENOMINATOR * RISK_SECONDS_PER_HOUR;
+export const RISK_SECONDS_PER_YEAR = 365n * 24n * 60n * 60n;
+export const RISK_EXTENSION_FEE_DENOMINATOR = RISK_BPS_DENOMINATOR * RISK_SECONDS_PER_YEAR;
 
 function integer(value: IntegerLike, label: string): bigint {
   if (typeof value === "number" && (!Number.isSafeInteger(value) || value < 0)) {
@@ -36,119 +16,57 @@ function integer(value: IntegerLike, label: string): bigint {
 }
 
 function ceilDiv(numerator: bigint, denominator: bigint): bigint {
-  if (denominator <= 0n) throw new RangeError("denominator must be positive");
   if (numerator === 0n) return 0n;
   return ((numerator - 1n) / denominator) + 1n;
 }
 
-/** max(intent amount - reusable base unbonded amount, 0). */
-export function calculateBondedAmount(amount: IntegerLike, baseUnbondedAmount: IntegerLike): bigint {
-  const intentAmount = integer(amount, "amount");
-  const baseAmount = integer(baseUnbondedAmount, "baseUnbondedAmount");
-  return intentAmount > baseAmount ? intentAmount - baseAmount : 0n;
-}
-
-/** ceil(A * s * (T - C) / (10_000 * 1 hour)); returns zero when the curve is disabled. */
-export function calculateMaxGriefingBond(amount: IntegerLike, terms: GriefingTerms): bigint {
-  const bondedAmount = integer(amount, "amount");
-  const maxIntentPeriod = integer(terms.maxIntentPeriod, "maxIntentPeriod");
-  const griefingCliff = integer(terms.griefingCliff, "griefingCliff");
-  const slope = integer(terms.griefingPenaltyBpsPerHour, "griefingPenaltyBpsPerHour");
-  if (slope === 0n || maxIntentPeriod <= griefingCliff) return 0n;
-  return ceilDiv(
-    bondedAmount * slope * (maxIntentPeriod - griefingCliff),
-    RISK_GRIEFING_DENOMINATOR,
-  );
-}
-
 /** ceil(A * r / 10_000); returns zero when chargeback coverage is disabled. */
 export function calculateChargebackReserve(amount: IntegerLike, reserveBps: IntegerLike): bigint {
-  const bondedAmount = integer(amount, "amount");
+  const grossAmount = integer(amount, "amount");
   const reserveRatio = integer(reserveBps, "reserveBps");
   if (reserveRatio > RISK_BPS_DENOMINATOR) throw new RangeError("reserveBps cannot exceed 10,000");
-  return ceilDiv(bondedAmount * reserveRatio, RISK_BPS_DENOMINATOR);
+  return ceilDiv(grossAmount * reserveRatio, RISK_BPS_DENOMINATOR);
 }
 
-/** max(maxGriefingBond, chargebackReserve), never their sum. */
-export function calculateRequiredReservation(
-  amount: IntegerLike,
-  terms: GriefingTerms,
-  reserveBps: IntegerLike,
-  baseUnbondedAmount: IntegerLike,
-): bigint {
-  const griefingBond = calculateMaxGriefingBond(calculateBondedAmount(amount, baseUnbondedAmount), terms);
-  const chargebackReserve = calculateChargebackReserve(amount, reserveBps);
-  return griefingBond > chargebackReserve ? griefingBond : chargebackReserve;
-}
-
-/** Capped, upward-rounded time-linear penalty used for cancellation and reconciliation. */
-export function calculateGriefingPenalty(
-  amount: IntegerLike,
-  createdAt: IntegerLike,
-  cancelledAt: IntegerLike,
-  terms: GriefingTerms,
-): GriefingPenalty {
-  const bondedAmount = integer(amount, "amount");
-  const created = integer(createdAt, "createdAt");
-  const cancelled = integer(cancelledAt, "cancelledAt");
-  const maxIntentPeriod = integer(terms.maxIntentPeriod, "maxIntentPeriod");
-  const griefingCliff = integer(terms.griefingCliff, "griefingCliff");
-  const slope = integer(terms.griefingPenaltyBpsPerHour, "griefingPenaltyBpsPerHour");
-  if (cancelled <= created) return { penalty: 0n, effectiveElapsed: 0n };
-
-  const elapsed = cancelled - created;
-  const effectiveElapsed = elapsed < maxIntentPeriod ? elapsed : maxIntentPeriod;
-  if (slope === 0n || effectiveElapsed <= griefingCliff) {
-    return { penalty: 0n, effectiveElapsed };
-  }
-
-  const chargeableTime = effectiveElapsed - griefingCliff;
-  return {
-    penalty: ceilDiv(bondedAmount * slope * chargeableTime, RISK_GRIEFING_DENOMINATOR),
-    effectiveElapsed,
-  };
-}
-
-/**
- * Inverts the exact rounded reservation curves. A null capacity denotes a disabled constraint.
- * Because ceil(A*n/d) <= S iff A*n <= S*d, each inverse uses floor(S*d/n).
- */
-export function calculateBondedTakingCapacity(
+/** Maximum gross chargebackable intent amount supported by the supplied free stake. */
+export function calculateChargebackTakingCapacity(
   freeStake: IntegerLike,
-  terms: GriefingTerms,
   reserveBps: IntegerLike,
-): RiskCapacity {
+): bigint | null {
   const available = integer(freeStake, "freeStake");
-  const maxIntentPeriod = integer(terms.maxIntentPeriod, "maxIntentPeriod");
-  const griefingCliff = integer(terms.griefingCliff, "griefingCliff");
-  const slope = integer(terms.griefingPenaltyBpsPerHour, "griefingPenaltyBpsPerHour");
   const reserveRatio = integer(reserveBps, "reserveBps");
   if (reserveRatio > RISK_BPS_DENOMINATOR) throw new RangeError("reserveBps cannot exceed 10,000");
-
-  const griefingRateNumerator = maxIntentPeriod > griefingCliff
-    ? slope * (maxIntentPeriod - griefingCliff)
-    : 0n;
-  const griefingCapacity = griefingRateNumerator === 0n
-    ? null
-    : (available * RISK_GRIEFING_DENOMINATOR) / griefingRateNumerator;
-  const chargebackCapacity = reserveRatio === 0n
-    ? null
-    : (available * RISK_BPS_DENOMINATOR) / reserveRatio;
-
-  let bondedTakingCapacity: bigint | null;
-  if (griefingCapacity === null) bondedTakingCapacity = chargebackCapacity;
-  else if (chargebackCapacity === null) bondedTakingCapacity = griefingCapacity;
-  else bondedTakingCapacity = griefingCapacity < chargebackCapacity ? griefingCapacity : chargebackCapacity;
-
-  return { griefingCapacity, chargebackCapacity, bondedTakingCapacity };
+  if (reserveRatio === 0n) return null;
+  return (available * RISK_BPS_DENOMINATOR) / reserveRatio;
 }
 
-/** Adds the reusable base tranche to a finite bonded capacity; null remains unbounded. */
-export function calculateTotalTakingCapacity(
-  bondedTakingCapacity: IntegerLike | null,
-  baseUnbondedAmount: IntegerLike,
-): bigint | null {
-  if (bondedTakingCapacity === null) return null;
-  return integer(bondedTakingCapacity, "bondedTakingCapacity")
-    + integer(baseUnbondedAmount, "baseUnbondedAmount");
+/** ceil(A * annualFeeBps * seconds / (10_000 * 365 days)). */
+export function calculateIntentExtensionFee(
+  amount: IntegerLike,
+  annualFeeBps: IntegerLike,
+  extensionSeconds: IntegerLike,
+): bigint {
+  const grossAmount = integer(amount, "amount");
+  const annualRate = integer(annualFeeBps, "annualFeeBps");
+  const duration = integer(extensionSeconds, "extensionSeconds");
+  if (annualRate > RISK_BPS_DENOMINATOR) {
+    throw new RangeError("annualFeeBps cannot exceed 10,000");
+  }
+  return ceilDiv(grossAmount * annualRate * duration, RISK_EXTENSION_FEE_DENOMINATOR);
+}
+
+/** Split-invariant marginal charge for additional purchased extension seconds. */
+export function calculateIntentExtensionFeeDelta(
+  amount: IntegerLike,
+  annualFeeBps: IntegerLike,
+  purchasedExtensionSeconds: IntegerLike,
+  extensionFeesPaid: IntegerLike,
+  additionalExtensionSeconds: IntegerLike,
+): bigint {
+  const purchased = integer(purchasedExtensionSeconds, "purchasedExtensionSeconds");
+  const paid = integer(extensionFeesPaid, "extensionFeesPaid");
+  const additional = integer(additionalExtensionSeconds, "additionalExtensionSeconds");
+  const cumulativeFee = calculateIntentExtensionFee(amount, annualFeeBps, purchased + additional);
+  if (paid > cumulativeFee) throw new RangeError("extensionFeesPaid exceeds cumulative fee");
+  return cumulativeFee - paid;
 }


### PR DESCRIPTION
## Outcome

This PR is rebuilt on current `main` as one focused commit. It is now **26 files, +1,106/-1,408** (previously 92 files, +6,313/-2,492).

The Across/bridge-hook changes were inherited from an obsolete stacked settlement-hook refactor. They had no dependency on intent expiry and have been removed completely.

## Behavior

- Cancellation and expiry cleanup are free; there is no cancellation slash or griefing reservation.
- The intent owner may extend an active intent through `OrchestratorV3`.
- The extension callback is bounded and fail-closed; Escrow changes expiry only after payment succeeds.
- The first Escrow-configured intent period remains free (one hour on Base staging); the replacement risk deployment sets a 20% annual extension rate.
- Total lifetime is capped at five days by the orchestrator and may be lower in the snapshotted risk-hook policy.
- Fees are cumulative and upward-rounded, so splitting an extension cannot reduce the total charge.
- Fees spend only free stake and credit LP compensation. Reserved, exiting, and pending-withdrawal stake is unavailable.
- Delegated stake requires a separate extension-fee authorization from the stake owner.
- Non-chargebackable intents reserve no stake during the free period. The former reusable 500 USDC base tranche is removed.
- Chargeback coverage and deferred-payout settlement remain independent and unchanged.
- The extension hook is optional and selected through the existing depositor-controlled risk-hook setting, so another implementation can replace `RiskManager`.

## Architecture

```text
intent owner
  -> OrchestratorV3.extendIntentExpiry
  -> bounded callback to snapshotted IIntentExtensionHook
  -> RiskManager calculates cumulative fee
  -> StakeVault spends free stake and credits LP
  -> EscrowV2 extends expiry atomically
```

There is no new linked library. The risk-hook snapshot/configuration and extension routing use the existing `BoundedCall` link already wired by V3 deployments. An inline implementation exceeds the EIP-170 contract-size limit; the linked build is 24,461 bytes, below the 24,576-byte limit. This keeps the historical link set (`BoundedCall` and `PostIntentHookExecutor`) and removes the extra deployment dependency introduced by the old PR.

## Retained files: file-by-file justification

| File | Why it remains |
|---|---|
| `STAKE_RISK_POLICY_SPEC.md` | Replaces the contradictory cancellation/base-tranche spec with the paid-extension invariants and edge cases. |
| `contracts/EscrowV2.sol` | Moves expiry mutation from guardian authority to the intent's owning orchestrator and prevents revival after expiry. |
| `contracts/OrchestratorV3.sol` | Adds the owner entry point and five-day protocol ceiling. |
| `contracts/RiskManager.sol` | Removes cancellation bonds and implements snapshotted extension pricing and charging. |
| `contracts/StakeVault.sol` | Adds separate delegated-spend authorization and immediate free-stake compensation accounting. |
| `contracts/interfaces/IEscrowV2.sol` | Exposes the expired-intent error used by the new authorization path. |
| `contracts/interfaces/IIntentExtensionHook.sol` | Defines the optional, swappable extension capability without forcing every risk hook to implement it. |
| `contracts/interfaces/IOrchestratorV3.sol` | Publishes the owner extension ABI, event, and errors. |
| `contracts/interfaces/IRiskManager.sol` | Hard-cuts griefing configuration/events and exposes extension snapshots and fee math. |
| `contracts/interfaces/IStakeVault.sol` | Publishes authorization and free-stake spend APIs/events. |
| `contracts/lib/BoundedCall.sol` | Consolidates V3 risk-hook routing and bounded fail-closed extension execution into the existing linked library. |
| `contracts/mocks/OrchestratorMock.sol` | Lets Escrow tests exercise the new orchestrator-only boundary. |
| `deploy/26_deploy_stake_risk_system.ts` | Makes the removed griefing ABI permanently non-executable while retaining its historical deployment body. |
| `deploy/28_deploy_paid_extension_stake_risk_system.ts` | Deploys and wires the hard-cut replacement with 20% APR, a five-day cap, and production disabled absent policy. |
| `packages/contracts/README.md` | Replaces the removed griefing helper in the public import example. |
| `packages/contracts/test/riskMath.spec.ts` | Tests the hard-cut public bigint helpers and split-invariant fee math. |
| `test-foundry/fuzz/RiskManagerMathFuzz.t.sol` | Fuzzes exact upward rounding for extension fees and chargeback coverage. |
| `test-foundry/invariant/RiskManagerInvariant.t.sol` | Updates invariant configuration to the new ABI. |
| `test-foundry/unit/RiskManager.t.sol` | Covers free cancellation, extension charging, and unchanged chargeback lifecycle. |
| `test/deploy/26_stakeRiskSystem.spec.ts` | Verifies deployment 26 is inert and deployment 28 has the correct links, wiring, policy, ownership, and production gate. |
| `test/escrowV2/escrowV2.branchCoverage.spec.ts` | Updates authorization/error branches from guardian to orchestrator. |
| `test/escrowV2/escrowV2.legacyCoverage.spec.ts` | Verifies only the intent's owning orchestrator can mutate expiry. |
| `test/staking/riskManager.coverage.spec.ts` | Updates exhaustive configuration and lifecycle coverage to the hard-cut ABI. |
| `test/staking/riskManager.spec.ts` | End-to-end coverage for owner, cap, exit, delegation, atomic payment, cancellation, and settlement. |
| `test/staking/stakeVault.spec.ts` | Verifies fees cannot consume reservations or pending withdrawals. |
| `utils/riskMath.ts` | Replaces removed griefing math with exact chargeback-capacity and extension-fee helpers. |

## Reverted as unrelated

<details>
<summary>69 files removed from the old PR diff</summary>

Repository/process changes:

```text
.agents/skills/zkp2p-contracts-publish/SKILL.md
.agents/skills/zkp2p-stack-impact/SKILL.md
AGENTS.md
CLAUDE.md
README.md
audits/differential/2026-07-19-pr-184.md
```

Payment-ID, verifier, settlement-hook, Across, and unrelated Orchestrator refactors:

```text
contracts/OrchestratorV2.sol
contracts/hooks/AcrossBridgeHookV2.sol
contracts/hooks/DeferredPayoutHook.sol
contracts/interfaces/IDeferredPayoutHook.sol
contracts/interfaces/IIntentRiskHook.sol
contracts/interfaces/IOrchestratorV2.sol
contracts/interfaces/IPaymentVerifierV3.sol
contracts/interfaces/ISettlementHook.sol
contracts/lib/OrchestratorV3FeeLib.sol
contracts/lib/OrchestratorV3RiskLib.sol
contracts/lib/OrchestratorV3Validation.sol
contracts/lib/RiskCallbackRecorder.sol
contracts/lib/SettlementHookExecutor.sol
contracts/mocks/IntentRiskHookMock.sol
contracts/mocks/PartialPullSettlementHookMock.sol
contracts/mocks/PaymentVerifierMock.sol
contracts/mocks/PaymentVerifierV3Mock.sol
contracts/mocks/PushSettlementHookMock.sol
contracts/mocks/ReentrantSettlementHook.sol
contracts/mocks/RiskManagerHarnessMocks.sol
contracts/mocks/SettlementHookMock.sol
contracts/unifiedVerifier/BaseUnifiedPaymentVerifier.sol
contracts/unifiedVerifier/UnifiedPaymentVerifier.sol
contracts/unifiedVerifier/UnifiedPaymentVerifierV3.sol
```

Deployment/config/package changes:

```text
deploy/28_deploy_payment_id_risk_system.ts
deploy/29_deploy_local_payment_id_risk_system.ts
deploy/deploy_summary.ts
deployments/helpers.ts
deployments/paidExtensionRiskPolicy.ts
deployments/parameters.ts
foundry.toml
package.json
packages/contracts/package.json
```

Unrelated or stacked tests/utilities:

```text
test-foundry/fork/AcrossBridgeHookFork.t.sol
test-foundry/unit/BoundedCall.t.sol
test-foundry/unit/StakeVault.t.sol
test/deploy/01_unifiedVerifier.spec.ts
test/deploy/02_venmoPaymentMethod.spec.ts
test/deploy/03_revolutPaymentMethod.spec.ts
test/deploy/04_cashappPaymentMethod.spec.ts
test/deploy/05_wisePaymentMethod.spec.ts
test/deploy/06_mercadopagoPaymentMethod.spec.ts
test/deploy/08_paypalPaymentMethod.spec.ts
test/deploy/09_monzoPaymentMethod.spec.ts
test/deploy/11_alipayPaymentMethod.spec.ts
test/deploy/12_chimePaymentMethod.spec.ts
test/deploy/14_v2System.spec.ts
test/deploy/27_removeLegacyZellePaymentMethods.spec.ts
test/deploy/28_paymentIdRiskSystem.spec.ts
test/deploy/29_localPaymentIdRiskSystem.spec.ts
test/hooks/whitelistPreIntentHook.spec.ts
test/orchestrator/preIntentHook.spec.ts
test/orchestratorV2/orchestratorV2.legacyCoverage.spec.ts
test/orchestratorV2/orchestratorV2.spec.ts
test/patchCoverage/patchCoverage.spec.ts
test/periphery/protocolViewerV2.spec.ts
test/staking/orchestratorV3Gating.spec.ts
test/staking/orchestratorV3Validation.spec.ts
test/unifiedVerifier/unifiedPaymentVerifier.spec.ts
test/unifiedVerifier/unifiedPaymentVerifierV2.spec.ts
utils/contracts.ts
utils/deploys.ts
utils/test/helpers.ts
```

</details>

## Deployment and downstream impact

- `deploy/26_deploy_stake_risk_system.ts` retains its historical body but is permanently skipped because it encodes the removed griefing ABI.
- `deploy/28_deploy_paid_extension_stake_risk_system.ts` is the only executable stake-risk deployment. Base production has no policy and cannot deploy; Base staging still requires the explicit deployment flag.
- The full localhost deployment continues to execute every unrelated script, including both Across hooks. There is no compatibility shim for the removed risk ABI.
- Direct active consumers proven by search and requiring separate owner PRs:
  - indexer: replace removed griefing events/entities with extension-fee events/config;
  - Curator: replace griefing/base capacity math with chargeback capacity and extension pricing;
  - Pay and support bot: remove guardian-relayer calls directly to `EscrowV2.extendIntentExpiry` and adopt the buyer-owned Orchestrator flow.
- Existing Escrow `IntentExpiryExtended` emission remains, so ordinary expiry observers keep the same event source.

## Validation

- `yarn compile`
- `yarn test` — 1,341 passing, 5 pending
- `forge test --no-match-path 'test-foundry/fork/*.t.sol'` — 129 passing
- `yarn pkg:build && yarn pkg:test` — 8 passing
- full localhost deploy + `yarn test:deploy --network localhost` — 168 passing
- `yarn transpile`
- `git diff --check`
- Across source/test diff against `main` — empty; unchanged Across suites pass in the full Hardhat run
- protocol workspace doctor — OK

The excluded Foundry fork test requires `ALCHEMY_API_KEY` or `BASE_RPC_URL`; it is unchanged by this PR.
