### PR TITLE
feat: replace free takes with reusable base tranche

### DIFF
--- a/STAKE_RISK_POLICY_SPEC.md
+++ b/STAKE_RISK_POLICY_SPEC.md
@@ -1,531 +1,227 @@
-# Stake-Based Risk Curves and Configurable Free Takes
+# Stake Risk Curves and Reusable Base-Unbonded Capacity
 
 ## Status
 
-Draft for final product and protocol review. This document defines the intended behavior before implementation.
+Hard-cut contract specification. The contract implementation follows this model; deployment and downstream consumers must migrate to the new ABI without compatibility aliases.
 
 ## Summary
 
-The protocol uses stake for two distinct purposes:
+The protocol uses stake for two independent risks:
 
-1. A **griefing bond** compensates an LP when a taker locks liquidity and later cancels or lets the intent expire. The penalty increases linearly with the time the liquidity was locked after a configured cliff.
-2. **Chargeback coverage** reserves stake for a configured period after a chargebackable payment settles. A valid chargeback can slash that reservation to compensate the LP.
+1. A griefing bond compensates an LP when a taker locks liquidity and later cancels or lets the intent expire.
+2. Chargeback coverage protects an LP for a configured period after a chargebackable payment settles.
 
-For a pending bonded intent, the protocol reserves the larger of these two requirements, not their sum. Only one risk can materialize:
+For non-chargebackable payment methods, every intent receives a reusable base-unbonded tranche. Only the amount above that base enters the griefing curve. The base is stateless: there is no lifetime count, usage mapping, or consumed allowance.
 
-- A cancelled intent can incur a griefing penalty but never creates chargeback exposure.
-- A fulfilled intent incurs no griefing penalty and transitions into chargeback coverage when the platform is chargebackable.
+For chargebackable payment methods, the base must be zero and the full intent amount remains subject to the existing chargeback policy.
 
-Each stake owner also receives a configurable number of lifetime free intents on each configured non-chargebackable platform. A free intent is an onboarding subsidy and reserves no stake.
+## Security Boundary
 
-The protocol does not impose tiers, cooldowns, stake-derived intent-count limits, maximum individual intent amounts, or protocol-wide exposure limits.
+The reusable base is economic policy, not identity or Sybil protection. The contract intentionally does not approximate account identity with wallet-local counters.
 
-## Goals
+If admission must be limited to one stable platform account, that constraint belongs in the platform-account gating or proof layer. Once an intent reaches `RiskManager`, the contract applies the configured base to every eligible intent, including concurrent intents.
 
-- Express risk policy using simple formulas instead of hardcoded tiers.
-- Make reservation and slashing behavior easy to read and audit.
-- Make stake the shared resource backing all of a stake owner's active risk positions.
-- Compensate LPs for long-lived cancelled intents.
-- Cover chargebacks for a clear, snapshotted period.
-- Let new onrampers try small non-chargebackable transactions once without staking.
-- Keep LPs responsible for selecting and pricing the risk they accept.
-
-## Non-goals
-
-- Establishing an on-chain reputation or identity system.
-- Preventing wallets from sybilling the configured free intents.
-- Underwriting aggregate platform losses with protocol funds.
-- Protecting LPs from chargebacks after the configured coverage window.
-- Limiting how an LP prices, advertises, or allocates its liquidity.
-- Replacing Escrow's operational bounds used to protect loops and gas usage.
+The model therefore accepts that base-only capacity can be reused without contract state. LPs and admission systems must price or gate that exposure explicitly.
 
 ## Terminology
 
-- **Taker**: The address that signals an intent.
-- **Stake owner**: The address whose stake backs the taker. This may be a Safe or another owner that authorized a relayer to use its stake.
-- **LP**: The depositor whose escrow liquidity is locked by an intent.
-- **Pending intent**: An intent that has been signaled but has not been fulfilled, released, cancelled, or pruned.
-- **Bonded amount**: The intent amount to which stake-based policy applies.
-- **Free intent**: One of a stake owner's configured lifetime non-chargebackable allowances that reserves no stake.
-- **Griefing bond**: The maximum cancellation penalty reserved while an intent is pending.
-- **Chargeback coverage**: Stake reserved after settlement and slashable during the chargeback coverage window.
+- `A`: complete intent amount.
+- `U`: reusable base-unbonded amount configured for the payment method.
+- `B`: bonded amount, `max(A - U, 0)`.
+- `S`: currently free stake for the selected stake owner.
+- `T`: snapshotted maximum intent period.
+- `C`: snapshotted griefing cliff.
+- `s`: griefing penalty slope in basis points per hour.
+- `r`: chargeback reserve ratio in basis points.
 
 ## Platform Configuration
 
-Each payment platform has a risk configuration containing at least:
-
 ```solidity
-/// @notice Controls post-settlement chargeback protection for a payment platform.
 struct ChargebackConfig {
-    bool chargebackable;           // Whether fulfilled payments can be charged back.
-    bool deferredPayoutEnabled;    // Whether proceeds can replace stake as chargeback protection.
-    uint16 reserveBps;             // Portion of the fulfilled amount reserved from stake, in basis points.
-    uint64 riskWindow;             // Time after settlement during which a valid chargeback can slash coverage.
+    bool chargebackable;
+    bool deferredPayoutEnabled;
+    uint16 reserveBps;
+    uint64 riskWindow;
 }
 
-/// @notice Controls pending-intent liquidity-lock penalties and onboarding free intents.
 struct GriefingConfig {
-    uint64 griefingCliff;                 // Cancellation grace period after signaling, in seconds.
-    uint32 griefingPenaltyBpsPerHour;     // Linear penalty slope applied after the cliff.
-    uint32 freeTakeCount;                 // Number of lifetime unbonded intents available to each stake owner.
-    uint256 freeTakeAmount;               // Maximum amount of each unbonded intent.
+    uint64 griefingCliff;
+    uint32 griefingPenaltyBpsPerHour;
+    uint256 baseUnbondedAmount;
 }
 
-/// @notice Combines admission status with the independent chargeback and griefing policies for a platform.
 struct PlatformRiskConfig {
-    bool enabled;                         // Whether the risk manager admits new intents for the platform.
-    ChargebackConfig chargeback;          // Post-settlement chargeback policy.
-    GriefingConfig griefing;              // Pre-settlement cancellation and onboarding policy.
+    bool enabled;
+    ChargebackConfig chargeback;
+    GriefingConfig griefing;
 }
 ```
 
-The exact Solidity types may change during implementation if narrower types improve packing without reducing clarity or safe configuration ranges.
-
-### Configuration rules
+Configuration rules:
 
 - `chargeback.reserveBps` is between `0` and `10_000`.
-- A platform with `chargeback.chargebackable == true` has a nonzero `chargeback.reserveBps` and a nonzero `chargeback.riskWindow`.
-- A platform with `chargeback.chargebackable == false` has `chargeback.reserveBps == 0` and `chargeback.deferredPayoutEnabled == false`.
-- `griefing.griefingCliff` must be shorter than the Escrow intent period used by the position.
-- The griefing penalty derived at the maximum intent period cannot exceed 100% of the intent amount.
-- `griefing.freeTakeCount` and `griefing.freeTakeAmount` must both be zero when `chargeback.chargebackable == true`.
-- A platform must configure both `griefing.freeTakeCount` and `griefing.freeTakeAmount`, or set both to zero.
-- Zero free-take values disable free intents for that platform.
-- A zero `griefing.griefingPenaltyBpsPerHour` disables the griefing bond for that platform.
+- A chargebackable method requires a nonzero reserve ratio, a nonzero bounded risk window, and `griefing.baseUnbondedAmount == 0`.
+- A non-chargebackable method requires `reserveBps == 0` and disables deferred payout.
+- The griefing cliff must be shorter than the Escrow intent period.
+- The maximum griefing rate cannot exceed 100% of the bonded amount.
+- A zero griefing slope disables the griefing curve.
 
-## Snapshotted Position Terms
+## Bonded Amount
 
-The following values are snapshotted when an intent is admitted:
-
-- Stake owner.
-- LP.
-- Payment platform.
-- Intent amount.
-- Creation timestamp.
-- Escrow maximum intent period.
-- Griefing cliff.
-- Griefing penalty slope.
-- Chargeback reserve ratio.
-- Chargeback coverage window.
-- Whether the position consumed a free intent.
-- Maximum griefing bond.
-- Initial reservation.
-
-Governance changes affect only subsequently created positions.
-
-The risk manager currently reads the maximum intent period from the intent's Escrow:
-
-```solidity
-IEscrowV2(intent.escrow).intentExpirationPeriod()
-```
-
-The getter must be declared on the interface. Escrow already exposes it through its public state variable.
-
-The risk manager snapshots the value because Escrow governance can change it. A future protocol version may move the maximum intent period into the risk manager without changing the formulas or position lifecycle defined here.
-
-## Curve One: Time-Based Griefing Bond
-
-### Inputs
-
-For a platform and intent:
+For every admission:
 
 ```text
-A = bonded intent amount
-t = elapsed time since intent creation
-T = snapshotted maximum intent period
-C = griefing.griefingCliff
-s = griefing.griefingPenaltyBpsPerHour
+B = max(A - U, 0)
 ```
 
-### Chargeable time
+Because chargebackable methods require `U = 0`, their bonded amount is the full intent amount.
 
-Elapsed time is capped at the snapshotted maximum intent period. Intent guardian extensions do not increase the taker's maximum liability.
+The position snapshots both `intentAmount` and `bondedAmount`. Later policy changes cannot alter the amount used for cancellation accounting.
+
+## Griefing Curve
+
+The maximum griefing bond is:
 
 ```text
-effectiveElapsed = min(t, T)
+chargeableMaximum = max(T - C, 0)
 
-chargeableTime =
-    0                              when effectiveElapsed <= C
-    effectiveElapsed - C           when effectiveElapsed > C
+Gmax = ceil(
+    B * s * chargeableMaximum
+    / (10_000 * 1 hour)
+)
 ```
 
-### Accrued cancellation penalty
+At cancellation:
 
 ```text
-griefingPenalty(A, t) =
-    ceil(
-        A
-        * s
-        * chargeableTime
-        / (10_000 * 1 hour)
-    )
+effectiveElapsed = min(cancelledAt - createdAt, T)
+chargeableElapsed = max(effectiveElapsed - C, 0)
+
+Gcancel = ceil(
+    B * s * chargeableElapsed
+    / (10_000 * 1 hour)
+)
 ```
 
-The penalty is zero at or before the cliff. Upward rounding makes every cancellation after the cliff liable for at least one smallest token unit.
+Rounding is upward. If `B == 0`, both values are zero at every timestamp.
 
-### Maximum griefing bond
+## Chargeback Curve
 
-The maximum possible penalty is reserved when the intent is admitted:
+For a chargebackable method:
 
 ```text
-maxChargeableTime = T - C
-
-maxGriefingBond(A) =
-    ceil(
-        A
-        * s
-        * maxChargeableTime
-        / (10_000 * 1 hour)
-    )
+Q = ceil(A * r / 10_000)
 ```
 
