### PR TITLE
refactor: remove privileged relayer intent access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,15 +22,15 @@
 
 ## Architecture Overview (v2.1)
 - Core: `Escrow` holds maker deposits and per-deposit config (methods, currencies, min rates, intent limits/expiry); `Orchestrator` manages intents, routes to verifiers, collects protocol/referrer fees; `ProtocolViewer` provides aggregated read views.
-- Registries: `PaymentVerifierRegistry` maps `paymentMethod` → verifier + currencies; `EscrowRegistry` whitelists escrows; `RelayerRegistry` whitelists relayers; `PostIntentHookRegistry` whitelists post‑intent hooks; `NullifierRegistry` records consumed nullifiers.
+- Registries: `PaymentVerifierRegistry` maps `paymentMethod` → verifier + currencies; `EscrowRegistry` whitelists escrows; `PostIntentHookRegistry` whitelists post‑intent hooks; `NullifierRegistry` records consumed nullifiers. `RelayerRegistry` is retained only for deployed legacy V1 support.
 - Unified Verifier: `unifiedVerifier/UnifiedPaymentVerifier.sol` validates EIP‑712 attestations, checks provider hashes and timestamp buffers (from `BaseUnifiedPaymentVerifier`), and nullifies payments.
-- Wiring: Deploy registries → deploy `Escrow` → deploy `Orchestrator` with registry addresses → `Escrow.setOrchestrator(...)` → deploy `UnifiedPaymentVerifier` and register it per `paymentMethod` in `PaymentVerifierRegistry` (also set provider hashes/timestamp buffers) → whitelist escrows/hooks/relayers as needed.
+- Wiring: Deploy registries → deploy `Escrow` → deploy `Orchestrator` with registry addresses → `Escrow.setOrchestrator(...)` → deploy `UnifiedPaymentVerifier` and register it per `paymentMethod` in `PaymentVerifierRegistry` (also set provider hashes/timestamp buffers) → whitelist escrows/hooks as needed. Active V2/V3 orchestrators have no relayer registry dependency.
 - Flow: Maker `createDeposit` on `Escrow` → Taker `signalIntent` on `Orchestrator` (escrow locks funds) → `fulfillIntent` calls method verifier → on success, `Orchestrator` unlocks/transfers from `Escrow`, applies fees, runs optional post‑intent hook.
 
 ### Minimal Diagram
 ```
 Maker ── createDeposit ──▶ Escrow
-Taker/Relayer ── signalIntent ──▶ Orchestrator ── lockFunds ──▶ Escrow
+Taker ── signalIntent ──▶ Orchestrator ── lockFunds ──▶ Escrow
 Orchestrator ── getVerifier(paymentMethod) ──▶ PaymentVerifierRegistry ──▶ UnifiedPaymentVerifier
 UnifiedPaymentVerifier ── verify(EIP‑712) ──▶ AttestationVerifier
 UnifiedPaymentVerifier ── nullify(paymentId) ──▶ NullifierRegistry

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 [![Coverage](https://codecov.io/gh/zkp2p/zkp2p-contracts/branch/main/graph/badge.svg?precision=2)](https://codecov.io/gh/zkp2p/zkp2p-contracts)
 
-Smart contracts for the ZKP2P fiat on/off-ramp, with the current repository centered on the v2 system:
+Smart contracts for the ZKP2P fiat on/off-ramp, with the current repository centered on the v2 system.
+The pristine deployed pre-cut `OrchestratorV2` source is archived outside the compilation tree.
 
 - `EscrowV2`: maker liquidity, per-deposit payment configuration, oracle-backed pricing, delegated rate managers.
-- `OrchestratorV2`: intent lifecycle, fee handling, pre-intent hooks, whitelist hooks, post-intent execution.
+- `OrchestratorV2`: intent lifecycle, fee handling, pre-intent hooks, whitelist hooks, post-intent execution, and unrestricted account-level concurrency.
 - `UnifiedPaymentVerifierV2`: shared attestation-based verifier registered across supported payment methods.
 - `ProtocolViewerV2`: batched read model for deposits, intents, supported payment methods, and effective rates.
 
@@ -56,7 +57,7 @@ The v2 system is built around four layers:
 2. Intent coordination and settlement.
    `OrchestratorV2` validates whether a taker can lock liquidity, snapshots fee terms and min intent size, verifies payments through the registry-selected verifier, and releases funds.
 3. Verification and registries.
-   `UnifiedPaymentVerifier` validates EIP-712 attestations and nullifies payments. Shared registries define which escrows, orchestrators, relayers, hooks, and payment methods are valid.
+   `UnifiedPaymentVerifier` validates EIP-712 attestations and nullifies payments. Active registries define which escrows, orchestrators, hooks, and payment methods are valid. `RelayerRegistry` remains only for the deployed legacy V1 stack.
 4. Read models and periphery.
    `ProtocolViewerV2`, oracle adapters, bridge hooks, and pre-intent hooks provide the ergonomic layer used by frontends, routing systems, and privileged operators.
 
@@ -135,7 +136,7 @@ Key v2 behavior:
 - Supports a generic pre-intent hook and a dedicated whitelist hook per deposit.
 - Supports optional post-intent hooks through `IPostIntentHookV2`.
 - Distributes protocol fees, manager fees, and multiple referral fees.
-- Supports relayer-authorized flows through `RelayerRegistry`.
+- Allows every account to hold multiple concurrent intents; V3 admission is governed only by the selected risk hook.
 
 Recent addition:
 
@@ -265,7 +266,7 @@ The v2 stack reuses and extends the existing registry model:
 - `OrchestratorRegistry`: whitelists both v1 and v2 orchestrators for escrow/verifier authorization
 - `PaymentVerifierRegistry`: maps payment method hash to verifier and supported currencies
 - `PostIntentHookRegistry`: whitelists post-intent hooks
-- `RelayerRegistry`: whitelists relayers
+- `RelayerRegistry`: retained only for deployed legacy V1 orchestrators
 - `NullifierRegistry`: stores consumed payment nullifiers
 
 ## Core Lifecycle
@@ -438,6 +439,9 @@ contracts/
   oracles/
   registries/
   unifiedVerifier/
+
+archive/
+  orchestrator-v2-pre-relayer-cut/  # pristine deployed legacy V2 source, excluded from compilation
 
 deploy/
   00_deploy_system.ts

--- a/archive/orchestrator-v2-pre-relayer-cut/OrchestratorV2.sol
+++ b/archive/orchestrator-v2-pre-relayer-cut/OrchestratorV2.sol
@@ -16,10 +16,11 @@ import { IReferralFee } from "./interfaces/IReferralFee.sol";
 import { IEscrow } from "./interfaces/IEscrow.sol";
 import { IEscrowV2 } from "./interfaces/IEscrowV2.sol";
 import { IEscrowRegistry } from "./interfaces/IEscrowRegistry.sol";
-import { IPostIntentHookV2 } from "./interfaces/IPostIntentHookV2.sol";
+import { ISettlementHook } from "./interfaces/ISettlementHook.sol";
 import { IPreIntentHook } from "./interfaces/IPreIntentHook.sol";
 import { IPaymentVerifier } from "./interfaces/IPaymentVerifier.sol";
 import { IPaymentVerifierRegistry } from "./interfaces/IPaymentVerifierRegistry.sol";
+import { IRelayerRegistry } from "./interfaces/IRelayerRegistry.sol";
 import { ReferralFeeLib } from "./lib/ReferralFeeLib.sol";
 
 /**
@@ -74,10 +75,13 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
     // Contract references
     IEscrowRegistry public escrowRegistry;                              // Registry of escrow contracts
     IPaymentVerifierRegistry public  paymentVerifierRegistry;          // Registry of payment verifiers
+    IRelayerRegistry public relayerRegistry;                           // Registry of relayers
 
     // Protocol fee configuration
     uint256 public protocolFee;                                     // Protocol fee taken from taker (in preciseUnits, 1e16 = 1%)
     address public protocolFeeRecipient;                            // Address that receives protocol fees
+
+    bool public allowMultipleIntents;                               // Whether to allow multiple intents per account
 
     uint256 public intentCounter;                                 // Counter for number of intents created; nonce for unique intent hashes
 
@@ -87,6 +91,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         uint256 _chainId,
         address _escrowRegistry,
         address _paymentVerifierRegistry,
+        address _relayerRegistry,
         uint256 _protocolFee,
         address _protocolFeeRecipient
     )
@@ -95,6 +100,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         chainId = _chainId;
         escrowRegistry = IEscrowRegistry(_escrowRegistry);
         paymentVerifierRegistry = IPaymentVerifierRegistry(_paymentVerifierRegistry);
+        relayerRegistry = IRelayerRegistry(_relayerRegistry);
         protocolFee = _protocolFee;
         protocolFeeRecipient = _protocolFeeRecipient;
 
@@ -148,7 +154,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         storedIntent.conversionRate = _params.conversionRate;
         storedIntent.payeeId = depData.payeeDetails;
         storedIntent.timestamp = block.timestamp;
-        storedIntent.postIntentHook = _params.postIntentHook;
+        storedIntent.settlementHook = _params.settlementHook;
         storedIntent.data = _params.data;
 
         for (uint256 i = 0; i < _params.referralFees.length; ++i) {
@@ -244,7 +250,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
      * @notice Anyone can submit a fulfill intent transaction, even if caller isn't the intent owner. Upon submission the
      * offchain payment proof is verified, payment details are validated, intent is removed, and escrow state is updated.
      * Deposit token is transferred to the intent.to address.
-     * @dev This function adds a reentrancy guard as it's calling the post intent hook contract which itself might call 
+     * @dev This function adds a reentrancy guard as it's calling the settlement hook contract which itself might call
      * malicious contracts.
      *
      * @param _params               Struct containing all the fulfill intent parameters
@@ -260,37 +266,36 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         address managerFeeRecipient = intentManagerFeeRecipient[_params.intentHash];
         uint256 managerFee = intentManagerFee[_params.intentHash];
         
-        address verifier = paymentVerifierRegistry.getVerifier(intent.paymentMethod);
-        if (verifier == address(0)) revert PaymentMethodDoesNotExist(intent.paymentMethod);
-        
-        IPaymentVerifier.PaymentVerificationResult memory verificationResult = IPaymentVerifier(verifier).verifyPayment(
-            IPaymentVerifier.VerifyPaymentData({
-                intentHash: _params.intentHash,
-                paymentProof: _params.paymentProof,
-                data: _params.verificationData
-            })
-        );
-        if (!verificationResult.success) revert PaymentVerificationFailed();
-        if (verificationResult.intentHash != _params.intentHash) revert HashMismatch(_params.intentHash, verificationResult.intentHash);
+        (uint256 releaseAmount, bytes32 paymentId) = _verifyPayment(_params, intent.paymentMethod);
 
         // Enforce snapshot min-at-signal to prevent sub-min partial fulfillments
         uint256 minAtSignal = intentMinAtSignal[_params.intentHash];
-        if (minAtSignal > 0 && verificationResult.releaseAmount < minAtSignal) {
-            revert AmountBelowMin(verificationResult.releaseAmount, minAtSignal);
+        if (minAtSignal > 0 && releaseAmount < minAtSignal) {
+            revert AmountBelowMin(releaseAmount, minAtSignal);
         }
 
         // Effects
-        _resolveIntent(_params.intentHash, IntentResolution.FULFILLED, verificationResult.releaseAmount);
+        _resolveIntentWithPaymentId(
+            _params.intentHash,
+            IntentResolution.FULFILLED,
+            releaseAmount,
+            paymentId
+        );
 
         // Interactions
-        IEscrow(intent.escrow).unlockAndTransferFunds(intent.depositId, _params.intentHash, verificationResult.releaseAmount, address(this));
+        IEscrow(intent.escrow).unlockAndTransferFunds(
+            intent.depositId,
+            _params.intentHash,
+            releaseAmount,
+            address(this)
+        );
 
         _collectFeesTransferFundsAndExecuteAction(
             deposit.token, 
             _params.intentHash, 
             intent, 
-            verificationResult.releaseAmount,
-            _params.postIntentHookData,
+            releaseAmount,
+            _params.settlementHookData,
             managerFeeRecipient,
             managerFee,
             false
@@ -315,7 +320,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         // Snapshot manager fee terms before pruning (pruning deletes the mappings).
         address managerFeeRecipient = intentManagerFeeRecipient[_intentHash];
         uint256 managerFee = intentManagerFee[_intentHash];
-        bool executePostIntentHook = _shouldExecutePostIntentHookOnManualRelease(_intentHash);
+        bool executeSettlementHook = _shouldExecuteSettlementHookOnManualRelease(_intentHash);
         
         // Effects
         _resolveIntent(_intentHash, IntentResolution.RELEASED, intent.amount);
@@ -323,7 +328,7 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         // Interactions
         IEscrow(intent.escrow).unlockAndTransferFunds(intent.depositId, _intentHash, intent.amount, address(this));
 
-        if (executePostIntentHook) {
+        if (executeSettlementHook) {
             _collectFeesTransferFundsAndExecuteAction(
                 deposit.token,
                 _intentHash,
@@ -439,6 +444,29 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
     }
 
     /**
+     * @notice GOVERNANCE ONLY: Sets whether all accounts can signal multiple intents.
+     *
+     * @param _allowMultiple   True to allow all accounts to signal multiple intents, false to restrict to whitelisted relayers only
+     */
+    function setAllowMultipleIntents(bool _allowMultiple) external onlyOwner {
+        allowMultipleIntents = _allowMultiple;
+        
+        emit AllowMultipleIntentsUpdated(_allowMultiple);
+    }
+
+    /**
+     * @notice GOVERNANCE ONLY: Updates the relayer registry address.
+     *
+     * @param _relayerRegistry   New relayer registry address
+     */
+    function setRelayerRegistry(address _relayerRegistry) external onlyOwner {
+        if (_relayerRegistry == address(0)) revert ZeroAddress();
+        
+        relayerRegistry = IRelayerRegistry(_relayerRegistry);
+        emit RelayerRegistryUpdated(_relayerRegistry);
+    }
+
+    /**
      * @notice GOVERNANCE ONLY: Pauses intent creation and fulfillment functionality.
      * 
      * Functionalities that are paused:
@@ -506,10 +534,47 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
     }
 
     /**
-     * @notice Returns whether manual release should execute the intent's post-intent hook.
+     * @notice Resolves a verified fulfillment with optional verifier-authenticated payment identity.
+     * @dev V2 ignores the identifier because its verifier ABI does not return one. V3 overrides this
+     *      extension point and transports the value to its risk hook and failed-callback record.
+     */
+    function _resolveIntentWithPaymentId(
+        bytes32 _intentHash,
+        IntentResolution _resolution,
+        uint256 _releasedAmount,
+        bytes32
+    ) internal virtual {
+        _resolveIntent(_intentHash, _resolution, _releasedAmount);
+    }
+
+    /** @dev Calls the legacy three-field verifier ABI. */
+    function _verifyPayment(
+        FulfillIntentParams calldata _params,
+        bytes32 _paymentMethod
+    ) internal virtual returns (uint256 releaseAmount, bytes32 paymentId) {
+        address verifier = paymentVerifierRegistry.getVerifier(_paymentMethod);
+        if (verifier == address(0)) revert PaymentMethodDoesNotExist(_paymentMethod);
+
+        IPaymentVerifier.PaymentVerificationResult memory result = IPaymentVerifier(verifier).verifyPayment(
+            IPaymentVerifier.VerifyPaymentData({
+                intentHash: _params.intentHash,
+                paymentProof: _params.paymentProof,
+                data: _params.verificationData
+            })
+        );
+        if (!result.success) revert PaymentVerificationFailed();
+        if (result.intentHash != _params.intentHash) {
+            revert HashMismatch(_params.intentHash, result.intentHash);
+        }
+
+        return (result.releaseAmount, bytes32(0));
+    }
+
+    /**
+     * @notice Returns whether manual release should execute the intent's settlement hook.
      * @dev V2 manual releases transfer directly to the intent recipient.
      */
-    function _shouldExecutePostIntentHookOnManualRelease(bytes32) internal view virtual returns (bool) {
+    function _shouldExecuteSettlementHookOnManualRelease(bytes32) internal view virtual returns (bool) {
         return false;
     }
 
@@ -517,13 +582,19 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
      * @notice Validates an intent before it is signaled.
      */
     function _validateSignalIntent(SignalIntentParams calldata _intent) internal view {
+        // Check if account can have multiple intents
+        bool canHaveMultipleIntents = relayerRegistry.isWhitelistedRelayer(msg.sender) || allowMultipleIntents;
+        if (!canHaveMultipleIntents && accountIntents[msg.sender].length > 0) {
+            revert AccountHasActiveIntent(msg.sender, accountIntents[msg.sender][0]);
+        }
+
         if (_intent.to == address(0)) revert ZeroAddress();
         
         ReferralFeeLib.validateReferralFees(_intent.referralFees);
 
-        if (address(_intent.postIntentHook) != address(0)) {
-            if (address(_intent.postIntentHook).code.length == 0) {
-                revert InvalidPostIntentHook(address(_intent.postIntentHook));
+        if (address(_intent.settlementHook) != address(0)) {
+            if (address(_intent.settlementHook).code.length == 0) {
+                revert InvalidSettlementHook(address(_intent.settlementHook));
             }
         }
 
@@ -707,14 +778,14 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
     }
 
     /**
-     * @notice Handles fee calculations and transfers, then executes any post-intent hooks if present. Called by fulfillIntent.
+     * @notice Handles fee calculations and transfers, then executes any settlement hooks if present. Called by fulfillIntent.
      */
     function _collectFeesTransferFundsAndExecuteAction(
         IERC20 _token, 
         bytes32 _intentHash, 
         Intent memory _intent, 
         uint256 _releaseAmount,
-        bytes memory _postIntentHookData,
+        bytes memory _settlementHookData,
         address _managerFeeRecipient,
         uint256 _managerFee,
         bool _isManualRelease
@@ -730,18 +801,18 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
         uint256 netAmount = _releaseAmount - netFees;
 
         address fundsTransferredTo = _intent.to;
-        if (address(_intent.postIntentHook) != address(0)) {
+        if (address(_intent.settlementHook) != address(0)) {
             // Snapshot balance to enforce exact consumption by the hook
             uint256 preBalance = _token.balanceOf(address(this));
 
-            // Grant exact allowance to the post-intent hook using SafeERC20 with zero-before-set
-            _token.safeApprove(address(_intent.postIntentHook), 0);
-            _token.safeApprove(address(_intent.postIntentHook), netAmount);
-            IPostIntentHookV2.HookExecutionContext memory hookCtx = IPostIntentHookV2.HookExecutionContext({
+            // Grant exact allowance to the settlement hook using SafeERC20 with zero-before-set
+            _token.safeApprove(address(_intent.settlementHook), 0);
+            _token.safeApprove(address(_intent.settlementHook), netAmount);
+            ISettlementHook.HookExecutionContext memory hookCtx = ISettlementHook.HookExecutionContext({
                 intentHash: _intentHash,
                 token: address(_token),
                 executableAmount: netAmount,
-                intent: IPostIntentHookV2.HookIntentContext({
+                intent: ISettlementHook.HookIntentContext({
                     owner: _intent.owner,
                     to: _intent.to,
                     escrow: _intent.escrow,
@@ -755,18 +826,18 @@ contract OrchestratorV2 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV2 {
                     signalHookData: _intent.data
                 })
             });
-            _intent.postIntentHook.execute(hookCtx, _postIntentHookData);
+            _intent.settlementHook.execute(hookCtx, _settlementHookData);
             
             // Enforce that the hook pulled exactly netAmount to prevent stranded funds
             uint256 postBalance = _token.balanceOf(address(this));
-            require(postBalance <= preBalance, "PostIntentHook: unexpected balance increase");
+            require(postBalance <= preBalance, "SettlementHook: unexpected balance increase");
             uint256 spent = preBalance - postBalance;
-            require(spent == netAmount, "PostIntentHook: must pull exact netAmount");
+            require(spent == netAmount, "SettlementHook: must pull exact netAmount");
 
             // Reset allowance to prevent residual balance drainage (and fail closed on non-standard ERC20s)
-            _token.safeApprove(address(_intent.postIntentHook), 0);
+            _token.safeApprove(address(_intent.settlementHook), 0);
 
-            fundsTransferredTo = address(_intent.postIntentHook);
+            fundsTransferredTo = address(_intent.settlementHook);
         } else {
             // Otherwise transfer directly to the intent recipient
             _token.safeTransfer(_intent.to, netAmount);

--- a/archive/orchestrator-v2-pre-relayer-cut/README.md
+++ b/archive/orchestrator-v2-pre-relayer-cut/README.md
@@ -1,0 +1,17 @@
+# Archived OrchestratorV2 Source
+
+`OrchestratorV2.sol` is the pristine pre-cut source retained to recover and
+verify the already-deployed legacy V2 implementation. It is historical source,
+not an active protocol implementation, and deliberately lives outside the
+Hardhat compilation root (`contracts/`) to avoid duplicate artifact names.
+
+- Repository: `zkp2p/zkp2p-contracts`
+- Source commit: `accfd0bcaa2cf26d5180c23f7f452e0d0b3139ba`
+- Commit date: `2026-07-17`
+- Commit subject: `feat: propagate verified payment IDs into chargeback risk (#181)`
+- Original path: `contracts/OrchestratorV2.sol`
+- Archived file SHA-256: `5c21a7e2c636ea2b41477c5bf3fa824a0d80dec7d697dfcc86991dd077dfb3e2`
+
+The file is preserved byte-for-byte from that commit. Its relative imports are
+therefore documentary; use the source commit above when reproducing the legacy
+build.

--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -36,12 +36,11 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
     /* ============ Constructor ============ */
 
     /**
-     * @notice Creates a V3 orchestrator while preserving all V2 constructor dependencies.
+     * @notice Creates a V3 orchestrator with risk-managed intent admission.
      * @param _owner Governance owner.
      * @param _chainId Chain identifier used by existing intent signature validation.
      * @param _escrowRegistry Registry of accepted escrow contracts.
      * @param _paymentVerifierRegistry Registry of payment proof verifiers.
-     * @param _relayerRegistry Existing relayer registry retained for compatibility.
      * @param _protocolFee Protocol fee in 1e18 precise units.
      * @param _protocolFeeRecipient Protocol fee recipient.
      * @param _riskCallbackGasLimit Gas forwarded to each risk callback.
@@ -51,7 +50,6 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
         uint256 _chainId,
         address _escrowRegistry,
         address _paymentVerifierRegistry,
-        address _relayerRegistry,
         uint256 _protocolFee,
         address _protocolFeeRecipient,
         uint256 _riskCallbackGasLimit
@@ -61,7 +59,6 @@ contract OrchestratorV3 is OrchestratorV2, IOrchestratorV3 {
             _chainId,
             _escrowRegistry,
             _paymentVerifierRegistry,
-            _relayerRegistry,
             _protocolFee,
             _protocolFeeRecipient
         )

--- a/contracts/interfaces/IOrchestratorV2.sol
+++ b/contracts/interfaces/IOrchestratorV2.sol
@@ -90,10 +90,7 @@ interface IOrchestratorV2 {
     event DepositPreIntentHookSet(address indexed escrow, uint256 indexed depositId, address indexed hook, address setter);
     event DepositWhitelistHookSet(address indexed escrow, uint256 indexed depositId, address indexed hook, address setter);
 
-    event AllowMultipleIntentsUpdated(bool allowMultiple);
-
     event PaymentVerifierRegistryUpdated(address indexed paymentVerifierRegistry);
-    event RelayerRegistryUpdated(address indexed relayerRegistry);
     event EscrowRegistryUpdated(address indexed escrowRegistry);
 
     event ProtocolFeeUpdated(uint256 protocolFee);
@@ -129,7 +126,6 @@ interface IOrchestratorV2 {
     error RateBelowMinimum(uint256 rate, uint256 minRate);
 
     // Validation errors
-    error AccountHasActiveIntent(address account, bytes32 existingIntent);
     error InvalidPostIntentHook(address hook);
     error InvalidPreIntentHook(address hook);
     error InvalidSignature();

--- a/deploy/28_deploy_risk_settlement_system.ts
+++ b/deploy/28_deploy_risk_settlement_system.ts
@@ -98,7 +98,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const legacyNullifierRegistryAddress = getDeployedContractAddress(network, "NullifierRegistry");
   const escrowRegistryAddress = getDeployedContractAddress(network, "EscrowRegistry");
   const paymentVerifierRegistryAddress = getDeployedContractAddress(network, "PaymentVerifierRegistry");
-  const relayerRegistryAddress = getDeployedContractAddress(network, "RelayerRegistry");
   const orchestratorRegistryAddress = getDeployedContractAddress(network, "OrchestratorRegistry");
   const escrowV2Address = getDeployedContractAddress(network, "EscrowV2");
   const paymentAttestationVerifierAddress = getDeployedContractAddress(network, "MultiAttestationVerifier");
@@ -205,7 +204,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       chainId,
       escrowRegistryAddress,
       paymentVerifierRegistryAddress,
-      relayerRegistryAddress,
       ORCHESTRATOR_V2_PROTOCOL_FEE[network],
       ORCHESTRATOR_V2_PROTOCOL_FEE_RECIPIENT[network] || deployer,
       RISK_CALLBACK_GAS_LIMIT,
@@ -260,11 +258,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     await waitForDeploymentDelay(hre);
   } else if (currentController.toLowerCase() !== riskManager.address.toLowerCase()) {
     throw new Error(`StakeVault controller mismatch: expected ${riskManager.address}, found ${currentController}`);
-  }
-
-  if (!(await orchestratorV3Contract.allowMultipleIntents())) {
-    await (await orchestratorV3Contract.setAllowMultipleIntents(true)).wait();
-    await waitForDeploymentDelay(hre);
   }
 
   if (!(await escrowV2Contract.intentExpirationPeriod()).eq(ONE_HOUR_IN_SECONDS)) {

--- a/diagrams/architecture.excalidraw
+++ b/diagrams/architecture.excalidraw
@@ -199,8 +199,8 @@
     },
     {
       "type": "text", "id": "orch_box_text", "x": 40, "y": 315, "width": 230, "height": 80,
-      "text": "OrchestratorV2\n\nSignal, Cancel, Fulfill\nFees, Hooks, Relayers",
-      "originalText": "OrchestratorV2\n\nSignal, Cancel, Fulfill\nFees, Hooks, Relayers",
+      "text": "OrchestratorV2\n\nSignal, Cancel, Fulfill\nFees, Hooks, Admission",
+      "originalText": "OrchestratorV2\n\nSignal, Cancel, Fulfill\nFees, Hooks, Admission",
       "fontSize": 14, "fontFamily": 3, "textAlign": "center", "verticalAlign": "middle",
       "strokeColor": "#ffffff", "backgroundColor": "transparent",
       "fillStyle": "solid", "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100,
@@ -527,7 +527,7 @@
     },
     {
       "type": "text", "id": "reg_relayer_text", "x": 845, "y": 580, "width": 120, "height": 25,
-      "text": "RelayerRegistry", "originalText": "RelayerRegistry",
+      "text": "RelayerRegistry (V1)", "originalText": "RelayerRegistry (V1)",
       "fontSize": 11, "fontFamily": 3, "textAlign": "center", "verticalAlign": "middle",
       "strokeColor": "#1e3a5f", "backgroundColor": "transparent",
       "fillStyle": "solid", "strokeWidth": 1, "strokeStyle": "solid", "roughness": 0, "opacity": 100,

--- a/packages/contracts/test/orchestratorAbi.spec.ts
+++ b/packages/contracts/test/orchestratorAbi.spec.ts
@@ -1,0 +1,31 @@
+import * as fs from "fs";
+import * as path from "path";
+
+describe("active orchestrator package ABI", () => {
+  it("publishes the relayer-free OrchestratorV3 constructor and surface", () => {
+    const abi = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, "../abis/contracts/OrchestratorV3.json"), "utf8")
+    );
+    const constructor = abi.find((entry: { type: string }) => entry.type === "constructor");
+    const retiredNames = new Set([
+      "AccountHasActiveIntent",
+      "AllowMultipleIntentsUpdated",
+      "RelayerRegistryUpdated",
+      "allowMultipleIntents",
+      "relayerRegistry",
+      "setAllowMultipleIntents",
+      "setRelayerRegistry",
+    ]);
+
+    expect(constructor.inputs.map((input: { name: string }) => input.name)).toEqual([
+      "_owner",
+      "_chainId",
+      "_escrowRegistry",
+      "_paymentVerifierRegistry",
+      "_protocolFee",
+      "_protocolFeeRecipient",
+      "_riskCallbackGasLimit",
+    ]);
+    expect(abi.filter((entry: { name?: string }) => entry.name && retiredNames.has(entry.name))).toEqual([]);
+  });
+});

--- a/test/deploy/14_v2System.spec.ts
+++ b/test/deploy/14_v2System.spec.ts
@@ -175,10 +175,11 @@ describe("V2 System Deployment", () => {
       expect(actualAddress).to.eq(expectedAddress);
     });
 
-    it("should have the correct relayer registry", async () => {
-      const expectedAddress = getDeployedContractAddress(network, "RelayerRegistry");
-      const actualAddress = await orchestratorV2.relayerRegistry();
-      expect(actualAddress).to.eq(expectedAddress);
+    it("should not expose retired relayer or global multiple-intent controls", async () => {
+      expect(orchestratorV2.interface.functions).not.to.have.property("relayerRegistry()");
+      expect(orchestratorV2.interface.functions).not.to.have.property("setRelayerRegistry(address)");
+      expect(orchestratorV2.interface.functions).not.to.have.property("allowMultipleIntents()");
+      expect(orchestratorV2.interface.functions).not.to.have.property("setAllowMultipleIntents(bool)");
     });
 
     it("should have the correct protocol fee", async () => {

--- a/test/deploy/27_removeLegacyZellePaymentMethods.spec.ts
+++ b/test/deploy/27_removeLegacyZellePaymentMethods.spec.ts
@@ -14,7 +14,6 @@ import {
   OrchestratorRegistry,
   OrchestratorV2,
   PaymentVerifierRegistry,
-  RelayerRegistry,
   SimpleAttestationVerifier,
   UnifiedPaymentVerifier,
   USDCMock,
@@ -46,7 +45,6 @@ describe("Remove legacy Zelle payment methods", () => {
   let escrowRegistry: EscrowRegistry;
   let orchestratorRegistry: OrchestratorRegistry;
   let paymentVerifierRegistry: PaymentVerifierRegistry;
-  let relayerRegistry: RelayerRegistry;
   let nullifierRegistry: NullifierRegistry;
   let escrow: EscrowV2;
   let orchestrator: OrchestratorV2;
@@ -114,7 +112,6 @@ describe("Remove legacy Zelle payment methods", () => {
     escrowRegistry = await deployer.deployEscrowRegistry();
     orchestratorRegistry = await deployer.deployOrchestratorRegistry();
     paymentVerifierRegistry = await deployer.deployPaymentVerifierRegistry();
-    relayerRegistry = await deployer.deployRelayerRegistry();
     nullifierRegistry = await deployer.deployNullifierRegistry();
 
     escrow = await deployer.deployEscrowV2(
@@ -132,7 +129,6 @@ describe("Remove legacy Zelle payment methods", () => {
       BigNumber.from(chainId),
       escrowRegistry.address,
       paymentVerifierRegistry.address,
-      relayerRegistry.address,
       ZERO,
       owner.address
     );

--- a/test/deploy/28_riskSettlementSystem.spec.ts
+++ b/test/deploy/28_riskSettlementSystem.spec.ts
@@ -137,10 +137,13 @@ describe("Risk-manager-owned settlement deployment", () => {
     }
   });
 
-  it("registers the new orchestrator and preserves the configured lifecycle controls", async () => {
+  it("registers the new orchestrator with risk-managed concurrency admission", async () => {
     const { orchestrator, orchestratorRegistry } = await contracts();
     expect(await orchestratorRegistry.isOrchestrator(orchestrator.address)).to.eq(true);
-    expect(await orchestrator.allowMultipleIntents()).to.eq(true);
+    expect(orchestrator.interface.functions).not.to.have.property("relayerRegistry()");
+    expect(orchestrator.interface.functions).not.to.have.property("setRelayerRegistry(address)");
+    expect(orchestrator.interface.functions).not.to.have.property("allowMultipleIntents()");
+    expect(orchestrator.interface.functions).not.to.have.property("setAllowMultipleIntents(bool)");
     expect(await orchestrator.riskCallbackGasLimit()).to.eq(RISK_CALLBACK_GAS_LIMIT);
   });
 

--- a/test/hooks/whitelistPreIntentHook.spec.ts
+++ b/test/hooks/whitelistPreIntentHook.spec.ts
@@ -15,7 +15,6 @@ import {
   OrchestratorV2,
   OrchestratorRegistry,
   PaymentVerifierRegistry,
-  RelayerRegistry,
   EscrowRegistry,
   USDCMock,
   PaymentVerifierMock,
@@ -41,7 +40,6 @@ describe("WhitelistPreIntentHook", () => {
   let orchestrator: OrchestratorV2;
   let orchestratorRegistry: OrchestratorRegistry;
   let paymentVerifierRegistry: PaymentVerifierRegistry;
-  let relayerRegistry: RelayerRegistry;
   let escrowRegistry: EscrowRegistry;
   let verifier: PaymentVerifierMock;
   let whitelistHook: WhitelistPreIntentHook;
@@ -64,7 +62,6 @@ describe("WhitelistPreIntentHook", () => {
 
     escrowRegistry = await deployer.deployEscrowRegistry();
     paymentVerifierRegistry = await deployer.deployPaymentVerifierRegistry();
-    relayerRegistry = await deployer.deployRelayerRegistry();
     orchestratorRegistry = await deployer.deployOrchestratorRegistry();
 
     escrow = await deployer.deployEscrowV2(
@@ -84,7 +81,6 @@ describe("WhitelistPreIntentHook", () => {
       chainId,
       escrowRegistry.address,
       paymentVerifierRegistry.address,
-      relayerRegistry.address,
       ZERO,
       feeRecipient.address
     );

--- a/test/orchestrator/preIntentHook.spec.ts
+++ b/test/orchestrator/preIntentHook.spec.ts
@@ -15,7 +15,6 @@ import {
   OrchestratorV2,
   OrchestratorRegistry,
   PaymentVerifierRegistry,
-  RelayerRegistry,
   EscrowRegistry,
   USDCMock,
   PaymentVerifierMock,
@@ -42,7 +41,6 @@ describe("OrchestratorV2 - PreIntentHook", () => {
   let orchestrator: OrchestratorV2;
   let orchestratorRegistry: OrchestratorRegistry;
   let paymentVerifierRegistry: PaymentVerifierRegistry;
-  let relayerRegistry: RelayerRegistry;
   let escrowRegistry: EscrowRegistry;
   let verifier: PaymentVerifierMock;
   let preIntentHookMock: PreIntentHookMock;
@@ -68,7 +66,6 @@ describe("OrchestratorV2 - PreIntentHook", () => {
 
     escrowRegistry = await deployer.deployEscrowRegistry();
     paymentVerifierRegistry = await deployer.deployPaymentVerifierRegistry();
-    relayerRegistry = await deployer.deployRelayerRegistry();
     orchestratorRegistry = await deployer.deployOrchestratorRegistry();
 
     escrow = await deployer.deployEscrowV2(
@@ -88,7 +85,6 @@ describe("OrchestratorV2 - PreIntentHook", () => {
       chainId,
       escrowRegistry.address,
       paymentVerifierRegistry.address,
-      relayerRegistry.address,
       ZERO,
       feeRecipient.address
     );
@@ -318,7 +314,7 @@ describe("OrchestratorV2 - PreIntentHook", () => {
       expect(await preIntentHookMock.callCount()).to.eq(0);
     });
 
-    it("prevents hook-driven reentrant signalIntent from bypassing one-active-intent rule", async () => {
+    it("prevents hook-driven reentrant signalIntent", async () => {
       await orchestrator.connect(depositor.wallet).setDepositPreIntentHook(
         escrow.address,
         ZERO,

--- a/test/orchestratorV2/orchestratorV2.legacyCoverage.spec.ts
+++ b/test/orchestratorV2/orchestratorV2.legacyCoverage.spec.ts
@@ -25,7 +25,6 @@ import {
   PostIntentHookV2Mock,
   PreIntentHookMock,
   PushPostIntentHookV2Mock,
-  RelayerRegistry,
   USDCMock,
 } from "@utils/contracts";
 
@@ -49,7 +48,6 @@ describe("OrchestratorV2", () => {
   let escrowRegistry: EscrowRegistry;
   let orchestratorRegistry: OrchestratorRegistry;
   let paymentVerifierRegistry: PaymentVerifierRegistry;
-  let relayerRegistry: RelayerRegistry;
   let verifier: PaymentVerifierMock;
   let preIntentHookMock: PreIntentHookMock;
   let whitelistHookMock: PreIntentHookMock;
@@ -178,7 +176,6 @@ describe("OrchestratorV2", () => {
     await usdcToken.transfer(depositor.address, usdc(100_000));
 
     paymentVerifierRegistry = await deployer.deployPaymentVerifierRegistry();
-    relayerRegistry = await deployer.deployRelayerRegistry();
     escrowRegistry = await deployer.deployEscrowRegistry();
     orchestratorRegistry = await deployer.deployOrchestratorRegistry();
 
@@ -209,7 +206,6 @@ describe("OrchestratorV2", () => {
       ONE,
       escrowRegistry.address,
       paymentVerifierRegistry.address,
-      relayerRegistry.address,
       ZERO,
       protocolFeeRecipient.address
     );
@@ -578,7 +574,6 @@ describe("OrchestratorV2", () => {
   describe("governance and views", () => {
     it("updates registry and fee configuration", async () => {
       const newEscrowRegistry = await deployer.deployEscrowRegistry();
-      const newRelayerRegistry = await deployer.deployRelayerRegistry();
 
       await expect(orchestrator.connect(owner.wallet).setEscrowRegistry(newEscrowRegistry.address))
         .to.emit(orchestrator, "EscrowRegistryUpdated")
@@ -589,12 +584,6 @@ describe("OrchestratorV2", () => {
       await expect(orchestrator.connect(owner.wallet).setProtocolFeeRecipient(other.address))
         .to.emit(orchestrator, "ProtocolFeeRecipientUpdated")
         .withArgs(other.address);
-      await expect(orchestrator.connect(owner.wallet).setAllowMultipleIntents(true))
-        .to.emit(orchestrator, "AllowMultipleIntentsUpdated")
-        .withArgs(true);
-      await expect(orchestrator.connect(owner.wallet).setRelayerRegistry(newRelayerRegistry.address))
-        .to.emit(orchestrator, "RelayerRegistryUpdated")
-        .withArgs(newRelayerRegistry.address);
 
       await orchestrator.connect(owner.wallet).pauseOrchestrator();
       expect(await orchestrator.paused()).to.eq(true);
@@ -609,18 +598,14 @@ describe("OrchestratorV2", () => {
         .to.be.revertedWithCustomError(orchestrator, "FeeExceedsMaximum");
       await expect(orchestrator.connect(owner.wallet).setProtocolFeeRecipient(ADDRESS_ZERO))
         .to.be.revertedWithCustomError(orchestrator, "ZeroAddress");
-      await expect(orchestrator.connect(owner.wallet).setRelayerRegistry(ADDRESS_ZERO))
-        .to.be.revertedWithCustomError(orchestrator, "ZeroAddress");
     });
 
     it("reverts governance-only functions for non-owner callers", async () => {
       await expect(orchestrator.connect(other.wallet).pauseOrchestrator()).to.be.revertedWith("Ownable: caller is not the owner");
       await expect(orchestrator.connect(other.wallet).unpauseOrchestrator()).to.be.revertedWith("Ownable: caller is not the owner");
-      await expect(orchestrator.connect(other.wallet).setAllowMultipleIntents(true)).to.be.revertedWith("Ownable: caller is not the owner");
       await expect(orchestrator.connect(other.wallet).setEscrowRegistry(escrowRegistry.address)).to.be.revertedWith("Ownable: caller is not the owner");
       await expect(orchestrator.connect(other.wallet).setProtocolFee(ether(0.01))).to.be.revertedWith("Ownable: caller is not the owner");
       await expect(orchestrator.connect(other.wallet).setProtocolFeeRecipient(other.address)).to.be.revertedWith("Ownable: caller is not the owner");
-      await expect(orchestrator.connect(other.wallet).setRelayerRegistry(relayerRegistry.address)).to.be.revertedWith("Ownable: caller is not the owner");
     });
 
     it("returns account intents and min-at-signal snapshot", async () => {
@@ -632,12 +617,14 @@ describe("OrchestratorV2", () => {
   });
 
   describe("signal validations and post-intent hook path", () => {
-    it("reverts when account already has an active intent", async () => {
-      await signalIntent({ subjectCaller: taker });
+    it("allows an account to create multiple active intents", async () => {
+      const firstIntentHash = await signalIntent({ subjectCaller: taker });
+      const secondIntentHash = await signalIntent({ subjectCaller: taker });
 
-      await expect(
-        signalIntent({ subjectCaller: taker })
-      ).to.be.revertedWithCustomError(orchestrator, "AccountHasActiveIntent");
+      expect(await orchestrator.getAccountIntents(taker.address)).to.deep.eq([
+        firstIntentHash,
+        secondIntentHash,
+      ]);
     });
 
     it("reverts when escrow is not whitelisted", async () => {

--- a/test/orchestratorV2/orchestratorV2.spec.ts
+++ b/test/orchestratorV2/orchestratorV2.spec.ts
@@ -17,7 +17,6 @@ import {
   PaymentVerifierMock,
   PaymentVerifierRegistry,
   RateManagerMock,
-  RelayerRegistry,
   USDCMock,
 } from "@utils/contracts";
 
@@ -37,7 +36,6 @@ describe("OrchestratorV2", () => {
   let escrowRegistry: EscrowRegistry;
   let orchestratorRegistry: OrchestratorRegistry;
   let paymentVerifierRegistry: PaymentVerifierRegistry;
-  let relayerRegistry: RelayerRegistry;
   let verifier: PaymentVerifierMock;
   let rateManagerMock: RateManagerMock;
 
@@ -53,7 +51,6 @@ describe("OrchestratorV2", () => {
     await usdcToken.transfer(depositor.address, usdc(100_000));
 
     paymentVerifierRegistry = await deployer.deployPaymentVerifierRegistry();
-    relayerRegistry = await deployer.deployRelayerRegistry();
     escrowRegistry = await deployer.deployEscrowRegistry();
     orchestratorRegistry = await deployer.deployOrchestratorRegistry();
 
@@ -84,7 +81,6 @@ describe("OrchestratorV2", () => {
       ONE,
       escrowRegistry.address,
       paymentVerifierRegistry.address,
-      relayerRegistry.address,
       ZERO,
       owner.address
     );
@@ -160,6 +156,20 @@ describe("OrchestratorV2", () => {
 
       expect(feeEvent?.args?.feeRecipient).to.eq(managerFeeRecipient.address);
       expect(feeEvent?.args?.fee).to.eq(ether(0.01));
+    });
+
+    it("allows an ordinary account to keep multiple concurrent intents", async () => {
+      await subject();
+      await subject();
+
+      expect(await orchestrator.getAccountIntents(taker.address)).to.have.length(2);
+    });
+
+    it("does not expose retired relayer or global multiple-intent controls", async () => {
+      expect(orchestrator.interface.functions).not.to.have.property("relayerRegistry()");
+      expect(orchestrator.interface.functions).not.to.have.property("setRelayerRegistry(address)");
+      expect(orchestrator.interface.functions).not.to.have.property("allowMultipleIntents()");
+      expect(orchestrator.interface.functions).not.to.have.property("setAllowMultipleIntents(bool)");
     });
 
     describe("when conversion rate is below delegated manager rate", () => {

--- a/test/patchCoverage/patchCoverage.spec.ts
+++ b/test/patchCoverage/patchCoverage.spec.ts
@@ -123,7 +123,6 @@ describe("Patch Coverage", () => {
       ONE,
       escrowRegistry.address,
       paymentVerifierRegistry.address,
-      relayerRegistry.address,
       ZERO,
       protocolFeeRecipient.address
     );

--- a/test/periphery/protocolViewerV2.spec.ts
+++ b/test/periphery/protocolViewerV2.spec.ts
@@ -13,7 +13,6 @@ import {
   PaymentVerifierMock,
   PaymentVerifierRegistry,
   RateManagerMock,
-  RelayerRegistry,
   USDCMock,
 } from "@utils/contracts";
 import { getAccounts, getWaffleExpect } from "@utils/test";
@@ -37,7 +36,6 @@ describe("ProtocolViewerV2", () => {
   let escrowRegistry: EscrowRegistry;
   let orchestratorRegistry: OrchestratorRegistry;
   let paymentVerifierRegistry: PaymentVerifierRegistry;
-  let relayerRegistry: RelayerRegistry;
   let verifier: PaymentVerifierMock;
   let protocolViewerV2: Contract;
 
@@ -52,7 +50,6 @@ describe("ProtocolViewerV2", () => {
     await usdcToken.transfer(depositor.address, usdc(100_000));
 
     paymentVerifierRegistry = await deployer.deployPaymentVerifierRegistry();
-    relayerRegistry = await deployer.deployRelayerRegistry();
     escrowRegistry = await deployer.deployEscrowRegistry();
     orchestratorRegistry = await deployer.deployOrchestratorRegistry();
 
@@ -81,7 +78,6 @@ describe("ProtocolViewerV2", () => {
       ONE,
       escrowRegistry.address,
       paymentVerifierRegistry.address,
-      relayerRegistry.address,
       ZERO,
       owner.address
     );
@@ -222,8 +218,6 @@ describe("ProtocolViewerV2", () => {
     let intentHash: string;
 
     beforeEach(async () => {
-      await orchestrator.connect(owner.wallet).setAllowMultipleIntents(true);
-
       const paramsOne = await createSignalIntentParams(
         orchestrator.address,
         escrow.address,

--- a/test/staking/riskManager.spec.ts
+++ b/test/staking/riskManager.spec.ts
@@ -25,7 +25,6 @@ describe("RiskManager and OrchestratorV3", () => {
       .deploy(usdc(1_000_000), "USD Coin", "USDC");
     const paymentVerifierRegistry = await (await ethers.getContractFactory("PaymentVerifierRegistry")).deploy();
     const escrowRegistry = await (await ethers.getContractFactory("EscrowRegistry")).deploy();
-    const relayerRegistry = await (await ethers.getContractFactory("RelayerRegistry")).deploy();
     const orchestratorRegistry = await (await ethers.getContractFactory("OrchestratorRegistry")).deploy();
     const legacyNullifierRegistry = await (await ethers.getContractFactory("NullifierRegistry")).deploy();
     const nullifierRegistry = await (await ethers.getContractFactory("NullifierRegistryV2"))
@@ -67,7 +66,6 @@ describe("RiskManager and OrchestratorV3", () => {
       network.chainId,
       escrowRegistry.address,
       paymentVerifierRegistry.address,
-      relayerRegistry.address,
       0,
       owner.address,
       2_000_000,
@@ -93,10 +91,8 @@ describe("RiskManager and OrchestratorV3", () => {
 
     await escrowRegistry.addEscrow(escrow.address);
     await orchestratorRegistry.addOrchestrator(orchestrator.address);
-    await orchestrator.setAllowMultipleIntents(true);
     await verifier.setShouldVerifyPayment(true);
     await verifier.setVerificationContext(orchestrator.address, escrow.address);
-
     await manager.setPlatformRiskConfig(ZELLE, {
       enabled: true,
       chargeback: {
@@ -432,6 +428,14 @@ describe("RiskManager and OrchestratorV3", () => {
   });
 
   describe("admission and portfolio reservations", () => {
+    it("exposes no relayer or global multiple-intent privilege", async () => {
+      const { orchestrator } = await loadFixture(deployFixture);
+      expect(orchestrator.interface.functions).not.to.have.property("relayerRegistry()");
+      expect(orchestrator.interface.functions).not.to.have.property("setRelayerRegistry(address)");
+      expect(orchestrator.interface.functions).not.to.have.property("allowMultipleIntents()");
+      expect(orchestrator.interface.functions).not.to.have.property("setAllowMultipleIntents(bool)");
+    });
+
     it("uses a delegated Safe as the shared stake owner", async () => {
       const { owner: safe, taker, escrow, orchestrator, token, vault, manager } = await loadFixture(deployFixture);
       await token.connect(safe).approve(vault.address, ethers.constants.MaxUint256);

--- a/test/unifiedVerifier/unifiedPaymentVerifierV2.spec.ts
+++ b/test/unifiedVerifier/unifiedPaymentVerifierV2.spec.ts
@@ -13,7 +13,6 @@ import {
   OrchestratorRegistry,
   OrchestratorV2,
   PaymentVerifierRegistry,
-  RelayerRegistry,
   SimpleAttestationVerifier,
   UnifiedPaymentVerifier,
   USDCMock,
@@ -38,7 +37,6 @@ describe("UnifiedPaymentVerifierV2 Compatibility", () => {
   let escrowRegistry: EscrowRegistry;
   let orchestratorRegistry: OrchestratorRegistry;
   let paymentVerifierRegistry: PaymentVerifierRegistry;
-  let relayerRegistry: RelayerRegistry;
   let nullifierRegistry: NullifierRegistry;
   let escrow: EscrowV2;
   let orchestrator: OrchestratorV2;
@@ -61,7 +59,6 @@ describe("UnifiedPaymentVerifierV2 Compatibility", () => {
     escrowRegistry = await deployer.deployEscrowRegistry();
     orchestratorRegistry = await deployer.deployOrchestratorRegistry();
     paymentVerifierRegistry = await deployer.deployPaymentVerifierRegistry();
-    relayerRegistry = await deployer.deployRelayerRegistry();
     nullifierRegistry = await deployer.deployNullifierRegistry();
 
     chainId = (await ethers.provider.getNetwork()).chainId;
@@ -82,7 +79,6 @@ describe("UnifiedPaymentVerifierV2 Compatibility", () => {
       BigNumber.from(chainId),
       escrowRegistry.address,
       paymentVerifierRegistry.address,
-      relayerRegistry.address,
       ZERO,
       owner.address,
     );

--- a/test/unifiedVerifier/unifiedPaymentVerifierV3.spec.ts
+++ b/test/unifiedVerifier/unifiedPaymentVerifierV3.spec.ts
@@ -24,7 +24,6 @@ describe("UnifiedPaymentVerifierV3 payment-to-intent bindings", () => {
     const escrowRegistry = await (await ethers.getContractFactory("EscrowRegistry", owner.wallet)).deploy();
     const orchestratorRegistry = await (await ethers.getContractFactory("OrchestratorRegistry", owner.wallet)).deploy();
     const paymentVerifierRegistry = await (await ethers.getContractFactory("PaymentVerifierRegistry", owner.wallet)).deploy();
-    const relayerRegistry = await (await ethers.getContractFactory("RelayerRegistry", owner.wallet)).deploy();
     const legacyNullifierRegistry = await (await ethers.getContractFactory("NullifierRegistry", owner.wallet)).deploy();
     const nullifierRegistry = await (await ethers.getContractFactory("NullifierRegistryV2", owner.wallet))
       .deploy(legacyNullifierRegistry.address);
@@ -51,7 +50,6 @@ describe("UnifiedPaymentVerifierV3 payment-to-intent bindings", () => {
       chainId,
       escrowRegistry.address,
       paymentVerifierRegistry.address,
-      relayerRegistry.address,
       0,
       owner.address,
     );
@@ -79,7 +77,6 @@ describe("UnifiedPaymentVerifierV3 payment-to-intent bindings", () => {
       chainId,
       escrowRegistry.address,
       paymentVerifierRegistry.address,
-      relayerRegistry.address,
       0,
       owner.address,
       2_000_000,
@@ -88,8 +85,6 @@ describe("UnifiedPaymentVerifierV3 payment-to-intent bindings", () => {
     await escrowRegistry.addEscrow(escrow.address);
     await orchestratorRegistry.addOrchestrator(orchestratorV2.address);
     await orchestratorRegistry.addOrchestrator(orchestratorV3.address);
-    await orchestratorV2.setAllowMultipleIntents(true);
-    await orchestratorV3.setAllowMultipleIntents(true);
     await nullifierRegistry.addWritePermission(verifier.address);
     await legacyNullifierRegistry.addWritePermission(owner.address);
     await verifier.addPaymentMethod(METHOD);

--- a/utils/deploys.ts
+++ b/utils/deploys.ts
@@ -176,7 +176,6 @@ export default class DeployHelper {
     chainId: BigNumber,
     escrowRegistry: Address,
     paymentVerifierRegistry: Address,
-    relayerRegistry: Address,
     protocolFee: BigNumber,
     protocolFeeRecipient: Address
   ): Promise<OrchestratorV2> {
@@ -185,7 +184,6 @@ export default class DeployHelper {
       chainId.toString(),
       escrowRegistry,
       paymentVerifierRegistry,
-      relayerRegistry,
       protocolFee,
       protocolFeeRecipient
     );


### PR DESCRIPTION
## Summary

- hard-cut relayer registry and global multiple-intent controls from active OrchestratorV2/V3 source and ABI
- make account concurrency unconditional in V2 and exclusively risk-hook governed in V3
- remove relayer wiring from the active risk-settlement deployment and update affected utilities, docs, and tests
- archive the pristine pre-cut OrchestratorV2 source outside the Hardhat compilation tree with commit provenance and a verified SHA-256
- add focused ABI and admission regression coverage, including the published active OrchestratorV3 package ABI

## Protocol invariant

Relayer identity has no privileged effect on intent admission. Any account may create multiple concurrent V2 intents. For V3, the selected RiskManager/risk hook is the sole admission and portfolio-concurrency rejection mechanism.

## Current-main validation

- clean package extraction compile: 124 Solidity files
- TypeScript transpilation: passed
- focused Hardhat V2/V3, RiskManager, hook, and UPV3 suites: 165 passing
- deterministic Foundry without live fork tests: 136 passing
- package extraction and build: passed
- package tests: 8 passing
- GitHub full Hardhat, coverage, and Foundry checks run on the rebased commit

## Deployment and downstream impact

This is a breaking constructor and ABI change. The active fresh risk-settlement deployment uses the relayer-free constructor. A future live rollout requires new addresses, downstream consumer updates, and an explicit package release. Legacy V1 contracts and their relayer registry remain unchanged.

Existing network ABI/address exports continue to describe deployed contracts until that rollout. No external deployment or package publication was performed.