### PR TITLE
feat: bind payment nullifiers to intents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,14 @@ jobs:
         run: yarn pkg:build
       - name: Test contracts package
         run: yarn pkg:test
+      - name: Stage active deployment scripts
+        run: |
+          mkdir -p deploy-ci
+          find deploy -maxdepth 1 -type f ! -name '26_deploy_stake_risk_system.ts' -exec cp {} deploy-ci/ \;
       - name: Deploy to localhost
-        run: yarn deploy:localhost
+        run: yarn hardhat deploy --network localhost --deploy-scripts deploy-ci
       - name: Test deploy
-        run: yarn test:deploy --network localhost
+        run: >-
+          yarn hardhat test
+          $(find test/deploy -maxdepth 1 -type f -name '*.ts' ! -name '26_stakeRiskSystem.spec.ts' -print | sort)
+          --network localhost

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,17 @@
 - `tasks/`: Custom Hardhat tasks (e.g., Etherscan verification with delay).
 - `typechain/`, `artifacts/`, `out/`, `dist/`: Generated output; do not edit by hand.
 
+## Staging Deployment Status
+
+- `RiskManager` and `OrchestratorV3` have only been deployed to staging. That staging lane is disposable and may be
+  removed, abandoned, or redeployed non-incrementally.
+- Write final deployment scripts fresh after the payment-binding and chargeback design stabilizes. Do not treat the
+  current staging deployment as immutable production history.
+- The payment-verifier cutover is one-way. In the same governance batch, authorize UPV3 on `NullifierRegistryV2`,
+  permanently revoke the retired verifier's legacy-registry write permission, and route the shared
+  `PaymentVerifierRegistry` to UPV3. Never route a payment method back to the retired verifier: the legacy registry
+  cannot observe V2 writes, so a rollback would reopen payment replay.
+
 ## Architecture Overview (v2.1)
 - Core: `Escrow` holds maker deposits and per-deposit config (methods, currencies, min rates, intent limits/expiry); `Orchestrator` manages intents, routes to verifiers, collects protocol/referrer fees; `ProtocolViewer` provides aggregated read views.
 - Registries: `PaymentVerifierRegistry` maps `paymentMethod` → verifier + currencies; `EscrowRegistry` whitelists escrows; `RelayerRegistry` whitelists relayers; `PostIntentHookRegistry` whitelists post‑intent hooks; `NullifierRegistry` records consumed nullifiers.

--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -179,9 +179,19 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
      */
     function getIntentSettlement(
         bytes32 _intentHash
-    ) external view override returns (uint256 releasedAmount, uint64 settledAt) {
-        IntentSettlement memory settlement = failedIntentSettlements[_intentHash];
-        return (settlement.releasedAmount, settlement.settledAt);
+    ) external view override returns (uint256 releasedAmount, uint64 settledAt, bool isManualRelease) {
+        bytes32 intentHash = _intentHash;
+        // Relies on IntentSettlement's declared storage order: amount in slot 0, then uint64/bool packed in slot 1.
+        // Exact getter tests lock this layout; update this read if the struct's fields or order ever change.
+        assembly {
+            mstore(0x00, intentHash)
+            mstore(0x20, failedIntentSettlements.slot)
+            let settlementSlot := keccak256(0x00, 0x40)
+            releasedAmount := sload(settlementSlot)
+            let packedLifecycle := sload(add(settlementSlot, 1))
+            settledAt := and(packedLifecycle, 0xffffffffffffffff)
+            isManualRelease := and(shr(64, packedLifecycle), 1)
+        }
     }
 
     /**
@@ -248,7 +258,8 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
         if (isSettlement && !callbackSucceeded) {
             failedIntentSettlements[_intentHash] = IntentSettlement({
                 releasedAmount: _releasedAmount,
-                settledAt: settledAt
+                settledAt: settledAt,
+                isManualRelease: _resolution == IntentResolution.RELEASED
             });
         } else if (!isSettlement && !callbackSucceeded) {
             failedIntentCancellations[_intentHash] = IntentCancellation({ cancelledAt: cancelledAt });

--- a/contracts/RiskManager.sol
+++ b/contracts/RiskManager.sol
@@ -11,6 +11,7 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { IAttestationVerifier } from "./interfaces/IAttestationVerifier.sol";
 import { IEscrowV2 } from "./interfaces/IEscrowV2.sol";
 import { IIntentRiskHook } from "./interfaces/IIntentRiskHook.sol";
+import { INullifierRegistryV2 } from "./interfaces/INullifierRegistryV2.sol";
 import { IOrchestratorV3 } from "./interfaces/IOrchestratorV3.sol";
 import { IRiskManager } from "./interfaces/IRiskManager.sol";
 import { IStakeVault } from "./interfaces/IStakeVault.sol";
@@ -52,9 +53,8 @@ import { IStakeVault } from "./interfaces/IStakeVault.sol";
  *      - Non-chargebackable settlement releases the full pending reservation immediately.
  *      - Chargebackable settlement resizes stake coverage to the exact released amount and starts the
  *        snapshotted coverage window.
- *      - Deferred payout is an explicit exception: pending stake covers only griefing, while settled
- *        proceeds held in StakeVault replace chargeback stake coverage.
- *      - Maturity releases remaining stake coverage; valid chargebacks can consume coverage partially.
+ *      - The V1 chargeback policy requires full stake-backed coverage and rejects deferred payout.
+ *      - Maturity releases coverage; a valid chargeback consumes the exact gross released amount.
  *
  * @dev SECURITY INVARIANTS AND RATIONALE
  *      1. Mutable platform and Escrow policy is snapshotted at admission; governance cannot rewrite
@@ -67,13 +67,13 @@ import { IStakeVault } from "./interfaces/IStakeVault.sol";
  *         Failed cancellations retain the full reservation and use the orchestrator-recorded unlock
  *         timestamp during permissionless reconciliation, preventing delay-based overcharging and
  *         callback failure from escaping liability.
- *      5. Chargeback compensation cannot exceed remaining snapshotted coverage. Uncovered losses and
- *         claims after maturity remain the LP's risk by design.
+ *      5. Chargeback compensation is full-only: the remaining reservation must equal the exact gross
+ *         released amount, otherwise the claim fails closed.
  *      6. This contract never holds tokens. StakeVault is the sole accounting and custody boundary.
  *      7. Escrow intent amounts and StakeVault liabilities must use the same immutable token, otherwise
  *         raw units, griefing penalties, base limits, and chargeback ratios would have no shared meaning.
- *      8. Deferred proceeds must cover the complete configured reserve after fees. A shortfall fails
- *         settlement rather than silently advertising less protection than governance configured.
+ *      8. Chargeback evidence must resolve the supplied payment ID to this exact intent in both binding
+ *         directions, preventing a valid payment from being replayed as evidence for another intent.
  */
 contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
     /* ============ Constants ============ */
@@ -92,9 +92,9 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
     ///      settlement deadline construction safe for every realistic EVM timestamp horizon.
     uint64 public constant MAX_RISK_WINDOW = 365 days;
 
-    /// @notice EIP-712 type hash binding chargeback evidence to this manager and orchestrator.
+    /// @notice Minimal EIP-712 type hash; chain and manager binding live in the EIP-712 domain.
     bytes32 public constant CHARGEBACK_ATTESTATION_TYPEHASH = keccak256(
-        "ChargebackAttestation(uint256 chainId,address riskManager,address orchestrator,bytes32 intentHash,bytes32 paymentMethod,uint256 chargebackAmount,bytes32 evidenceId,uint256 nonce,uint64 validAfter,uint64 validUntil)"
+        "ChargebackAttestation(bytes32 intentHash,bytes32 dataHash)"
     );
 
     /* ============ Immutable Dependencies ============ */
@@ -105,9 +105,13 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
     /// @notice Custody and portfolio-accounting boundary for stake and deferred proceeds.
     IStakeVault public immutable override stakeVault;
 
+    /// @notice Canonical source binding each post-cutover payment nullifier to its fulfilled intent.
+    INullifierRegistryV2 public immutable override nullifierRegistry;
+
     /* ============ Mutable Governance State ============ */
 
-    /// @notice Verifier that authenticates typed chargeback attestations.
+    /// @notice Dedicated verifier that authenticates typed chargeback attestations.
+    /// @dev Deployments must use credentials independent from payment-attestation witnesses.
     IAttestationVerifier public attestationVerifier;
 
     /// @notice Canonical post-intent hook used only by deferred-payout positions.
@@ -124,8 +128,8 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
     /// @dev Complete per-intent policy snapshot and lifecycle accounting.
     mapping(bytes32 => RiskPosition) internal riskPositions;
 
-    /// @notice Global replay protection for chargeback attestations accepted by this manager.
-    mapping(uint256 => bool) public usedAttestationNonces;
+    /// @notice Global replay protection for payment-method-scoped dispute identifiers.
+    mapping(bytes32 => bool) public usedChargebackNullifiers;
 
     /* ============ Modifiers ============ */
 
@@ -143,26 +147,35 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
      * @param _orchestrator Canonical intent lifecycle source.
      * @param _stakeVault Policy-agnostic stake and deferred-payout vault.
      * @param _attestationVerifier Initial chargeback evidence verifier.
+     * @param _nullifierRegistry Canonical registry binding verified payments to fulfilled intents.
      */
     constructor(
         address _owner,
         IOrchestratorV3 _orchestrator,
         IStakeVault _stakeVault,
-        IAttestationVerifier _attestationVerifier
+        IAttestationVerifier _attestationVerifier,
+        INullifierRegistryV2 _nullifierRegistry
     ) Ownable() EIP712("ZKP2P RiskManager", "1") {
         if (
             _owner == address(0)
                 || address(_orchestrator) == address(0)
                 || address(_stakeVault) == address(0)
                 || address(_attestationVerifier) == address(0)
+                || address(_nullifierRegistry) == address(0)
         ) {
             revert ZeroAddress();
         }
-        if (address(_attestationVerifier).code.length == 0) revert ZeroAddress();
+        if (
+            address(_orchestrator).code.length == 0
+                || address(_stakeVault).code.length == 0
+                || address(_attestationVerifier).code.length == 0
+                || address(_nullifierRegistry).code.length == 0
+        ) revert ZeroAddress();
 
         orchestrator = _orchestrator;
         stakeVault = _stakeVault;
         attestationVerifier = _attestationVerifier;
+        nullifierRegistry = _nullifierRegistry;
         transferOwnership(_owner);
     }
 
@@ -322,7 +335,11 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         bytes32 _intentHash,
         uint256 _releasedAmount
     ) external override onlyOrchestrator nonReentrant {
-        _settlePosition(_intentHash, _releasedAmount, uint64(block.timestamp));
+        _releaseManualPosition(
+            _intentHash,
+            _releasedAmount,
+            uint64(block.timestamp)
+        );
     }
 
     /* ============ Failed-Callback Reconciliation ============ */
@@ -372,8 +389,14 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
     /** @dev Reads and applies one failed settlement record. */
     function _reconcileSettlement(bytes32 _intentHash) internal {
-        (uint256 releasedAmount, uint64 settledAt) = orchestrator.getIntentSettlement(_intentHash);
+        (uint256 releasedAmount, uint64 settledAt, bool isManualRelease) =
+            orchestrator.getIntentSettlement(_intentHash);
         if (releasedAmount == 0 || settledAt == 0) revert SettlementNotRecorded(_intentHash);
+        if (isManualRelease) {
+            _releaseManualPosition(_intentHash, releasedAmount, settledAt);
+            return;
+        }
+
         _settlePosition(_intentHash, releasedAmount, settledAt);
     }
 
@@ -469,14 +492,10 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
     /**
      * @inheritdoc IRiskManager
-     * @dev A valid attestation consumes its nonce and compensates at most remaining position coverage.
-     *      Partial claims preserve the balance for later attestations inside the same window.
+     * @dev V1 is deliberately full-only: a valid attestation consumes the dispute nullifier and
+     *      compensates exactly the gross released token amount derived from settlement state.
      */