-The reservation is based on the predefined intent period, not on a separately configured maximum penalty. If an intent guardian extends an intent beyond `T`, the penalty stops accruing at `T`.
-
-For a fixed intent amount, the penalty is linear in time after the cliff. For a fixed elapsed time, it is linear in the intent amount.
-
-## Curve Two: Chargeback Coverage
-
-For a chargebackable platform:
-
-```text
-r = chargeback.reserveBps
-
-chargebackReserve(A) =
-    ceil(A * r / 10_000)
-```
-
-At `chargeback.reserveBps == 10_000`, one unit of stake covers one unit of taking. At a lower reserve ratio, the LP accepts partial coverage:
-
-```text
-reserveBps = 10_000   =>   100% covered
-reserveBps = 5_000    =>    50% covered
-reserveBps = 2_000    =>    20% covered
-```
-
-Chargeback coverage is not a penalty. The stake is returned if no valid chargeback is submitted during the coverage window.
-
-## Capacity Form of the Two Curves
-
-The formulas above calculate required stake from an intent amount. The same curves can be inverted to calculate maximum bonded taking from currently free stake.
-
-For one platform:
-
-```text
-S = free stake
-
-maximumGriefingBondRate =
-    s * (T - C) / (10_000 * 1 hour)
-
-chargebackReserveRate =
-    chargeback.reserveBps / 10_000
-
-griefingCapacity(S) =
-    S / maximumGriefingBondRate
-
-chargebackCapacity(S) =
-    S / chargebackReserveRate
-
-bondedTakingCapacity(S) =
-    min(griefingCapacity(S), chargebackCapacity(S))
-```
-
-A disabled curve does not constrain capacity. Chargeback coverage is disabled on a non-chargebackable platform, and a zero griefing slope disables the griefing curve.
-
-At 100% chargeback coverage, `chargebackCapacity(S) == S`. When that curve dominates, a stake owner with 1,000 USDC of free stake can have at most 1,000 USDC of additional stake-backed taking admitted.
-
-If the stake owner has unused free intents, its total immediate capacity on an eligible non-chargebackable platform is:
-
-```text
-remainingFreeTakes = griefing.freeTakeCount - freeTakesUsed
-freeTakingCapacity = remainingFreeTakes * griefing.freeTakeAmount
-
-up to remainingFreeTakes separate intents,
-each no larger than griefing.freeTakeAmount
-+ bonded intents up to bondedTakingCapacity(S)
-```
-
-Each free allowance is a separate intent rather than a partial tranche, so free amounts cannot be combined with each other or with bonded capacity inside one intent. All remaining free intents may be used concurrently. Across multiple platforms, capacity must be evaluated using the shared portfolio reservation constraint rather than adding each platform's standalone capacity.
+Chargeback coverage is calculated from the complete intent amount. The base-unbonded policy never reduces post-settlement chargeback coverage.
 
 ## Admission Reservation
 
-For a normal stake-backed intent:
+For an ordinary position:
 
 ```text
-requiredReservation(A) =
-    max(
-        maxGriefingBond(A),
-        chargebackReserve(A)
-    )
+requiredReservation = max(Gmax, Q)
 ```
 
-For a non-chargebackable platform, `chargebackReserve(A) == 0`, so the griefing bond controls admission.
+Cancellation and settlement are mutually exclusive outcomes, so the liabilities are not added.
 
-For a chargebackable platform with 100% coverage, chargeback coverage normally dominates the smaller griefing bond.
+For deferred payout, the existing chargeback policy remains unchanged. Because chargebackable methods require `U = 0`, the reusable base does not alter deferred admission or settlement accounting.
 
-The manager admits the intent only when:
+## Modes
+
+- `UNBONDED`: `B == 0`; reserves and slashes no stake.
+- `STAKE_BACKED`: `B > 0` and ordinary stake backs the position.
+- `DEFERRED_PAYOUT`: the configured deferred hook backs settlement while pending stake covers the griefing exposure.
+
+There is no count-based or lifetime-subsidy mode.
+
+## Capacity Math
+
+For a non-chargebackable method with a nonzero griefing rate:
 
 ```text
-requiredReservation(A) <= freeStake(stakeOwner)
+griefingRateNumerator = s * (T - C)
+
+bondedTakingCapacity(S) = floor(
+    S * 10_000 * 1 hour
+    / griefingRateNumerator
+)
+
+maximumIntentAmount(S) = U + bondedTakingCapacity(S)
 ```
 
-The manager reserves the maximum rather than adding both amounts because cancellation and fulfillment are mutually exclusive outcomes.
-
-## Portfolio Constraint
-
-Stake is shared across all platforms and all intents belonging to the same stake owner.
-
-At all times:
+For a chargebackable method, `U = 0` and the existing chargeback capacity also constrains admission:
 
 ```text
-sum(pending intent reservations)
-+ sum(settled chargeback reservations)
-<= eligible stake
+chargebackCapacity(S) = floor(S * 10_000 / r)
+
+maximumIntentAmount(S) = min(
+    griefingCapacity(S),
+    chargebackCapacity(S)
+)
 ```
 
-The taker can use available capacity in one intent or split it across multiple intents. The economic policy does not care about the number of intents.
+A disabled curve does not constrain capacity. If every applicable curve is disabled, capacity is unbounded by `RiskManager`; other protocol and LP limits still apply.
 
-Escrow may retain structural intent-count bounds to protect iteration and gas usage. Those bounds are operational safeguards, not stake tiers or taker risk policy.
-
-## Configurable Free Intents
-
-### Purpose
-
-Free intents let a new onramper try a configured number of small transactions without first acquiring or depositing stake.
-
-### Eligibility
-
-A free intent is available only when all of the following are true:
-
-- The platform is enabled.
-- The platform is non-chargebackable.
-- `griefing.freeTakeCount` and `griefing.freeTakeAmount` are nonzero.
-- The stake owner has consumed fewer than `griefing.freeTakeCount` free intents for that platform.
-- The entire intent amount is less than or equal to `griefing.freeTakeAmount`.
-
-Eligibility is keyed by stake owner and payment platform:
-
-```solidity
-mapping(address stakeOwner => mapping(bytes32 paymentMethod => uint32)) freeTakesUsed;
-```
-
-Using the stake owner prevents multiple authorized relayers for one Safe from receiving separate allowances.
-
-### Consumption
-
-One allowance is consumed when a free intent is successfully signaled:
+Across multiple active positions, admission remains subject to the shared portfolio invariant:
 
 ```text
-freeTakesUsed[stakeOwner][paymentMethod] += 1
+sum(active stake reservations) <= eligible stake
 ```
 
-The consumed allowance is not restored when the intent is cancelled, expires, or fails to fulfill. This prevents repeated cost-free liquidity locking beyond the configured count.
-
-If signaling reverts, all state changes revert and the allowance remains available.
-
-### No partial free tranche
-
-The protocol does not apply the free amount as an unbonded tranche inside a larger intent.
-
-```text
-intent amount <= griefing.freeTakeAmount
-and freeTakesUsed < griefing.freeTakeCount
-    => entire intent is free
-
-otherwise
-    => entire intent follows the bonded policy
-```
-
-A staked taker may use any remaining free intents alongside separate bonded intents, subject to the shared stake constraint.
-
-### Sybil behavior
-
-Free intents are intentionally wallet-sybilable. They are a small onboarding subsidy, not a security boundary. Both the count and amount should remain small, and indexer and client surfaces should identify each intent as unbonded.
+The reusable base itself is not reserved and does not create a portfolio counter. Multiple base-only intents can be open concurrently.
 
 ## Lifecycle
 
-### Free, non-chargebackable intent
+### Base-only non-chargebackable intent
 
+- Snapshots `bondedAmount = 0` and mode `UNBONDED`.
 - Reserves no stake.
-- Consumes one lifetime free allowance at successful signaling.
-- Fulfillment, cancellation, or expiry makes the position terminal.
-- No allowance is restored.
+- Cancellation or expiry charges zero.
+- Settlement creates no chargeback position.
+- A later intent receives the same configured base.
 
-### Bonded, non-chargebackable intent
+### Partially bonded non-chargebackable intent
 
-At admission:
+- Snapshots `bondedAmount = A - U`.
+- Reserves `Gmax` calculated only from that excess.
+- Cancellation slashes the accrued excess-only penalty and releases the remainder.
+- Settlement releases the complete pending reservation.
 
-```text
-reservation = maxGriefingBond(intentAmount)
-```
+### Chargebackable intent
 
-On fulfillment:
+- Requires `U = 0`, so `B = A`.
+- Uses the existing stake-backed or deferred-payout lifecycle.
+- Cancellation charges only accrued griefing exposure.
+- Settlement transitions to the configured chargeback coverage.
 
-- Release the entire griefing reservation.
-- Charge no griefing penalty.
-- Make the position terminal.
+## Position and Event Surface
 
-On cancellation or expiry:
+The hard-cut ABI:
 
-- Calculate the penalty using the snapshotted creation and cancellation timestamps.
-- Slash the accrued penalty to the LP.
-- Release the unused remainder of the reservation.
-- Make the position terminal.
+- replaces risk mode `FREE` with `UNBONDED`;
+- replaces `freeTakeCount` and `freeTakeAmount` with `baseUnbondedAmount`;
+- removes `freeTakesUsed` and the consumption event;
+- removes the consumed-allowance flag from positions;
+- adds snapshotted `bondedAmount` to positions and `RiskPositionCreated`;
+- emits `baseUnbondedAmount` in platform configuration updates.
 
-### Stake-backed, chargebackable intent
-
-At admission:
-
-```text
-reservation = max(maxGriefingBond(intentAmount), chargebackReserve(intentAmount))
-```
-
-On cancellation or expiry:
-
-- Calculate and slash the accrued griefing penalty to the LP.
-- Release the remainder of the reservation.
-- Make the position terminal.
-
-On fulfillment or manual release:
-
-- Charge no griefing penalty.
-- Resize the reservation to the chargeback reserve calculated from the exact released amount.
-- Start the chargeback coverage window at settlement.
-- Retain the reservation until a valid chargeback consumes it or the coverage window matures.
-
-On a valid chargeback:
-
-- Slash up to the remaining covered amount to the LP.
-- Preserve any remaining coverage if the chargeback uses only part of the reservation.
-
-On maturity:
-
-- Release the remaining chargeback reservation.
-- Make the position terminal.
-
-The LP bears chargeback losses above the covered amount and all chargebacks submitted after the coverage deadline.
-
-### Deferred-payout chargebackable intent
-
-Deferred payout remains an alternative when stake can cover the griefing bond but cannot cover the chargeback reservation.
-
-At admission:
-
-```text
-freeStake >= maxGriefingBond(intentAmount)
-freeStake < max(maxGriefingBond(intentAmount), chargebackReserve(intentAmount))
-deferred payout is enabled and the required post-intent hook is selected
-```
-
-The manager reserves only the maximum griefing bond while the intent is pending.
-
-On cancellation or expiry:
-
-- Slash the accrued griefing penalty to the LP.
-- Release the unused griefing reservation.
-
-On fulfillment:
-
-- Release the griefing reservation without penalty.
-- Hold the payout through the deferred-payout mechanism for the chargeback coverage window.
-
-Free intents do not apply to chargebackable deferred-payout intents.
-
-## Cancellation Semantics and Callback Failure
-
-Every cancellation after the cliff is liable, including taker cancellation and expiry cleanup. A cancellation reason is therefore unnecessary for determining liability.
-
-The penalty must use the time when liquidity stopped being locked, not the time of a later reconciliation transaction.
-
-Orchestrator V3 currently treats terminal risk callbacks as best-effort so a broken hook cannot block cancellation or escrow cleanup. Financial enforcement must preserve that liveness while preventing callback failure from avoiding a penalty:
-
-1. Record the cancellation timestamp when the terminal callback fails.
-2. Keep the maximum griefing bond reserved.
-3. Allow anyone to reconcile the failed cancellation.
-4. Calculate the penalty using the recorded cancellation timestamp.
-5. Slash the penalty and release the unused reservation.
-
-The implementation must not calculate a larger penalty from the later reconciliation timestamp.
-
-## LP Risk Model
-
-The LP opts into the risk hook for its deposit. The protocol provides enforcement and accounting but does not underwrite the LP's aggregate risk.
-
-The protocol helps the LP by:
-
-- Reserving taker stake.
-- Penalizing long-lived cancelled intents.
-- Compensating valid chargebacks during the coverage window.
-- Supporting deferred payout when configured.
-- Emitting the data required to measure current and historical exposure.
-
-The LP remains responsible for:
-
-- Deciding whether to use the risk hook.
-- Accepting the configured reserve ratio and coverage window.
-- Measuring its own outstanding exposure.
-- Pricing partial coverage and post-coverage chargeback tail risk.
-- Managing its deposit liquidity.
-
-There is no protocol-wide maximum exposure. One LP's activity must not prevent another LP from accepting otherwise valid intents.
-
-## Events and Indexer Requirements
-
-Events should remain simple and describe economic state changes. The final event shapes should allow the indexer to derive at least:
-
-- The snapshotted platform policy for each position.
-- Maximum griefing bond reserved.
-- Accrued griefing penalty charged.
-- Reservation released after cancellation or fulfillment.
-- Chargeback coverage amount and expiry.
-- Chargeback amount requested, amount compensated, and remaining coverage.
-- Whether an intent consumed a free allowance.
-- Free allowances used and remaining for each stake owner and platform.
-- LP exposure grouped by platform and coverage-expiry bucket.
-- Protected, uncovered, matured, and deferred-payout exposure.
-
-Suggested semantic events include:
-
-```solidity
-event FreeTakeConsumed(
-    bytes32 indexed intentHash,
-    address indexed stakeOwner,
-    bytes32 indexed paymentMethod,
-    uint256 amount,
-    uint32 freeTakesUsed,
-    uint32 freeTakeCount
-);
-
-event GriefingPenaltyCharged(
-    bytes32 indexed intentHash,
-    address indexed stakeOwner,
-    address indexed lp,
-    uint256 penalty,
-    uint256 elapsedTime
-);
-```
-
-Existing reservation, settlement, chargeback, and maturity events should be reused or adjusted rather than duplicated where they already convey the required transition clearly.
+Indexers must derive unbonded versus bonded exposure from the position mode and `bondedAmount`. They must not reconstruct removed usage counters.
 
 ## Core Invariants
 
-1. Free intents are available only on a non-chargebackable platform.
-2. A stake owner cannot consume more than the platform's configured free-take count.
-3. A free intent reserves and slashes no stake.
-4. A bonded pending intent reserves exactly the larger of its maximum griefing bond and chargeback reserve.
-5. A cancellation can slash no more than the maximum griefing bond reserved for that intent.
-6. A guardian extension cannot increase the griefing penalty beyond the snapshotted maximum intent period.
+1. Chargebackable methods configure a zero base-unbonded amount.
+2. `bondedAmount == max(intentAmount - baseUnbondedAmount, 0)` at admission.
+3. An unbonded position reserves and slashes zero stake.
+4. A pending ordinary position reserves exactly `max(Gmax, Q)`.
+5. Cancellation penalty never exceeds the snapshotted maximum griefing bond.
+6. Cancellation uses the snapshotted bonded amount and maximum intent period.
 7. Fulfillment never charges a griefing penalty.
-8. A chargeback can slash no more than the remaining position coverage.
-9. Position policy changes cannot apply retroactively.
-10. All reservations across all platforms share the same stake owner's free-stake balance.
-11. Failed terminal callbacks cannot create an unreserved liability or allow a reserved liability to be silently released.
-12. The LP, not the protocol, bears uncovered and post-coverage chargeback risk.
+8. A chargeback never consumes more than the remaining position coverage.
+9. Governance changes affect only future positions.
+10. All stake-backed positions share the same stake-owner portfolio balance.
 
-## Illustrative Configurations
-
-These values demonstrate the formulas and are not final launch recommendations.
-
-### Non-chargebackable platform
+## Illustrative Non-Chargebackable Policy
 
 ```text
 chargeback:
@@ -536,22 +232,21 @@ chargeback:
 griefing:
   griefingCliff:                 15 minutes
   griefingPenaltyBpsPerHour:     10
-  freeTakeCount:                 3
-  freeTakeAmount:                20 USDC
+  baseUnbondedAmount:            500 USDC
 Escrow maximum intent period:    6 hours
 ```
 
-For a bonded 1,000 USDC intent:
+Examples:
 
 ```text
-maximum chargeable time = 5.75 hours
-maximum griefing rate   = 57.5 bps
-maximum griefing bond   = 5.75 USDC
+A = 500 USDC  => B =   0 USDC => Gmax = 0
+A = 700 USDC  => B = 200 USDC => Gmax = 1.15 USDC
+A = 1,000 USDC => B = 500 USDC => Gmax = 2.875 USDC
 ```
 
-A stake owner with no stake can signal up to three lifetime free intents of no more than 20 USDC each. The allowances may be used concurrently. All subsequent intents require a griefing bond.
+The 500 USDC base is reusable for every admitted intent. It is not a one-time allowance and is not Sybil resistance.
 
-### Chargebackable platform
+## Illustrative Chargebackable Policy
 
 ```text
 chargeback:
@@ -562,42 +257,19 @@ chargeback:
 griefing:
   griefingCliff:                 15 minutes
   griefingPenaltyBpsPerHour:     10
-  freeTakeCount:                 0
-  freeTakeAmount:                0
+  baseUnbondedAmount:            0
 Escrow maximum intent period:    6 hours
 ```
 
-For a 1,000 USDC intent:
+For a 1,000 USDC intent, the maximum griefing bond is 5.75 USDC and ordinary chargeback coverage is 1,000 USDC, so ordinary admission reserves 1,000 USDC.
 
-```text
-maximum griefing bond = 5.75 USDC
-chargeback reserve    = 1,000 USDC
-admission reservation = max(5.75, 1,000) = 1,000 USDC
-```
+## Rollout
 
-If the taker cancels two hours after creation, the chargeable time is 1.75 hours and the griefing penalty is 1.75 USDC. The LP receives 1.75 USDC and the remaining 998.25 USDC is released.
+This ABI is a hard cut. A release requires:
 
-If the intent fulfills, no griefing penalty is charged. The exact released amount remains reserved for the 30-day chargeback window.
+1. A fresh `RiskManager` deployment and explicit platform configuration.
+2. A contracts package release containing the new ABI and risk math.
+3. Indexer migration to the new config and position event shapes.
+4. Curator and client migration from usage-based capacity to `base + bonded capacity`.
 
-## Explicitly Removed Tier Behavior
-
-The implementation should remove contract-level dependencies on:
-
-- Named taker tiers.
-- Tier stake thresholds.
-- Tier-specific amount caps.
-- Tier-specific concurrency limits.
-- Tier-derived fee discounts.
-- Tier-derived cooldowns.
-
-Clients may derive product labels from continuous stake or capacity values, but those labels have no protocol authority.
-
-## Review Decisions Required Before Implementation
-
-The following values must be selected for each launch platform before deployment, but do not change the model:
-
-- `griefing.freeTakeCount` and `griefing.freeTakeAmount` for each eligible non-chargebackable platform.
-- `griefing.griefingCliff`.
-- `griefing.griefingPenaltyBpsPerHour`.
-- `chargeback.reserveBps` for each chargebackable platform.
-- `chargeback.riskWindow` for each chargebackable platform.
+Historical deployment artifacts remain immutable. No legacy fields, aliases, or dual event decoding are added to the active contract.

--- a/contracts/RiskManager.sol
+++ b/contracts/RiskManager.sol
@@ -25,12 +25,14 @@ import { IStakeVault } from "./interfaces/IStakeVault.sol";
  *      which may owe the LP a griefing penalty, or settlement, which may create chargeback exposure.
  *      Admission therefore reserves the maximum of those liabilities instead of their sum:
  *
- *        maxGriefingBond = ceil(A * s * (T - C) / (10_000 * 1 hour))
+ *        B = max(A - U, 0)
+ *        maxGriefingBond = ceil(B * s * (T - C) / (10_000 * 1 hour))
  *        chargebackReserve = ceil(A * r / 10_000)
  *        initialReservation = max(maxGriefingBond, chargebackReserve)
  *
- *      where A is intent amount, s is penalty basis points per hour, T is the Escrow's snapshotted
- *      maximum intent period, C is the griefing cliff, and r is the chargeback reserve ratio.
+ *      where A is intent amount, U is the platform's reusable unbonded base, B is the bonded amount,
+ *      s is penalty basis points per hour, T is the Escrow's snapshotted maximum intent period, C is
+ *      the griefing cliff, and r is the chargeback reserve ratio. Chargebackable platforms require U=0.
  *
  * @dev CANCELLATION CURVE
  *      At cancellation, elapsed time is capped at T so an intent-guardian extension cannot increase
@@ -38,14 +40,14 @@ import { IStakeVault } from "./interfaces/IStakeVault.sol";
  *
  *        effectiveElapsed = min(cancelledAt - createdAt, T)
  *        chargeableTime = max(effectiveElapsed - C, 0)
- *        penalty = ceil(A * s * chargeableTime / (10_000 * 1 hour))
+ *        penalty = ceil(B * s * chargeableTime / (10_000 * 1 hour))
  *
  *      Rounding is always upward. Every cancellation strictly after the cliff therefore pays at
  *      least one smallest token unit whenever the slope and amount are nonzero.
  *
  * @dev LIFECYCLE
- *      - Eligible free intents consume one lifetime allowance, reserve no stake, and are never slashed.
- *      - Bonded pending intents reserve stake once using the maximum formula above.
+ *      - Non-chargebackable intents receive the reusable unbonded base on every admission.
+ *      - Only the amount above that base enters the griefing curve and reserves stake.
  *      - Cancellation slashes only the accrued griefing penalty and releases every unused unit.
  *      - Non-chargebackable settlement releases the full pending reservation immediately.
  *      - Chargebackable settlement resizes stake coverage to the exact released amount and starts the
@@ -59,8 +61,8 @@ import { IStakeVault } from "./interfaces/IStakeVault.sol";
  *         existing liabilities.
  *      2. All positions for one stake owner share StakeVault.freeStake, so reservations compose across
  *         takers and platforms without a protocol-wide exposure gate.
- *      3. Free allowances are keyed by stake owner and platform, consumed before admission completes,
- *         and never restored after a terminal outcome. Transaction reverts restore the increment.
+ *      3. The base unbonded amount is stateless contract policy. Sybil-resistant account gating is a
+ *         separate admission concern and is not approximated with wallet-local usage state.
  *      4. Terminal callbacks are intentionally fail-open in OrchestratorV3 for liquidity liveness.
  *         Failed cancellations retain the full reservation and use the orchestrator-recorded unlock
  *         timestamp during permissionless reconciliation, preventing delay-based overcharging and
@@ -69,7 +71,7 @@ import { IStakeVault } from "./interfaces/IStakeVault.sol";
  *         claims after maturity remain the LP's risk by design.
  *      6. This contract never holds tokens. StakeVault is the sole accounting and custody boundary.
  *      7. Escrow intent amounts and StakeVault liabilities must use the same immutable token, otherwise
- *         raw units, griefing penalties, free limits, and chargeback ratios would have no shared meaning.
+ *         raw units, griefing penalties, base limits, and chargeback ratios would have no shared meaning.
  *      8. Deferred proceeds must cover the complete configured reserve after fees. A shortfall fails
  *         settlement rather than silently advertising less protection than governance configured.
  */
@@ -122,9 +124,6 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
     /// @dev Complete per-intent policy snapshot and lifecycle accounting.
     mapping(bytes32 => RiskPosition) internal riskPositions;
 
-    /// @inheritdoc IRiskManager
-    mapping(address => mapping(bytes32 => uint32)) public override freeTakesUsed;
-
     /// @notice Global replay protection for chargeback attestations accepted by this manager.
     mapping(uint256 => bool) public usedAttestationNonces;
 