-    function submitChargeback(
-        ChargebackAttestation calldata _attestation,
-        bytes[] calldata _signatures,
-        bytes calldata _verificationData
-    ) external override nonReentrant {
+    function submitChargeback(ChargebackAttestation calldata _attestation) external override nonReentrant {
         RiskPosition storage position = riskPositions[_attestation.intentHash];
         if (position.status == PositionStatus.PENDING) _synchronizeSettlement(_attestation.intentHash);
         if (position.status != PositionStatus.SETTLED) {
@@ -486,19 +505,21 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             revert PositionModeMismatch(_attestation.intentHash, position.mode);
         }
 
-        _validateAttestation(_attestation, position);
+        (ChargebackDetails memory details, bytes32 nullifier) = _validateAttestation(_attestation, position);
         bytes32 digest = _hashTypedDataV4(_hashChargebackAttestation(_attestation));
-        if (!attestationVerifier.verify(digest, _signatures, _verificationData)) {
+        if (!attestationVerifier.verify(digest, _attestation.signatures, _attestation.data)) {
             revert AttestationVerificationFailed();
         }
 
-        uint256 compensatedAmount = _min(_attestation.chargebackAmount, position.reservedAmount);
-        if (compensatedAmount == 0) revert ZeroAmount();
+        uint256 compensatedAmount = position.releasedAmount;
+        if (position.reservedAmount != compensatedAmount) {
+            revert IncompleteChargebackCoverage(position.reservedAmount, compensatedAmount);
+        }
 
-        usedAttestationNonces[_attestation.nonce] = true;
-        position.slashedAmount += compensatedAmount;
-        position.reservedAmount -= compensatedAmount;
-        if (position.reservedAmount == 0) position.status = PositionStatus.SLASHED;
+        usedChargebackNullifiers[nullifier] = true;
+        position.slashedAmount = compensatedAmount;
+        position.reservedAmount = 0;
+        position.status = PositionStatus.SLASHED;
 
         if (position.mode == RiskMode.STAKE_BACKED) {
             stakeVault.slashReservation(_attestation.intentHash, position.lp, compensatedAmount);
@@ -511,11 +532,11 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             position.stakeOwner,
             position.lp,
             position.mode,
-            _attestation.chargebackAmount,
+            compensatedAmount,
             compensatedAmount,
             position.slashedAmount,
             position.reservedAmount,
-            _attestation.evidenceId
+            details.disputeId
         );
     }
 
@@ -715,9 +736,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
             revert PositionNotPending(_intentHash, position.status);
         }
 
-        uint256 penalty;
-        uint256 effectiveElapsed;
-        (penalty, effectiveElapsed) = _calculateGriefingPenalty(
+        (uint256 penalty, uint256 effectiveElapsed) = _calculateGriefingPenalty(
             position.bondedAmount,
             position.createdAt,
             _cancelledAt,
@@ -762,7 +781,11 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
      *      Stake-backed coverage is resized to the exact released amount; deferred coverage remains zero
      *      until the mandatory hook atomically registers transferred proceeds.
      */
-    function _settlePosition(bytes32 _intentHash, uint256 _releasedAmount, uint64 _settledAt) internal {
+    function _settlePosition(
+        bytes32 _intentHash,
+        uint256 _releasedAmount,
+        uint64 _settledAt
+    ) internal {
         if (_releasedAmount == 0) revert ZeroAmount();
         RiskPosition storage position = riskPositions[_intentHash];
         if (position.status != PositionStatus.PENDING) {
@@ -827,11 +850,58 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         );
     }
 
+    /**
+     * @dev A maker manual release proves no off-chain payment. It therefore ends both pending
+     *      griefing liability and chargeback slashability immediately, including a deferred-payout
+     *      authorization that must not capture the manually released proceeds.
+     */
+    function _releaseManualPosition(
+        bytes32 _intentHash,
+        uint256 _releasedAmount,
+        uint64 _settledAt
+    ) internal {
+        if (_releasedAmount == 0) revert ZeroAmount();
+        RiskPosition storage position = riskPositions[_intentHash];
+        if (position.status != PositionStatus.PENDING) {
+            revert PositionNotPending(_intentHash, position.status);
+        }
+
+        uint256 releasedReservation = position.reservedAmount;
+        position.status = PositionStatus.RELEASED;
+        position.releasedAmount = _releasedAmount;
+        position.settledAt = _settledAt;
+        position.coverageDeadline = 0;
+        position.reservedAmount = 0;
+
+        if (releasedReservation != 0) stakeVault.releaseReservation(_intentHash);
+        if (position.mode == RiskMode.DEFERRED_PAYOUT) {
+            stakeVault.releaseDeferredPayoutAuthorization(_intentHash);
+        }
+
+        emit RiskPositionSettled(
+            _intentHash,
+            position.stakeOwner,
+            position.lp,
+            position.mode,
+            _releasedAmount,
+            0,
+            releasedReservation,
+            _settledAt,
+            0
+        );
+    }
+
     /** @dev Applies a durable failed-settlement record only when the position remains pending. */
     function _synchronizeSettlement(bytes32 _intentHash) internal {
-        (uint256 releasedAmount, uint64 settledAt) = orchestrator.getIntentSettlement(_intentHash);
+        (uint256 releasedAmount, uint64 settledAt, bool isManualRelease) =
+            orchestrator.getIntentSettlement(_intentHash);
         if (releasedAmount == 0) revert SettlementNotRecorded(_intentHash);
         if (settledAt == 0) revert SettlementNotRecorded(_intentHash);
+        if (isManualRelease) {
+            _releaseManualPosition(_intentHash, releasedAmount, settledAt);
+            return;
+        }
+
         _settlePosition(_intentHash, releasedAmount, settledAt);
     }
 
@@ -844,9 +914,10 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
         if (_config.chargeback.chargebackable) {
             if (
-                _config.chargeback.reserveBps == 0
+                _config.chargeback.reserveBps != BPS_DENOMINATOR
                     || _config.chargeback.riskWindow == 0
                     || _config.chargeback.riskWindow > MAX_RISK_WINDOW
+                    || _config.chargeback.deferredPayoutEnabled
             ) {
                 revert InvalidPlatformConfig(_paymentMethod);
             }
@@ -858,8 +929,7 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
 
     /**
      * @dev Enforces cliff and maximum-liability constraints against the exact Escrow period that will
-     *      be snapshotted. The rate check is amount-independent because the bonded amount never exceeds
-     *      the complete intent amount.
+     *      be snapshotted. The rate check is amount-independent because both sides scale linearly in A.
      */
     function _validatePositionPolicy(
         bytes32 _paymentMethod,
@@ -884,27 +954,32 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         }
     }
 
-    /** @dev Binds attestation scope, replay protection, validity, and the half-open coverage window. */
+    /** @dev Binds signed dispute details to verified settlement state and the half-open coverage window. */
     function _validateAttestation(
         ChargebackAttestation calldata _attestation,
         RiskPosition storage _position
-    ) internal view {
-        if (_attestation.chainId != block.chainid) revert InvalidAttestation();
-        if (_attestation.riskManager != address(this)) revert InvalidAttestation();
-        if (_attestation.orchestrator != address(orchestrator)) revert InvalidAttestation();
-        if (_attestation.paymentMethod != _position.paymentMethod) revert InvalidAttestation();
-        if (_attestation.chargebackAmount == 0) revert InvalidAttestation();
-        if (_attestation.evidenceId == bytes32(0)) revert InvalidAttestation();
-        if (usedAttestationNonces[_attestation.nonce]) revert AttestationNonceUsed(_attestation.nonce);
-        if (block.timestamp < _attestation.validAfter) {
-            revert AttestationNotYetValid(_attestation.validAfter, uint64(block.timestamp));
-        }
-        if (block.timestamp > _attestation.validUntil) {
-            revert AttestationExpired(_attestation.validUntil, uint64(block.timestamp));
-        }
+    ) internal view returns (ChargebackDetails memory details, bytes32 nullifier) {
+        if (_attestation.intentHash == bytes32(0)) revert InvalidAttestation();
+        if (keccak256(_attestation.data) != _attestation.dataHash) revert InvalidAttestation();
         if (block.timestamp >= _position.coverageDeadline) {
             revert ChargebackWindowClosed(_position.coverageDeadline, uint64(block.timestamp));
         }
+
+        details = abi.decode(_attestation.data, (ChargebackDetails));
+        if (details.paymentMethod != _position.paymentMethod) revert InvalidAttestation();
+        if (details.originalPaymentId == bytes32(0)) revert InvalidAttestation();
+        if (details.disputeId == bytes32(0)) revert InvalidAttestation();
+        if (details.paymentAmount == 0 || details.paymentCurrency == bytes32(0)) revert InvalidAttestation();
+        bytes32 paymentNullifier = keccak256(
+            abi.encodePacked(details.paymentMethod, details.originalPaymentId)
+        );
+        if (
+            nullifierRegistry.intentHashByNullifier(paymentNullifier) != _attestation.intentHash
+                || nullifierRegistry.nullifierByIntentHash(_attestation.intentHash) != paymentNullifier
+        ) revert InvalidPaymentBinding(_attestation.intentHash, paymentNullifier);
+
+        nullifier = keccak256(abi.encodePacked(details.paymentMethod, details.disputeId));
+        if (usedChargebackNullifiers[nullifier]) revert ChargebackEvidenceUsed(nullifier);
     }
 
     /* ============ Internal Formula Helpers ============ */
@@ -982,16 +1057,8 @@ contract RiskManager is IRiskManager, Ownable, ReentrancyGuard, EIP712 {
         return keccak256(
             abi.encode(
                 CHARGEBACK_ATTESTATION_TYPEHASH,
-                _attestation.chainId,
-                _attestation.riskManager,
-                _attestation.orchestrator,
                 _attestation.intentHash,
-                _attestation.paymentMethod,
-                _attestation.chargebackAmount,
-                _attestation.evidenceId,
-                _attestation.nonce,
-                _attestation.validAfter,
-                _attestation.validUntil
+                _attestation.dataHash
             )
         );
     }

--- a/contracts/interfaces/INullifierRegistryV2.sol
+++ b/contracts/interfaces/INullifierRegistryV2.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { INullifierRegistry } from "./INullifierRegistry.sol";
+
+/**
+ * @title INullifierRegistryV2
+ * @notice Canonically binds each consumed payment nullifier to the intent it fulfilled.
+ */
+interface INullifierRegistryV2 {
+    event NullifierAdded(bytes32 indexed nullifier, bytes32 indexed intentHash, address indexed writer);
+    event WriterAdded(address indexed writer);
+    event WriterRemoved(address indexed writer);
+
+    error ZeroAddress();
+    error ZeroNullifier();
+    error ZeroIntentHash();
+    error UnauthorizedWriter(address caller);
+    error WriterAlreadyAuthorized(address writer);
+    error WriterNotAuthorized(address writer);
+    error NullifierAlreadyExists(bytes32 nullifier);
+    error IntentAlreadyBound(bytes32 intentHash, bytes32 nullifier);
+
+    function legacyNullifierRegistry() external view returns (INullifierRegistry);
+    function isNullified(bytes32 _nullifier) external view returns (bool);
+    function intentHashByNullifier(bytes32 _nullifier) external view returns (bytes32);
+    function nullifierByIntentHash(bytes32 _intentHash) external view returns (bytes32);
+    function addNullifier(bytes32 _nullifier, bytes32 _intentHash) external;
+    function isWriter(address _writer) external view returns (bool);
+    function getWriters() external view returns (address[] memory);
+    function addWritePermission(address _writer) external;
+    function removeWritePermission(address _writer) external;
+}

--- a/contracts/interfaces/IOrchestratorV3.sol
+++ b/contracts/interfaces/IOrchestratorV3.sol
@@ -26,6 +26,8 @@ interface IOrchestratorV3 is IOrchestratorV2 {
     struct IntentSettlement {
         uint256 releasedAmount;
         uint64 settledAt;
+        /// @notice Distinguishes an evidence-free maker release from verified fulfillment recovery.
+        bool isManualRelease;
     }
 
     struct IntentCancellation {
@@ -70,7 +72,9 @@ interface IOrchestratorV3 is IOrchestratorV2 {
      * @notice Returns recovery data when a settlement callback failed open.
      * @dev Successful settlement callbacks leave this record empty.
      */
-    function getIntentSettlement(bytes32 _intentHash) external view returns (uint256 releasedAmount, uint64 settledAt);
+    function getIntentSettlement(
+        bytes32 _intentHash
+    ) external view returns (uint256 releasedAmount, uint64 settledAt, bool isManualRelease);
     /**
      * @notice Returns the liquidity-unlock timestamp when a cancellation callback failed open.
      * @dev The risk hook must use this timestamp during reconciliation rather than the later transaction time.

--- a/contracts/interfaces/IRiskManager.sol
+++ b/contracts/interfaces/IRiskManager.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.18;
 
 import { IIntentRiskHook } from "./IIntentRiskHook.sol";
+import { INullifierRegistryV2 } from "./INullifierRegistryV2.sol";
 import { IOrchestratorV3 } from "./IOrchestratorV3.sol";
 import { IStakeVault } from "./IStakeVault.sol";
 
@@ -40,7 +41,7 @@ interface IRiskManager is IIntentRiskHook {
         bool chargebackable;
         /// @notice Whether held settlement proceeds may replace membership stake as post-settlement coverage.
         bool deferredPayoutEnabled;
-        /// @notice Upward-rounded portion of the exact released amount retained as coverage, in basis points.
+        /// @notice Portion of the exact released amount retained as coverage; chargebackable v1 policy requires 10_000.
         uint16 reserveBps;
         /// @notice Half-open period after settlement during which authenticated chargebacks may slash coverage.
         uint64 riskWindow;
@@ -124,28 +125,32 @@ interface IRiskManager is IIntentRiskHook {
         uint256 slashedAmount;
     }
 
-    /** @notice Signed evidence authorizing compensation from an active chargeback position. */
+    /** @notice Signed evidence authorizing full compensation from an active chargeback position. */
     struct ChargebackAttestation {
-        /// @notice Chain domain preventing cross-chain replay.
-        uint256 chainId;
-        /// @notice RiskManager domain preventing replay across manager replacements.
-        address riskManager;
-        /// @notice Orchestrator domain preventing replay across intent namespaces.
-        address orchestrator;
-        /// @notice Position whose remaining coverage may be consumed.
+        /// @notice Position whose full released amount may be consumed.
         bytes32 intentHash;
-        /// @notice Payment platform bound to the position snapshot.
+        /// @notice Hash of `data`, binding all chargeback details to the witness signatures.
+        bytes32 dataHash;
+        /// @notice Signatures from the dedicated chargeback witness set.
+        bytes[] signatures;
+        /// @notice ABI-encoded `ChargebackDetails` authenticated by `dataHash`.
+        bytes data;
+        /// @notice Optional unsigned metadata for off-chain correlation.
+        bytes metadata;
+    }
+
+    /** @notice Verifier-derived dispute details bound to the original fulfilled payment. */
+    struct ChargebackDetails {
+        /// @notice Payment-method hash recorded by the payment verifier.
         bytes32 paymentMethod;
-        /// @notice LP loss requested; compensation is capped at remaining coverage.
-        uint256 chargebackAmount;
-        /// @notice Nonzero off-chain evidence identifier emitted for audit correlation.
-        bytes32 evidenceId;
-        /// @notice Manager-wide one-time nonce preventing attestation replay.
-        uint256 nonce;
-        /// @notice First timestamp at which the attestation is valid.
-        uint64 validAfter;
-        /// @notice Last timestamp at which the attestation itself is valid.
-        uint64 validUntil;
+        /// @notice Hashed provider payment identifier recorded by the payment verifier.
+        bytes32 originalPaymentId;
+        /// @notice Nonzero provider dispute identifier used for global replay protection.
+        bytes32 disputeId;
+        /// @notice Original fiat amount in the payment method's minor unit (for example, cents).
+        uint256 paymentAmount;
+        /// @notice Fiat-currency hash recorded by the payment verifier.
+        bytes32 paymentCurrency;
     }
 
     /* ============ Events ============ */
@@ -224,11 +229,11 @@ interface IRiskManager is IIntentRiskHook {
         address indexed stakeOwner,
         address indexed lp,
         RiskMode mode,
-        uint256 requestedAmount,
+        uint256 releasedAmount,
         uint256 compensatedAmount,
         uint256 totalCompensated,
         uint256 remainingCoverage,
-        bytes32 evidenceId
+        bytes32 disputeId
     );
     event AttestationVerifierUpdated(address indexed previousVerifier, address indexed newVerifier);
     event DeferredPayoutHookUpdated(address indexed previousHook, address indexed newHook);
@@ -263,10 +268,10 @@ interface IRiskManager is IIntentRiskHook {
     error InsufficientDeferredPayoutCoverage(uint256 availableCoverage, uint256 requiredCoverage);
     error PositionNotMature(uint64 coverageDeadline, uint64 currentTime);
     error InvalidAttestation();
-    error AttestationNotYetValid(uint64 validAfter, uint64 currentTime);
-    error AttestationExpired(uint64 validUntil, uint64 currentTime);
+    error InvalidPaymentBinding(bytes32 intentHash, bytes32 nullifier);
     error ChargebackWindowClosed(uint64 coverageDeadline, uint64 currentTime);
-    error AttestationNonceUsed(uint256 nonce);
+    error ChargebackEvidenceUsed(bytes32 nullifier);
+    error IncompleteChargebackCoverage(uint256 available, uint256 required);
     error AttestationVerificationFailed();
     error TimestampOverflow(uint256 timestamp);
 
@@ -299,12 +304,8 @@ interface IRiskManager is IIntentRiskHook {
     function releaseMaturedPosition(bytes32 _intentHash) external;
     /** @notice Atomically matures several settled positions. */
     function releaseMaturedPositions(bytes32[] calldata _intentHashes) external;
-    /** @notice Authenticates chargeback evidence and compensates the LP up to remaining coverage. */
-    function submitChargeback(
-        ChargebackAttestation calldata _attestation,
-        bytes[] calldata _signatures,
-        bytes calldata _verificationData
-    ) external;
+    /** @notice Authenticates chargeback evidence and compensates the LP for the full gross released amount. */
+    function submitChargeback(ChargebackAttestation calldata _attestation) external;
 
     /* ============ View and Math Functions ============ */
 
@@ -348,4 +349,6 @@ interface IRiskManager is IIntentRiskHook {
     function orchestrator() external view returns (IOrchestratorV3);
     /** @notice Returns the immutable policy-agnostic custody and reservation vault. */
     function stakeVault() external view returns (IStakeVault);
+    /** @notice Returns the immutable registry that binds verified payment nullifiers to intents. */
+    function nullifierRegistry() external view returns (INullifierRegistryV2);
 }

--- a/contracts/mocks/OrchestratorV3HarnessMocks.sol
+++ b/contracts/mocks/OrchestratorV3HarnessMocks.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import { OrchestratorV3 } from "../OrchestratorV3.sol";
+import { IIntentRiskHook } from "../interfaces/IIntentRiskHook.sol";
+
+/** @notice State harness for defensive branches that valid admission keeps unreachable. */
+contract OrchestratorV3StateHarness is OrchestratorV3 {
+    constructor(
+        address _owner,
+        uint256 _chainId,
+        address _escrowRegistry,
+        address _paymentVerifierRegistry,
+        address _relayerRegistry,
+        uint256 _protocolFee,
+        address _protocolFeeRecipient,
+        uint256 _riskCallbackGasLimit
+    ) OrchestratorV3(
+        _owner,
+        _chainId,
+        _escrowRegistry,
+        _paymentVerifierRegistry,
+        _relayerRegistry,
+        _protocolFee,
+        _protocolFeeRecipient,
+        _riskCallbackGasLimit
+    ) { }
+
+    function clearPostIntentHook(bytes32 _intentHash) external {
+        delete intents[_intentHash].postIntentHook;
+    }
+}
+
+interface IOrchestratorV3ReentryTarget {
+    function cancelIntent(bytes32 _intentHash) external;
+    function cleanupOrphanedIntents(bytes32[] calldata _intentHashes) external;
+    function setDepositRiskHook(address _escrow, uint256 _depositId, IIntentRiskHook _hook) external;
+}
+
+/** @notice Risk hook that catches deliberate attempts to reenter each guarded V3 entrypoint. */
+contract OrchestratorV3ReentrantRiskHook is IIntentRiskHook {
+    IOrchestratorV3ReentryTarget public immutable orchestrator;
+    address public immutable escrow;
+    bool public reenterOnCreate;
+    bool public setterReentrySucceeded;
+    bool public cancelReentrySucceeded;
+    bool public cleanupReentrySucceeded;
+
+    constructor(IOrchestratorV3ReentryTarget _orchestrator, address _escrow) {
+        orchestrator = _orchestrator;
+        escrow = _escrow;
+    }
+
+    function setReenterOnCreate(bool _enabled) external {
+        reenterOnCreate = _enabled;
+    }
+
+    function onIntentCreated(bytes32) external override returns (bool) {
+        if (reenterOnCreate) {
+            try orchestrator.setDepositRiskHook(escrow, 0, this) {
+                setterReentrySucceeded = true;
+            } catch { }
+        }
+        return false;
+    }
+
+    function onIntentCancelled(bytes32 _intentHash) external override {
+        try orchestrator.cancelIntent(_intentHash) {
+            cancelReentrySucceeded = true;
+        } catch { }
+        bytes32[] memory intentHashes = new bytes32[](1);
+        intentHashes[0] = _intentHash;
+        try orchestrator.cleanupOrphanedIntents(intentHashes) {
+            cleanupReentrySucceeded = true;
+        } catch { }
+    }
+
+    function onIntentFulfilled(bytes32, uint256) external override { }
+    function onIntentReleased(bytes32, uint256) external override { }
+}

--- a/contracts/mocks/RiskManagerHarnessMocks.sol
+++ b/contracts/mocks/RiskManagerHarnessMocks.sol
@@ -7,10 +7,13 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IEscrowV2 } from "../interfaces/IEscrowV2.sol";
 import { IAttestationVerifier } from "../interfaces/IAttestationVerifier.sol";
 import { IIntentRiskHook } from "../interfaces/IIntentRiskHook.sol";
+import { INullifierRegistryV2 } from "../interfaces/INullifierRegistryV2.sol";
 import { IOrchestratorV3 } from "../interfaces/IOrchestratorV3.sol";
 import { IRiskManager } from "../interfaces/IRiskManager.sol";
 import { IStakeVault } from "../interfaces/IStakeVault.sol";
 import { RiskManager } from "../RiskManager.sol";
+import { NullifierRegistryV2 } from "../registries/NullifierRegistryV2.sol";
+import { INullifierRegistry } from "../interfaces/INullifierRegistry.sol";
 
 /**
  * @title RiskManagerStateHarness
@@ -23,8 +26,13 @@ contract RiskManagerStateHarness is RiskManager {
         address _owner,
         IOrchestratorV3 _orchestrator,
         IStakeVault _stakeVault,
-        IAttestationVerifier _attestationVerifier
-    ) RiskManager(_owner, _orchestrator, _stakeVault, _attestationVerifier) { }
+        IAttestationVerifier _attestationVerifier,
+        INullifierRegistryV2 _nullifierRegistry
+    ) RiskManager(_owner, _orchestrator, _stakeVault, _attestationVerifier, _nullifierRegistry) { }
+
+    function forcePlatformRiskConfig(bytes32 _paymentMethod, PlatformRiskConfig calldata _config) external {
+        platformRiskConfigs[_paymentMethod] = _config;
+    }
 
     function forcePosition(
         bytes32 _intentHash,
@@ -44,6 +52,22 @@ contract RiskManagerStateHarness is RiskManager {
         position.coverageDeadline = _coverageDeadline;
     }
 
+    function forceRiskPosition(bytes32 _intentHash, RiskPosition calldata _position) external {
+        riskPositions[_intentHash] = _position;
+    }
+
+    function exposedReleaseManualPosition(
+        bytes32 _intentHash,
+        uint256 _releasedAmount,
+        uint64 _settledAt
+    ) external {
+        _releaseManualPosition(_intentHash, _releasedAmount, _settledAt);
+    }
+
+    function exposedSynchronizeSettlement(bytes32 _intentHash) external {
+        _synchronizeSettlement(_intentHash);
+    }
+
     /** @notice Calls a target while this manager's inherited reentrancy guard is entered. */
     function callWhileEntered(address _target, bytes calldata _data) external nonReentrant {
         (bool success, bytes memory returnData) = _target.call(_data);
@@ -51,6 +75,15 @@ contract RiskManagerStateHarness is RiskManager {
         assembly {
             revert(add(returnData, 0x20), mload(returnData))
         }
+    }
+}
+
+/** @notice Corrupts one binding direction solely to exercise RiskManager's defensive two-way check. */
+contract NullifierRegistryV2StateHarness is NullifierRegistryV2 {
+    constructor(INullifierRegistry _legacyNullifierRegistry) NullifierRegistryV2(_legacyNullifierRegistry) { }
+
+    function forceNullifierByIntentHash(bytes32 _intentHash, bytes32 _nullifier) external {
+        nullifierByIntentHash[_intentHash] = _nullifier;
     }
 }
 
@@ -64,7 +97,6 @@ contract RiskManagerOrchestratorHarness {
     mapping(bytes32 => IOrchestratorV3.RiskIntentData) internal riskIntents;
     mapping(bytes32 => uint64) internal cancellationTimes;
     mapping(bytes32 => IOrchestratorV3.IntentSettlement) internal settlements;
-
     function setRiskIntent(bytes32 _intentHash, IOrchestratorV3.RiskIntentData calldata _intent) external {
         riskIntents[_intentHash] = _intent;
     }
@@ -73,8 +105,13 @@ contract RiskManagerOrchestratorHarness {
         cancellationTimes[_intentHash] = _cancelledAt;
     }
 
-    function setIntentSettlement(bytes32 _intentHash, uint256 _releasedAmount, uint64 _settledAt) external {
-        settlements[_intentHash] = IOrchestratorV3.IntentSettlement(_releasedAmount, _settledAt);
+    function setIntentSettlement(
+        bytes32 _intentHash,
+        uint256 _releasedAmount,
+        uint64 _settledAt,
+        bool _isManualRelease
+    ) external {
+        settlements[_intentHash] = IOrchestratorV3.IntentSettlement(_releasedAmount, _settledAt, _isManualRelease);
     }
 
     function getRiskIntent(bytes32 _intentHash) external view returns (IOrchestratorV3.RiskIntentData memory) {
@@ -85,9 +122,9 @@ contract RiskManagerOrchestratorHarness {
         return cancellationTimes[_intentHash];
     }
 
-    function getIntentSettlement(bytes32 _intentHash) external view returns (uint256, uint64) {
+    function getIntentSettlement(bytes32 _intentHash) external view returns (uint256, uint64, bool) {
         IOrchestratorV3.IntentSettlement memory settlement = settlements[_intentHash];
-        return (settlement.releasedAmount, settlement.settledAt);
+        return (settlement.releasedAmount, settlement.settledAt, settlement.isManualRelease);
     }
 
     function createPosition(IIntentRiskHook _hook, bytes32 _intentHash) external returns (bool) {
@@ -263,4 +300,5 @@ contract RiskManagerVaultHarness {
     function acceptController() external {
         acceptControllerCalls += 1;
     }
+
 }

--- a/contracts/mocks/UnifiedPaymentVerifierV3Harness.sol
+++ b/contracts/mocks/UnifiedPaymentVerifierV3Harness.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import { IOrchestrator } from "../interfaces/IOrchestrator.sol";
+import { IPaymentVerifier } from "../interfaces/IPaymentVerifier.sol";
+
+/** @notice Legacy-orchestrator-shaped caller used to cover UPV V3's V1 snapshot path. */
+contract UnifiedPaymentVerifierV3CallerHarness {
+    mapping(bytes32 => IOrchestrator.Intent) internal intents;
+
+    function setIntent(bytes32 _intentHash, IOrchestrator.Intent calldata _intent) external {
+        intents[_intentHash] = _intent;
+    }
+
+    function getIntent(bytes32 _intentHash) external view returns (IOrchestrator.Intent memory) {
+        return intents[_intentHash];
+    }
+
+    function verifyPayment(
+        IPaymentVerifier _verifier,
+        IPaymentVerifier.VerifyPaymentData calldata _data
+    ) external returns (IPaymentVerifier.PaymentVerificationResult memory) {
+        return _verifier.verifyPayment(_data);
+    }
+}

--- a/contracts/registries/NullifierRegistryV2.sol
+++ b/contracts/registries/NullifierRegistryV2.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
+import { AddressArrayUtils } from "../external/AddressArrayUtils.sol";
+import { INullifierRegistry } from "../interfaces/INullifierRegistry.sol";
+import { INullifierRegistryV2 } from "../interfaces/INullifierRegistryV2.sol";
+
+/**
+ * @title NullifierRegistryV2
+ * @notice Enforces payment replay protection while binding every new payment to exactly one intent.
+ * @dev The immutable predecessor keeps every pre-cutover nullifier authoritative. New writes are local
+ *      and bidirectional; neither side of a binding can ever be replaced.
+ * @dev CUTOVER INVARIANT: before this registry accepts its first live write, every retired verifier must
+ *      permanently lose write permission on the legacy registry and payment methods must never be routed
+ *      back to it. The legacy registry cannot observe V2 writes, so rollback would otherwise reopen replay.
+ */
+contract NullifierRegistryV2 is Ownable, INullifierRegistryV2 {
+    using AddressArrayUtils for address[];
+
+    INullifierRegistry public immutable override legacyNullifierRegistry;
+
+    mapping(bytes32 => bytes32) public override intentHashByNullifier;
+    mapping(bytes32 => bytes32) public override nullifierByIntentHash;
+    mapping(address => bool) public override isWriter;
+    address[] internal writers;
+
+    modifier onlyWriter() {
+        if (!isWriter[msg.sender]) revert UnauthorizedWriter(msg.sender);
+        _;
+    }
+
+    constructor(INullifierRegistry _legacyNullifierRegistry) Ownable() {
+        if (address(_legacyNullifierRegistry).code.length == 0) revert ZeroAddress();
+        legacyNullifierRegistry = _legacyNullifierRegistry;
+    }
+
+    function isNullified(bytes32 _nullifier) public view override returns (bool) {
+        return intentHashByNullifier[_nullifier] != bytes32(0)
+            || legacyNullifierRegistry.isNullified(_nullifier);
+    }
+
+    function addNullifier(bytes32 _nullifier, bytes32 _intentHash) external override onlyWriter {
+        if (_nullifier == bytes32(0)) revert ZeroNullifier();
+        if (_intentHash == bytes32(0)) revert ZeroIntentHash();
+        if (isNullified(_nullifier)) revert NullifierAlreadyExists(_nullifier);
+
+        bytes32 existingNullifier = nullifierByIntentHash[_intentHash];
+        if (existingNullifier != bytes32(0)) {
+            revert IntentAlreadyBound(_intentHash, existingNullifier);
+        }
+
+        intentHashByNullifier[_nullifier] = _intentHash;
+        nullifierByIntentHash[_intentHash] = _nullifier;
+
+        emit NullifierAdded(_nullifier, _intentHash, msg.sender);
+    }
+
+    function addWritePermission(address _writer) external override onlyOwner {
+        if (_writer == address(0)) revert ZeroAddress();
+        if (isWriter[_writer]) revert WriterAlreadyAuthorized(_writer);
+
+        isWriter[_writer] = true;
+        writers.push(_writer);
+        emit WriterAdded(_writer);
+    }
+
+    function removeWritePermission(address _writer) external override onlyOwner {
+        if (!isWriter[_writer]) revert WriterNotAuthorized(_writer);
+
+        isWriter[_writer] = false;
+        writers.removeStorage(_writer);
+        emit WriterRemoved(_writer);
+    }
+
+    function getWriters() external view override returns (address[] memory) {
+        return writers;
+    }
+}

--- a/contracts/unifiedVerifier/BaseUnifiedPaymentVerifierV3.sol
+++ b/contracts/unifiedVerifier/BaseUnifiedPaymentVerifierV3.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { Bytes32ArrayUtils } from "../external/Bytes32ArrayUtils.sol";
+import { IAttestationVerifier } from "../interfaces/IAttestationVerifier.sol";
+import { INullifierRegistryV2 } from "../interfaces/INullifierRegistryV2.sol";
+import { IOrchestratorRegistry } from "../interfaces/IOrchestratorRegistry.sol";
+
+/**
+ * @title BaseUnifiedPaymentVerifierV3
+ * @notice Base contract for unified payment verification that manages configuration for multiple payment methods.
+ *
+ * This contract handles:
+ * - Supported payment methods
+ * - Attestation verification through pluggable attestation verifiers
+ *
+ * @dev This is an abstract contract that must be inherited by concrete implementations.
+ *      It replaces the previous BaseReclaimVerifier with a more flexible architecture.
+ */
+abstract contract BaseUnifiedPaymentVerifierV3 is Ownable {
+
+    using Bytes32ArrayUtils for bytes32[];
+
+    /* ============ Constants ============ */
+
+    uint256 internal constant PRECISE_UNIT = 1e18;
+
+    /* ============ Events ============ */
+
+    event PaymentMethodAdded(bytes32 indexed paymentMethod);
+    event PaymentMethodRemoved(bytes32 indexed paymentMethod);
+    event AttestationVerifierUpdated(address indexed oldVerifier, address indexed newVerifier);
+    /* ============ State Variables ============ */
+
+    IOrchestratorRegistry public immutable orchestratorRegistry;
+    INullifierRegistryV2 public immutable nullifierRegistry;
+    IAttestationVerifier public attestationVerifier;
+
+    bytes32[] public paymentMethods;
+    mapping(bytes32 => bool) public isPaymentMethod;
+
+    /* ============ Modifiers ============ */
+
+    /**
+     * Modifier to ensure only an authorized orchestrator can call.
+     */
+    modifier onlyOrchestrator() {
+        require(orchestratorRegistry.isOrchestrator(msg.sender), "Only orchestrator can call");
+        _;
+    }
+
+    /* ============ Constructor ============ */
+
+    /**
+     * @notice Initializes base payment verifier
+     * @param _orchestratorRegistry The orchestrator registry contract that authorizes orchestrators
+     * @param _nullifierRegistry The nullifier registry contract that will be used to prevent double-spends
+     * @param _attestationVerifier The attestation verifier contract that will be used to verify attestation by the
+     * offchain / ZK attestation service
+     */
+    constructor(
+        IOrchestratorRegistry _orchestratorRegistry,
+        INullifierRegistryV2 _nullifierRegistry,
+        IAttestationVerifier _attestationVerifier
+    ) Ownable() {
+        require(address(_orchestratorRegistry).code.length != 0, "UPV: Invalid orchestrator registry");
+        require(address(_nullifierRegistry).code.length != 0, "UPV: Invalid nullifier registry");
+        require(address(_attestationVerifier).code.length != 0, "UPV: Invalid attestation verifier");
+        orchestratorRegistry = _orchestratorRegistry;
+        nullifierRegistry = _nullifierRegistry;
+        attestationVerifier = _attestationVerifier;
+    }
+
+    /* ============ External Functions ============ */
+
+    /**
+     * ONLY OWNER: Adds a new payment method with timestamp buffer
+     * @param _paymentMethod The payment method hash; Hash the payment method name in lowercase
+     */
+    function addPaymentMethod(bytes32 _paymentMethod) external onlyOwner {
+        require(!isPaymentMethod[_paymentMethod], "UPV: Payment method already exists");
+
+        isPaymentMethod[_paymentMethod] = true;
+        paymentMethods.push(_paymentMethod);
+
+        emit PaymentMethodAdded(_paymentMethod);
+    }
+
+    /**
+     * ONLY OWNER: Removes a payment method and associated configuration
+     * @param _paymentMethod The payment method to remove
+     */
+    function removePaymentMethod(bytes32 _paymentMethod) external onlyOwner {
+        require(isPaymentMethod[_paymentMethod], "UPV: Payment method does not exist");
+
+        delete isPaymentMethod[_paymentMethod];
+        paymentMethods.removeStorage(_paymentMethod);
+
+        emit PaymentMethodRemoved(_paymentMethod);
+    }
+
+    /**
+     * @notice Updates the attestation verifier contract
+     * @param _newVerifier The new attestation verifier address
+     */
+    function setAttestationVerifier(address _newVerifier) external onlyOwner {
+        address oldVerifier = address(attestationVerifier);
+        require(_newVerifier.code.length != 0, "UPV: Invalid attestation verifier");
+        require(_newVerifier != oldVerifier, "UPV: Same verifier");
+
+        attestationVerifier = IAttestationVerifier(_newVerifier);
+        emit AttestationVerifierUpdated(oldVerifier, _newVerifier);
+    }
+
+    /* ============ View Functions ============ */
+
+    function getPaymentMethods() external view returns (bytes32[] memory) {
+        return paymentMethods;
+    }
+
+    /* ============ Internal Functions ============ */
+
+    /**
+     * Validates and adds a nullifier to prevent double-spending
+     * @param _nullifier The nullifier to add
+     */
+    function _validateAndAddNullifier(bytes32 _nullifier, bytes32 _intentHash) internal {
+        require(!nullifierRegistry.isNullified(_nullifier), "Nullifier has already been used");
+        nullifierRegistry.addNullifier(_nullifier, _intentHash);
+    }
+}

--- a/contracts/unifiedVerifier/UnifiedPaymentVerifierV3.sol
+++ b/contracts/unifiedVerifier/UnifiedPaymentVerifierV3.sol
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import { BaseUnifiedPaymentVerifierV3 } from "./BaseUnifiedPaymentVerifierV3.sol";
+import { INullifierRegistryV2 } from "../interfaces/INullifierRegistryV2.sol";
+import { IPaymentVerifier } from "../interfaces/IPaymentVerifier.sol";
+import { IAttestationVerifier } from "../interfaces/IAttestationVerifier.sol";
+import { IOrchestrator } from "../interfaces/IOrchestrator.sol";
+import { IOrchestratorV2 } from "../interfaces/IOrchestratorV2.sol";
+import { IOrchestratorRegistry } from "../interfaces/IOrchestratorRegistry.sol";
+import { IEscrow } from "../interfaces/IEscrow.sol";
+
+/**
+ * @title UnifiedPaymentVerifierV3
+ * @notice Verifies payment proofs for multiple payment methods. This is a unified verifier that
+ * replaces individual payment verifiers (VenmoVerifier, PayPalVerifier, etc.) with a single
+ * configurable contract. This contract holds no critical state and can be swapped easily for another
+ * verifier contract.
+ *
+ * Key features:
+ * - Supports multiple payment methods, each with custom configuration
+ * - Uses AttestationVerifier to validate offchain payment attestations
+ * - Ensures trust anchor integrity for off-chain verification processes
+ * - Verifies standardized payment details against provided data
+ * @dev The payment attestation should be signed using the EIP-712 standard
+ */
+contract UnifiedPaymentVerifierV3 is IPaymentVerifier, BaseUnifiedPaymentVerifierV3 {
+
+    /* ============ Constants ============ */
+
+    // Max timestamp buffer
+    uint256 private constant MAX_TIMESTAMP_BUFFER = 48 * 60 * 60 * 1000; // 48 hours
+
+    // EIP-712 Domain Separator
+    bytes32 private constant DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
+
+    // EIP-712 Type Hash for PaymentAttestation
+    bytes32 private constant PAYMENT_ATTESTATION_TYPEHASH = keccak256(
+        "PaymentAttestation(bytes32 intentHash,uint256 releaseAmount,bytes32 dataHash)"
+    );
+
+    // Used to detect V2 orchestrators that expose getDepositPreIntentHook(address,uint256).
+    bytes4 private constant GET_DEPOSIT_PRE_INTENT_HOOK_SELECTOR =
+        bytes4(keccak256("getDepositPreIntentHook(address,uint256)"));
+
+    /* ============ State Variables ============ */
+
+    // EIP-712 Domain Separator (computed once at deployment)
+    bytes32 public immutable DOMAIN_SEPARATOR;
+
+    /* ============ Events ============ */
+
+    /**
+     * @notice Capture and emit payment details for offchain reconciliation
+     */
+    event PaymentVerified(
+        bytes32 indexed intentHash,
+        bytes32 indexed method,
+        bytes32 indexed currency,
+        uint256 amount,
+        uint256 timestamp,
+        bytes32 paymentId,
+        bytes32 payeeId
+    );
+
+    /* ============ Structs ============ */
+
+    struct PaymentDetails {
+        bytes32 method;           // Payment method hash (e.g., "venmo", "paypal", "wise")
+        bytes32 payeeId;          // Payment recipient ID (hashed payee details to preserve privacy)
+        uint256 amount;           // Payment amount in smallest currency unit (i.e. cents)
+        bytes32 currency;         // Payment currency hash (e.g., "USD", "EUR")
+        uint256 timestamp;        // Payment timestamp in UTC in milliseconds
+        bytes32 paymentId;        // Hashed payment identifier from the service (e.g. hashed venmo payment ID to preserve privacy)
+    }
+
+    struct IntentSnapshot {
+        bytes32 intentHash;
+        uint256 amount;
+        bytes32 paymentMethod;
+        bytes32 fiatCurrency;
+        bytes32 payeeDetails;
+        uint256 conversionRate;
+        uint256 signalTimestamp;
+        uint256 timestampBuffer;
+    }
+
+    struct PaymentAttestation {
+        bytes32 intentHash;       // Binds the payment to the intent on Orchestrator
+        uint256 releaseAmount;    // Final token amount to release on-chain after FX
+        bytes32 dataHash;         // Hash of the additional data to verify integrity
+        bytes[] signatures;       // Array of signatures from witnesses
+        bytes data;               // Data for verification
+        bytes metadata;           // Additional metadata; isn't signed by the witnesses
+    }
+
+    /* ============ Constructor ============ */
+
+    constructor(
+        IOrchestratorRegistry _orchestratorRegistry,
+        INullifierRegistryV2 _nullifierRegistry,
+        IAttestationVerifier _attestationVerifier
+    ) BaseUnifiedPaymentVerifierV3(
+        _orchestratorRegistry,
+        _nullifierRegistry,
+        _attestationVerifier
+    ) {
+        // Compute EIP-712 domain separator
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                DOMAIN_TYPEHASH,
+                keccak256(bytes("UnifiedPaymentVerifier")), // name
+                keccak256(bytes("1")),                      // version
+                block.chainid,                              // chainId
+                address(this)                               // verifyingContract
+            )
+        );
+    }
+
+    /* ============ External Functions ============ */
+
+    /**
+     * ONLY ORCHESTRATOR: Verifies a standardized payment attestation generated by the attestation service.
+     * NOTE: This contract has write permissions on nullifier registry, and nullifies the payment after verification.
+     * Hence only Orchestrator can call this function to prevent griefing.
+     *
+     * @param _verifyPaymentData Payment proof and intent details required for verification
+     * @return result The payment verification result containing success status, intent hash, and release amount
+     * @dev Ensure the orchestrator verifies the intent exists before calling this function
+     */
+    function verifyPayment(
+        VerifyPaymentData calldata _verifyPaymentData
+    )
+        external
+        override
+        onlyOrchestrator()
+        returns (PaymentVerificationResult memory result)
+    {
+        PaymentAttestation memory attestation = _decodeAttestation(_verifyPaymentData.paymentProof);
+        require(attestation.intentHash == _verifyPaymentData.intentHash, "UPV: Attestation hash mismatch");
+        require(attestation.releaseAmount != 0, "UPV: Invalid release amount");
+
+        (
+            PaymentDetails memory paymentDetails,
+            IntentSnapshot memory intentSnapshot
+        ) = _decodeAttestationPayload(attestation.data);
+        require(isPaymentMethod[paymentDetails.method], "UPV: Invalid payment method");
+        require(paymentDetails.method == intentSnapshot.paymentMethod, "UPV: Payment method mismatch");
+        require(paymentDetails.paymentId != bytes32(0), "UPV: Invalid payment ID");
+        require(paymentDetails.amount != 0, "UPV: Invalid payment amount");
+        require(paymentDetails.currency != bytes32(0), "UPV: Invalid payment currency");
+
+        _validateIntentSnapshot(_verifyPaymentData.intentHash, intentSnapshot);
+
+        bool isValid = _verifyAttestation(attestation);
+        require(isValid, "UPV: Invalid attestation");
+
+        // Nullify the payment to prevent double-spending
+        _nullifyPayment(paymentDetails.method, paymentDetails.paymentId, attestation.intentHash);
+
+        _emitPaymentDetails(attestation.intentHash, paymentDetails);
+
+        uint256 releaseAmount = _calculateReleaseAmount(attestation.releaseAmount, intentSnapshot.amount);
+        result = PaymentVerificationResult({
+            success: true,
+            intentHash: attestation.intentHash,
+            releaseAmount: releaseAmount
+        });
+
+        return result;
+    }
+
+    /* ============ Internal Functions ============ */
+
+    function _decodeAttestation(bytes memory paymentProof) internal pure returns (PaymentAttestation memory) {
+        return abi.decode(paymentProof, (PaymentAttestation));
+    }
+
+    function _decodeAttestationPayload(bytes memory paymentData)
+        internal
+        pure
+        returns (PaymentDetails memory paymentDetails, IntentSnapshot memory intentSnapshot)
+    {
+        (paymentDetails, intentSnapshot) = abi.decode(paymentData, (PaymentDetails, IntentSnapshot));
+    }
+
+    /**
+     * Verifies the EIP-712 attestation using the attestation verifier. Also verifies the integrity of the
+     * verify payment data using the data hash attached to the attestation.
+     */
+    function _verifyAttestation(PaymentAttestation memory attestation) internal view returns (bool) {
+        bytes32 structHash = keccak256(
+            abi.encode(
+                PAYMENT_ATTESTATION_TYPEHASH,
+                attestation.intentHash,
+                attestation.releaseAmount,
+                attestation.dataHash
+            )
+        );
+
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                DOMAIN_SEPARATOR,
+                structHash
+            )
+        );
+
+        // Verify data integrity - the data hash must match what was signed
+        require(
+            keccak256(attestation.data) == attestation.dataHash,
+            "UPV: Data hash mismatch"
+        );
+
+        bool isValid = attestationVerifier.verify(
+            digest,
+            attestation.signatures,
+            attestation.data
+        );
+
+        return isValid;
+    }
+
+    /**
+     * Reads intent data from the Orchestrator and checks them against the intent data provided by the
+     * attestation verifier.
+     */
+    function _validateIntentSnapshot(
+        bytes32 intentHash,
+        IntentSnapshot memory snapshot
+    ) internal view {
+        require(snapshot.intentHash == intentHash, "UPV: Snapshot hash mismatch");
+
+        if (_isV2Orchestrator(msg.sender)) {
+            IOrchestratorV2.Intent memory intentV2 = IOrchestratorV2(msg.sender).getIntent(intentHash);
+            _validateSnapshotAgainstIntent(
+                snapshot,
+                intentV2.payeeId,
+                intentV2.amount,
+                intentV2.paymentMethod,
+                intentV2.fiatCurrency,
+                intentV2.conversionRate,
+                intentV2.timestamp
+            );
+        } else {
+            IOrchestrator.Intent memory intent = IOrchestrator(msg.sender).getIntent(intentHash);
+            _validateSnapshotAgainstIntent(
+                snapshot,
+                intent.payeeId,
+                intent.amount,
+                intent.paymentMethod,
+                intent.fiatCurrency,
+                intent.conversionRate,
+                intent.timestamp
+            );
+        }
+
+        require(snapshot.timestampBuffer <= MAX_TIMESTAMP_BUFFER, "UPV: Snapshot timestamp buffer exceeds maximum");
+    }
+
+    function _validateSnapshotAgainstIntent(
+        IntentSnapshot memory snapshot,
+        bytes32 payeeId,
+        uint256 amount,
+        bytes32 paymentMethod,
+        bytes32 fiatCurrency,
+        uint256 conversionRate,
+        uint256 signalTimestamp
+    ) internal pure {
+        require(snapshot.payeeDetails == payeeId, "UPV: Snapshot payee mismatch");
+        require(snapshot.amount == amount, "UPV: Snapshot amount mismatch");
+        require(snapshot.paymentMethod == paymentMethod, "UPV: Snapshot method mismatch");
+        require(snapshot.fiatCurrency == fiatCurrency, "UPV: Snapshot currency mismatch");
+        require(snapshot.conversionRate == conversionRate, "UPV: Snapshot rate mismatch");
+        require(snapshot.signalTimestamp == signalTimestamp, "UPV: Snapshot timestamp mismatch");
+    }
+
+    function _isV2Orchestrator(address orchestrator) internal view returns (bool isV2Orchestrator) {
+        (isV2Orchestrator, ) = orchestrator.staticcall(
+            abi.encodeWithSelector(
+                GET_DEPOSIT_PRE_INTENT_HOOK_SELECTOR,
+                address(0),
+                0
+            )
+        );
+    }
+
+    /**
+     * Nullifies a payment to prevent double-spending
+     * @dev Creates a unique nullifier by encoding both the payment method and payment ID together.
+     * This prevents collisions where the same payment ID could exist across different payment
+     * methods (e.g., Venmo transaction #123 vs PayPal transaction #123).
+     */
+    function _nullifyPayment(bytes32 paymentMethod, bytes32 paymentId, bytes32 intentHash) internal {
+        bytes32 nullifier = keccak256(abi.encodePacked(paymentMethod, paymentId));
+        _validateAndAddNullifier(nullifier, intentHash);
+    }
+
+    /**
+     * Calculates the release amount for an intent by capping the release amount to the intent amount
+     */
+    function _calculateReleaseAmount(uint256 releaseAmount, uint256 intentAmount) internal pure returns (uint256) {
+        if (releaseAmount > intentAmount) {
+            return intentAmount;
+        }
+        return releaseAmount;
+    }
+
+    /**
+     * Emits the payment details for offchain reconciliation
+     */
+    function _emitPaymentDetails(bytes32 intentHash, PaymentDetails memory paymentDetails) internal {
+        emit PaymentVerified(
+            intentHash,                 // Tie the payment details to the intent hash
+            paymentDetails.method,
+            paymentDetails.currency,
+            paymentDetails.amount,
+            paymentDetails.timestamp,
+            paymentDetails.paymentId,
+            paymentDetails.payeeId
+        );
+    }
+}

--- a/test-foundry/fuzz/RiskManagerMathFuzz.t.sol
+++ b/test-foundry/fuzz/RiskManagerMathFuzz.t.sol
@@ -7,6 +7,7 @@ import { Test } from "forge-std/Test.sol";
 import { RiskManager } from "../../contracts/RiskManager.sol";
 import { IAttestationVerifier } from "../../contracts/interfaces/IAttestationVerifier.sol";
 import { IOrchestratorV3 } from "../../contracts/interfaces/IOrchestratorV3.sol";
+import { INullifierRegistryV2 } from "../../contracts/interfaces/INullifierRegistryV2.sol";
 import { IRiskManager } from "../../contracts/interfaces/IRiskManager.sol";
 import { IStakeVault } from "../../contracts/interfaces/IStakeVault.sol";
 
@@ -18,7 +19,8 @@ contract RiskManagerMathFuzzTest is Test {
             address(this),
             IOrchestratorV3(address(this)),
             IStakeVault(address(this)),
-            IAttestationVerifier(address(this))
+            IAttestationVerifier(address(this)),
+            INullifierRegistryV2(address(this))
         );
     }
 

--- a/test-foundry/invariant/RiskManagerInvariant.t.sol
+++ b/test-foundry/invariant/RiskManagerInvariant.t.sol
@@ -10,6 +10,7 @@ import { RiskManager } from "../../contracts/RiskManager.sol";
 import { StakeVault } from "../../contracts/StakeVault.sol";
 import { IEscrowV2 } from "../../contracts/interfaces/IEscrowV2.sol";
 import { IOrchestratorV3 } from "../../contracts/interfaces/IOrchestratorV3.sol";
+import { INullifierRegistryV2 } from "../../contracts/interfaces/INullifierRegistryV2.sol";
 import { IRiskManager } from "../../contracts/interfaces/IRiskManager.sol";
 import { IStakeVault } from "../../contracts/interfaces/IStakeVault.sol";
 import { AttestationVerifierMock } from "../../contracts/mocks/AttestationVerifierMock.sol";
@@ -138,7 +139,8 @@ contract RiskManagerInvariantTest is StdInvariant, Test {
             address(this),
             IOrchestratorV3(address(handler)),
             IStakeVault(address(vault)),
-            verifier
+            verifier,
+            INullifierRegistryV2(address(this))
         );
         handler.setManager(manager);
         vault.initializeController(address(manager));

--- a/test-foundry/unit/RiskManager.t.sol
+++ b/test-foundry/unit/RiskManager.t.sol
@@ -13,6 +13,8 @@ import { IOrchestratorV3 } from "../../contracts/interfaces/IOrchestratorV3.sol"
 import { IPostIntentHookV2 } from "../../contracts/interfaces/IPostIntentHookV2.sol";
 import { IRiskManager } from "../../contracts/interfaces/IRiskManager.sol";
 import { IStakeVault } from "../../contracts/interfaces/IStakeVault.sol";
+import { NullifierRegistry } from "../../contracts/registries/NullifierRegistry.sol";
+import { NullifierRegistryV2 } from "../../contracts/registries/NullifierRegistryV2.sol";
 import { AttestationVerifierMock } from "../../contracts/mocks/AttestationVerifierMock.sol";
 import { USDCMock } from "../../contracts/mocks/USDCMock.sol";
 
@@ -67,9 +69,9 @@ contract RiskOrchestratorHarness {
         return intents[_intentHash];
     }
 
-    function getIntentSettlement(bytes32 _intentHash) external view returns (uint256, uint64) {
+    function getIntentSettlement(bytes32 _intentHash) external view returns (uint256, uint64, bool) {
         IOrchestratorV3.IntentSettlement memory settlement = settlements[_intentHash];
-        return (settlement.releasedAmount, settlement.settledAt);
+        return (settlement.releasedAmount, settlement.settledAt, settlement.isManualRelease);
     }
 
     function getIntentCancellation(bytes32 _intentHash) external view returns (uint64) {
@@ -98,7 +100,8 @@ contract RiskOrchestratorHarness {
     function recordSettlementWithoutCallback(bytes32 _intentHash, uint256 _amount, uint64 _settledAt) external {
         settlements[_intentHash] = IOrchestratorV3.IntentSettlement({
             releasedAmount: _amount,
-            settledAt: _settledAt
+            settledAt: _settledAt,
+            isManualRelease: false
         });
         delete intents[_intentHash];
     }
@@ -124,6 +127,7 @@ contract RiskManagerTest is Test {
     RiskOrchestratorHarness internal orchestrator;
     RiskEscrowHarness internal escrow;
     AttestationVerifierMock internal verifier;
+    NullifierRegistryV2 internal nullifierRegistry;
 
     function setUp() public {
         vm.warp(1_000_000);
@@ -131,12 +135,16 @@ contract RiskManagerTest is Test {
         orchestrator = new RiskOrchestratorHarness();
         escrow = new RiskEscrowHarness(maker, token, MAX_INTENT_PERIOD);
         verifier = new AttestationVerifierMock();
+        NullifierRegistry legacyNullifierRegistry = new NullifierRegistry();
+        nullifierRegistry = new NullifierRegistryV2(legacyNullifierRegistry);
+        nullifierRegistry.addWritePermission(address(this));
         vault = new StakeVault(owner, token, address(this), 30 days, DAY);
         manager = new RiskManager(
             owner,
             IOrchestratorV3(address(orchestrator)),
             IStakeVault(address(vault)),
-            verifier
+            verifier,
+            nullifierRegistry
         );
 
         vm.prank(owner);
@@ -146,7 +154,7 @@ contract RiskManagerTest is Test {
         manager.acceptVaultController();
 
         vm.startPrank(owner);
-        manager.setPlatformRiskConfig(PAYPAL, _chargebackConfig(10_000, 30 days, true));
+        manager.setPlatformRiskConfig(PAYPAL, _chargebackConfig(10_000, 30 days, false));
         manager.setPlatformRiskConfig(ZELLE, _nonChargebackableConfig(20e6));
         manager.setDeferredPayoutHook(address(verifier));
         vm.stopPrank();
@@ -227,20 +235,27 @@ contract RiskManagerTest is Test {
 
     function _chargeback(
         bytes32 _intentHash,
-        uint256 _amount,
+        uint256 _paymentAmount,
         uint256 _nonce
-    ) internal view returns (IRiskManager.ChargebackAttestation memory) {
-        return IRiskManager.ChargebackAttestation({
-            chainId: block.chainid,
-            riskManager: address(manager),
-            orchestrator: address(orchestrator),
-            intentHash: _intentHash,
+    ) internal returns (IRiskManager.ChargebackAttestation memory) {
+        bytes32 paymentId = keccak256(abi.encodePacked("payment", _intentHash));
+        bytes32 paymentNullifier = keccak256(abi.encodePacked(PAYPAL, paymentId));
+        if (!nullifierRegistry.isNullified(paymentNullifier)) {
+            nullifierRegistry.addNullifier(paymentNullifier, _intentHash);
+        }
+        bytes memory data = abi.encode(IRiskManager.ChargebackDetails({
             paymentMethod: PAYPAL,
-            chargebackAmount: _amount,
-            evidenceId: keccak256(abi.encode(_intentHash, _nonce)),
-            nonce: _nonce,
-            validAfter: uint64(block.timestamp - 1),
-            validUntil: uint64(block.timestamp + DAY)
+            originalPaymentId: paymentId,
+            disputeId: keccak256(abi.encode(_intentHash, _nonce)),
+            paymentAmount: _paymentAmount,
+            paymentCurrency: keccak256("USD")
+        }));
+        return IRiskManager.ChargebackAttestation({
+            intentHash: _intentHash,
+            dataHash: keccak256(data),
+            signatures: new bytes[](0),
+            data: data,
+            metadata: ""
         });
     }
 
@@ -453,31 +468,34 @@ contract RiskManagerTest is Test {
         assertEq(position.reservedAmount, 700e6);
     }
 
-    function test_PartialChargebackPreservesRemainingCoverage() public {
+    function test_ChargebackCompensatesExactGrossRelease() public {
         _stake(taker, 500e6);
         bytes32 intentHash = keccak256("partial-chargeback");
         _setIntent(intentHash, taker, 500e6, PAYPAL, address(0));
         _createPosition(intentHash);
         orchestrator.fulfillPosition(manager, intentHash, 500e6);
 
-        manager.submitChargeback(_chargeback(intentHash, 200e6, 1), new bytes[](0), "");
+        manager.submitChargeback(_chargeback(intentHash, 500e6, 1));
 
-        assertEq(vault.claimableCompensation(maker), 200e6);
-        assertEq(vault.reservedStake(taker), 300e6);
-        assertEq(manager.getRiskPosition(intentHash).reservedAmount, 300e6);
+        assertEq(vault.claimableCompensation(maker), 500e6);
+        assertEq(vault.reservedStake(taker), 0);
+        assertEq(manager.getRiskPosition(intentHash).reservedAmount, 0);
     }
 
-    function test_ChargebackCapsCompensationAtRemainingCoverage() public {
+    function test_ChargebackUsesGrossReleaseNotWitnessFiatAmount() public {
         _stake(taker, 500e6);
-        bytes32 intentHash = keccak256("capped-chargeback");
+        bytes32 intentHash = keccak256("chargeback-fiat-metadata");
         _setIntent(intentHash, taker, 500e6, PAYPAL, address(0));
         _createPosition(intentHash);
         orchestrator.fulfillPosition(manager, intentHash, 500e6);
 
-        manager.submitChargeback(_chargeback(intentHash, 900e6, 1), new bytes[](0), "");
+        manager.submitChargeback(_chargeback(intentHash, 900e6, 1));
 
         assertEq(vault.claimableCompensation(maker), 500e6);
-        assertEq(uint256(manager.getRiskPosition(intentHash).status), uint256(IRiskManager.PositionStatus.SLASHED));
+        IRiskManager.RiskPosition memory position = manager.getRiskPosition(intentHash);
+        assertEq(position.releasedAmount, 500e6);
+        assertEq(position.slashedAmount, 500e6);
+        assertEq(uint256(position.status), uint256(IRiskManager.PositionStatus.SLASHED));
     }
 
     function test_MaturityReleasesRemainingStakeCoverage() public {
@@ -494,41 +512,9 @@ contract RiskManagerTest is Test {
         assertEq(uint256(manager.getRiskPosition(intentHash).status), uint256(IRiskManager.PositionStatus.RELEASED));
     }
 
-    function test_DeferredAdmissionReservesOnlyGriefingBond() public {
-        _stake(taker, 10e6);
-        bytes32 intentHash = keccak256("deferred");
-        _setIntent(intentHash, taker, 700e6, PAYPAL, address(verifier));
-
-        bool requiresHook = _createPosition(intentHash);
-
-        IRiskManager.RiskPosition memory position = manager.getRiskPosition(intentHash);
-        assertTrue(requiresHook);
-        assertEq(uint256(position.mode), uint256(IRiskManager.RiskMode.DEFERRED_PAYOUT));
-        assertEq(position.initialReservation, 4.025e6);
-        assertEq(vault.reservedStake(taker), 4.025e6);
-    }
-
-    function test_DeferredRegistrationRejectsCoverageBelowConfiguredReserve() public {
-        _stake(taker, 10e6);
-        bytes32 intentHash = keccak256("deferred-shortfall");
-        _setIntent(intentHash, taker, 700e6, PAYPAL, address(verifier));
-        _createPosition(intentHash);
-        orchestrator.fulfillPosition(manager, intentHash, 700e6);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IRiskManager.InsufficientDeferredPayoutCoverage.selector,
-                350e6,
-                700e6
-            )
-        );
-        vm.prank(address(verifier));
-        manager.registerDeferredPayout(intentHash, taker, 350e6);
-    }
-
     function test_PlatformChangesDoNotAlterPositionSnapshots() public {
         vm.prank(owner);
-        manager.setPlatformRiskConfig(PAYPAL, _chargebackConfig(5_000, 10 days, false));
+        manager.setPlatformRiskConfig(PAYPAL, _chargebackConfig(10_000, 10 days, false));
         _stake(taker, 500e6);
         bytes32 intentHash = keccak256("snapshot");
         _setIntent(intentHash, taker, 500e6, PAYPAL, address(0));
@@ -538,8 +524,8 @@ contract RiskManagerTest is Test {
         manager.setPlatformRiskConfig(PAYPAL, _chargebackConfig(10_000, 30 days, false));
 
         IRiskManager.RiskPosition memory position = manager.getRiskPosition(intentHash);
-        assertEq(position.chargebackReserveBps, 5_000);
+        assertEq(position.chargebackReserveBps, 10_000);
         assertEq(position.riskWindow, 10 days);
-        assertEq(position.initialReservation, 250e6);
+        assertEq(position.initialReservation, 500e6);
     }
 }

--- a/test/registries/nullifierRegistryV2.spec.ts
+++ b/test/registries/nullifierRegistryV2.spec.ts
@@ -1,0 +1,87 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+
+describe("NullifierRegistryV2", () => {
+  async function fixture() {
+    const [owner, writer, other] = await ethers.getSigners();
+    const legacy = await (await ethers.getContractFactory("NullifierRegistry")).deploy();
+    const registry = await (await ethers.getContractFactory("NullifierRegistryV2")).deploy(legacy.address);
+    return { owner, writer, other, legacy, registry };
+  }
+
+  it("requires a deployed legacy registry", async () => {
+    const [owner] = await ethers.getSigners();
+    const factory = await ethers.getContractFactory("NullifierRegistryV2");
+    await expect(factory.deploy(ethers.constants.AddressZero)).to.be.revertedWithCustomError(factory, "ZeroAddress");
+    await expect(factory.deploy(owner.address)).to.be.revertedWithCustomError(factory, "ZeroAddress");
+  });
+
+  it("reads predecessor nullifiers without inventing a binding", async () => {
+    const { owner, legacy, registry } = await loadFixture(fixture);
+    const nullifier = ethers.utils.id("legacy-payment");
+    await legacy.addWritePermission(owner.address);
+    await legacy.addNullifier(nullifier);
+
+    expect(await registry.isNullified(nullifier)).to.eq(true);
+    expect(await registry.intentHashByNullifier(nullifier)).to.eq(ethers.constants.HashZero);
+    expect(await registry.nullifierByIntentHash(ethers.utils.id("intent"))).to.eq(ethers.constants.HashZero);
+  });
+
+  it("atomically creates an immutable bidirectional binding", async () => {
+    const { writer, registry } = await loadFixture(fixture);
+    const nullifier = ethers.utils.id("new-payment");
+    const intentHash = ethers.utils.id("new-intent");
+    await registry.addWritePermission(writer.address);
+
+    await expect(registry.connect(writer).addNullifier(nullifier, intentHash))
+      .to.emit(registry, "NullifierAdded")
+      .withArgs(nullifier, intentHash, writer.address);
+    expect(await registry.isNullified(nullifier)).to.eq(true);
+    expect(await registry.intentHashByNullifier(nullifier)).to.eq(intentHash);
+    expect(await registry.nullifierByIntentHash(intentHash)).to.eq(nullifier);
+
+    await expect(registry.connect(writer).addNullifier(nullifier, ethers.utils.id("other-intent")))
+      .to.be.revertedWithCustomError(registry, "NullifierAlreadyExists");
+    await expect(registry.connect(writer).addNullifier(ethers.utils.id("other-payment"), intentHash))
+      .to.be.revertedWithCustomError(registry, "IntentAlreadyBound");
+  });
+
+  it("rejects predecessor replay, zero values, and unauthorized writes", async () => {
+    const { owner, writer, other, legacy, registry } = await loadFixture(fixture);
+    const legacyNullifier = ethers.utils.id("legacy-replay");
+    await legacy.addWritePermission(owner.address);
+    await legacy.addNullifier(legacyNullifier);
+    await registry.addWritePermission(writer.address);
+
+    await expect(registry.connect(other).addNullifier(ethers.utils.id("x"), ethers.utils.id("y")))
+      .to.be.revertedWithCustomError(registry, "UnauthorizedWriter");
+    await expect(registry.connect(writer).addNullifier(ethers.constants.HashZero, ethers.utils.id("y")))
+      .to.be.revertedWithCustomError(registry, "ZeroNullifier");
+    await expect(registry.connect(writer).addNullifier(ethers.utils.id("x"), ethers.constants.HashZero))
+      .to.be.revertedWithCustomError(registry, "ZeroIntentHash");
+    await expect(registry.connect(writer).addNullifier(legacyNullifier, ethers.utils.id("y")))
+      .to.be.revertedWithCustomError(registry, "NullifierAlreadyExists");
+  });
+
+  it("governs an explicit enumerable writer set", async () => {
+    const { owner, writer, other, registry } = await loadFixture(fixture);
+    await expect(registry.connect(other).addWritePermission(writer.address)).to.be.revertedWith("Ownable: caller is not the owner");
+    await expect(registry.addWritePermission(ethers.constants.AddressZero))
+      .to.be.revertedWithCustomError(registry, "ZeroAddress");
+    await expect(registry.addWritePermission(writer.address))
+      .to.emit(registry, "WriterAdded").withArgs(writer.address);
+    await expect(registry.addWritePermission(writer.address))
+      .to.be.revertedWithCustomError(registry, "WriterAlreadyAuthorized");
+    await registry.addWritePermission(owner.address);
+    expect(await registry.getWriters()).to.deep.eq([writer.address, owner.address]);
+
+    await expect(registry.connect(other).removeWritePermission(writer.address)).to.be.revertedWith("Ownable: caller is not the owner");
+    await expect(registry.removeWritePermission(other.address))
+      .to.be.revertedWithCustomError(registry, "WriterNotAuthorized");
+    await expect(registry.removeWritePermission(writer.address))
+      .to.emit(registry, "WriterRemoved").withArgs(writer.address);
+    expect(await registry.getWriters()).to.deep.eq([owner.address]);
+    expect(await registry.isWriter(writer.address)).to.eq(false);
+  });
+});

--- a/test/staking/riskManager.coverage.spec.ts
+++ b/test/staking/riskManager.coverage.spec.ts
@@ -20,7 +20,7 @@ function chargebackConfig(overrides: Record<string, unknown> = {}) {
     enabled: true,
     chargeback: {
       chargebackable: true,
-      deferredPayoutEnabled: true,
+      deferredPayoutEnabled: false,
       reserveBps: 10_000,
       riskWindow: DAY,
       ...((overrides.chargeback as Record<string, unknown>) ?? {}),
@@ -63,12 +63,18 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
     const escrow = await (await ethers.getContractFactory("RiskManagerEscrowHarness"))
       .deploy(MAX_INTENT_PERIOD, maker.address);
     const verifier = await (await ethers.getContractFactory("AttestationVerifierMock")).deploy();
+    const legacyNullifierRegistry = await (await ethers.getContractFactory("NullifierRegistry")).deploy();
+    const nullifierRegistry = await (await ethers.getContractFactory("NullifierRegistryV2"))
+      .deploy(legacyNullifierRegistry.address);
     const manager = await (await ethers.getContractFactory("RiskManager")).deploy(
       owner.address,
       orchestrator.address,
       vault.address,
       verifier.address,
+      nullifierRegistry.address,
     );
+    await nullifierRegistry.addWritePermission(owner.address);
+    await legacyNullifierRegistry.addWritePermission(owner.address);
 
     await manager.setDeferredPayoutHook(orchestrator.address);
     await manager.setPlatformRiskConfig(PAYPAL, chargebackConfig());
@@ -77,7 +83,10 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
     }));
     await vault.setTakerState(taker.address, taker.address, usdc(100_000), usdc(100_000), false);
 
-    return { owner, taker, maker, beneficiary, other, orchestrator, vault, escrow, verifier, manager };
+    return {
+      owner, taker, maker, beneficiary, other, orchestrator, vault, escrow, verifier, manager,
+      legacyNullifierRegistry, nullifierRegistry,
+    };
   }
 
   async function setRiskIntent(
@@ -113,75 +122,150 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
     await fixture.orchestrator.createPosition(fixture.manager.address, intentHash);
   }
 
-  async function createDeferredPosition(
-    fixture: Awaited<ReturnType<typeof deployHarnessFixture>>,
-    intentHash: string,
-    amount = usdc(100),
-  ) {
-    await fixture.vault.setTakerState(fixture.taker.address, fixture.taker.address, usdc(1), usdc(1), false);
-    await createPosition(fixture, intentHash, {
-      amount,
-      paymentMethod: PAYPAL,
-      postIntentHook: fixture.orchestrator.address,
-    });
-  }
-
   async function validAttestation(
     fixture: Awaited<ReturnType<typeof deployHarnessFixture>>,
     intentHash: string,
+    options: {
+      paymentMethod?: string;
+      originalPaymentId?: string;
+      disputeId?: string;
+      paymentAmount?: BigNumber;
+      paymentCurrency?: string;
+      data?: string;
+      dataHash?: string;
+      bindPayment?: boolean;
+    } = {},
+  ) {
+    const paymentId = options.originalPaymentId ?? ethers.utils.keccak256(
+      ethers.utils.solidityPack(["string", "bytes32"], ["payment", intentHash]),
+    );
+    const canonicalPaymentId = ethers.utils.keccak256(
+      ethers.utils.solidityPack(["string", "bytes32"], ["payment", intentHash]),
+    );
+    const canonicalNullifier = ethers.utils.keccak256(
+      ethers.utils.solidityPack(["bytes32", "bytes32"], [PAYPAL, canonicalPaymentId]),
+    );
+    if (
+      options.bindPayment !== false
+        && intentHash !== ethers.constants.HashZero
+        && (await fixture.nullifierRegistry.intentHashByNullifier(canonicalNullifier)) === ethers.constants.HashZero
+    ) {
+      await fixture.nullifierRegistry.addNullifier(canonicalNullifier, intentHash);
+    }
+    const data = options.data ?? ethers.utils.defaultAbiCoder.encode(
+      ["tuple(bytes32 paymentMethod,bytes32 originalPaymentId,bytes32 disputeId,uint256 paymentAmount,bytes32 paymentCurrency)"],
+      [{
+        paymentMethod: options.paymentMethod ?? PAYPAL,
+        originalPaymentId: paymentId,
+        disputeId: options.disputeId ?? ethers.utils.id(`evidence-${intentHash}`),
+        paymentAmount: options.paymentAmount ?? usdc(50),
+        paymentCurrency: options.paymentCurrency ?? ethers.utils.id("USD"),
+      }],
+    );
+    return {
+      intentHash,
+      dataHash: options.dataHash ?? ethers.utils.keccak256(data),
+      signatures: [],
+      data,
+      metadata: "0x",
+    };
+  }
+
+  async function forcedRiskPosition(
+    fixture: Awaited<ReturnType<typeof deployHarnessFixture>>,
     overrides: Record<string, unknown> = {},
   ) {
     const now = await time.latest();
-    const { chainId } = await ethers.provider.getNetwork();
     return {
-      chainId,
-      riskManager: fixture.manager.address,
-      orchestrator: fixture.orchestrator.address,
-      intentHash,
+      taker: fixture.taker.address,
+      stakeOwner: fixture.taker.address,
+      lp: fixture.maker.address,
       paymentMethod: PAYPAL,
-      chargebackAmount: usdc(10),
-      evidenceId: ethers.utils.id(`evidence-${intentHash}`),
-      nonce: 1,
-      validAfter: now - 1,
-      validUntil: now + DAY,
+      mode: 2,
+      status: 3,
+      deferredPayoutHook: ZERO,
+      payoutRecipient: fixture.beneficiary.address,
+      chargebackReserveBps: 10_000,
+      griefingPenaltyBpsPerHour: SLOPE,
+      riskWindow: DAY,
+      createdAt: now,
+      maxIntentPeriod: MAX_INTENT_PERIOD,
+      griefingCliff: CLIFF,
+      cancelledAt: 0,
+      settledAt: now,
+      coverageDeadline: now + DAY,
+      intentAmount: usdc(50),
+      bondedAmount: usdc(50),
+      maxGriefingBond: 0,
+      initialReservation: 0,
+      reservedAmount: usdc(50),
+      releasedAmount: usdc(50),
+      deferredPayoutAmount: 0,
+      slashedAmount: 0,
       ...overrides,
     };
   }
 
   describe("constructor and governance", () => {
     it("rejects a zero owner", async () => {
-      const { orchestrator, vault, verifier } = await loadFixture(deployHarnessFixture);
+      const { orchestrator, vault, nullifierRegistry, verifier } = await loadFixture(deployHarnessFixture);
       await expect((await ethers.getContractFactory("RiskManager")).deploy(
-        ZERO, orchestrator.address, vault.address, verifier.address,
-      )).to.be.revertedWithCustomError(await ethers.getContractFactory("RiskManager"), "ZeroAddress");
+        ZERO, orchestrator.address, vault.address, verifier.address, nullifierRegistry.address,
+      )).to.be.reverted;
     });
 
     it("rejects a zero orchestrator", async () => {
-      const { owner, vault, verifier } = await loadFixture(deployHarnessFixture);
+      const { owner, vault, nullifierRegistry, verifier } = await loadFixture(deployHarnessFixture);
       await expect((await ethers.getContractFactory("RiskManager")).deploy(
-        owner.address, ZERO, vault.address, verifier.address,
+        owner.address, ZERO, vault.address, verifier.address, nullifierRegistry.address,
       )).to.be.reverted;
     });
 
     it("rejects a zero vault", async () => {
-      const { owner, orchestrator, verifier } = await loadFixture(deployHarnessFixture);
+      const { owner, orchestrator, nullifierRegistry, verifier } = await loadFixture(deployHarnessFixture);
       await expect((await ethers.getContractFactory("RiskManager")).deploy(
-        owner.address, orchestrator.address, ZERO, verifier.address,
+        owner.address, orchestrator.address, ZERO, verifier.address, nullifierRegistry.address,
       )).to.be.reverted;
     });
 
     it("rejects a zero attestation verifier", async () => {
-      const { owner, orchestrator, vault } = await loadFixture(deployHarnessFixture);
+      const { owner, orchestrator, vault, nullifierRegistry } = await loadFixture(deployHarnessFixture);
       await expect((await ethers.getContractFactory("RiskManager")).deploy(
-        owner.address, orchestrator.address, vault.address, ZERO,
+        owner.address, orchestrator.address, vault.address, ZERO, nullifierRegistry.address,
       )).to.be.reverted;
     });
 
     it("rejects an EOA attestation verifier", async () => {
-      const { owner, other, orchestrator, vault } = await loadFixture(deployHarnessFixture);
+      const { owner, other, orchestrator, vault, nullifierRegistry } = await loadFixture(deployHarnessFixture);
       await expect((await ethers.getContractFactory("RiskManager")).deploy(
-        owner.address, orchestrator.address, vault.address, other.address,
+        owner.address, orchestrator.address, vault.address, other.address, nullifierRegistry.address,
       )).to.be.reverted;
+    });
+
+    it("rejects EOA orchestrator and vault dependencies", async () => {
+      const { owner, other, orchestrator, vault, nullifierRegistry, verifier } =
+        await loadFixture(deployHarnessFixture);
+      const factory = await ethers.getContractFactory("RiskManager");
+      await expect(factory.deploy(
+        owner.address, other.address, vault.address, verifier.address, nullifierRegistry.address,
+      )).to.be.revertedWithCustomError(factory, "ZeroAddress");
+      await expect(factory.deploy(
+        owner.address, orchestrator.address, other.address, verifier.address, nullifierRegistry.address,
+      )).to.be.revertedWithCustomError(factory, "ZeroAddress");
+    });
+
+    it("uses the immutable binding registry", async () => {
+      const { manager, nullifierRegistry } = await loadFixture(deployHarnessFixture);
+      expect(await manager.nullifierRegistry()).to.eq(nullifierRegistry.address);
+    });
+
+    it("rejects a zero or non-contract binding registry", async () => {
+      const { owner, other, orchestrator, vault, verifier } = await loadFixture(deployHarnessFixture);
+      const factory = await ethers.getContractFactory("RiskManager");
+      await expect(factory.deploy(owner.address, orchestrator.address, vault.address, verifier.address, ZERO))
+        .to.be.revertedWithCustomError(factory, "ZeroAddress");
+      await expect(factory.deploy(owner.address, orchestrator.address, vault.address, verifier.address, other.address))
+        .to.be.revertedWithCustomError(factory, "ZeroAddress");
     });
 
     it("updates the attestation verifier", async () => {
@@ -321,6 +405,13 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
     it("rejects deferred payout on a non-chargebackable platform", async () => {
       const { manager } = await loadFixture(deployHarnessFixture);
       await expect(manager.setPlatformRiskConfig(OTHER_METHOD, nonChargebackConfig({
+        chargeback: { deferredPayoutEnabled: true },
+      }))).to.be.revertedWithCustomError(manager, "InvalidPlatformConfig");
+    });
+
+    it("rejects deferred payout on a chargebackable platform in v1", async () => {
+      const { manager } = await loadFixture(deployHarnessFixture);
+      await expect(manager.setPlatformRiskConfig(OTHER_METHOD, chargebackConfig({
         chargeback: { deferredPayoutEnabled: true },
       }))).to.be.revertedWithCustomError(manager, "InvalidPlatformConfig");
     });
@@ -513,37 +604,6 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
         .to.be.revertedWithCustomError(fixture.manager, "InsufficientCollateral");
     });
 
-    it("requires the canonical hook for deferred payout admission", async () => {
-      const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("deferred-hook-required");
-      await fixture.vault.setTakerState(
-        fixture.taker.address,
-        fixture.taker.address,
-        usdc(1),
-        usdc(1),
-        false,
-      );
-      await setRiskIntent(fixture, intentHash);
-      await expect(fixture.orchestrator.createPosition(fixture.manager.address, intentHash))
-        .to.be.revertedWithCustomError(fixture.manager, "DeferredPayoutHookRequired");
-    });
-
-    it("requires a configured canonical hook for deferred payout admission", async () => {
-      const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("deferred-hook-unconfigured");
-      await fixture.manager.setDeferredPayoutHook(ZERO);
-      await fixture.vault.setTakerState(
-        fixture.taker.address,
-        fixture.taker.address,
-        usdc(1),
-        usdc(1),
-        false,
-      );
-      await setRiskIntent(fixture, intentHash);
-      await expect(fixture.orchestrator.createPosition(fixture.manager.address, intentHash))
-        .to.be.revertedWithCustomError(fixture.manager, "DeferredPayoutHookRequired");
-    });
-
     it("rejects a bonded position for an exiting stake owner", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
       const intentHash = ethers.utils.id("exiting-stake-owner");
@@ -561,7 +621,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
         .to.be.revertedWithCustomError(fixture.manager, "DeferredPayoutHookNotAllowed");
     });
 
-    it("rejects the deferred hook for an unbonded position", async () => {
+    it("rejects the deferred hook for a free position", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
       const intentHash = ethers.utils.id("deferred-hook-with-free");
       await setRiskIntent(fixture, intentHash, {
@@ -582,34 +642,6 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       expect((await fixture.manager.getRiskPosition(intentHash)).initialReservation).to.eq(0);
     });
 
-    it("admits a zero-griefing deferred position", async () => {
-      const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("zero-griefing-deferred");
-      await fixture.manager.setPlatformRiskConfig(OTHER_METHOD, chargebackConfig({
-        griefing: { griefingPenaltyBpsPerHour: 0 },
-      }));
-      await fixture.vault.setTakerState(fixture.taker.address, fixture.taker.address, 0, 0, false);
-      await createPosition(fixture, intentHash, {
-        paymentMethod: OTHER_METHOD, postIntentHook: fixture.orchestrator.address,
-      });
-      const position = await fixture.manager.getRiskPosition(intentHash);
-      expect(position.mode).to.eq(3);
-      expect(position.initialReservation).to.eq(0);
-    });
-
-    it("settles a zero-griefing deferred position without releasing stake", async () => {
-      const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("zero-griefing-deferred-settlement");
-      await fixture.manager.setPlatformRiskConfig(OTHER_METHOD, chargebackConfig({
-        griefing: { griefingPenaltyBpsPerHour: 0 },
-      }));
-      await fixture.vault.setTakerState(fixture.taker.address, fixture.taker.address, 0, 0, false);
-      await createPosition(fixture, intentHash, {
-        paymentMethod: OTHER_METHOD, postIntentHook: fixture.orchestrator.address,
-      });
-      await fixture.orchestrator.fulfillPosition(fixture.manager.address, intentHash, usdc(50));
-      expect((await fixture.manager.getRiskPosition(intentHash)).status).to.eq(3);
-    });
   });
 
   describe("terminal callbacks and reconciliation", () => {
@@ -644,20 +676,12 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       expect((await fixture.manager.getRiskPosition(intentHash)).releasedAmount).to.eq(usdc(50));
     });
 
-    it("settles an unbonded non-chargebackable position without a vault release", async () => {
+    it("settles a free non-chargebackable position without a vault release", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
       const intentHash = ethers.utils.id("free-settlement");
       await createPosition(fixture, intentHash, { amount: usdc(20), paymentMethod: ZELLE });
       await fixture.orchestrator.fulfillPosition(fixture.manager.address, intentHash, usdc(20));
       expect((await fixture.manager.getRiskPosition(intentHash)).status).to.eq(4);
-    });
-
-    it("releases deferred authorization on cancellation", async () => {
-      const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("deferred-cancellation");
-      await createDeferredPosition(fixture, intentHash);
-      await fixture.orchestrator.cancelPosition(fixture.manager.address, intentHash);
-      expect((await fixture.vault.deferredPayouts(intentHash)).authorized).to.eq(false);
     });
 
     it("rejects cancellation reconciliation without a durable record", async () => {
@@ -676,7 +700,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       expect((await fixture.manager.getRiskPosition(intentHash)).status).to.eq(2);
     });
 
-    it("reconciles an unbonded cancellation after the cliff without a penalty", async () => {
+    it("reconciles a free cancellation after the cliff without a penalty", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
       const intentHash = ethers.utils.id("free-cancel-reconciliation");
       await createPosition(fixture, intentHash, { amount: usdc(20), paymentMethod: ZELLE });
@@ -713,7 +737,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
     it("rejects settlement reconciliation without a released amount", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
       const intentHash = ethers.utils.id("missing-settlement-amount");
-      await fixture.orchestrator.setIntentSettlement(intentHash, 0, await time.latest());
+      await fixture.orchestrator.setIntentSettlement(intentHash, 0, await time.latest(), false);
       await expect(fixture.manager.reconcileSettlement(intentHash))
         .to.be.revertedWithCustomError(fixture.manager, "SettlementNotRecorded");
     });
@@ -721,7 +745,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
     it("rejects settlement reconciliation without a settlement timestamp", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
       const intentHash = ethers.utils.id("missing-settlement-time");
-      await fixture.orchestrator.setIntentSettlement(intentHash, 1, 0);
+      await fixture.orchestrator.setIntentSettlement(intentHash, 1, 0, false);
       await expect(fixture.manager.reconcileSettlement(intentHash))
         .to.be.revertedWithCustomError(fixture.manager, "SettlementNotRecorded");
     });
@@ -730,9 +754,34 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       const fixture = await loadFixture(deployHarnessFixture);
       const intentHash = ethers.utils.id("single-settlement");
       await createPosition(fixture, intentHash);
-      await fixture.orchestrator.setIntentSettlement(intentHash, usdc(50), await time.latest());
+      await fixture.orchestrator.setIntentSettlement(intentHash, usdc(50), await time.latest(), false);
       await fixture.manager.reconcileSettlement(intentHash);
       expect((await fixture.manager.getRiskPosition(intentHash)).releasedAmount).to.eq(usdc(50));
+    });
+
+    it("reconciles a failed manual release by releasing stake immediately", async () => {
+      const fixture = await loadFixture(deployHarnessFixture);
+      const intentHash = ethers.utils.id("failed-manual-release");
+      await createPosition(fixture, intentHash);
+      await fixture.orchestrator.setIntentSettlement(intentHash, usdc(50), await time.latest(), true);
+      await fixture.manager.reconcileSettlement(intentHash);
+
+      const position = await fixture.manager.getRiskPosition(intentHash);
+      expect(position.status).to.eq(4);
+      expect(position.coverageDeadline).to.eq(0);
+      expect(position.reservedAmount).to.eq(0);
+      expect(await fixture.vault.reservedStake(fixture.taker.address)).to.eq(0);
+    });
+
+    it("reconciles a failed verified fulfillment without transporting payment evidence", async () => {
+      const fixture = await loadFixture(deployHarnessFixture);
+      const intentHash = ethers.utils.id("failed-verified-without-evidence");
+      await createPosition(fixture, intentHash);
+      await fixture.orchestrator.setIntentSettlement(intentHash, usdc(50), await time.latest(), false);
+      await fixture.manager.reconcileSettlement(intentHash);
+      const position = await fixture.manager.getRiskPosition(intentHash);
+      expect(position.status).to.eq(3);
+      expect(position.reservedAmount).to.eq(usdc(50));
     });
 
     it("rejects an empty settlement reconciliation batch", async () => {
@@ -747,8 +796,8 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       await createPosition(fixture, first);
       await createPosition(fixture, second);
       const now = await time.latest();
-      await fixture.orchestrator.setIntentSettlement(first, usdc(40), now);
-      await fixture.orchestrator.setIntentSettlement(second, usdc(50), now);
+      await fixture.orchestrator.setIntentSettlement(first, usdc(40), now, false);
+      await fixture.orchestrator.setIntentSettlement(second, usdc(50), now, false);
       await fixture.manager.reconcileSettlements([first, second]);
       expect((await fixture.manager.getRiskPosition(second)).status).to.eq(3);
     });
@@ -757,133 +806,20 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       const fixture = await loadFixture(deployHarnessFixture);
       const intentHash = ethers.utils.id("coverage-overflow");
       await createPosition(fixture, intentHash);
-      await fixture.orchestrator.setIntentSettlement(intentHash, usdc(50), BigNumber.from(2).pow(64).sub(1));
+      await fixture.orchestrator.setIntentSettlement(
+        intentHash, usdc(50), BigNumber.from(2).pow(64).sub(1), false,
+      );
       await expect(fixture.manager.reconcileSettlement(intentHash))
         .to.be.revertedWithCustomError(fixture.manager, "TimestampOverflow");
     });
   });
 
-  describe("deferred payout registration", () => {
-    it("rejects a zero deferred payout", async () => {
+  describe("settlement policy", () => {
+    it("rejects partial chargeback coverage in the full-only v1 policy", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
-      await expect(fixture.orchestrator.registerDeferredPayout(
-        fixture.manager.address, ethers.utils.id("zero-deferred"), fixture.beneficiary.address, 0,
-      )).to.be.revertedWithCustomError(fixture.manager, "ZeroAmount");
-    });
-
-    it("rejects an unauthorized deferred payout hook", async () => {
-      const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("unauthorized-deferred");
-      await createDeferredPosition(fixture, intentHash);
-      await expect(fixture.manager.connect(fixture.other).registerDeferredPayout(
-        intentHash, fixture.beneficiary.address, usdc(10),
-      )).to.be.revertedWithCustomError(fixture.manager, "UnauthorizedDeferredPayoutHook");
-    });
-
-    it("requires a failed-settlement record before synchronizing a pending payout", async () => {
-      const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("deferred-no-settlement");
-      await createDeferredPosition(fixture, intentHash);
-      await expect(fixture.orchestrator.registerDeferredPayout(
-        fixture.manager.address, intentHash, fixture.beneficiary.address, usdc(10),
-      )).to.be.revertedWithCustomError(fixture.manager, "SettlementNotRecorded");
-    });
-
-    it("rejects a failed-settlement record without its original timestamp", async () => {
-      const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("deferred-settlement-without-time");
-      await createDeferredPosition(fixture, intentHash);
-      await fixture.orchestrator.setIntentSettlement(intentHash, usdc(50), 0);
-      await expect(fixture.orchestrator.registerDeferredPayout(
-        fixture.manager.address, intentHash, fixture.beneficiary.address, usdc(10),
-      )).to.be.revertedWithCustomError(fixture.manager, "SettlementNotRecorded");
-    });
-
-    it("synchronizes a failed settlement before registering proceeds", async () => {
-      const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("deferred-sync");
-      await createDeferredPosition(fixture, intentHash);
-      await fixture.orchestrator.setIntentSettlement(intentHash, usdc(50), await time.latest());
-      await fixture.orchestrator.registerDeferredPayout(
-        fixture.manager.address, intentHash, fixture.beneficiary.address, usdc(50),
-      );
-      expect((await fixture.manager.getRiskPosition(intentHash)).deferredPayoutAmount).to.eq(usdc(50));
-    });
-
-    it("rejects registration after a deferred position is cancelled", async () => {
-      const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("deferred-cancelled-register");
-      await createDeferredPosition(fixture, intentHash);
-      await fixture.orchestrator.cancelPosition(fixture.manager.address, intentHash);
-      await expect(fixture.orchestrator.registerDeferredPayout(
-        fixture.manager.address, intentHash, fixture.beneficiary.address, usdc(10),
-      )).to.be.revertedWithCustomError(fixture.manager, "PositionNotSettled");
-    });
-
-    it("rejects a beneficiary that differs from the snapshotted recipient", async () => {
-      const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("deferred-wrong-beneficiary");
-      await createDeferredPosition(fixture, intentHash);
-      await fixture.orchestrator.fulfillPosition(fixture.manager.address, intentHash, usdc(50));
-      await expect(fixture.orchestrator.registerDeferredPayout(
-        fixture.manager.address, intentHash, fixture.other.address, usdc(50),
-      )).to.be.revertedWithCustomError(fixture.manager, "IntentStateMismatch");
-    });
-
-    it("rejects deferred proceeds above the released amount", async () => {
-      const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("deferred-too-large");
-      await createDeferredPosition(fixture, intentHash);
-      await fixture.orchestrator.fulfillPosition(fixture.manager.address, intentHash, usdc(50));
-      await expect(fixture.orchestrator.registerDeferredPayout(
-        fixture.manager.address, intentHash, fixture.beneficiary.address, usdc(51),
-      )).to.be.revertedWithCustomError(fixture.manager, "DeferredPayoutExceedsReleasedAmount");
-    });
-
-    it("rejects registering deferred proceeds twice", async () => {
-      const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("deferred-twice");
-      await createDeferredPosition(fixture, intentHash);
-      await fixture.orchestrator.fulfillPosition(fixture.manager.address, intentHash, usdc(50));
-      await fixture.orchestrator.registerDeferredPayout(
-        fixture.manager.address, intentHash, fixture.beneficiary.address, usdc(50),
-      );
-      await expect(fixture.orchestrator.registerDeferredPayout(
-        fixture.manager.address, intentHash, fixture.beneficiary.address, usdc(50),
-      )).to.be.revertedWithCustomError(fixture.manager, "DeferredPayoutAlreadyRegistered");
-    });
-
-    it("rejects deferred proceeds below the configured coverage", async () => {
-      const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("deferred-less-than-coverage");
-      await createDeferredPosition(fixture, intentHash);
-      await fixture.orchestrator.fulfillPosition(fixture.manager.address, intentHash, usdc(50));
-      await expect(fixture.orchestrator.registerDeferredPayout(
-        fixture.manager.address, intentHash, fixture.beneficiary.address, usdc(20),
-      )).to.be.revertedWithCustomError(fixture.manager, "InsufficientDeferredPayoutCoverage");
-    });
-
-    it("caps coverage at the configured ratio when proceeds are larger", async () => {
-      const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("deferred-more-than-coverage");
-      await fixture.manager.setPlatformRiskConfig(OTHER_METHOD, chargebackConfig({
+      await expect(fixture.manager.setPlatformRiskConfig(OTHER_METHOD, chargebackConfig({
         chargeback: { reserveBps: 5_000 },
-      }));
-      await fixture.vault.setTakerState(
-        fixture.taker.address,
-        fixture.taker.address,
-        usdc(1),
-        usdc(1),
-        false,
-      );
-      await createPosition(fixture, intentHash, {
-        paymentMethod: OTHER_METHOD, postIntentHook: fixture.orchestrator.address,
-      });
-      await fixture.orchestrator.fulfillPosition(fixture.manager.address, intentHash, usdc(50));
-      await fixture.orchestrator.registerDeferredPayout(
-        fixture.manager.address, intentHash, fixture.beneficiary.address, usdc(50),
-      );
-      expect((await fixture.manager.getRiskPosition(intentHash)).reservedAmount).to.eq(usdc(25));
+      }))).to.be.revertedWithCustomError(fixture.manager, "InvalidPlatformConfig");
     });
 
     it("settles at the maximum supported chargeback risk window", async () => {
@@ -932,7 +868,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       const intentHash = ethers.utils.id("maturity-sync");
       await fixture.manager.setPlatformRiskConfig(OTHER_METHOD, chargebackConfig({ chargeback: { riskWindow: 1 } }));
       await createPosition(fixture, intentHash, { paymentMethod: OTHER_METHOD });
-      await fixture.orchestrator.setIntentSettlement(intentHash, usdc(50), (await time.latest()) - 2);
+      await fixture.orchestrator.setIntentSettlement(intentHash, usdc(50), (await time.latest()) - 2, false);
       await fixture.manager.releaseMaturedPosition(intentHash);
       expect((await fixture.manager.getRiskPosition(intentHash)).status).to.eq(4);
     });
@@ -956,19 +892,6 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       expect((await fixture.manager.getRiskPosition(second)).status).to.eq(4);
     });
 
-    it("marks matured deferred coverage released without touching stake", async () => {
-      const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("maturity-deferred");
-      await createDeferredPosition(fixture, intentHash);
-      await fixture.orchestrator.fulfillPosition(fixture.manager.address, intentHash, usdc(50));
-      await fixture.orchestrator.registerDeferredPayout(
-        fixture.manager.address, intentHash, fixture.beneficiary.address, usdc(50),
-      );
-      const deadline = (await fixture.manager.getRiskPosition(intentHash)).coverageDeadline.toNumber();
-      await time.increaseTo(deadline);
-      await fixture.manager.releaseMaturedPosition(intentHash);
-      expect((await fixture.manager.getRiskPosition(intentHash)).status).to.eq(4);
-    });
   });
 
   describe("chargeback evidence validation", () => {
@@ -984,9 +907,9 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       const fixture = await loadFixture(deployHarnessFixture);
       const intentHash = ethers.utils.id("claim-sync");
       await createPosition(fixture, intentHash);
-      await fixture.orchestrator.setIntentSettlement(intentHash, usdc(50), await time.latest());
-      await fixture.manager.submitChargeback(await validAttestation(fixture, intentHash), [], "0x");
-      expect((await fixture.manager.getRiskPosition(intentHash)).slashedAmount).to.eq(usdc(10));
+      await fixture.orchestrator.setIntentSettlement(intentHash, usdc(50), await time.latest(), false);
+      await fixture.manager.submitChargeback(await validAttestation(fixture, intentHash));
+      expect((await fixture.manager.getRiskPosition(intentHash)).slashedAmount).to.eq(usdc(50));
     });
 
     it("rejects a claim against a released non-chargebackable position", async () => {
@@ -994,84 +917,327 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       const intentHash = ethers.utils.id("claim-free-position");
       await createPosition(fixture, intentHash, { amount: usdc(20), paymentMethod: ZELLE });
       await fixture.orchestrator.fulfillPosition(fixture.manager.address, intentHash, usdc(20));
-      await expect(fixture.manager.submitChargeback(await validAttestation(fixture, intentHash), [], "0x"))
+      await expect(fixture.manager.submitChargeback(await validAttestation(fixture, intentHash)))
         .to.be.revertedWithCustomError(fixture.manager, "PositionNotSettled");
     });
 
-    it("rejects a claim scoped to another chain", async () => {
+    it("rejects a mismatched payment method", async () => {
       const fixture = await loadFixture(settledFixture);
       await expect(fixture.manager.submitChargeback(
-        await validAttestation(fixture, fixture.intentHash, { chainId: 1 }), [], "0x",
+        await validAttestation(fixture, fixture.intentHash, { paymentMethod: OTHER_METHOD }),
       )).to.be.revertedWithCustomError(fixture.manager, "InvalidAttestation");
     });
 
-    it("rejects a claim scoped to another risk manager", async () => {
+    it("rejects a mismatched original payment identifier", async () => {
       const fixture = await loadFixture(settledFixture);
       await expect(fixture.manager.submitChargeback(
-        await validAttestation(fixture, fixture.intentHash, { riskManager: fixture.other.address }), [], "0x",
+        await validAttestation(fixture, fixture.intentHash, { originalPaymentId: ethers.utils.id("wrong") }),
+      )).to.be.revertedWithCustomError(fixture.manager, "InvalidPaymentBinding");
+    });
+
+    it("rejects a predecessor-only nullifier because it has no intent binding", async () => {
+      const fixture = await loadFixture(settledFixture);
+      const paymentId = ethers.utils.keccak256(
+        ethers.utils.solidityPack(["string", "bytes32"], ["payment", fixture.intentHash]),
+      );
+      const nullifier = ethers.utils.keccak256(
+        ethers.utils.solidityPack(["bytes32", "bytes32"], [PAYPAL, paymentId]),
+      );
+      await fixture.legacyNullifierRegistry.addNullifier(nullifier);
+      await expect(fixture.manager.submitChargeback(await validAttestation(fixture, fixture.intentHash, {
+        bindPayment: false,
+      }))).to.be.revertedWithCustomError(fixture.manager, "InvalidPaymentBinding");
+    });
+
+    it("accepts nonzero witness-attested fiat metadata without a false token comparison", async () => {
+      const fixture = await loadFixture(settledFixture);
+      await fixture.manager.submitChargeback(await validAttestation(fixture, fixture.intentHash, {
+        paymentAmount: BigNumber.from(1),
+        paymentCurrency: ethers.utils.id("EUR"),
+      }));
+      expect((await fixture.manager.getRiskPosition(fixture.intentHash)).status).to.eq(5);
+    });
+
+    it("rejects zero witness-attested fiat metadata", async () => {
+      const fixture = await loadFixture(settledFixture);
+      await expect(fixture.manager.submitChargeback(
+        await validAttestation(fixture, fixture.intentHash, { paymentAmount: BigNumber.from(0) }),
+      )).to.be.revertedWithCustomError(fixture.manager, "InvalidAttestation");
+      await expect(fixture.manager.submitChargeback(
+        await validAttestation(fixture, fixture.intentHash, { paymentCurrency: ethers.constants.HashZero }),
       )).to.be.revertedWithCustomError(fixture.manager, "InvalidAttestation");
     });
 
-    it("rejects a claim scoped to another orchestrator", async () => {
+    it("rejects a zero dispute identifier and a data hash mismatch", async () => {
       const fixture = await loadFixture(settledFixture);
       await expect(fixture.manager.submitChargeback(
-        await validAttestation(fixture, fixture.intentHash, { orchestrator: fixture.other.address }), [], "0x",
+        await validAttestation(fixture, fixture.intentHash, { disputeId: ethers.constants.HashZero }),
+      )).to.be.revertedWithCustomError(fixture.manager, "InvalidAttestation");
+      await expect(fixture.manager.submitChargeback(
+        await validAttestation(fixture, fixture.intentHash, { dataHash: ethers.utils.id("wrong-data") }),
       )).to.be.revertedWithCustomError(fixture.manager, "InvalidAttestation");
     });
 
-    it("rejects a claim for another payment method", async () => {
+    it("rejects a zero intent hash and zero original payment identifier", async () => {
       const fixture = await loadFixture(settledFixture);
-      await expect(fixture.manager.submitChargeback(
-        await validAttestation(fixture, fixture.intentHash, { paymentMethod: OTHER_METHOD }), [], "0x",
-      )).to.be.revertedWithCustomError(fixture.manager, "InvalidAttestation");
+      const stateManager = await (await ethers.getContractFactory("RiskManagerStateHarness")).deploy(
+        fixture.owner.address,
+        fixture.orchestrator.address,
+        fixture.vault.address,
+        fixture.verifier.address,
+        fixture.nullifierRegistry.address,
+      );
+      await stateManager.forceRiskPosition(ethers.constants.HashZero, await forcedRiskPosition(fixture));
+      await expect(stateManager.submitChargeback(
+        await validAttestation({ ...fixture, manager: stateManager } as any, ethers.constants.HashZero),
+      )).to.be.revertedWithCustomError(stateManager, "InvalidAttestation");
+
+      await expect(fixture.manager.submitChargeback(await validAttestation(fixture, fixture.intentHash, {
+        originalPaymentId: ethers.constants.HashZero,
+      }))).to.be.revertedWithCustomError(fixture.manager, "InvalidAttestation");
     });
 
-    it("rejects a zero chargeback amount", async () => {
+    it("checks the reverse intent-to-nullifier binding independently", async () => {
       const fixture = await loadFixture(settledFixture);
-      await expect(fixture.manager.submitChargeback(
-        await validAttestation(fixture, fixture.intentHash, { chargebackAmount: 0 }), [], "0x",
-      )).to.be.revertedWithCustomError(fixture.manager, "InvalidAttestation");
+      const registry = await (await ethers.getContractFactory("NullifierRegistryV2StateHarness"))
+        .deploy(fixture.legacyNullifierRegistry.address);
+      await registry.addWritePermission(fixture.owner.address);
+      const manager = await (await ethers.getContractFactory("RiskManagerStateHarness")).deploy(
+        fixture.owner.address,
+        fixture.orchestrator.address,
+        fixture.vault.address,
+        fixture.verifier.address,
+        registry.address,
+      );
+      const intentHash = ethers.utils.id("reverse-binding-defense");
+      await manager.forceRiskPosition(intentHash, await forcedRiskPosition(fixture));
+      const scopedFixture = { ...fixture, manager, nullifierRegistry: registry } as any;
+      const attestation = await validAttestation(scopedFixture, intentHash);
+      await registry.forceNullifierByIntentHash(intentHash, ethers.utils.id("corrupt-reverse-binding"));
+      await expect(manager.submitChargeback(attestation))
+        .to.be.revertedWithCustomError(manager, "InvalidPaymentBinding");
     });
 
-    it("rejects an empty evidence identifier", async () => {
+    it("rejects incomplete full-only coverage before slashing", async () => {
       const fixture = await loadFixture(settledFixture);
-      await expect(fixture.manager.submitChargeback(
-        await validAttestation(fixture, fixture.intentHash, { evidenceId: ethers.constants.HashZero }), [], "0x",
-      )).to.be.revertedWithCustomError(fixture.manager, "InvalidAttestation");
-    });
-
-    it("rejects an attestation before validAfter", async () => {
-      const fixture = await loadFixture(settledFixture);
-      const now = await time.latest();
-      await expect(fixture.manager.submitChargeback(
-        await validAttestation(fixture, fixture.intentHash, { validAfter: now + DAY, validUntil: now + 2 * DAY }), [], "0x",
-      )).to.be.revertedWithCustomError(fixture.manager, "AttestationNotYetValid");
-    });
-
-    it("rejects an expired attestation", async () => {
-      const fixture = await loadFixture(settledFixture);
-      const now = await time.latest();
-      await expect(fixture.manager.submitChargeback(
-        await validAttestation(fixture, fixture.intentHash, { validAfter: now - DAY, validUntil: now - 1 }), [], "0x",
-      )).to.be.revertedWithCustomError(fixture.manager, "AttestationExpired");
+      const manager = await (await ethers.getContractFactory("RiskManagerStateHarness")).deploy(
+        fixture.owner.address,
+        fixture.orchestrator.address,
+        fixture.vault.address,
+        fixture.verifier.address,
+        fixture.nullifierRegistry.address,
+      );
+      const intentHash = ethers.utils.id("incomplete-full-coverage");
+      await manager.forceRiskPosition(intentHash, await forcedRiskPosition(fixture, {
+        reservedAmount: usdc(49),
+      }));
+      await expect(manager.submitChargeback(
+        await validAttestation({ ...fixture, manager } as any, intentHash),
+      )).to.be.revertedWithCustomError(manager, "IncompleteChargebackCoverage");
     });
 
     it("rejects an attestation that fails verification", async () => {
       const fixture = await loadFixture(settledFixture);
       await fixture.verifier.setResult(false);
       await expect(fixture.manager.submitChargeback(
-        await validAttestation(fixture, fixture.intentHash), [], "0x",
+        await validAttestation(fixture, fixture.intentHash),
       )).to.be.revertedWithCustomError(fixture.manager, "AttestationVerificationFailed");
     });
 
-    it("rejects a claim before deferred proceeds establish coverage", async () => {
+    it("rejects maker manual release evidence", async () => {
       const fixture = await loadFixture(deployHarnessFixture);
-      const intentHash = ethers.utils.id("claim-zero-deferred-coverage");
-      await createDeferredPosition(fixture, intentHash);
-      await fixture.orchestrator.fulfillPosition(fixture.manager.address, intentHash, usdc(50));
+      const intentHash = ethers.utils.id("claim-manual-release");
+      await createPosition(fixture, intentHash);
+      await fixture.orchestrator.releasePosition(fixture.manager.address, intentHash, usdc(50));
       await expect(fixture.manager.submitChargeback(
-        await validAttestation(fixture, intentHash), [], "0x",
+        await validAttestation(fixture, intentHash),
+      )).to.be.revertedWithCustomError(fixture.manager, "PositionNotSettled");
+    });
+
+  });
+
+  describe("deferred-payout defensive lifecycle", () => {
+    async function deferredFixture() {
+      const fixture = await deployHarnessFixture();
+      const manager = await (await ethers.getContractFactory("RiskManagerStateHarness")).deploy(
+        fixture.owner.address,
+        fixture.orchestrator.address,
+        fixture.vault.address,
+        fixture.verifier.address,
+        fixture.nullifierRegistry.address,
+      );
+      await manager.setDeferredPayoutHook(fixture.orchestrator.address);
+      await manager.forcePlatformRiskConfig(PAYPAL, chargebackConfig({
+        chargeback: { deferredPayoutEnabled: true },
+      }));
+      await fixture.vault.setTakerState(
+        fixture.taker.address,
+        fixture.taker.address,
+        usdc(100_000),
+        usdc(1),
+        false,
+      );
+      return { ...fixture, manager };
+    }
+
+    async function createDeferredPosition(
+      fixture: Awaited<ReturnType<typeof deferredFixture>>,
+      intentHash: string,
+    ) {
+      await createPosition(fixture as any, intentHash, {
+        postIntentHook: fixture.orchestrator.address,
+      });
+    }
+
+    it("admits, synchronizes, validates, and registers exact deferred coverage", async () => {
+      const fixture = await loadFixture(deferredFixture);
+      const intentHash = ethers.utils.id("deferred-registration");
+      await createDeferredPosition(fixture, intentHash);
+      const position = await fixture.manager.getRiskPosition(intentHash);
+      expect(position.mode).to.eq(3);
+      await fixture.orchestrator.setIntentSettlement(intentHash, usdc(50), await time.latest(), false);
+
+      await expect(fixture.orchestrator.registerDeferredPayout(
+        fixture.manager.address, intentHash, fixture.beneficiary.address, 0,
       )).to.be.revertedWithCustomError(fixture.manager, "ZeroAmount");
+      await expect(fixture.manager.registerDeferredPayout(intentHash, fixture.beneficiary.address, usdc(50)))
+        .to.be.revertedWithCustomError(fixture.manager, "UnauthorizedDeferredPayoutHook");
+      await expect(fixture.orchestrator.registerDeferredPayout(
+        fixture.manager.address, intentHash, fixture.other.address, usdc(50),
+      )).to.be.revertedWithCustomError(fixture.manager, "IntentStateMismatch");
+      await expect(fixture.orchestrator.registerDeferredPayout(
+        fixture.manager.address, intentHash, fixture.beneficiary.address, usdc(51),
+      )).to.be.revertedWithCustomError(fixture.manager, "DeferredPayoutExceedsReleasedAmount");
+      await expect(fixture.orchestrator.registerDeferredPayout(
+        fixture.manager.address, intentHash, fixture.beneficiary.address, usdc(49),
+      )).to.be.revertedWithCustomError(fixture.manager, "InsufficientDeferredPayoutCoverage");
+      await expect(fixture.orchestrator.registerDeferredPayout(
+        fixture.manager.address, intentHash, fixture.beneficiary.address, usdc(50),
+      )).to.emit(fixture.manager, "DeferredPayoutRegistered");
+      await expect(fixture.orchestrator.registerDeferredPayout(
+        fixture.manager.address, intentHash, fixture.beneficiary.address, usdc(50),
+      )).to.be.revertedWithCustomError(fixture.manager, "DeferredPayoutAlreadyRegistered");
+    });
+
+    it("rejects registration when a forced deferred position is not settled", async () => {
+      const fixture = await loadFixture(deferredFixture);
+      const intentHash = ethers.utils.id("deferred-not-settled");
+      await fixture.manager.forceRiskPosition(intentHash, await forcedRiskPosition(fixture as any, {
+        mode: 3,
+        status: 2,
+        deferredPayoutHook: fixture.orchestrator.address,
+      }));
+      await expect(fixture.orchestrator.registerDeferredPayout(
+        fixture.manager.address, intentHash, fixture.beneficiary.address, 1,
+      )).to.be.revertedWithCustomError(fixture.manager, "PositionNotSettled");
+    });
+
+    it("releases deferred authorization on cancellation and manual release", async () => {
+      const fixture = await loadFixture(deferredFixture);
+      const cancelled = ethers.utils.id("deferred-cancel");
+      await createDeferredPosition(fixture, cancelled);
+      await fixture.orchestrator.cancelPosition(fixture.manager.address, cancelled);
+      expect((await fixture.vault.deferredPayouts(cancelled)).authorized).to.eq(false);
+
+      const manual = ethers.utils.id("deferred-manual");
+      await createDeferredPosition(fixture, manual);
+      await fixture.orchestrator.releasePosition(fixture.manager.address, manual, usdc(50));
+      expect((await fixture.vault.deferredPayouts(manual)).authorized).to.eq(false);
+
+      const zeroReservation = ethers.utils.id("deferred-manual-zero-reservation");
+      await fixture.manager.forceRiskPosition(zeroReservation, await forcedRiskPosition(fixture as any, {
+        mode: 3,
+        status: 1,
+        deferredPayoutHook: fixture.orchestrator.address,
+        reservedAmount: 0,
+        initialReservation: 0,
+      }));
+      await fixture.orchestrator.releasePosition(fixture.manager.address, zeroReservation, usdc(1));
+    });
+
+    it("slashes deferred proceeds and releases deferred positions at maturity", async () => {
+      const fixture = await loadFixture(deferredFixture);
+      const slashed = ethers.utils.id("deferred-slash");
+      await createDeferredPosition(fixture, slashed);
+      await fixture.orchestrator.setIntentSettlement(slashed, usdc(50), await time.latest(), false);
+      await fixture.orchestrator.registerDeferredPayout(
+        fixture.manager.address, slashed, fixture.beneficiary.address, usdc(50),
+      );
+      await fixture.manager.submitChargeback(await validAttestation(fixture as any, slashed));
+      expect((await fixture.manager.getRiskPosition(slashed)).status).to.eq(5);
+
+      const matured = ethers.utils.id("deferred-matured");
+      await createDeferredPosition(fixture, matured);
+      await fixture.orchestrator.setIntentSettlement(matured, usdc(50), await time.latest(), false);
+      await fixture.orchestrator.registerDeferredPayout(
+        fixture.manager.address, matured, fixture.beneficiary.address, usdc(50),
+      );
+      const deadline = (await fixture.manager.getRiskPosition(matured)).coverageDeadline.toNumber();
+      await time.increaseTo(deadline);
+      await fixture.manager.releaseMaturedPosition(matured);
+      expect((await fixture.manager.getRiskPosition(matured)).status).to.eq(4);
+    });
+
+    it("settles a forced zero-reservation deferred position", async () => {
+      const fixture = await loadFixture(deferredFixture);
+      const intentHash = ethers.utils.id("deferred-zero-reservation-settlement");
+      await fixture.manager.forceRiskPosition(intentHash, await forcedRiskPosition(fixture as any, {
+        mode: 3,
+        status: 1,
+        reservedAmount: 0,
+        initialReservation: 0,
+      }));
+      await fixture.orchestrator.fulfillPosition(fixture.manager.address, intentHash, usdc(1));
+      expect((await fixture.manager.getRiskPosition(intentHash)).status).to.eq(3);
+    });
+
+    it("requires the deferred hook for both zero-hook and mismatched-hook admission", async () => {
+      const fixture = await loadFixture(deferredFixture);
+      const mismatched = ethers.utils.id("deferred-mismatched-hook");
+      await setRiskIntent(fixture as any, mismatched, { postIntentHook: ZERO });
+      await expect(fixture.orchestrator.createPosition(fixture.manager.address, mismatched))
+        .to.be.revertedWithCustomError(fixture.manager, "DeferredPayoutHookRequired");
+
+      await fixture.manager.setDeferredPayoutHook(ZERO);
+      const missing = ethers.utils.id("deferred-zero-hook");
+      await setRiskIntent(fixture as any, missing, { postIntentHook: ZERO });
+      await expect(fixture.orchestrator.createPosition(fixture.manager.address, missing))
+        .to.be.revertedWithCustomError(fixture.manager, "DeferredPayoutHookRequired");
+    });
+
+    it("covers manual-release guards and durable manual synchronization directly", async () => {
+      const fixture = await loadFixture(deferredFixture);
+      const now = await time.latest();
+      const zeroRelease = ethers.utils.id("manual-zero-release");
+      await fixture.manager.forceRiskPosition(zeroRelease, await forcedRiskPosition(fixture as any, {
+        status: 1,
+      }));
+      await expect(fixture.manager.exposedReleaseManualPosition(zeroRelease, 0, now))
+        .to.be.revertedWithCustomError(fixture.manager, "ZeroAmount");
+
+      const nonPending = ethers.utils.id("manual-non-pending");
+      await fixture.manager.forceRiskPosition(nonPending, await forcedRiskPosition(fixture as any, {
+        status: 2,
+      }));
+      await expect(fixture.manager.exposedReleaseManualPosition(nonPending, 1, now))
+        .to.be.revertedWithCustomError(fixture.manager, "PositionNotPending");
+
+      const zeroTimestamp = ethers.utils.id("manual-zero-timestamp");
+      await fixture.manager.forceRiskPosition(zeroTimestamp, await forcedRiskPosition(fixture as any, {
+        status: 1,
+      }));
+      await fixture.orchestrator.setIntentSettlement(zeroTimestamp, 1, 0, true);
+      await expect(fixture.manager.exposedSynchronizeSettlement(zeroTimestamp))
+        .to.be.revertedWithCustomError(fixture.manager, "SettlementNotRecorded");
+
+      const synchronized = ethers.utils.id("manual-synchronized");
+      await fixture.manager.forceRiskPosition(synchronized, await forcedRiskPosition(fixture as any, {
+        status: 1,
+        reservedAmount: 0,
+      }));
+      await fixture.orchestrator.setIntentSettlement(synchronized, 1, now, true);
+      await fixture.manager.exposedSynchronizeSettlement(synchronized);
+      expect((await fixture.manager.getRiskPosition(synchronized)).status).to.eq(4);
     });
   });
 
@@ -1083,6 +1249,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
         fixture.orchestrator.address,
         fixture.vault.address,
         fixture.verifier.address,
+        fixture.nullifierRegistry.address,
       );
       return { ...fixture, manager };
     }
@@ -1200,7 +1367,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       const attestation = await validAttestation(fixture, ethers.constants.HashZero);
       await expectGuardRevert(
         fixture,
-        fixture.manager.interface.encodeFunctionData("submitChargeback", [attestation, [], "0x"]),
+        fixture.manager.interface.encodeFunctionData("submitChargeback", [attestation]),
       );
     });
   });
@@ -1213,6 +1380,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
         fixture.orchestrator.address,
         fixture.vault.address,
         fixture.verifier.address,
+        fixture.nullifierRegistry.address,
       );
       return { ...fixture, manager };
     }
@@ -1229,7 +1397,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       )).to.be.revertedWithCustomError(fixture.manager, "PositionModeMismatch");
     });
 
-    it("rejects settlement for an impossible chargebackable unbonded position", async () => {
+    it("rejects settlement for an impossible chargebackable free position", async () => {
       const fixture = await loadFixture(deployStateHarnessFixture);
       const intentHash = ethers.utils.id("forced-settlement-mode");
       await fixture.manager.forcePosition(intentHash, 1, 1, ZERO, PAYPAL, 1, 0);
@@ -1237,7 +1405,7 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
         .to.be.revertedWithCustomError(fixture.manager, "PositionModeMismatch");
     });
 
-    it("rejects chargeback evidence for an impossible settled unbonded position", async () => {
+    it("rejects chargeback evidence for an impossible settled free position", async () => {
       const fixture = await loadFixture(deployStateHarnessFixture);
       const intentHash = ethers.utils.id("forced-claim-mode");
       await fixture.manager.forcePosition(
@@ -1251,8 +1419,6 @@ describe("RiskManager -- exhaustive policy and recovery coverage", () => {
       );
       await expect(fixture.manager.submitChargeback(
         await validAttestation(fixture, intentHash),
-        [],
-        "0x",
       )).to.be.revertedWithCustomError(fixture.manager, "PositionModeMismatch");
     });
 

--- a/test/staking/riskManager.spec.ts
+++ b/test/staking/riskManager.spec.ts
@@ -28,6 +28,9 @@ describe("RiskManager and OrchestratorV3", () => {
     const escrowRegistry = await (await ethers.getContractFactory("EscrowRegistry")).deploy();
     const relayerRegistry = await (await ethers.getContractFactory("RelayerRegistry")).deploy();
     const orchestratorRegistry = await (await ethers.getContractFactory("OrchestratorRegistry")).deploy();
+    const legacyNullifierRegistry = await (await ethers.getContractFactory("NullifierRegistry")).deploy();
+    const nullifierRegistry = await (await ethers.getContractFactory("NullifierRegistryV2"))
+      .deploy(legacyNullifierRegistry.address);
     const verifier = await (await ethers.getContractFactory("PaymentVerifierMock")).deploy();
     const attestationVerifier = await (await ethers.getContractFactory("AttestationVerifierMock")).deploy();
 
@@ -46,7 +49,7 @@ describe("RiskManager and OrchestratorV3", () => {
     );
     const boundedCall = await (await ethers.getContractFactory("BoundedCall")).deploy();
     const postIntentHookExecutor = await (await ethers.getContractFactory("PostIntentHookExecutor")).deploy();
-    const orchestrator = await (await ethers.getContractFactory("OrchestratorV3", {
+    const orchestrator = await (await ethers.getContractFactory("OrchestratorV3StateHarness", {
       libraries: {
         BoundedCall: boundedCall.address,
         PostIntentHookExecutor: postIntentHookExecutor.address,
@@ -73,7 +76,9 @@ describe("RiskManager and OrchestratorV3", () => {
       orchestrator.address,
       vault.address,
       attestationVerifier.address,
+      nullifierRegistry.address,
     );
+    await nullifierRegistry.addWritePermission(owner.address);
     const deferredHook = await (await ethers.getContractFactory("DeferredPayoutHook")).deploy(
       token.address,
       vault.address,
@@ -110,7 +115,7 @@ describe("RiskManager and OrchestratorV3", () => {
       enabled: true,
       chargeback: {
         chargebackable: true,
-        deferredPayoutEnabled: true,
+        deferredPayoutEnabled: false,
         reserveBps: 10_000,
         riskWindow: 30 * DAY,
       },
@@ -167,8 +172,6 @@ describe("RiskManager and OrchestratorV3", () => {
       manager,
       deferredHook,
       orchestratorRegistry,
-      verifier,
-      attestationVerifier,
     };
   }
 
@@ -233,24 +236,41 @@ describe("RiskManager and OrchestratorV3", () => {
 
   async function chargebackAttestation(
     manager: Contract,
-    orchestrator: Contract,
     intentHash: string,
-    amount: BigNumber,
-    nonce = 1,
+    paymentAmount: BigNumber,
+    disputeId = ethers.utils.id(`dispute-${intentHash}`),
+    detailsOverrides: Record<string, unknown> = {},
   ) {
-    const now = await time.latest();
-    const { chainId } = await ethers.provider.getNetwork();
-    return {
-      chainId,
-      riskManager: manager.address,
-      orchestrator: orchestrator.address,
-      intentHash,
+    const details = {
       paymentMethod: PAYPAL,
-      chargebackAmount: amount,
-      evidenceId: ethers.utils.id(`evidence-${nonce}`),
-      nonce,
-      validAfter: now - 1,
-      validUntil: now + DAY,
+      originalPaymentId: ethers.utils.keccak256(
+        ethers.utils.solidityPack(["string", "bytes32"], ["payment", intentHash]),
+      ),
+      disputeId,
+      paymentAmount,
+      paymentCurrency: USD,
+      ...detailsOverrides,
+    };
+    const nullifierRegistry = await ethers.getContractAt("NullifierRegistryV2", await manager.nullifierRegistry());
+    const canonicalPaymentId = ethers.utils.keccak256(
+      ethers.utils.solidityPack(["string", "bytes32"], ["payment", intentHash]),
+    );
+    const canonicalNullifier = ethers.utils.keccak256(
+      ethers.utils.solidityPack(["bytes32", "bytes32"], [PAYPAL, canonicalPaymentId]),
+    );
+    if ((await nullifierRegistry.intentHashByNullifier(canonicalNullifier)) === ethers.constants.HashZero) {
+      await nullifierRegistry.addNullifier(canonicalNullifier, intentHash);
+    }
+    const data = ethers.utils.defaultAbiCoder.encode(
+      ["tuple(bytes32 paymentMethod,bytes32 originalPaymentId,bytes32 disputeId,uint256 paymentAmount,bytes32 paymentCurrency)"],
+      [details],
+    );
+    return {
+      intentHash,
+      dataHash: ethers.utils.keccak256(data),
+      signatures: [],
+      data,
+      metadata: "0x",
     };
   }
 
@@ -272,6 +292,15 @@ describe("RiskManager and OrchestratorV3", () => {
       await expect(manager.setPlatformRiskConfig(PAYPAL, {
         enabled: true,
         chargeback: { chargebackable: true, deferredPayoutEnabled: false, reserveBps: 10_001, riskWindow: DAY },
+        griefing: { griefingCliff: 1, griefingPenaltyBpsPerHour: 1, baseUnbondedAmount: 0 },
+      })).to.be.revertedWithCustomError(manager, "InvalidPlatformConfig");
+    });
+
+    it("rejects deferred payout for a chargebackable platform in v1", async () => {
+      const { manager } = await loadFixture(deployFixture);
+      await expect(manager.setPlatformRiskConfig(PAYPAL, {
+        enabled: true,
+        chargeback: { chargebackable: true, deferredPayoutEnabled: true, reserveBps: 10_000, riskWindow: DAY },
         griefing: { griefingCliff: 1, griefingPenaltyBpsPerHour: 1, baseUnbondedAmount: 0 },
       })).to.be.revertedWithCustomError(manager, "InvalidPlatformConfig");
     });
@@ -427,7 +456,7 @@ describe("RiskManager and OrchestratorV3", () => {
       const { taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
       await manager.setPlatformRiskConfig(PAYPAL, {
         enabled: true,
-        chargeback: { chargebackable: true, deferredPayoutEnabled: true, reserveBps: 5_000, riskWindow: DAY },
+        chargeback: { chargebackable: true, deferredPayoutEnabled: false, reserveBps: 10_000, riskWindow: DAY },
         griefing: {
           griefingCliff: GRIEFING_CLIFF,
           griefingPenaltyBpsPerHour: GRIEFING_SLOPE,
@@ -438,7 +467,7 @@ describe("RiskManager and OrchestratorV3", () => {
       const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(500), PAYPAL);
       await manager.setPlatformRiskConfig(PAYPAL, {
         enabled: true,
-        chargeback: { chargebackable: true, deferredPayoutEnabled: true, reserveBps: 10_000, riskWindow: 30 * DAY },
+        chargeback: { chargebackable: true, deferredPayoutEnabled: false, reserveBps: 10_000, riskWindow: 30 * DAY },
         griefing: {
           griefingCliff: 30 * MINUTE,
           griefingPenaltyBpsPerHour: 20,
@@ -446,7 +475,7 @@ describe("RiskManager and OrchestratorV3", () => {
         },
       });
       const position = await manager.getRiskPosition(intentHash);
-      expect(position.chargebackReserveBps).to.eq(5_000);
+      expect(position.chargebackReserveBps).to.eq(10_000);
       expect(position.riskWindow).to.eq(DAY);
       expect(position.griefingCliff).to.eq(GRIEFING_CLIFF);
     });
@@ -458,7 +487,7 @@ describe("RiskManager and OrchestratorV3", () => {
       await vault.connect(taker).depositStake(usdc(1_000));
       const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(1_000), PAYPAL);
       const createdAt = (await manager.getRiskPosition(intentHash)).createdAt.toNumber();
-      await time.increaseTo(createdAt + GRIEFING_CLIFF);
+      await time.setNextBlockTimestamp(createdAt + GRIEFING_CLIFF);
       await orchestrator.connect(taker).cancelIntent(intentHash);
       expect(await vault.reservedStake(taker.address)).to.eq(0);
       expect(await vault.claimableCompensation((await manager.getRiskPosition(intentHash)).lp)).to.eq(0);
@@ -469,7 +498,7 @@ describe("RiskManager and OrchestratorV3", () => {
       await vault.connect(taker).depositStake(usdc(1_000));
       const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(1_000), PAYPAL);
       const createdAt = (await manager.getRiskPosition(intentHash)).createdAt.toNumber();
-      await time.increaseTo(createdAt + 2 * HOUR);
+      await time.setNextBlockTimestamp(createdAt + 2 * HOUR);
       await orchestrator.connect(taker).cancelIntent(intentHash);
       expect(await vault.claimableCompensation(maker.address)).to.eq(usdc("1.75"));
       expect(await vault.stakeBalance(taker.address)).to.eq(usdc("998.25"));
@@ -522,48 +551,72 @@ describe("RiskManager and OrchestratorV3", () => {
       expect(await vault.reservedStake(taker.address)).to.eq(usdc(600));
     });
 
-    it("starts the coverage window at maker manual release", async () => {
-      const { maker, taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
+    it("makes a maker manual release immediately non-chargebackable and releases its reservation", async () => {
+      const { maker, taker, escrow, orchestrator, token, vault, manager } = await loadFixture(deployFixture);
       await vault.connect(taker).depositStake(usdc(500));
       const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(500), PAYPAL);
+      const balanceBefore = await token.balanceOf(taker.address);
       await orchestrator.connect(maker).releaseFundsToPayer(intentHash);
       const position = await manager.getRiskPosition(intentHash);
-      expect(position.coverageDeadline.sub(position.settledAt)).to.eq(30 * DAY);
+      expect(position.status).to.eq(4);
+      expect(position.coverageDeadline).to.eq(0);
+      expect(position.reservedAmount).to.eq(0);
+      expect(await vault.reservedStake(taker.address)).to.eq(0);
+      expect(await token.balanceOf(taker.address)).to.eq(balanceBefore.add(usdc(500)));
     });
 
-    it("slashes a partial chargeback and preserves remaining coverage", async () => {
+    it("authenticates the payment-style typed data and compensates the exact gross release", async () => {
       const { maker, taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
       await vault.connect(taker).depositStake(usdc(500));
       const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(500), PAYPAL);
       await fulfillIntent(orchestrator, intentHash, usdc(500));
-      const claim = await chargebackAttestation(manager, orchestrator, intentHash, usdc(200));
-      await manager.submitChargeback(claim, [], "0x");
-      expect(await vault.claimableCompensation(maker.address)).to.eq(usdc(200));
-      expect(await vault.reservedStake(taker.address)).to.eq(usdc(300));
-      expect((await manager.getRiskPosition(intentHash)).status).to.eq(3);
-    });
-
-    it("caps a chargeback request at the remaining coverage", async () => {
-      const { maker, taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
-      await vault.connect(taker).depositStake(usdc(500));
-      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(500), PAYPAL);
-      await fulfillIntent(orchestrator, intentHash, usdc(500));
-      const claim = await chargebackAttestation(manager, orchestrator, intentHash, usdc(800));
-      await manager.submitChargeback(claim, [], "0x");
+      const claim = await chargebackAttestation(manager, intentHash, usdc(500));
+      const { chainId } = await ethers.provider.getNetwork();
+      expect(await manager.hashChargebackAttestation(claim)).to.eq(ethers.utils._TypedDataEncoder.hash(
+        { name: "ZKP2P RiskManager", version: "1", chainId, verifyingContract: manager.address },
+        { ChargebackAttestation: [
+          { name: "intentHash", type: "bytes32" },
+          { name: "dataHash", type: "bytes32" },
+        ] },
+        { intentHash: claim.intentHash, dataHash: claim.dataHash },
+      ));
+      await manager.submitChargeback(claim);
       expect(await vault.claimableCompensation(maker.address)).to.eq(usdc(500));
       expect((await manager.getRiskPosition(intentHash)).status).to.eq(5);
     });
 
-    it("rejects replaying a chargeback nonce", async () => {
+    it("rejects reused dispute evidence across positions", async () => {
       const { taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
-      await vault.connect(taker).depositStake(usdc(500));
-      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(500), PAYPAL);
-      await fulfillIntent(orchestrator, intentHash, usdc(500));
-      const first = await chargebackAttestation(manager, orchestrator, intentHash, usdc(100), 7);
-      await manager.submitChargeback(first, [], "0x");
-      const replay = await chargebackAttestation(manager, orchestrator, intentHash, usdc(100), 7);
-      await expect(manager.submitChargeback(replay, [], "0x"))
-        .to.be.revertedWithCustomError(manager, "AttestationNonceUsed");
+      await vault.connect(taker).depositStake(usdc(1_000));
+      const firstHash = await signalIntent(orchestrator, escrow, taker, usdc(500), PAYPAL);
+      const secondHash = await signalIntent(orchestrator, escrow, taker, usdc(500), PAYPAL);
+      await fulfillIntent(orchestrator, firstHash, usdc(500));
+      await fulfillIntent(orchestrator, secondHash, usdc(500));
+      const disputeId = ethers.utils.id("shared-dispute");
+      await manager.submitChargeback(await chargebackAttestation(manager, firstHash, usdc(500), disputeId));
+      await expect(manager.submitChargeback(
+        await chargebackAttestation(manager, secondHash, usdc(500), disputeId),
+      )).to.be.revertedWithCustomError(manager, "ChargebackEvidenceUsed");
+    });
+
+    it("rejects manual release and a mismatched original payment identifier", async () => {
+      const { maker, taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
+      await vault.connect(taker).depositStake(usdc(1_000));
+      const manualHash = await signalIntent(orchestrator, escrow, taker, usdc(500), PAYPAL);
+      await orchestrator.connect(maker).releaseFundsToPayer(manualHash);
+      await expect(manager.submitChargeback(
+        await chargebackAttestation(manager, manualHash, usdc(500)),
+      )).to.be.revertedWithCustomError(manager, "PositionNotSettled");
+
+      const verifiedHash = await signalIntent(orchestrator, escrow, taker, usdc(500), PAYPAL);
+      await fulfillIntent(orchestrator, verifiedHash, usdc(500));
+      await expect(manager.submitChargeback(await chargebackAttestation(
+        manager,
+        verifiedHash,
+        usdc(500),
+        undefined,
+        { originalPaymentId: ethers.utils.id("wrong-payment") },
+      ))).to.be.revertedWithCustomError(manager, "InvalidPaymentBinding");
     });
 
     it("releases remaining coverage at maturity", async () => {
@@ -585,97 +638,85 @@ describe("RiskManager and OrchestratorV3", () => {
       await fulfillIntent(orchestrator, intentHash, usdc(500));
       const deadline = (await manager.getRiskPosition(intentHash)).coverageDeadline.toNumber();
       await time.increaseTo(deadline);
-      const claim = await chargebackAttestation(manager, orchestrator, intentHash, usdc(100));
-      await expect(manager.submitChargeback(claim, [], "0x"))
+      const claim = await chargebackAttestation(manager, intentHash, usdc(500));
+      await expect(manager.submitChargeback(claim))
         .to.be.revertedWithCustomError(manager, "ChargebackWindowClosed");
     });
   });
 
-  describe("deferred payout exception", () => {
-    it("reserves only the maximum griefing bond when stake cannot cover chargebacks", async () => {
-      const { taker, escrow, orchestrator, vault, manager, deferredHook } = await loadFixture(deployFixture);
-      await vault.connect(taker).depositStake(usdc(10));
+  describe("OrchestratorV3 control and recovery surface", () => {
+    it("exposes hook snapshots, account counts, and guarded governance", async () => {
+      const { owner, maker, taker, other, escrow, orchestrator, manager } = await loadFixture(deployFixture);
+      expect(await orchestrator.getDepositRiskHook(escrow.address, 0)).to.eq(manager.address);
+      await expect(orchestrator.connect(other).setRiskCallbackGasLimit(1_000_000))
+        .to.be.revertedWith("Ownable: caller is not the owner");
+      await expect(orchestrator.setRiskCallbackGasLimit(749_999))
+        .to.be.revertedWithCustomError(orchestrator, "RiskCallbackGasLimitTooLow");
+      await expect(orchestrator.connect(owner).setRiskCallbackGasLimit(1_000_000))
+        .to.emit(orchestrator, "RiskCallbackGasLimitUpdated").withArgs(1_000_000);
+
+      await expect(orchestrator.connect(other).setDepositRiskHook(escrow.address, 0, ZERO))
+        .to.be.revertedWithCustomError(orchestrator, "UnauthorizedCallerOrDelegate");
+      await expect(orchestrator.connect(maker).setDepositRiskHook(ZERO, 0, ZERO))
+        .to.be.revertedWithCustomError(orchestrator, "ZeroAddress");
+      await expect(orchestrator.connect(maker).setDepositRiskHook(escrow.address, 0, other.address))
+        .to.be.revertedWithCustomError(orchestrator, "InvalidRiskHook");
+
+      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE);
+      expect(await orchestrator.getIntentRiskHook(intentHash)).to.eq(manager.address);
+      expect(await orchestrator.getAccountIntentCount(taker.address)).to.eq(1);
+      const riskIntent = await orchestrator.getRiskIntent(intentHash);
+      expect(riskIntent.owner).to.eq(taker.address);
+      expect((await orchestrator.getIntentSettlement(intentHash)).releasedAmount).to.eq(0);
+
+      await orchestrator.cleanupOrphanedIntents([ethers.utils.id("unknown-orphan"), intentHash]);
+      expect(await orchestrator.getAccountIntentCount(taker.address)).to.eq(1);
+    });
+
+    it("records whether a failed settlement callback was manual or verified", async () => {
+      const { maker, taker, escrow, orchestrator } = await loadFixture(deployFixture);
+      const hook = await (await ethers.getContractFactory("IntentRiskHookMock")).deploy();
+      await orchestrator.connect(maker).setDepositRiskHook(escrow.address, 0, hook.address);
+      await hook.setRevertOnTerminal(true);
+
+      const verified = await signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE);
+      await fulfillIntent(orchestrator, verified, usdc(20));
+      const verifiedSettlement = await orchestrator.getIntentSettlement(verified);
+      expect(verifiedSettlement.releasedAmount).to.eq(usdc(20));
+      expect(verifiedSettlement.isManualRelease).to.eq(false);
+
+      const manual = await signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE);
+      await orchestrator.connect(maker).releaseFundsToPayer(manual);
+      const manualSettlement = await orchestrator.getIntentSettlement(manual);
+      expect(manualSettlement.releasedAmount).to.eq(usdc(20));
+      expect(manualSettlement.isManualRelease).to.eq(true);
+    });
+
+    it("rejects a manual release when snapshotted state requires a now-missing post-intent hook", async () => {
+      const { maker, taker, escrow, orchestrator, deferredHook } = await loadFixture(deployFixture);
+      const hook = await (await ethers.getContractFactory("IntentRiskHookMock")).deploy();
+      await hook.setRequiresPostIntentHook(true);
+      await orchestrator.connect(maker).setDepositRiskHook(escrow.address, 0, hook.address);
       const intentHash = await signalIntent(
-        orchestrator,
-        escrow,
-        taker,
-        usdc(700),
-        PAYPAL,
-        deferredHook.address,
+        orchestrator, escrow, taker, usdc(20), ZELLE, deferredHook.address,
       );
-      const position = await manager.getRiskPosition(intentHash);
-      expect(position.mode).to.eq(3);
-      expect(position.initialReservation).to.eq(usdc("4.025"));
-      expect(await vault.reservedStake(taker.address)).to.eq(usdc("4.025"));
+      await orchestrator.clearPostIntentHook(intentHash);
+      await expect(orchestrator.connect(maker).releaseFundsToPayer(intentHash))
+        .to.be.revertedWithCustomError(orchestrator, "RequiredPostIntentHookMissing");
     });
 
-    it("holds settled proceeds as chargeback coverage and releases griefing stake", async () => {
-      const { taker, escrow, orchestrator, vault, manager, deferredHook } = await loadFixture(deployFixture);
-      await vault.connect(taker).depositStake(usdc(10));
-      const intentHash = await signalIntent(
-        orchestrator,
-        escrow,
-        taker,
-        usdc(700),
-        PAYPAL,
-        deferredHook.address,
+    it("blocks reentry into every guarded V3 lifecycle entrypoint", async () => {
+      const { maker, taker, escrow, orchestrator } = await loadFixture(deployFixture);
+      const hook = await (await ethers.getContractFactory("OrchestratorV3ReentrantRiskHook")).deploy(
+        orchestrator.address, escrow.address,
       );
-      await fulfillIntent(orchestrator, intentHash, usdc(700));
-      expect(await vault.reservedStake(taker.address)).to.eq(0);
-      expect((await vault.getDeferredPayout(intentHash)).amount).to.eq(usdc(700));
-      expect((await manager.getRiskPosition(intentHash)).reservedAmount).to.eq(usdc(700));
-    });
-
-    it("rejects a self-referral that would reduce deferred proceeds below configured coverage", async () => {
-      const { taker, escrow, orchestrator, vault, manager, deferredHook } = await loadFixture(deployFixture);
-      await vault.connect(taker).depositStake(usdc(10));
-      const tx = await orchestrator.connect(taker).signalIntent(signalParams(
-        escrow,
-        taker.address,
-        usdc(700),
-        PAYPAL,
-        deferredHook.address,
-        [{ recipient: taker.address, fee: precise("0.5") }],
-      ));
-      const intentHash = intentHashFrom(await tx.wait());
-      await expect(fulfillIntent(orchestrator, intentHash, usdc(700)))
-        .to.be.revertedWithCustomError(manager, "InsufficientDeferredPayoutCoverage");
-      expect((await manager.getRiskPosition(intentHash)).status).to.eq(1);
-      expect(await vault.reservedStake(taker.address)).to.eq(usdc("4.025"));
-    });
-
-    it("requires the canonical deferred hook for the exception", async () => {
-      const { taker, escrow, orchestrator, vault, manager } = await loadFixture(deployFixture);
-      await vault.connect(taker).depositStake(usdc(10));
-      await expect(signalIntent(orchestrator, escrow, taker, usdc(700), PAYPAL))
-        .to.be.revertedWithCustomError(orchestrator, "RiskHookAdmissionFailed");
-    });
-
-    it("rejects the deferred hook when stake already covers the full reservation", async () => {
-      const { taker, escrow, orchestrator, vault, manager, deferredHook } = await loadFixture(deployFixture);
-      await vault.connect(taker).depositStake(usdc(700));
-      await expect(signalIntent(orchestrator, escrow, taker, usdc(700), PAYPAL, deferredHook.address))
-        .to.be.revertedWithCustomError(orchestrator, "RiskHookAdmissionFailed");
-    });
-
-    it("slashes deferred proceeds without reducing membership stake", async () => {
-      const { maker, taker, escrow, orchestrator, vault, manager, deferredHook } =
-        await loadFixture(deployFixture);
-      await vault.connect(taker).depositStake(usdc(10));
-      const intentHash = await signalIntent(
-        orchestrator,
-        escrow,
-        taker,
-        usdc(700),
-        PAYPAL,
-        deferredHook.address,
-      );
-      await fulfillIntent(orchestrator, intentHash, usdc(700));
-      const claim = await chargebackAttestation(manager, orchestrator, intentHash, usdc(200));
-      await manager.submitChargeback(claim, [], "0x");
-      expect(await vault.stakeBalance(taker.address)).to.eq(usdc(10));
-      expect(await vault.claimableCompensation(maker.address)).to.eq(usdc(200));
-      expect((await vault.getDeferredPayout(intentHash)).amount).to.eq(usdc(500));
+      await hook.setReenterOnCreate(true);
+      await orchestrator.connect(maker).setDepositRiskHook(escrow.address, 0, hook.address);
+      const intentHash = await signalIntent(orchestrator, escrow, taker, usdc(20), ZELLE);
+      expect(await hook.setterReentrySucceeded()).to.eq(false);
+      await orchestrator.connect(taker).cancelIntent(intentHash);
+      expect(await hook.cancelReentrySucceeded()).to.eq(false);
+      expect(await hook.cleanupReentrySucceeded()).to.eq(false);
     });
   });
 });

--- a/test/unifiedVerifier/unifiedPaymentVerifierV3.spec.ts
+++ b/test/unifiedVerifier/unifiedPaymentVerifierV3.spec.ts
@@ -1,0 +1,418 @@
+import "module-alias/register";
+
+import { expect } from "chai";
+import { BigNumber, Contract } from "ethers";
+import { ethers } from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+
+import { getAccounts } from "@utils/test/index";
+import { buildUnifiedPaymentProof, BuildPaymentProofOverrides } from "@utils/unifiedVerifierUtils";
+import { Currency } from "@utils/protocolUtils";
+import { ADDRESS_ZERO, EMPTY_ORACLE_RATE_CONFIG, ZERO } from "@utils/constants";
+
+const METHOD = ethers.utils.id("venmo");
+const OTHER_METHOD = ethers.utils.id("paypal");
+const PAYEE = ethers.utils.id("binding-payee");
+const EMPTY_BYTES = "0x";
+
+describe("UnifiedPaymentVerifierV3 payment-to-intent bindings", () => {
+  async function fixture() {
+    const [owner, maker, taker, witness, fulfiller] = await getAccounts();
+    const chainId = (await ethers.provider.getNetwork()).chainId;
+    const token = await (await ethers.getContractFactory("USDCMock", owner.wallet))
+      .deploy(ethers.utils.parseUnits("1000000", 6), "USDC", "USDC");
+    const escrowRegistry = await (await ethers.getContractFactory("EscrowRegistry", owner.wallet)).deploy();
+    const orchestratorRegistry = await (await ethers.getContractFactory("OrchestratorRegistry", owner.wallet)).deploy();
+    const paymentVerifierRegistry = await (await ethers.getContractFactory("PaymentVerifierRegistry", owner.wallet)).deploy();
+    const relayerRegistry = await (await ethers.getContractFactory("RelayerRegistry", owner.wallet)).deploy();
+    const legacyNullifierRegistry = await (await ethers.getContractFactory("NullifierRegistry", owner.wallet)).deploy();
+    const nullifierRegistry = await (await ethers.getContractFactory("NullifierRegistryV2", owner.wallet))
+      .deploy(legacyNullifierRegistry.address);
+    const attestationVerifier = await (await ethers.getContractFactory("SimpleAttestationVerifier", owner.wallet))
+      .deploy(witness.address);
+    const verifier = await (await ethers.getContractFactory("UnifiedPaymentVerifierV3", owner.wallet)).deploy(
+      orchestratorRegistry.address,
+      nullifierRegistry.address,
+      attestationVerifier.address,
+    );
+
+    const escrow = await (await ethers.getContractFactory("EscrowV2", owner.wallet)).deploy(
+      owner.address,
+      chainId,
+      orchestratorRegistry.address,
+      paymentVerifierRegistry.address,
+      owner.address,
+      0,
+      20,
+      3600,
+    );
+    const orchestratorV2 = await (await ethers.getContractFactory("OrchestratorV2", owner.wallet)).deploy(
+      owner.address,
+      chainId,
+      escrowRegistry.address,
+      paymentVerifierRegistry.address,
+      relayerRegistry.address,
+      0,
+      owner.address,
+    );
+    const boundedCall = await (await ethers.getContractFactory("BoundedCall", owner.wallet)).deploy();
+    const executor = await (await ethers.getContractFactory("PostIntentHookExecutor", owner.wallet)).deploy();
+    const orchestratorV3 = await (await ethers.getContractFactory("OrchestratorV3", {
+      signer: owner.wallet,
+      libraries: { BoundedCall: boundedCall.address, PostIntentHookExecutor: executor.address },
+    })).deploy(
+      owner.address,
+      chainId,
+      escrowRegistry.address,
+      paymentVerifierRegistry.address,
+      relayerRegistry.address,
+      0,
+      owner.address,
+      2_000_000,
+    );
+
+    await escrowRegistry.addEscrow(escrow.address);
+    await orchestratorRegistry.addOrchestrator(orchestratorV2.address);
+    await orchestratorRegistry.addOrchestrator(orchestratorV3.address);
+    await orchestratorV2.setAllowMultipleIntents(true);
+    await orchestratorV3.setAllowMultipleIntents(true);
+    await nullifierRegistry.addWritePermission(verifier.address);
+    await legacyNullifierRegistry.addWritePermission(owner.address);
+    await verifier.addPaymentMethod(METHOD);
+    await verifier.addPaymentMethod(OTHER_METHOD);
+    await paymentVerifierRegistry.addPaymentMethod(METHOD, verifier.address, [Currency.USD]);
+
+    await token.transfer(maker.address, ethers.utils.parseUnits("1000", 6));
+    await token.connect(maker.wallet).approve(escrow.address, ethers.constants.MaxUint256);
+    await escrow.connect(maker.wallet).createDeposit({
+      token: token.address,
+      amount: ethers.utils.parseUnits("1000", 6),
+      intentAmountRange: { min: 1, max: ethers.utils.parseUnits("500", 6) },
+      paymentMethods: [METHOD],
+      paymentMethodData: [{ intentGatingService: ADDRESS_ZERO, payeeDetails: PAYEE, data: EMPTY_BYTES }],
+      currencies: [[{
+        code: Currency.USD,
+        minConversionRate: ethers.utils.parseEther("1"),
+        oracleRateConfig: EMPTY_ORACLE_RATE_CONFIG,
+      }]],
+      delegate: ADDRESS_ZERO,
+      intentGuardian: ADDRESS_ZERO,
+      retainOnEmpty: true,
+    });
+
+    return {
+      owner, maker, taker, witness, fulfiller, chainId, token, escrow, orchestratorV2, orchestratorV3,
+      orchestratorRegistry, paymentVerifierRegistry, legacyNullifierRegistry, nullifierRegistry,
+      attestationVerifier, verifier,
+    };
+  }
+
+  async function signal(f: Awaited<ReturnType<typeof fixture>>, orchestrator: Contract) {
+    const tx = await orchestrator.connect(f.taker.wallet).signalIntent({
+      escrow: f.escrow.address,
+      depositId: ZERO,
+      amount: ethers.utils.parseUnits("50", 6),
+      to: f.taker.address,
+      paymentMethod: METHOD,
+      fiatCurrency: Currency.USD,
+      conversionRate: ethers.utils.parseEther("1"),
+      referralFees: [],
+      gatingServiceSignature: EMPTY_BYTES,
+      signatureExpiration: ZERO,
+      postIntentHook: ADDRESS_ZERO,
+      preIntentHookData: EMPTY_BYTES,
+      data: EMPTY_BYTES,
+    });
+    const receipt = await tx.wait();
+    return receipt.events?.find((event: any) => event.event === "IntentSignaled")?.args?.intentHash as string;
+  }
+
+  async function proof(
+    f: Awaited<ReturnType<typeof fixture>>,
+    orchestrator: Contract,
+    intentHash: string,
+    paymentId: string,
+    overrides: BuildPaymentProofOverrides = {},
+    verifier = f.verifier,
+  ) {
+    const intent = await orchestrator.getIntent(intentHash);
+    return buildUnifiedPaymentProof({
+      verifier: verifier.address,
+      witness: f.witness,
+      chainId: f.chainId,
+      paymentPaymentMethod: overrides.paymentPaymentMethod ?? METHOD,
+      paymentPayeeId: PAYEE,
+      paymentAmount: overrides.paymentAmount ?? intent.amount,
+      paymentCurrency: overrides.paymentCurrency ?? Currency.USD,
+      paymentTimestamp: BigNumber.from(intent.timestamp).mul(1000),
+      paymentPaymentId: overrides.paymentPaymentId ?? paymentId,
+      attestationSigner: overrides.attestationSigner,
+      attestationIntentHash: overrides.attestationIntentHash ?? intentHash,
+      attestationReleaseAmount: overrides.attestationReleaseAmount ?? intent.amount,
+      attestationDataHash: overrides.attestationDataHash,
+      attestationData: overrides.attestationData,
+      snapshotIntentHash: overrides.snapshotIntentHash ?? intentHash,
+      snapshotIntentAmount: overrides.snapshotIntentAmount ?? intent.amount,
+      snapshotIntentPaymentMethod: overrides.snapshotIntentPaymentMethod ?? METHOD,
+      snapshotIntentFiatCurrency: overrides.snapshotIntentFiatCurrency ?? Currency.USD,
+      snapshotIntentPayeeDetails: overrides.snapshotIntentPayeeDetails ?? PAYEE,
+      snapshotIntentConversionRate: overrides.snapshotIntentConversionRate ?? intent.conversionRate,
+      snapshotIntentSignalTimestamp: overrides.snapshotIntentSignalTimestamp ?? intent.timestamp,
+      snapshotIntentTimestampBuffer: overrides.snapshotIntentTimestampBuffer ?? ZERO,
+      intentDepositId: ZERO,
+      intentEscrow: f.escrow.address,
+      intentTo: f.taker.address,
+    });
+  }
+
+  async function fulfill(orchestrator: Contract, fulfiller: any, intentHash: string, paymentProof: any) {
+    return orchestrator.connect(fulfiller.wallet).fulfillIntent({
+      paymentProof,
+      intentHash,
+      verificationData: EMPTY_BYTES,
+      postIntentHookData: EMPTY_BYTES,
+    });
+  }
+
+  it("serves Orchestrator V2 and V3 through the existing three-field verifier ABI", async () => {
+    const f = await loadFixture(fixture);
+    const abiResult = f.verifier.interface.getFunction("verifyPayment").outputs?.[0].components;
+    expect(abiResult?.map((component: any) => component.name)).to.deep.eq(["success", "intentHash", "releaseAmount"]);
+
+    for (const [orchestrator, label] of [[f.orchestratorV2, "v2"], [f.orchestratorV3, "v3"]] as const) {
+      const intentHash = await signal(f, orchestrator);
+      const paymentId = ethers.utils.id(`payment-${label}`);
+      const built = await proof(f, orchestrator, intentHash, paymentId);
+      await expect(fulfill(orchestrator, f.fulfiller, intentHash, built.paymentProof))
+        .to.emit(f.verifier, "PaymentVerified")
+        .withArgs(intentHash, METHOD, Currency.USD, built.paymentDetails.amount,
+          built.paymentDetails.timestamp, paymentId, PAYEE);
+      const nullifier = ethers.utils.solidityKeccak256(["bytes32", "bytes32"], [METHOD, paymentId]);
+      expect(await f.nullifierRegistry.intentHashByNullifier(nullifier)).to.eq(intentHash);
+      expect(await f.nullifierRegistry.nullifierByIntentHash(intentHash)).to.eq(nullifier);
+    }
+  });
+
+  it("rejects predecessor replay and replay between live orchestrators", async () => {
+    const f = await loadFixture(fixture);
+    const predecessorPaymentId = ethers.utils.id("predecessor-payment");
+    const predecessorNullifier = ethers.utils.solidityKeccak256(
+      ["bytes32", "bytes32"], [METHOD, predecessorPaymentId],
+    );
+    await f.legacyNullifierRegistry.addNullifier(predecessorNullifier);
+    const oldIntent = await signal(f, f.orchestratorV2);
+    const oldProof = await proof(f, f.orchestratorV2, oldIntent, predecessorPaymentId);
+    await expect(fulfill(f.orchestratorV2, f.fulfiller, oldIntent, oldProof.paymentProof))
+      .to.be.revertedWith("Nullifier has already been used");
+
+    const sharedPaymentId = ethers.utils.id("shared-live-payment");
+    const firstIntent = await signal(f, f.orchestratorV2);
+    await fulfill(f.orchestratorV2, f.fulfiller, firstIntent,
+      (await proof(f, f.orchestratorV2, firstIntent, sharedPaymentId)).paymentProof);
+    const secondIntent = await signal(f, f.orchestratorV3);
+    await expect(fulfill(f.orchestratorV3, f.fulfiller, secondIntent,
+      (await proof(f, f.orchestratorV3, secondIntent, sharedPaymentId)).paymentProof))
+      .to.be.revertedWith("Nullifier has already been used");
+  });
+
+  it("rejects an attested method different from the intent and zero payment fields", async () => {
+    const f = await loadFixture(fixture);
+    const cases: Array<[BuildPaymentProofOverrides, string]> = [
+      [{ paymentPaymentMethod: OTHER_METHOD }, "UPV: Payment method mismatch"],
+      [{ paymentPaymentId: ethers.constants.HashZero }, "UPV: Invalid payment ID"],
+      [{ paymentAmount: BigNumber.from(0) }, "UPV: Invalid payment amount"],
+      [{ paymentCurrency: ethers.constants.HashZero }, "UPV: Invalid payment currency"],
+    ];
+    for (const [overrides, message] of cases) {
+      const intentHash = await signal(f, f.orchestratorV2);
+      const built = await proof(f, f.orchestratorV2, intentHash, ethers.utils.id(message), overrides);
+      await expect(fulfill(f.orchestratorV2, f.fulfiller, intentHash, built.paymentProof)).to.be.revertedWith(message);
+    }
+  });
+
+  it("rejects an attestation bound to a different intent before writing its nullifier", async () => {
+    const f = await loadFixture(fixture);
+    const intentHash = await signal(f, f.orchestratorV2);
+    const otherIntentHash = ethers.utils.id("other-intent");
+    const paymentId = ethers.utils.id("wrong-intent-attestation");
+    const built = await proof(f, f.orchestratorV2, intentHash, paymentId, {
+      attestationIntentHash: otherIntentHash,
+    });
+
+    await expect(fulfill(f.orchestratorV2, f.fulfiller, intentHash, built.paymentProof))
+      .to.be.revertedWith("UPV: Attestation hash mismatch");
+    const nullifier = ethers.utils.solidityKeccak256(["bytes32", "bytes32"], [METHOD, paymentId]);
+    expect(await f.nullifierRegistry.isNullified(nullifier)).to.eq(false);
+  });
+
+  it("rejects a zero attested release before writing its nullifier", async () => {
+    const f = await loadFixture(fixture);
+    const intentHash = await signal(f, f.orchestratorV3);
+    const paymentId = ethers.utils.id("zero-release-attestation");
+    const built = await proof(f, f.orchestratorV3, intentHash, paymentId, {
+      attestationReleaseAmount: BigNumber.from(0),
+    });
+
+    await expect(fulfill(f.orchestratorV3, f.fulfiller, intentHash, built.paymentProof))
+      .to.be.revertedWith("UPV: Invalid release amount");
+    const nullifier = ethers.utils.solidityKeccak256(["bytes32", "bytes32"], [METHOD, paymentId]);
+    expect(await f.nullifierRegistry.isNullified(nullifier)).to.eq(false);
+  });
+
+  it("accepts only a distinct deployed attestation verifier", async () => {
+    const f = await loadFixture(fixture);
+    const replacement = await (await ethers.getContractFactory("SimpleAttestationVerifier", f.owner.wallet))
+      .deploy(f.fulfiller.address);
+
+    await expect(f.verifier.connect(f.taker.wallet).setAttestationVerifier(replacement.address))
+      .to.be.revertedWith("Ownable: caller is not the owner");
+    await expect(f.verifier.setAttestationVerifier(ethers.constants.AddressZero))
+      .to.be.revertedWith("UPV: Invalid attestation verifier");
+    await expect(f.verifier.setAttestationVerifier(f.taker.address))
+      .to.be.revertedWith("UPV: Invalid attestation verifier");
+    await expect(f.verifier.setAttestationVerifier(f.attestationVerifier.address))
+      .to.be.revertedWith("UPV: Same verifier");
+    await expect(f.verifier.setAttestationVerifier(replacement.address))
+      .to.emit(f.verifier, "AttestationVerifierUpdated")
+      .withArgs(f.attestationVerifier.address, replacement.address);
+    expect(await f.verifier.attestationVerifier()).to.eq(replacement.address);
+  });
+
+  it("fully enforces constructor and payment-method governance", async () => {
+    const f = await loadFixture(fixture);
+    const factory = await ethers.getContractFactory("UnifiedPaymentVerifierV3", f.owner.wallet);
+
+    await expect(factory.deploy(f.taker.address, f.nullifierRegistry.address, f.attestationVerifier.address))
+      .to.be.revertedWith("UPV: Invalid orchestrator registry");
+    await expect(factory.deploy(f.orchestratorRegistry.address, f.taker.address, f.attestationVerifier.address))
+      .to.be.revertedWith("UPV: Invalid nullifier registry");
+    await expect(factory.deploy(f.orchestratorRegistry.address, f.nullifierRegistry.address, f.taker.address))
+      .to.be.revertedWith("UPV: Invalid attestation verifier");
+
+    expect(await f.verifier.getPaymentMethods()).to.deep.eq([METHOD, OTHER_METHOD]);
+    await expect(f.verifier.connect(f.taker.wallet).addPaymentMethod(ethers.utils.id("unauthorized")))
+      .to.be.revertedWith("Ownable: caller is not the owner");
+    await expect(f.verifier.addPaymentMethod(METHOD)).to.be.revertedWith("UPV: Payment method already exists");
+    await expect(f.verifier.removePaymentMethod(OTHER_METHOD))
+      .to.emit(f.verifier, "PaymentMethodRemoved").withArgs(OTHER_METHOD);
+    expect(await f.verifier.isPaymentMethod(OTHER_METHOD)).to.eq(false);
+    await expect(f.verifier.removePaymentMethod(OTHER_METHOD)).to.be.revertedWith("UPV: Payment method does not exist");
+    await expect(f.verifier.connect(f.taker.wallet).removePaymentMethod(METHOD))
+      .to.be.revertedWith("Ownable: caller is not the owner");
+  });
+
+  it("rejects unauthorized callers, unsupported methods, invalid signatures, and tampered data", async () => {
+    const f = await loadFixture(fixture);
+    const intentHash = await signal(f, f.orchestratorV2);
+    const paymentId = ethers.utils.id("invalid-proof-cases");
+    const valid = await proof(f, f.orchestratorV2, intentHash, paymentId);
+
+    await expect(f.verifier.connect(f.taker.wallet).verifyPayment({
+      intentHash, paymentProof: valid.paymentProof, data: EMPTY_BYTES,
+    }), "unauthorized caller").to.be.revertedWith("Only orchestrator can call");
+
+    const unsupported = await proof(f, f.orchestratorV2, intentHash, paymentId, {
+      paymentPaymentMethod: ethers.utils.id("unsupported-method"),
+      snapshotIntentPaymentMethod: METHOD,
+    });
+    await expect(fulfill(f.orchestratorV2, f.fulfiller, intentHash, unsupported.paymentProof), "unsupported method")
+      .to.be.revertedWith("UPV: Invalid payment method");
+
+    const badSigner = await proof(f, f.orchestratorV2, intentHash, paymentId, {
+      attestationSigner: f.taker,
+    });
+    await expect(fulfill(f.orchestratorV2, f.fulfiller, intentHash, badSigner.paymentProof), "bad signer")
+      .to.be.revertedWith("ThresholdSigVerifierUtils: Not enough valid witness signatures");
+
+    const tamperedData = ethers.utils.hexConcat([valid.attestation.data as string, "0x00"]);
+    const tampered = ethers.utils.defaultAbiCoder.encode(
+      ["tuple(bytes32,uint256,bytes32,bytes[],bytes,bytes)"],
+      [[valid.attestation.intentHash, valid.attestation.releaseAmount, valid.attestation.dataHash,
+        valid.attestation.signatures, tamperedData, valid.attestation.metadata]],
+    );
+    await expect(fulfill(f.orchestratorV2, f.fulfiller, intentHash, tampered), "tampered data")
+      .to.be.revertedWith("UPV: Data hash mismatch");
+
+    const failingVerifier = await (await ethers.getContractFactory("FailingAttestationVerifier", f.owner.wallet)).deploy();
+    await f.verifier.setAttestationVerifier(failingVerifier.address);
+    await expect(fulfill(f.orchestratorV2, f.fulfiller, intentHash, valid.paymentProof), "false verifier")
+      .to.be.revertedWith("UPV: Invalid attestation");
+  });
+
+  it("validates every attested intent snapshot field and the timestamp-buffer ceiling", async () => {
+    const f = await loadFixture(fixture);
+    const cases: Array<[BuildPaymentProofOverrides, string]> = [
+      [{ snapshotIntentHash: ethers.constants.HashZero }, "UPV: Snapshot hash mismatch"],
+      [{ snapshotIntentPayeeDetails: ethers.utils.id("wrong-payee") }, "UPV: Snapshot payee mismatch"],
+      [{ snapshotIntentAmount: BigNumber.from(1) }, "UPV: Snapshot amount mismatch"],
+      [{ paymentPaymentMethod: OTHER_METHOD, snapshotIntentPaymentMethod: OTHER_METHOD }, "UPV: Snapshot method mismatch"],
+      [{ snapshotIntentFiatCurrency: ethers.utils.id("EUR") }, "UPV: Snapshot currency mismatch"],
+      [{ snapshotIntentConversionRate: BigNumber.from(1) }, "UPV: Snapshot rate mismatch"],
+      [{ snapshotIntentSignalTimestamp: BigNumber.from(1) }, "UPV: Snapshot timestamp mismatch"],
+      [{ snapshotIntentTimestampBuffer: BigNumber.from(48 * 60 * 60 * 1000 + 1) },
+        "UPV: Snapshot timestamp buffer exceeds maximum"],
+    ];
+
+    for (const [overrides, message] of cases) {
+      const intentHash = await signal(f, f.orchestratorV2);
+      const built = await proof(f, f.orchestratorV2, intentHash, ethers.utils.id(message), overrides);
+      await expect(fulfill(f.orchestratorV2, f.fulfiller, intentHash, built.paymentProof), message)
+        .to.be.revertedWith(message);
+    }
+  });
+
+  it("caps overpayment and exercises the legacy orchestrator snapshot shape", async () => {
+    const f = await loadFixture(fixture);
+    const caller = await (await ethers.getContractFactory("UnifiedPaymentVerifierV3CallerHarness", f.owner.wallet)).deploy();
+    await f.orchestratorRegistry.addOrchestrator(caller.address);
+    const intentHash = ethers.utils.id("legacy-shape-intent");
+    const amount = ethers.utils.parseUnits("50", 6);
+    const timestamp = await ethers.provider.getBlock("latest").then((block) => block.timestamp);
+    await caller.setIntent(intentHash, {
+      owner: f.taker.address, to: f.taker.address, escrow: f.escrow.address, depositId: 0,
+      amount, timestamp, paymentMethod: METHOD, fiatCurrency: Currency.USD,
+      conversionRate: ethers.utils.parseEther("1"), payeeId: PAYEE,
+      referrer: ethers.constants.AddressZero, referrerFee: 0,
+      postIntentHook: ethers.constants.AddressZero, data: EMPTY_BYTES,
+    });
+    const paymentId = ethers.utils.id("legacy-shape-payment");
+    const built = await buildUnifiedPaymentProof({
+      verifier: f.verifier.address, witness: f.witness, chainId: f.chainId,
+      paymentPaymentMethod: METHOD, paymentPayeeId: PAYEE, paymentAmount: amount,
+      paymentCurrency: Currency.USD, paymentTimestamp: BigNumber.from(timestamp).mul(1000),
+      paymentPaymentId: paymentId, attestationIntentHash: intentHash,
+      attestationReleaseAmount: amount.mul(2), snapshotIntentHash: intentHash,
+      snapshotIntentAmount: amount, snapshotIntentPaymentMethod: METHOD,
+      snapshotIntentFiatCurrency: Currency.USD, snapshotIntentPayeeDetails: PAYEE,
+      snapshotIntentConversionRate: ethers.utils.parseEther("1"),
+      snapshotIntentSignalTimestamp: BigNumber.from(timestamp), snapshotIntentTimestampBuffer: ZERO,
+    });
+    const result = await caller.callStatic.verifyPayment(f.verifier.address, {
+      intentHash, paymentProof: built.paymentProof, data: EMPTY_BYTES,
+    });
+    expect(result.releaseAmount).to.eq(amount);
+    await caller.verifyPayment(f.verifier.address, { intentHash, paymentProof: built.paymentProof, data: EMPTY_BYTES });
+  });
+
+  it("survives verifier rotation while the retired verifier loses write authority", async () => {
+    const f = await loadFixture(fixture);
+    const replacement = await (await ethers.getContractFactory("UnifiedPaymentVerifierV3", f.owner.wallet)).deploy(
+      f.orchestratorRegistry.address,
+      f.nullifierRegistry.address,
+      f.attestationVerifier.address,
+    );
+    await replacement.addPaymentMethod(METHOD);
+    await f.nullifierRegistry.addWritePermission(replacement.address);
+    await f.paymentVerifierRegistry.removePaymentMethod(METHOD);
+    await f.paymentVerifierRegistry.addPaymentMethod(METHOD, replacement.address, [Currency.USD]);
+    await f.nullifierRegistry.removeWritePermission(f.verifier.address);
+
+    const intentHash = await signal(f, f.orchestratorV3);
+    const paymentId = ethers.utils.id("rotated-payment");
+    const built = await proof(f, f.orchestratorV3, intentHash, paymentId, {}, replacement);
+    await fulfill(f.orchestratorV3, f.fulfiller, intentHash, built.paymentProof);
+    const nullifier = ethers.utils.solidityKeccak256(["bytes32", "bytes32"], [METHOD, paymentId]);
+    expect(await f.nullifierRegistry.intentHashByNullifier(nullifier)).to.eq(intentHash);
+    expect(await f.nullifierRegistry.isWriter(f.verifier.address)).to.eq(false);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,8 @@
   ],
   "files": [
     "hardhat.config.ts",
+  ],
+  "exclude": [
+    "./test/deploy/26_stakeRiskSystem.spec.ts"
   ]
 }


### PR DESCRIPTION
## Summary

Related: https://github.com/zkp2p/protocol/issues/21

- rebuild PR #175's chargeback semantics cleanly on the pre-#175 baseline plus the current #185 reusable-base policy
- add `NullifierRegistryV2`, with immutable read-through to the legacy nullifier registry and atomic one-to-one `nullifier <-> intentHash` bindings for new payments
- add `UnifiedPaymentVerifierV3`, which keeps the existing `IPaymentVerifier` ABI while writing the canonical payment binding after attestation and intent-snapshot validation
- make chargeback evidence identify the original payment, then have `RiskManager` independently verify both registry directions before compensating the exact gross release
- distinguish maker manual releases from verified fulfillments in OrchestratorV3 callback-recovery records, so manual releases cannot remain chargebackable
- retain the current reusable base-unbonded risk policy from #185; chargebackable V1 positions alone require 100% stake-backed coverage and disallow deferred payout

## Relationship to PR #175

This is a clean reconstruction of #175's chargeback behavior, not a byte-for-byte replay of its patch.

Preserved from #175:

- the exact EIP-712 chargeback envelope and `ChargebackDetails(paymentMethod,originalPaymentId,disputeId,paymentAmount,paymentCurrency)` payload
- a dedicated, independently governed chargeback attestation-verifier boundary
- payment-method-scoped dispute replay protection
- full-only compensation equal to the gross on-chain `releasedAmount`
- the half-open chargeback window and fail-closed full-coverage requirement
- rejection of maker manual releases, including preservation of the manual/verified distinction when an OrchestratorV3 callback fails and is reconciled later
- 100% stake-backed chargebackable positions with deferred payout disabled

The payment-evidence architecture is intentionally replaced:

- #175 modified the existing UnifiedPaymentVerifier to store a full payment-details commitment keyed by `(orchestrator, intentHash)`, and RiskManager snapshotted that verifier
- this PR leaves the legacy verifier unchanged, introduces UPV3, and binds `keccak256(paymentMethod, paymentId)` directly to `intentHash` in `NullifierRegistryV2`
- RiskManager stores neither the raw payment ID nor a payment-details hash; at chargeback time it derives the payment nullifier from the signed details and verifies both registry directions

Other deliberate differences from #175:

- the branch inherits #185's reusable base-unbonded tranche instead of #175's lifetime free-take model; chargebackable methods still require a zero unbonded base
- #175's staging deployment and witness-set wiring is not carried forward; RiskManager and OrchestratorV3 are staging-only, and fresh deployment scripts will be written after the interface stabilizes
- the broader #176 hybrid-risk fixes and the later settlement-hook rename are intentionally not bundled into this PR
- UPV3 adds explicit attestation-intent equality, nonzero-release, and deployed-dependency checks found during the clean security review

## Implementation diff references

- [`BaseUnifiedPaymentVerifier` → `BaseUnifiedPaymentVerifierV3`](https://www.diffchecker.com/78KovpiS/)
- [`UnifiedPaymentVerifier` → `UnifiedPaymentVerifierV3`](https://www.diffchecker.com/citvOstv/)

## Why UPV3 is stricter

These checks do not change the `IPaymentVerifier` ABI. They only reject malformed or internally inconsistent attestations before creating the canonical payment binding.

- `isPaymentMethod[paymentDetails.method]` already exists in the legacy verifier; it is not a V3 addition
- `attestation.intentHash == _verifyPaymentData.intentHash` makes UPV3 itself guarantee that the signed intent, validated snapshot, returned result, and registry binding all refer to the same intent; current orchestrators also check the returned hash, but the registry invariant should not depend on that outer check
- nonzero `releaseAmount` prevents consuming a payment for a zero-token settlement and preserves OrchestratorV3/RiskManager recovery, where zero means no recoverable settlement record
- `paymentDetails.method == intentSnapshot.paymentMethod` ensures the method used to namespace the payment nullifier is the method snapshotted by the intent
- nonzero `paymentId` prevents a missing provider identifier from becoming the canonical payment nullifier
- nonzero payment `amount` and `currency` preserve #175's fail-closed rule that a verified payment must carry meaningful economic metadata

## Exact signing format

Domain:

- `name`: `ZKP2P RiskManager`
- `version`: `1`
- `chainId`: current chain
- `verifyingContract`: RiskManager

Signed type:

```text
ChargebackAttestation(bytes32 intentHash,bytes32 dataHash)
```

`dataHash = keccak256(data)`, where `data` is ABI encoding of:

```text
ChargebackDetails(bytes32 paymentMethod,bytes32 originalPaymentId,bytes32 disputeId,uint256 paymentAmount,bytes32 paymentCurrency)
```

The envelope also carries `bytes[] signatures`, `bytes data`, and unsigned `bytes metadata`, matching the payment-attestation pattern.

## Architecture and cutover

```text
Orchestrator V2 ---+
                   +--> shared PaymentVerifierRegistry --> UnifiedPaymentVerifierV3
Orchestrator V3 ---+                                      |
                                                          | addNullifier(nullifier, intentHash)
                                                          v
                                             NullifierRegistryV2
                                               |             |
                                               |             +--> immutable bidirectional binding
                                               +--> legacy NullifierRegistry read-through

chargeback attestation(payment ID)
        |
        +--> keccak256(paymentMethod, paymentId) --> RiskManager
                                                        |
                                                        +--> verifies both binding directions
```

`intentHash` is the canonical binding value. Its derivation already includes the orchestrator address, so wrapping it again as `keccak256(abi.encode(orchestrator, intentHash))` would duplicate namespace information without improving isolation.

The cutover is hard and one-way. In the same governance batch: grant UPV3 write permission on the new registry, permanently revoke the retired verifier's permission on the legacy registry, and rotate each payment method in the shared `PaymentVerifierRegistry` to UPV3. Never route back to the retired verifier: the legacy registry cannot observe V2 writes, so rollback would reopen replay. Both Orchestrator V2 and V3 remain live through the unchanged verifier ABI.

Issue #21's older rollout plan must be refreshed to describe this shared-registry / UPV3 hard cut before deployment.

## Security properties

- predecessor nullifiers remain authoritative and cannot be rebound
- new nullifiers and intent hashes are nonzero, immutable, and one-to-one
- RiskManager checks `intentHashByNullifier` and `nullifierByIntentHash` independently
- provider dispute IDs have payment-method-scoped replay protection
- chargeback compensation fails closed unless the full gross release remains reserved
- dedicated chargeback witnesses are explicitly required to be independent of payment-attestation witnesses
- every changed external dependency is checked for deployed code
- all affected lifecycle entrypoints remain non-reentrant

## Tests

- `yarn test` — 1,361 passing, 5 pending
- `forge test --no-match-path 'test-foundry/fork/*'` — 132 passing
- `yarn coverage` — 1,394 passing, 5 pending
- exact 100% statements / branches / functions / lines for:
  - `OrchestratorV3`
  - `RiskManager`
  - `NullifierRegistryV2`
  - `BaseUnifiedPaymentVerifierV3`
  - `UnifiedPaymentVerifierV3`
- `yarn build`
- active localhost deployment with all 29 selected scripts — passed
- deployed bytecode: OrchestratorV3 19,684 B; RiskManager 19,379 B; UPV3 7,470 B; NullifierRegistryV2 2,453 B

## Deployment impact

No deployment script, address artifact, or deployment parameter changes are included. `RiskManager` and `OrchestratorV3` are staging-only; that lane is disposable/non-incremental. Fresh numbered deployment scripts should be written only after this interface stabilizes. Existing deployment history is intentionally untouched.

Generic CI stages and runs the active deployment lane while excluding only the explicitly abandoned staging-only `deploy/26_deploy_stake_risk_system.ts` and `test/deploy/26_stakeRiskSystem.spec.ts` files: 29 deploy scripts and 22 deployment tests remain selected. Both historical 26 files remain byte-for-byte unchanged. The root TypeScript project excludes only the historical 26 deployment test so the abandoned staging ABI does not block compilation; all active tests remain typechecked.