@@ -172,8 +171,8 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
     /**
      * @inheritdoc IIntentRiskHook
      * @dev Admission is fail-closed. This function resolves delegation, validates the current platform
-     *      against the intent's Escrow period, snapshots every liability input, consumes a whole free
-     *      allowance when eligible, and reserves shared portfolio stake before returning.
+     *      against the intent's Escrow period, snapshots every liability input, applies the configured
+     *      base tranche, and reserves shared portfolio stake before returning.
      */
     function onIntentCreated(bytes32 _intentHash)
         external
@@ -197,26 +196,16 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         IEscrowV2.Deposit memory deposit = IEscrowV2(intent.escrow).getDeposit(intent.depositId);
         _validateIntentToken(deposit.token);
         address stakeOwner = stakeVault.stakeOwnerOf(intent.owner);
+        uint256 bondedAmount = _calculateBondedAmount(intent.amount, config.griefing.baseUnbondedAmount);
 
         (uint256 maxGriefingBond, uint256 chargebackReserve, uint256 requiredReservation) =
             _calculateRequiredReservation(intent.amount, maxIntentPeriod, config);
 
-        bool consumedFreeTake = _isFreeTakeEligible(stakeOwner, intent, config);
         RiskMode mode;
         uint256 initialReservation;
 
-        if (consumedFreeTake) {
-            mode = RiskMode.FREE;
-            uint32 used = freeTakesUsed[stakeOwner][intent.paymentMethod] + 1;
-            freeTakesUsed[stakeOwner][intent.paymentMethod] = used;
-            emit FreeTakeConsumed(
-                _intentHash,
-                stakeOwner,
-                intent.paymentMethod,
-                intent.amount,
-                used,
-                config.griefing.freeTakeCount
-            );
+        if (bondedAmount == 0) {
+            mode = RiskMode.UNBONDED;
         } else {
             uint256 available = stakeVault.freeStake(stakeOwner);
             if (available >= requiredReservation) {
@@ -257,7 +246,6 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         position.paymentMethod = intent.paymentMethod;
         position.mode = mode;
         position.status = PositionStatus.PENDING;
-        position.consumedFreeTake = consumedFreeTake;
         position.deferredPayoutHook = mode == RiskMode.DEFERRED_PAYOUT ? deferredPayoutHook : address(0);
         position.payoutRecipient = intent.to;
         position.chargebackReserveBps = config.chargeback.reserveBps;
@@ -267,6 +255,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         position.maxIntentPeriod = maxIntentPeriod;
         position.griefingCliff = config.griefing.griefingCliff;
         position.intentAmount = intent.amount;
+        position.bondedAmount = bondedAmount;
         position.maxGriefingBond = maxGriefingBond;
         position.initialReservation = initialReservation;
         position.reservedAmount = initialReservation;
@@ -295,6 +284,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             _position.paymentMethod,
             _position.mode,
             _position.intentAmount,
+            _position.bondedAmount,
             _position.createdAt,
             _position.maxIntentPeriod,
             _position.griefingCliff,
@@ -552,8 +542,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             _config.chargeback.riskWindow,
             _config.griefing.griefingCliff,
             _config.griefing.griefingPenaltyBpsPerHour,
-            _config.griefing.freeTakeCount,
-            _config.griefing.freeTakeAmount
+            _config.griefing.baseUnbondedAmount
         );
     }
 
@@ -631,16 +620,26 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
     /**
      * @inheritdoc IRiskManager
+     */
+    function calculateBondedAmount(
+        uint256 _amount,
+        uint256 _baseUnbondedAmount
+    ) external pure override returns (uint256) {
+        return _calculateBondedAmount(_amount, _baseUnbondedAmount);
+    }
+
+    /**
+     * @inheritdoc IRiskManager
      * @dev Uses full-precision multiplication and upward rounding. Invalid `cliff >= period` inputs
      *      return zero here; platform admission separately rejects such a configuration.
      */
     function calculateMaxGriefingBond(
-        uint256 _amount,
+        uint256 _intentAmount,
         uint64 _maxIntentPeriod,
         GriefingConfig calldata _config
     ) external pure override returns (uint256) {
         return _calculateMaxGriefingBond(
-            _amount,
+            _calculateBondedAmount(_intentAmount, _config.baseUnbondedAmount),
             _maxIntentPeriod,
             _config.griefingCliff,
             _config.griefingPenaltyBpsPerHour
@@ -652,7 +651,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
      * @dev `effectiveElapsed` is elapsed wall time capped by the snapshotted maximum intent period.
      */
     function calculateGriefingPenalty(
-        uint256 _amount,
+        uint256 _bondedAmount,
         uint64 _createdAt,
         uint64 _cancelledAt,
         uint64 _maxIntentPeriod,
@@ -660,7 +659,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         uint32 _griefingPenaltyBpsPerHour
     ) external pure override returns (uint256 penalty, uint256 effectiveElapsed) {
         return _calculateGriefingPenalty(
-            _amount,
+            _bondedAmount,
             _createdAt,
             _cancelledAt,
             _maxIntentPeriod,
@@ -683,7 +682,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
      * @inheritdoc IRiskManager
      */
     function calculateRequiredReservation(
-        uint256 _amount,
+        uint256 _intentAmount,
         uint64 _maxIntentPeriod,
         PlatformRiskConfig calldata _config
     ) external pure override returns (
@@ -691,7 +690,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         uint256 chargebackReserve,
         uint256 requiredReservation
     ) {
-        return _calculateRequiredReservation(_amount, _maxIntentPeriod, _config);
+        return _calculateRequiredReservation(_intentAmount, _maxIntentPeriod, _config);
     }
 
     /**
@@ -718,16 +717,14 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
         uint256 penalty;
         uint256 effectiveElapsed;
-        if (position.mode != RiskMode.FREE) {
-            (penalty, effectiveElapsed) = _calculateGriefingPenalty(
-                position.intentAmount,
-                position.createdAt,
-                _cancelledAt,
-                position.maxIntentPeriod,
-                position.griefingCliff,
-                position.griefingPenaltyBpsPerHour
-            );
-        }
+        (penalty, effectiveElapsed) = _calculateGriefingPenalty(
+            position.bondedAmount,
+            position.createdAt,
+            _cancelledAt,
+            position.maxIntentPeriod,
+            position.griefingCliff,
+            position.griefingPenaltyBpsPerHour
+        );
         uint256 releasedReservation = position.reservedAmount - penalty;
 
         position.status = PositionStatus.CANCELLED;
@@ -845,10 +842,6 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         if (_paymentMethod == bytes32(0)) revert InvalidPlatformConfig(_paymentMethod);
         if (_config.chargeback.reserveBps > BPS_DENOMINATOR) revert InvalidPlatformConfig(_paymentMethod);
 
-        bool hasFreeCount = _config.griefing.freeTakeCount != 0;
-        bool hasFreeAmount = _config.griefing.freeTakeAmount != 0;
-        if (hasFreeCount != hasFreeAmount) revert InvalidPlatformConfig(_paymentMethod);
-
         if (_config.chargeback.chargebackable) {
             if (
                 _config.chargeback.reserveBps == 0
@@ -857,8 +850,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             ) {
                 revert InvalidPlatformConfig(_paymentMethod);
             }
-            // The equality check above guarantees both free-take fields are either set or unset.
-            if (hasFreeCount) revert InvalidPlatformConfig(_paymentMethod);
+            if (_config.griefing.baseUnbondedAmount != 0) revert InvalidPlatformConfig(_paymentMethod);
         } else if (_config.chargeback.reserveBps != 0 || _config.chargeback.deferredPayoutEnabled) {
             revert InvalidPlatformConfig(_paymentMethod);
         }
@@ -866,7 +858,8 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
     /**
      * @dev Enforces cliff and maximum-liability constraints against the exact Escrow period that will
-     *      be snapshotted. The rate check is amount-independent because both sides scale linearly in A.
+     *      be snapshotted. The rate check is amount-independent because the bonded amount never exceeds
+     *      the complete intent amount.
      */
     function _validatePositionPolicy(
         bytes32 _paymentMethod,
@@ -889,19 +882,6 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         if (address(_intentToken) != expectedToken) {
             revert IntentTokenMismatch(expectedToken, address(_intentToken));
         }
-    }
-
-    /** @dev Returns true only for a whole, non-chargebackable intent within an unused lifetime allowance. */
-    function _isFreeTakeEligible(
-        address _stakeOwner,
-        IOrchestratorV3.RiskIntentData memory _intent,
-        PlatformRiskConfig memory _config
-    ) internal view returns (bool) {
-        return !_config.chargeback.chargebackable
-            && _config.griefing.freeTakeCount != 0
-            && _config.griefing.freeTakeAmount != 0
-            && freeTakesUsed[_stakeOwner][_intent.paymentMethod] < _config.griefing.freeTakeCount
-            && _intent.amount <= _config.griefing.freeTakeAmount;
     }
 
     /** @dev Binds attestation scope, replay protection, validity, and the half-open coverage window. */
@@ -929,9 +909,17 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
     /* ============ Internal Formula Helpers ============ */
 
-    /** @dev Implements ceil(A * s * (T - C) / (10_000 * 1 hour)) without intermediate overflow. */
-    function _calculateMaxGriefingBond(
+    /** @dev Returns the reusable base-subtracted amount exposed to the griefing curve. */
+    function _calculateBondedAmount(
         uint256 _amount,
+        uint256 _baseUnbondedAmount
+    ) internal pure returns (uint256) {
+        return _amount > _baseUnbondedAmount ? _amount - _baseUnbondedAmount : 0;
+    }
+
+    /** @dev Implements ceil(B * s * (T - C) / (10_000 * 1 hour)) without intermediate overflow. */
+    function _calculateMaxGriefingBond(
+        uint256 _bondedAmount,
         uint64 _maxIntentPeriod,
         uint64 _griefingCliff,
         uint32 _griefingPenaltyBpsPerHour
@@ -939,12 +927,12 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         if (_griefingPenaltyBpsPerHour == 0 || _maxIntentPeriod <= _griefingCliff) return 0;
         uint256 rateNumerator =
             uint256(_griefingPenaltyBpsPerHour) * (_maxIntentPeriod - _griefingCliff);
-        return Math.mulDiv(_amount, rateNumerator, GRIEFING_DENOMINATOR, Math.Rounding.Up);
+        return Math.mulDiv(_bondedAmount, rateNumerator, GRIEFING_DENOMINATOR, Math.Rounding.Up);
     }
 
     /** @dev Implements the capped time-linear cancellation formula with exact upward rounding. */
     function _calculateGriefingPenalty(
-        uint256 _amount,
+        uint256 _bondedAmount,
         uint64 _createdAt,
         uint64 _cancelledAt,
         uint64 _maxIntentPeriod,
@@ -958,7 +946,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         }
         uint256 chargeableTime = effectiveElapsed - _griefingCliff;
         uint256 rateNumerator = uint256(_griefingPenaltyBpsPerHour) * chargeableTime;
-        penalty = Math.mulDiv(_amount, rateNumerator, GRIEFING_DENOMINATOR, Math.Rounding.Up);
+        penalty = Math.mulDiv(_bondedAmount, rateNumerator, GRIEFING_DENOMINATOR, Math.Rounding.Up);
     }
 
     /** @dev Implements ceil(A * r / 10_000) with full-precision multiplication. */
@@ -969,7 +957,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
     /** @dev Computes both mutually exclusive liabilities and reserves their maximum. */
     function _calculateRequiredReservation(
-        uint256 _amount,
+        uint256 _intentAmount,
         uint64 _maxIntentPeriod,
         PlatformRiskConfig memory _config
     ) internal pure returns (
@@ -978,12 +966,12 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         uint256 requiredReservation
     ) {
         maxGriefingBond = _calculateMaxGriefingBond(
-            _amount,
+            _calculateBondedAmount(_intentAmount, _config.griefing.baseUnbondedAmount),
             _maxIntentPeriod,
             _config.griefing.griefingCliff,
             _config.griefing.griefingPenaltyBpsPerHour
         );
-        chargebackReserve = _calculateChargebackReserve(_amount, _config.chargeback.reserveBps);
+        chargebackReserve = _calculateChargebackReserve(_intentAmount, _config.chargeback.reserveBps);
         requiredReservation = _max(maxGriefingBond, chargebackReserve);
     }
 

--- a/contracts/interfaces/IRiskManager.sol
+++ b/contracts/interfaces/IRiskManager.sol
@@ -17,7 +17,7 @@ interface IRiskManager is IIntentRiskHook {
     /** @notice Economic source backing a position. */
     enum RiskMode {
         NONE,
-        FREE,
+        UNBONDED,
         STAKE_BACKED,
         DEFERRED_PAYOUT
     }
@@ -46,16 +46,14 @@ interface IRiskManager is IIntentRiskHook {
         uint64 riskWindow;
     }
 
-    /// @notice Controls pending-intent liquidity-lock penalties and onboarding free intents.
+    /// @notice Controls pending-intent liquidity-lock penalties and the reusable unbonded base tranche.
     struct GriefingConfig {
         /// @notice Cancellation grace period after signaling during which the accrued penalty is zero.
         uint64 griefingCliff;
         /// @notice Time-linear penalty slope applied after the cliff, in basis points per hour.
         uint32 griefingPenaltyBpsPerHour;
-        /// @notice Lifetime number of whole unbonded intents available to each stake owner on this platform.
-        uint32 freeTakeCount;
-        /// @notice Maximum amount of each whole free intent; no portion is applied to a larger intent.
-        uint256 freeTakeAmount;
+        /// @notice Reusable per-intent amount excluded from the griefing bond on non-chargebackable platforms.
+        uint256 baseUnbondedAmount;
     }
 
     /// @notice Combines admission status with the independent chargeback and griefing policies for a platform.
@@ -64,7 +62,7 @@ interface IRiskManager is IIntentRiskHook {
         bool enabled;
         /// @notice Post-settlement reversal policy, independent of pending-intent griefing exposure.
         ChargebackConfig chargeback;
-        /// @notice Pending cancellation and lifetime onboarding-subsidy policy.
+        /// @notice Pending cancellation and reusable base-unbonded policy.
         GriefingConfig griefing;
     }
 
@@ -76,7 +74,7 @@ interface IRiskManager is IIntentRiskHook {
     struct RiskPosition {
         /// @notice Intent owner whose action created the position.
         address taker;
-        /// @notice Portfolio owner whose shared stake or free allowance backs the position.
+        /// @notice Portfolio owner whose shared stake backs any amount above the unbonded base.
         address stakeOwner;
         /// @notice Escrow depositor compensated by griefing penalties and valid chargebacks.
         address lp;
@@ -86,8 +84,6 @@ interface IRiskManager is IIntentRiskHook {
         RiskMode mode;
         /// @notice Current lifecycle state; terminal transitions never return to pending.
         PositionStatus status;
-        /// @notice Whether admission permanently consumed one lifetime free allowance.
-        bool consumedFreeTake;
         /// @notice Canonical deferred hook snapshotted only for a deferred-payout position.
         address deferredPayoutHook;
         /// @notice Original intent recipient entitled to unslashed deferred proceeds.
@@ -112,6 +108,8 @@ interface IRiskManager is IIntentRiskHook {
         uint64 coverageDeadline;
         /// @notice Original locked amount on which maximum pending liabilities were calculated.
         uint256 intentAmount;
+        /// @notice Portion of the intent amount exposed to the griefing curve after subtracting the base tranche.
+        uint256 bondedAmount;
         /// @notice Maximum time-capped griefing penalty at admission.
         uint256 maxGriefingBond;
         /// @notice Stake reserved at admission before terminal resizing or release.
@@ -161,8 +159,7 @@ interface IRiskManager is IIntentRiskHook {
         uint64 riskWindow,
         uint64 griefingCliff,
         uint32 griefingPenaltyBpsPerHour,
-        uint32 freeTakeCount,
-        uint256 freeTakeAmount
+        uint256 baseUnbondedAmount
     );
     event RiskPositionCreated(
         bytes32 indexed intentHash,
@@ -172,6 +169,7 @@ interface IRiskManager is IIntentRiskHook {
         bytes32 paymentMethod,
         RiskMode mode,
         uint256 intentAmount,
+        uint256 bondedAmount,
         uint64 createdAt,
         uint64 maxIntentPeriod,
         uint64 griefingCliff,
@@ -181,14 +179,6 @@ interface IRiskManager is IIntentRiskHook {
         uint256 maxGriefingBond,
         uint256 chargebackReserve,
         uint256 initialReservation
-    );
-    event FreeTakeConsumed(
-        bytes32 indexed intentHash,
-        address indexed stakeOwner,
-        bytes32 indexed paymentMethod,
-        uint256 amount,
-        uint32 freeTakesUsed,
-        uint32 freeTakeCount
     );
     event GriefingPenaltyCharged(
         bytes32 indexed intentHash,
@@ -322,22 +312,22 @@ interface IRiskManager is IIntentRiskHook {
     function getPlatformRiskConfig(bytes32 _paymentMethod) external view returns (PlatformRiskConfig memory);
     /** @notice Returns the complete immutable snapshot and mutable lifecycle accounting for an intent. */
     function getRiskPosition(bytes32 _intentHash) external view returns (RiskPosition memory);
-    /** @notice Returns lifetime free intents consumed by one stake owner on one platform. */
-    function freeTakesUsed(address _stakeOwner, bytes32 _paymentMethod) external view returns (uint32);
     /** @notice Returns the delegated portfolio owner and current aggregate stake capacity for a taker. */
     function getTakerState(address _taker)
         external
         view
         returns (address stakeOwner, uint256 totalStake, uint256 reserved, uint256 free, bool exiting);
-    /** @notice Returns ceil(amount * slope * (period - cliff) / (10_000 * 1 hour)). */
+    /** @notice Returns max(intent amount - base unbonded amount, 0). */
+    function calculateBondedAmount(uint256 _amount, uint256 _baseUnbondedAmount) external pure returns (uint256);
+    /** @notice Returns ceil(bonded amount * slope * (period - cliff) / (10_000 * 1 hour)). */
     function calculateMaxGriefingBond(
-        uint256 _amount,
+        uint256 _intentAmount,
         uint64 _maxIntentPeriod,
         GriefingConfig calldata _config
     ) external pure returns (uint256);
-    /** @notice Returns the time-capped, upward-rounded penalty and effective elapsed time at cancellation. */
+    /** @notice Returns the time-capped penalty for a bonded amount and effective elapsed time at cancellation. */
     function calculateGriefingPenalty(
-        uint256 _amount,
+        uint256 _bondedAmount,
         uint64 _createdAt,
         uint64 _cancelledAt,
         uint64 _maxIntentPeriod,
@@ -348,7 +338,7 @@ interface IRiskManager is IIntentRiskHook {
     function calculateChargebackReserve(uint256 _amount, uint16 _reserveBps) external pure returns (uint256);
     /** @notice Returns both mutually exclusive liabilities and their maximum admission reservation. */
     function calculateRequiredReservation(
-        uint256 _amount,
+        uint256 _intentAmount,
         uint64 _maxIntentPeriod,
         PlatformRiskConfig calldata _config
     ) external pure returns (uint256 maxGriefingBond, uint256 chargebackReserve, uint256 requiredReservation);

--- a/deployments/parameters.ts
+++ b/deployments/parameters.ts
@@ -148,8 +148,7 @@ const INITIAL_STAKE_RISK_PLATFORM_POLICY = {
     griefing: {
       griefingCliff: 15 * 60,
       griefingPenaltyBpsPerHour: 10,
-      freeTakeCount: 0,
-      freeTakeAmount: 0,
+      baseUnbondedAmount: 0,
     },
   },
   nonChargebackable: {
@@ -163,8 +162,7 @@ const INITIAL_STAKE_RISK_PLATFORM_POLICY = {
     griefing: {
       griefingCliff: 15 * 60,
       griefingPenaltyBpsPerHour: 10,
-      freeTakeCount: 3,
-      freeTakeAmount: usdc(20),
+      baseUnbondedAmount: usdc(500),
     },
   },
 };

--- a/packages/contracts/test/riskMath.spec.ts
+++ b/packages/contracts/test/riskMath.spec.ts
@@ -1,10 +1,11 @@
 import {
   calculateBondedTakingCapacity,
+  calculateBondedAmount,
   calculateChargebackReserve,
-  calculateFreeTakeCapacity,
   calculateGriefingPenalty,
   calculateMaxGriefingBond,
   calculateRequiredReservation,
+  calculateTotalTakingCapacity,
 } from "../utils/riskMath";
 
 const HOUR = 3_600n;
@@ -15,6 +16,12 @@ const terms = {
 };
 
 describe("riskMath", () => {
+  it("subtracts the reusable base without underflow", () => {
+    expect(calculateBondedAmount(700_000_000n, 500_000_000n)).toBe(200_000_000n);
+    expect(calculateBondedAmount(500_000_000n, 500_000_000n)).toBe(0n);
+    expect(calculateBondedAmount(400_000_000n, 500_000_000n)).toBe(0n);
+  });
+
   it("rounds the maximum griefing bond upward", () => {
     expect(calculateMaxGriefingBond(1_000_000_001n, terms)).toBe(5_750_001n);
   });
@@ -32,7 +39,7 @@ describe("riskMath", () => {
   });
 
   it("takes the maximum of griefing and chargeback requirements", () => {
-    expect(calculateRequiredReservation(1_000_000_000n, terms, 10_000)).toBe(1_000_000_000n);
+    expect(calculateRequiredReservation(1_000_000_000n, terms, 10_000, 0)).toBe(1_000_000_000n);
   });
 
   it("charges nothing at the griefing cliff", () => {
@@ -77,15 +84,9 @@ describe("riskMath", () => {
     });
   });
 
-  it("computes remaining free intents without underflow", () => {
-    expect(calculateFreeTakeCapacity(3, 1, 20_000_000)).toEqual({
-      remainingFreeTakes: 2n,
-      freeTakingCapacity: 40_000_000n,
-    });
-    expect(calculateFreeTakeCapacity(3, 5, 20_000_000)).toEqual({
-      remainingFreeTakes: 0n,
-      freeTakingCapacity: 0n,
-    });
+  it("adds the reusable base to finite bonded capacity", () => {
+    expect(calculateTotalTakingCapacity(200_000_000n, 500_000_000n)).toBe(700_000_000n);
+    expect(calculateTotalTakingCapacity(null, 500_000_000n)).toBeNull();
   });
 
   it("rejects unsafe number inputs", () => {

--- a/test-foundry/fuzz/RiskManagerMathFuzz.t.sol
+++ b/test-foundry/fuzz/RiskManagerMathFuzz.t.sol
@@ -24,6 +24,7 @@ contract RiskManagerMathFuzzTest is Test {
 
     function testFuzz_GriefingPenaltyNeverExceedsMaximumBond(
         uint96 rawAmount,
+        uint96 rawBaseUnbondedAmount,
         uint32 rawMaxPeriod,
         uint32 rawCliff,
         uint16 rawSlope,
@@ -37,6 +38,8 @@ contract RiskManagerMathFuzzTest is Test {
         uint64 elapsed = uint64(bound(uint256(rawElapsed), 0, 2 * uint256(maxPeriod)));
         uint64 createdAt = 1_000_000;
         uint64 cancelledAt = createdAt + elapsed;
+        uint256 baseUnbondedAmount = uint256(rawBaseUnbondedAmount);
+        uint256 bondedAmount = manager.calculateBondedAmount(amount, baseUnbondedAmount);
 
         uint256 maximumBond = manager.calculateMaxGriefingBond(
             amount,
@@ -44,11 +47,11 @@ contract RiskManagerMathFuzzTest is Test {
             IRiskManager.GriefingConfig({
                 griefingCliff: cliff,
                 griefingPenaltyBpsPerHour: slope,
-                baseUnbondedAmount: 0
+                baseUnbondedAmount: baseUnbondedAmount
             })
         );
         (uint256 penalty,) = manager.calculateGriefingPenalty(
-            amount,
+            bondedAmount,
             createdAt,
             cancelledAt,
             maxPeriod,
@@ -56,6 +59,7 @@ contract RiskManagerMathFuzzTest is Test {
             slope
         );
 
+        assertEq(bondedAmount, amount > baseUnbondedAmount ? amount - baseUnbondedAmount : 0);
         assertLe(penalty, maximumBond);
     }
 
@@ -95,12 +99,15 @@ contract RiskManagerMathFuzzTest is Test {
 
     function testFuzz_RequiredReservationEqualsMaximumCurve(
         uint96 rawAmount,
+        uint96 rawBaseUnbondedAmount,
         uint16 rawReserveBps,
         uint16 rawSlope
     ) public view {
         uint256 amount = bound(uint256(rawAmount), 1, type(uint96).max);
         uint16 reserveBps = uint16(bound(uint256(rawReserveBps), 0, 10_000));
         uint32 slope = uint32(bound(uint256(rawSlope), 0, 1_000));
+        uint256 baseUnbondedAmount = reserveBps == 0 ? uint256(rawBaseUnbondedAmount) : 0;
+        uint256 bondedAmount = manager.calculateBondedAmount(amount, baseUnbondedAmount);
         IRiskManager.PlatformRiskConfig memory config = IRiskManager.PlatformRiskConfig({
             enabled: true,
             chargeback: IRiskManager.ChargebackConfig({
@@ -112,7 +119,7 @@ contract RiskManagerMathFuzzTest is Test {
             griefing: IRiskManager.GriefingConfig({
                 griefingCliff: 15 minutes,
                 griefingPenaltyBpsPerHour: slope,
-                baseUnbondedAmount: 0
+                baseUnbondedAmount: baseUnbondedAmount
             })
         });
 
@@ -120,7 +127,7 @@ contract RiskManagerMathFuzzTest is Test {
             manager.calculateRequiredReservation(amount, 6 hours, config);
 
         assertEq(required, griefing > chargeback ? griefing : chargeback);
-        assertLe(griefing, amount);
+        assertLe(griefing, bondedAmount);
         assertLe(chargeback, amount);
     }
 }

--- a/test-foundry/fuzz/RiskManagerMathFuzz.t.sol
+++ b/test-foundry/fuzz/RiskManagerMathFuzz.t.sol
@@ -44,8 +44,7 @@ contract RiskManagerMathFuzzTest is Test {
             IRiskManager.GriefingConfig({
                 griefingCliff: cliff,
                 griefingPenaltyBpsPerHour: slope,
-                freeTakeCount: 0,
-                freeTakeAmount: 0
+                baseUnbondedAmount: 0
             })
         );
         (uint256 penalty,) = manager.calculateGriefingPenalty(
@@ -113,8 +112,7 @@ contract RiskManagerMathFuzzTest is Test {
             griefing: IRiskManager.GriefingConfig({
                 griefingCliff: 15 minutes,
                 griefingPenaltyBpsPerHour: slope,
-                freeTakeCount: 0,
-                freeTakeAmount: 0
+                baseUnbondedAmount: 0
             })
         });
 

--- a/test-foundry/invariant/RiskManagerInvariant.t.sol
+++ b/test-foundry/invariant/RiskManagerInvariant.t.sol
@@ -146,8 +146,7 @@ contract RiskManagerInvariantTest is StdInvariant, Test {
         IRiskManager.GriefingConfig memory griefing = IRiskManager.GriefingConfig({
             griefingCliff: 15 minutes,
             griefingPenaltyBpsPerHour: 10,
-            freeTakeCount: 0,
-            freeTakeAmount: 0
+            baseUnbondedAmount: 0
         });
         manager.setPlatformRiskConfig(PAYPAL, IRiskManager.PlatformRiskConfig({
             enabled: true,
@@ -159,8 +158,7 @@ contract RiskManagerInvariantTest is StdInvariant, Test {
             }),
             griefing: griefing
         }));
-        griefing.freeTakeCount = 2;
-        griefing.freeTakeAmount = 20e6;
+        griefing.baseUnbondedAmount = 20e6;
         manager.setPlatformRiskConfig(ZELLE, IRiskManager.PlatformRiskConfig({
             enabled: true,
             chargeback: IRiskManager.ChargebackConfig({
@@ -207,10 +205,10 @@ contract RiskManagerInvariantTest is StdInvariant, Test {
         assertEq(positionReservations, vault.reservedStake(stakeOwner));
     }
 
-    function invariant_FreePositionsNeverReserveOrSlashStake() public view {
+    function invariant_UnbondedPositionsNeverReserveOrSlashStake() public view {
         for (uint256 index = 0; index < handler.hashCount(); index++) {
             IRiskManager.RiskPosition memory position = manager.getRiskPosition(handler.hashAt(index));
-            if (position.mode == IRiskManager.RiskMode.FREE) {
+            if (position.mode == IRiskManager.RiskMode.UNBONDED) {
                 assertEq(position.initialReservation, 0);
                 assertEq(position.reservedAmount, 0);
                 assertEq(position.slashedAmount, 0);

--- a/test-foundry/unit/RiskManager.t.sol
+++ b/test-foundry/unit/RiskManager.t.sol
@@ -147,7 +147,7 @@ contract RiskManagerTest is Test {
 
         vm.startPrank(owner);
         manager.setPlatformRiskConfig(PAYPAL, _chargebackConfig(10_000, 30 days, true));
-        manager.setPlatformRiskConfig(ZELLE, _nonChargebackableConfig(2, 20e6));
+        manager.setPlatformRiskConfig(ZELLE, _nonChargebackableConfig(20e6));
         manager.setDeferredPayoutHook(address(verifier));
         vm.stopPrank();
 
@@ -175,15 +175,13 @@ contract RiskManagerTest is Test {
             griefing: IRiskManager.GriefingConfig({
                 griefingCliff: GRIEFING_CLIFF,
                 griefingPenaltyBpsPerHour: GRIEFING_SLOPE,
-                freeTakeCount: 0,
-                freeTakeAmount: 0
+                baseUnbondedAmount: 0
             })
         });
     }
 
     function _nonChargebackableConfig(
-        uint32 _freeTakeCount,
-        uint256 _freeTakeAmount
+        uint256 _baseUnbondedAmount
     ) internal pure returns (IRiskManager.PlatformRiskConfig memory) {
         return IRiskManager.PlatformRiskConfig({
             enabled: true,
@@ -196,8 +194,7 @@ contract RiskManagerTest is Test {
             griefing: IRiskManager.GriefingConfig({
                 griefingCliff: GRIEFING_CLIFF,
                 griefingPenaltyBpsPerHour: GRIEFING_SLOPE,
-                freeTakeCount: _freeTakeCount,
-                freeTakeAmount: _freeTakeAmount
+                baseUnbondedAmount: _baseUnbondedAmount
             })
         });
     }
@@ -260,32 +257,34 @@ contract RiskManagerTest is Test {
         assertEq(vault.reservedStake(taker), 1_000e6);
     }
 
-    function test_FreeTakeConsumesAllowanceWithoutReservation() public {
-        bytes32 intentHash = keccak256("free");
+    function test_BaseAmountIsUnbondedWithoutReservation() public {
+        bytes32 intentHash = keccak256("base-unbonded");
         _setIntent(intentHash, taker, 20e6, ZELLE, address(0));
 
         _createPosition(intentHash);
 
         IRiskManager.RiskPosition memory position = manager.getRiskPosition(intentHash);
-        assertEq(uint256(position.mode), uint256(IRiskManager.RiskMode.FREE));
-        assertTrue(position.consumedFreeTake);
-        assertEq(manager.freeTakesUsed(taker, ZELLE), 1);
+        assertEq(uint256(position.mode), uint256(IRiskManager.RiskMode.UNBONDED));
+        assertEq(position.bondedAmount, 0);
         assertEq(vault.reservedStake(taker), 0);
     }
 
-    function test_FreeTakeIsNotRestoredAfterCancellation() public {
-        bytes32 intentHash = keccak256("cancelled-free");
-        _setIntent(intentHash, taker, 20e6, ZELLE, address(0));
-        _createPosition(intentHash);
+    function test_BaseAmountIsReusableAfterCancellation() public {
+        bytes32 firstIntentHash = keccak256("cancelled-base");
+        _setIntent(firstIntentHash, taker, 20e6, ZELLE, address(0));
+        _createPosition(firstIntentHash);
 
-        orchestrator.cancelPosition(manager, intentHash);
+        orchestrator.cancelPosition(manager, firstIntentHash);
 
-        assertEq(manager.freeTakesUsed(taker, ZELLE), 1);
-        assertEq(uint256(manager.getRiskPosition(intentHash).status), uint256(IRiskManager.PositionStatus.CANCELLED));
+        bytes32 secondIntentHash = keccak256("reused-base");
+        _setIntent(secondIntentHash, taker, 20e6, ZELLE, address(0));
+        _createPosition(secondIntentHash);
+        assertEq(uint256(manager.getRiskPosition(secondIntentHash).mode), uint256(IRiskManager.RiskMode.UNBONDED));
+        assertEq(vault.reservedStake(taker), 0);
     }
 
-    function test_FreeCancellationAfterCliffNeverChargesStake() public {
-        bytes32 intentHash = keccak256("cancelled-free-after-cliff");
+    function test_BaseAmountCancellationAfterCliffNeverChargesStake() public {
+        bytes32 intentHash = keccak256("cancelled-base-after-cliff");
         _setIntent(intentHash, taker, 20e6, ZELLE, address(0));
         _createPosition(intentHash);
         uint64 createdAt = manager.getRiskPosition(intentHash).createdAt;
@@ -299,8 +298,8 @@ contract RiskManagerTest is Test {
         assertEq(vault.claimableCompensation(maker), 0);
     }
 
-    function test_FreeCancellationReconciliationAfterCliffNeverChargesStake() public {
-        bytes32 intentHash = keccak256("reconciled-free-after-cliff");
+    function test_BaseAmountCancellationReconciliationAfterCliffNeverChargesStake() public {
+        bytes32 intentHash = keccak256("reconciled-base-after-cliff");
         _setIntent(intentHash, taker, 20e6, ZELLE, address(0));
         _createPosition(intentHash);
         uint64 createdAt = manager.getRiskPosition(intentHash).createdAt;
@@ -395,7 +394,7 @@ contract RiskManagerTest is Test {
 
         orchestrator.cancelPosition(manager, intentHash);
 
-        assertEq(vault.claimableCompensation(maker), 5.75e6);
+        assertEq(vault.claimableCompensation(maker), 5.635e6);
     }
 
     function test_ReconcileCancellationUsesRecordedTimestamp() public {

--- a/test/deploy/26_stakeRiskSystem.spec.ts
+++ b/test/deploy/26_stakeRiskSystem.spec.ts
@@ -1,9 +1,9 @@
 import "module-alias/register";
 
 import { expect } from "chai";
-import hre, { deployments, ethers } from "hardhat";
+import { deployments, ethers } from "hardhat";
 
-import deployStakeRiskSystem, {
+import {
   stakeRiskPlatformPolicyForNetwork,
 } from "../../deploy/26_deploy_stake_risk_system";
 import {
@@ -111,18 +111,18 @@ describe("Affine stake risk system deployment", () => {
       expect(config.griefing.griefingCliff).to.eq(platformPolicy.reversible.griefing.griefingCliff);
       expect(config.griefing.griefingPenaltyBpsPerHour)
         .to.eq(platformPolicy.reversible.griefing.griefingPenaltyBpsPerHour);
-      expect(config.griefing.freeTakeCount).to.eq(0);
+      expect(config.griefing.baseUnbondedAmount).to.eq(0);
     });
   }
 
-  it("configures Zelle lifetime free takes only on the non-chargebackable platform", async () => {
+  it("configures a reusable Zelle base only on the non-chargebackable platform", async () => {
     const { manager } = await contracts();
     const config = await manager.getPlatformRiskConfig(ZELLE);
     expect(config.enabled).to.eq(true);
     expect(config.chargeback.chargebackable).to.eq(false);
     expect(config.chargeback.reserveBps).to.eq(0);
-    expect(config.griefing.freeTakeCount).to.eq(platformPolicy.nonChargebackable.griefing.freeTakeCount);
-    expect(config.griefing.freeTakeAmount).to.eq(platformPolicy.nonChargebackable.griefing.freeTakeAmount);
+    expect(config.griefing.baseUnbondedAmount)
+      .to.eq(platformPolicy.nonChargebackable.griefing.baseUnbondedAmount);
   });
 
   it("refuses nonlocal deployment without governance-ratified platform policy", async () => {
@@ -180,15 +180,5 @@ describe("Affine stake risk system deployment", () => {
       const signature = await deployer._signTypedData(domain, types, chargeback);
       expect(await verifier.verify(digest, [signature], "0x")).to.eq(true);
     }
-  });
-
-  it("reruns idempotently without changing initialized wiring", async function () {
-    this.timeout(180_000);
-    const before = await contracts();
-    const controller = await before.vault.controller();
-    const deferredHook = await before.manager.deferredPayoutHook();
-    await deployStakeRiskSystem(hre);
-    expect(await before.vault.controller()).to.eq(controller);
-    expect(await before.manager.deferredPayoutHook()).to.eq(deferredHook);
   });
 });

--- a/test/staking/riskManager.coverage.spec.ts
+++ b/test/staking/riskManager.coverage.spec.ts
@@ -28,8 +28,7 @@ function chargebackConfig(overrides: Record<string, unknown> = {}) {
     griefing: {
       griefingCliff: CLIFF,
       griefingPenaltyBpsPerHour: SLOPE,
-      freeTakeCount: 0,
-      freeTakeAmount: 0,
+      baseUnbondedAmount: 0,
       ...((overrides.griefing as Record<string, unknown>) ?? {}),
     },
     ...Object.fromEntries(Object.entries(overrides).filter(([key]) => key !== "chargeback" && key !== "griefing")),
@@ -49,8 +48,7 @@ function nonChargebackConfig(overrides: Record<string, unknown> = {}) {
     griefing: {
       griefingCliff: CLIFF,
       griefingPenaltyBpsPerHour: SLOPE,
-      freeTakeCount: 0,
-      freeTakeAmount: 0,
+      baseUnbondedAmount: 0,
       ...((overrides.griefing as Record<string, unknown>) ?? {}),
     },
     ...Object.fromEntries(Object.entries(overrides).filter(([key]) => key !== "chargeback" && key !== "griefing")),
@@ -75,7 +73,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
     await manager.setDeferredPayoutHook(orchestrator.address);
     await manager.setPlatformRiskConfig(PAYPAL, chargebackConfig());
     await manager.setPlatformRiskConfig(ZELLE, nonChargebackConfig({
-      griefing: { freeTakeCount: 2, freeTakeAmount: usdc(20) },
+      griefing: { baseUnbondedAmount: usdc(20) },
     }));
     await vault.setTakerState(taker.address, taker.address, usdc(100_000), usdc(100_000), false);
 
@@ -276,10 +274,10 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
         .to.be.revertedWithCustomError(manager, "InvalidPlatformConfig");
     });
 
-    it("rejects a free-take amount without a free-take count", async () => {
+    it("rejects a base unbonded amount on a chargebackable platform", async () => {
       const { manager } = await loadFixture(deployHarnessFixture);
-      await expect(manager.setPlatformRiskConfig(OTHER_METHOD, nonChargebackConfig({
-        griefing: { freeTakeCount: 0, freeTakeAmount: 1 },
+      await expect(manager.setPlatformRiskConfig(OTHER_METHOD, chargebackConfig({
+        griefing: { baseUnbondedAmount: 1 },
       }))).to.be.revertedWithCustomError(manager, "InvalidPlatformConfig");
     });
 
@@ -338,14 +336,14 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
     it("returns zero maximum griefing bond for a zero slope", async () => {
       const { manager } = await loadFixture(deployHarnessFixture);
       expect(await manager.calculateMaxGriefingBond(100, MAX_INTENT_PERIOD, {
-        griefingCliff: CLIFF, griefingPenaltyBpsPerHour: 0, freeTakeCount: 0, freeTakeAmount: 0,
+        griefingCliff: CLIFF, griefingPenaltyBpsPerHour: 0, baseUnbondedAmount: 0,
       })).to.eq(0);
     });
 
     it("returns zero maximum griefing bond when the cliff reaches the period", async () => {
       const { manager } = await loadFixture(deployHarnessFixture);
       expect(await manager.calculateMaxGriefingBond(100, MAX_INTENT_PERIOD, {
-        griefingCliff: MAX_INTENT_PERIOD, griefingPenaltyBpsPerHour: SLOPE, freeTakeCount: 0, freeTakeAmount: 0,
+        griefingCliff: MAX_INTENT_PERIOD, griefingPenaltyBpsPerHour: SLOPE, baseUnbondedAmount: 0,
       })).to.eq(0);
     });
 
@@ -563,7 +561,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
         .to.be.revertedWithCustomError(fixture.manager, "DeferredPayoutHookNotAllowed");
     });
 
-    it("rejects the deferred hook for a free position", async () => {
+    it("rejects the deferred hook for an unbonded position", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
       const intentHash = ethers.utils.id("deferred-hook-with-free");
       await setRiskIntent(fixture, intentHash, {
@@ -646,7 +644,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       expect((await fixture.manager.getRiskPosition(intentHash)).releasedAmount).to.eq(usdc(50));
     });
 
-    it("settles a free non-chargebackable position without a vault release", async () => {
+    it("settles an unbonded non-chargebackable position without a vault release", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
       const intentHash = ethers.utils.id("free-settlement");
       await createPosition(fixture, intentHash, { amount: usdc(20), paymentMethod: ZELLE });
@@ -678,7 +676,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       expect((await fixture.manager.getRiskPosition(intentHash)).status).to.eq(2);
     });
 
-    it("reconciles a free cancellation after the cliff without a penalty", async () => {
+    it("reconciles an unbonded cancellation after the cliff without a penalty", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
       const intentHash = ethers.utils.id("free-cancel-reconciliation");
       await createPosition(fixture, intentHash, { amount: usdc(20), paymentMethod: ZELLE });
@@ -1231,7 +1229,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       )).to.be.revertedWithCustomError(fixture.manager, "PositionModeMismatch");
     });
 
-    it("rejects settlement for an impossible chargebackable free position", async () => {
+    it("rejects settlement for an impossible chargebackable unbonded position", async () => {
       const fixture = await loadFixture(deployStateHarnessFixture);
       const intentHash = ethers.utils.id("forced-settlement-mode");
       await fixture.manager.forcePosition(intentHash, 1, 1, ZERO, PAYPAL, 1, 0);
@@ -1239,7 +1237,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
         .to.be.revertedWithCustomError(fixture.manager, "PositionModeMismatch");
     });
 
-    it("rejects chargeback evidence for an impossible settled free position", async () => {
+    it("rejects chargeback evidence for an impossible settled unbonded position", async () => {
       const fixture = await loadFixture(deployStateHarnessFixture);
       const intentHash = ethers.utils.id("forced-claim-mode");
       await fixture.manager.forcePosition(

--- a/test/staking/riskManager.spec.ts
+++ b/test/staking/riskManager.spec.ts
@@ -103,8 +103,7 @@ describe("RiskManager and OrchestratorV3", () => {
       griefing: {
         griefingCliff: GRIEFING_CLIFF,
         griefingPenaltyBpsPerHour: GRIEFING_SLOPE,
-        freeTakeCount: 2,
-        freeTakeAmount: usdc(20),
+        baseUnbondedAmount: usdc(20),
       },
     });
     await manager.setPlatformRiskConfig(PAYPAL, {
@@ -118,8 +117,7 @@ describe("RiskManager and OrchestratorV3", () => {
       griefing: {
         griefingCliff: GRIEFING_CLIFF,
         griefingPenaltyBpsPerHour: GRIEFING_SLOPE,
-        freeTakeCount: 0,
-        freeTakeAmount: 0,
+        baseUnbondedAmount: 0,
       },
     });
 
@@ -274,26 +272,27 @@ describe("RiskManager and OrchestratorV3", () => {
       await expect(manager.setPlatformRiskConfig(PAYPAL, {
         enabled: true,
         chargeback: { chargebackable: true, deferredPayoutEnabled: false, reserveBps: 10_001, riskWindow: DAY },
-        griefing: { griefingCliff: 1, griefingPenaltyBpsPerHour: 1, freeTakeCount: 0, freeTakeAmount: 0 },
+        griefing: { griefingCliff: 1, griefingPenaltyBpsPerHour: 1, baseUnbondedAmount: 0 },
       })).to.be.revertedWithCustomError(manager, "InvalidPlatformConfig");
     });
 
-    it("rejects free takes on a chargebackable platform", async () => {
+    it("rejects a base unbonded amount on a chargebackable platform", async () => {
       const { manager } = await loadFixture(deployFixture);
       await expect(manager.setPlatformRiskConfig(PAYPAL, {
         enabled: true,
         chargeback: { chargebackable: true, deferredPayoutEnabled: false, reserveBps: 10_000, riskWindow: DAY },
-        griefing: { griefingCliff: 1, griefingPenaltyBpsPerHour: 1, freeTakeCount: 1, freeTakeAmount: 1 },
+        griefing: { griefingCliff: 1, griefingPenaltyBpsPerHour: 1, baseUnbondedAmount: 1 },
       })).to.be.revertedWithCustomError(manager, "InvalidPlatformConfig");
     });
 
-    it("rejects a free-take count without a free-take amount", async () => {
+    it("accepts a reusable base unbonded amount on a non-chargebackable platform", async () => {
       const { manager } = await loadFixture(deployFixture);
-      await expect(manager.setPlatformRiskConfig(ZELLE, {
+      await manager.setPlatformRiskConfig(ZELLE, {
         enabled: true,
         chargeback: { chargebackable: false, deferredPayoutEnabled: false, reserveBps: 0, riskWindow: 0 },
-        griefing: { griefingCliff: 1, griefingPenaltyBpsPerHour: 1, freeTakeCount: 1, freeTakeAmount: 0 },
-      })).to.be.revertedWithCustomError(manager, "InvalidPlatformConfig");
+        griefing: { griefingCliff: 1, griefingPenaltyBpsPerHour: 1, baseUnbondedAmount: usdc(500) },
+      });
+      expect((await manager.getPlatformRiskConfig(ZELLE)).griefing.baseUnbondedAmount).to.eq(usdc(500));
     });
 
     it("calculates the illustrative 5.75 USDC maximum griefing bond", async () => {
@@ -301,9 +300,18 @@ describe("RiskManager and OrchestratorV3", () => {
       expect(await manager.calculateMaxGriefingBond(usdc(1_000), MAX_INTENT_PERIOD, {
         griefingCliff: GRIEFING_CLIFF,
         griefingPenaltyBpsPerHour: GRIEFING_SLOPE,
-        freeTakeCount: 0,
-        freeTakeAmount: 0,
+        baseUnbondedAmount: 0,
       })).to.eq(usdc("5.75"));
+    });
+
+    it("subtracts the reusable base before calculating the maximum griefing bond", async () => {
+      const { manager } = await loadFixture(deployFixture);
+      expect(await manager.calculateBondedAmount(usdc(700), usdc(500))).to.eq(usdc(200));
+      expect(await manager.calculateMaxGriefingBond(usdc(700), MAX_INTENT_PERIOD, {
+        griefingCliff: GRIEFING_CLIFF,
+        griefingPenaltyBpsPerHour: GRIEFING_SLOPE,
+        baseUnbondedAmount: usdc(500),
+      })).to.eq(usdc("1.15"));
     });
 
     it("rounds a chargeback reserve upward", async () => {
@@ -321,26 +329,26 @@ describe("RiskManager and OrchestratorV3", () => {
     });
   });
 
-  describe("free takes", () => {
-    it("admits an eligible whole intent without stake", async () => {
+  describe("base unbonded tranche", () => {
+    it("admits an intent at the base without stake", async () => {
       const { taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
       const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE);
       const position = await manager.getRiskPosition(intentHash);
       expect(position.mode).to.eq(1);
-      expect(position.consumedFreeTake).to.eq(true);
+      expect(position.bondedAmount).to.eq(0);
       expect(await vault.reservedStake(taker.address)).to.eq(0);
-      expect(await manager.freeTakesUsed(taker.address, ZELLE)).to.eq(1);
     });
 
-    it("does not restore a free take after cancellation", async () => {
-      const { taker, escrow, orchestrator, manager } = await loadFixture(deployFixture);
-      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE);
-      await orchestrator.connect(taker).cancelIntent(intentHash);
-      expect(await manager.freeTakesUsed(taker.address, ZELLE)).to.eq(1);
-      expect((await manager.getRiskPosition(intentHash)).status).to.eq(2);
+    it("reuses the base after cancellation without counter state", async () => {
+      const { taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
+      const firstIntentHash = await signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE);
+      await orchestrator.connect(taker).cancelIntent(firstIntentHash);
+      const secondIntentHash = await signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE);
+      expect((await manager.getRiskPosition(secondIntentHash)).mode).to.eq(1);
+      expect(await vault.reservedStake(taker.address)).to.eq(0);
     });
 
-    it("cancels a free intent after the griefing cliff without charging stake", async () => {
+    it("cancels an intent at the base after the griefing cliff without charging stake", async () => {
       const { taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
       const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE);
       await time.increase(GRIEFING_CLIFF + 1);
@@ -351,7 +359,7 @@ describe("RiskManager and OrchestratorV3", () => {
       expect(await vault.reservedStake(taker.address)).to.eq(0);
     });
 
-    it("expires a free intent after the griefing cliff without charging stake", async () => {
+    it("expires an intent at the base after the griefing cliff without charging stake", async () => {
       const { taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
       const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE);
       await time.increase(MAX_INTENT_PERIOD + 1);
@@ -362,23 +370,27 @@ describe("RiskManager and OrchestratorV3", () => {
       expect(await vault.reservedStake(taker.address)).to.eq(0);
     });
 
-    it("does not apply a partial free tranche to a larger intent", async () => {
-      const { taker, escrow, orchestrator, manager } = await loadFixture(deployFixture);
-      await expect(signalIntent(orchestrator, escrow, taker, usdc(21), ZELLE))
-        .to.be.revertedWithCustomError(orchestrator, "RiskHookAdmissionFailed");
-      expect(await manager.freeTakesUsed(taker.address, ZELLE)).to.eq(0);
+    it("applies the base tranche to a larger intent and bonds only the excess", async () => {
+      const { taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
+      await vault.connect(taker).depositStake(usdc(1));
+      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(21), ZELLE);
+      const position = await manager.getRiskPosition(intentHash);
+      expect(position.mode).to.eq(2);
+      expect(position.intentAmount).to.eq(usdc(21));
+      expect(position.bondedAmount).to.eq(usdc(1));
+      expect(position.maxGriefingBond).to.eq(usdc("0.00575"));
     });
 
-    it("shares lifetime allowances across relayers using one stake owner", async () => {
+    it("reuses the base concurrently across delegated takers", async () => {
       const { owner: safe, taker, secondTaker, escrow, orchestrator, vault, manager } =
         await loadFixture(deployFixture);
       await vault.connect(safe).setTakerAuthorization(taker.address, true);
       await vault.connect(safe).setTakerAuthorization(secondTaker.address, true);
-      await signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE);
-      await signalIntent(orchestrator, escrow, secondTaker, usdc(20), ZELLE);
-      expect(await manager.freeTakesUsed(safe.address, ZELLE)).to.eq(2);
-      await expect(signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE))
-        .to.be.revertedWithCustomError(orchestrator, "RiskHookAdmissionFailed");
+      const first = await signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE);
+      const second = await signalIntent(orchestrator, escrow, secondTaker, usdc(20), ZELLE);
+      expect((await manager.getRiskPosition(first)).mode).to.eq(1);
+      expect((await manager.getRiskPosition(second)).mode).to.eq(1);
+      expect(await vault.reservedStake(safe.address)).to.eq(0);
     });
   });
 
@@ -419,8 +431,7 @@ describe("RiskManager and OrchestratorV3", () => {
         griefing: {
           griefingCliff: GRIEFING_CLIFF,
           griefingPenaltyBpsPerHour: GRIEFING_SLOPE,
-          freeTakeCount: 0,
-          freeTakeAmount: 0,
+          baseUnbondedAmount: 0,
         },
       });
       await vault.connect(taker).depositStake(usdc(500));
@@ -431,8 +442,7 @@ describe("RiskManager and OrchestratorV3", () => {
         griefing: {
           griefingCliff: 30 * MINUTE,
           griefingPenaltyBpsPerHour: 20,
-          freeTakeCount: 0,
-          freeTakeAmount: 0,
+          baseUnbondedAmount: 0,
         },
       });
       const position = await manager.getRiskPosition(intentHash);
@@ -474,7 +484,7 @@ describe("RiskManager and OrchestratorV3", () => {
       const createdAt = (await manager.getRiskPosition(intentHash)).createdAt.toNumber();
       await time.increaseTo(createdAt + DAY);
       await orchestrator.connect(taker).cancelIntent(intentHash);
-      expect(await vault.claimableCompensation(maker.address)).to.eq(usdc("5.75"));
+      expect(await vault.claimableCompensation(maker.address)).to.eq(usdc("5.635"));
     });
 
     it("records the original cancellation time when a terminal callback fails", async () => {

--- a/utils/riskMath.ts
+++ b/utils/riskMath.ts
@@ -17,11 +17,6 @@ export interface RiskCapacity {
   bondedTakingCapacity: bigint | null;
 }
 
-export interface FreeTakeCapacity {
-  remainingFreeTakes: bigint;
-  freeTakingCapacity: bigint;
-}
-
 export interface GriefingPenalty {
   penalty: bigint;
   effectiveElapsed: bigint;
@@ -44,6 +39,13 @@ function ceilDiv(numerator: bigint, denominator: bigint): bigint {
   if (denominator <= 0n) throw new RangeError("denominator must be positive");
   if (numerator === 0n) return 0n;
   return ((numerator - 1n) / denominator) + 1n;
+}
+
+/** max(intent amount - reusable base unbonded amount, 0). */
+export function calculateBondedAmount(amount: IntegerLike, baseUnbondedAmount: IntegerLike): bigint {
+  const intentAmount = integer(amount, "amount");
+  const baseAmount = integer(baseUnbondedAmount, "baseUnbondedAmount");
+  return intentAmount > baseAmount ? intentAmount - baseAmount : 0n;
 }
 
 /** ceil(A * s * (T - C) / (10_000 * 1 hour)); returns zero when the curve is disabled. */
@@ -72,8 +74,9 @@ export function calculateRequiredReservation(
   amount: IntegerLike,
   terms: GriefingTerms,
   reserveBps: IntegerLike,
+  baseUnbondedAmount: IntegerLike,
 ): bigint {
-  const griefingBond = calculateMaxGriefingBond(amount, terms);
+  const griefingBond = calculateMaxGriefingBond(calculateBondedAmount(amount, baseUnbondedAmount), terms);
   const chargebackReserve = calculateChargebackReserve(amount, reserveBps);
   return griefingBond > chargebackReserve ? griefingBond : chargebackReserve;
 }
@@ -140,15 +143,12 @@ export function calculateBondedTakingCapacity(
   return { griefingCapacity, chargebackCapacity, bondedTakingCapacity };
 }
 
-/** Computes remaining separate free intents and their aggregate display capacity. */
-export function calculateFreeTakeCapacity(
-  freeTakeCount: IntegerLike,
-  freeTakesUsed: IntegerLike,
-  freeTakeAmount: IntegerLike,
-): FreeTakeCapacity {
-  const count = integer(freeTakeCount, "freeTakeCount");
-  const used = integer(freeTakesUsed, "freeTakesUsed");
-  const amount = integer(freeTakeAmount, "freeTakeAmount");
-  const remainingFreeTakes = used >= count ? 0n : count - used;
-  return { remainingFreeTakes, freeTakingCapacity: remainingFreeTakes * amount };
+/** Adds the reusable base tranche to a finite bonded capacity; null remains unbounded. */
+export function calculateTotalTakingCapacity(
+  bondedTakingCapacity: IntegerLike | null,
+  baseUnbondedAmount: IntegerLike,
+): bigint | null {
+  if (bondedTakingCapacity === null) return null;
+  return integer(bondedTakingCapacity, "bondedTakingCapacity")
+    + integer(baseUnbondedAmount, "baseUnbondedAmount");
 }


### PR DESCRIPTION
## Summary

- replace count-based lifetime free takes with a stateless reusable `baseUnbondedAmount`
- calculate griefing reservations and cancellation penalties only over `max(intentAmount - baseUnbondedAmount, 0)`
- keep chargebackable platforms fully bonded by requiring `baseUnbondedAmount == 0`
- hard-cut the ABI, events, TypeScript risk math, platform parameters, and tests from free-take usage to bonded/unbonded amounts

## Why

Small non-chargebackable intents should be admitted without stake on every transaction, with only the amount above the configured base entering the griefing curve. Wallet-local lifetime counters do not represent the intended admission policy.

## Deployment and downstream impact

- Existing risk-management deployments are staging-only and will be abandoned.
- This requires a fresh `RiskManager` deployment; historical script 26 reruns are intentionally not preserved.
- The indexer ABI/schema/handler hard cut is in [zkp2p-indexer#199](https://github.com/zkp2p/zkp2p-indexer/pull/199).
- Curator still consumes the old free-take usage schema and requires a coordinated follow-up before publishing/deploying the new indexer schema.

## Validation

- Hardhat RiskManager suites: 157 passing
- Foundry RiskManager unit/fuzz/invariant suites: 29 passing
- Package build: passing
- Package tests: 15 passing
- Full Solidity coverage: 1,381 passing, 5 pending
- `RiskManager.sol`: 100% statements, branches, functions, and lines
- `git diff --check`: passing
