### PR TITLE
fix(staking): settlement event completeness, gating replay, and stake accounting hardening

### DIFF
--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -359,8 +359,8 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
     /**
      * @notice Allows depositor to release funds to the payer in case of a failed fulfill intent or because of some other arrangement
      * between the two parties. Upon submission we check to make sure the msg.sender is the depositor, the intent is removed, and
-     * escrow state is updated. Manual release routes through the shared post-funds risk-settlement gate before the deposit token
-     * is transferred to the payer.
+     * escrow state is updated. Manual release routes through the shared post-funds risk-settlement gate, then executes the
+     * configured post-intent hook or transfers the deposit token directly to the payer when no hook is configured.
      *
      * @param _intentHash        Hash of intent to resolve by releasing the funds
      */

--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -768,7 +768,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         bool _isManualRelease
     ) internal {
         IIntentRiskHook riskHook = intentRiskHooks[_intentHash];
-        (address fundsTransferredTo, uint256 netAmount) = FeeSettlementLib.executeSettlement(
+        (address fundsTransferredTo, uint256 reportedAmount) = FeeSettlementLib.executeSettlement(
             _token,
             riskHook,
             _intentHash,
@@ -786,7 +786,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         );
         delete intentRiskHooks[_intentHash];
 
-        emit IntentFulfilled(_intentHash, fundsTransferredTo, netAmount, _isManualRelease);
+        emit IntentFulfilled(_intentHash, fundsTransferredTo, reportedAmount, _isManualRelease);
     }
 
     function _setRiskCallbackGasLimit(uint256 _gasLimit) internal {

--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -273,7 +273,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
 
     /**
      * @notice Sets or removes the risk hook used by future intents for one deposit.
-     * @dev Existing intents keep their snapshotted hook.
+     * @dev Callable only by the deposit's depositor. Existing intents keep their snapshotted hook.
      *
      * @param _escrow       Escrow address.
      * @param _depositId    Deposit id.
@@ -292,11 +292,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         }
 
         IEscrow.Deposit memory deposit = IEscrow(_escrow).getDeposit(_depositId);
-        bool isDepositorOrDelegate = msg.sender == deposit.depositor
-            || (deposit.delegate != address(0) && msg.sender == deposit.delegate);
-        if (!isDepositorOrDelegate) {
-            revert UnauthorizedCallerOrDelegate(msg.sender, deposit.depositor, deposit.delegate);
-        }
+        if (msg.sender != deposit.depositor) revert UnauthorizedCaller(msg.sender, deposit.depositor);
 
         depositRiskHooks[_escrow][_depositId] = _hook;
         emit DepositRiskHookSet(_escrow, _depositId, hookAddress, msg.sender);

--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -73,6 +73,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
     mapping(address => mapping(uint256 => IIntentRiskHook)) internal depositRiskHooks;
     mapping(bytes32 => IIntentRiskHook) internal intentRiskHooks;
     mapping(bytes32 => IntentCancellation) internal failedIntentCancellations;
+    mapping(bytes32 => bool) public usedGatingSignatureDigests;
 
     // Contract references
     IEscrowRegistry public escrowRegistry;                              // Registry of escrow contracts
@@ -633,7 +634,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
     /**
      * @notice Validates an intent before it is signaled.
      */
-    function _validateSignalIntent(SignalIntentParams calldata _intent) internal view {
+    function _validateSignalIntent(SignalIntentParams calldata _intent) internal {
         if (_intent.to == address(0)) revert ZeroAddress();
 
         ReferralFeeLib.validateReferralFees(_intent.referralFees);
@@ -671,9 +672,15 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
                 revert SignatureExpired(_intent.signatureExpiration, block.timestamp);
             }
 
-            if (!_isValidIntentGatingSignature(_intent, intentGatingService, msg.sender)) {
+            bytes32 verifierPayload = _getIntentGatingSignatureDigest(_intent, msg.sender);
+            if (!_isValidIntentGatingSignature(_intent, intentGatingService, verifierPayload)) {
                 revert InvalidSignature();
             }
+
+            if (usedGatingSignatureDigests[verifierPayload]) {
+                revert GatingSignatureAlreadyUsed(verifierPayload);
+            }
+            usedGatingSignatureDigests[verifierPayload] = true;
         }
     }
 
@@ -801,11 +808,22 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
     function _isValidIntentGatingSignature(
         SignalIntentParams calldata _intent,
         address _intentGatingService,
-        address _caller
+        bytes32 _verifierPayload
     )
         internal
         view
         returns(bool)
+    {
+        return _intentGatingService.isValidSignatureNow(_verifierPayload, _intent.gatingServiceSignature);
+    }
+
+    function _getIntentGatingSignatureDigest(
+        SignalIntentParams calldata _intent,
+        address _caller
+    )
+        internal
+        view
+        returns(bytes32)
     {
         bytes memory message = abi.encodePacked(
             address(this),
@@ -818,11 +836,12 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
             _intent.fiatCurrency,
             _intent.conversionRate,
             ReferralFeeLib.hashReferralFees(_intent.referralFees),
+            address(_intent.postIntentHook),
+            keccak256(_intent.data),
             _intent.signatureExpiration,
             chainId
         );
 
-        bytes32 verifierPayload = keccak256(message).toEthSignedMessageHash();
-        return _intentGatingService.isValidSignatureNow(verifierPayload, _intent.gatingServiceSignature);
+        return keccak256(message).toEthSignedMessageHash();
     }
 }

--- a/contracts/StakeVault.sol
+++ b/contracts/StakeVault.sol
@@ -432,9 +432,10 @@ contract StakeVault is IStakeVault, Ownable, ReentrancyGuard {
 
     /**
      * @notice Adds free stake to, or refreshes the release time of, an active reservation.
-     * @dev Settlement uses `updateReservation`, which intentionally remains available during a pause.
-     *      New paid extension exposure and zero-increment expiry refreshes must use this function
-     *      so admission pause, exit, and controller gates remain authoritative.
+     * @dev Settlement may only decrease or refresh reservations through `updateReservation`, which
+     *      intentionally remains available during a pause. New paid extension exposure and
+     *      zero-increment expiry refreshes must use this function so admission pause, exit, and
+     *      controller gates remain authoritative.
      */
     function increaseReservation(
         bytes32 _positionId,
@@ -470,7 +471,9 @@ contract StakeVault is IStakeVault, Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Replaces a reservation amount and maturity after exact release accounting is known.
+     * @notice Decreases a reservation amount and updates its maturity after settlement accounting.
+     * @dev Settlement resizing remains available during a pause. Increases must use
+     *      `increaseReservation` so its admission pause, exit, and current-controller gates apply.
      */
     function updateReservation(
         bytes32 _intentHash,
@@ -484,11 +487,9 @@ contract StakeVault is IStakeVault, Ownable, ReentrancyGuard {
 
         uint256 previousAmount = reservation.amount;
         if (_newAmount > previousAmount) {
-            uint256 increase = _newAmount - previousAmount;
-            uint256 available = freeStake(reservation.staker);
-            if (increase > available) revert InsufficientFreeStake(reservation.staker, available, increase);
-            reservedStake[reservation.staker] += increase;
-        } else if (_newAmount < previousAmount) {
+            revert InvalidReservationAmount(_newAmount, previousAmount);
+        }
+        if (_newAmount < previousAmount) {
             reservedStake[reservation.staker] -= previousAmount - _newAmount;
         }
 

--- a/contracts/StakeVault.sol
+++ b/contracts/StakeVault.sol
@@ -650,6 +650,12 @@ contract StakeVault is IStakeVault, Ownable, ReentrancyGuard {
         for (uint256 allocationIndex = 0; allocationIndex < _feeAllocations.length; allocationIndex++) {
             if (_feeAllocations[allocationIndex].amount != 0) {
                 deferredFeeAllocations[_intentHash].push(_feeAllocations[allocationIndex]);
+                emit DeferredFeeContingent(
+                    _intentHash,
+                    _feeAllocations[allocationIndex].recipient,
+                    _feeAllocations[allocationIndex].feeType,
+                    _feeAllocations[allocationIndex].amount
+                );
             }
         }
 
@@ -753,6 +759,16 @@ contract StakeVault is IStakeVault, Ownable, ReentrancyGuard {
         }
 
         delete reservations[_intentHash];
+        IIntentRiskHook.FeeAllocation[] storage allocations = deferredFeeAllocations[_intentHash];
+        for (uint256 allocationIndex = 0; allocationIndex < allocations.length; allocationIndex++) {
+            IIntentRiskHook.FeeAllocation storage allocation = allocations[allocationIndex];
+            emit DeferredFeeCancelled(
+                _intentHash,
+                allocation.recipient,
+                allocation.feeType,
+                allocation.amount
+            );
+        }
         delete deferredFeeAllocations[_intentHash];
         delete deferredStakes[_intentHash];
         reservedStake[deferredStake.staker] -= deferredStake.grossAmount;

--- a/contracts/interfaces/IOrchestratorV3.sol
+++ b/contracts/interfaces/IOrchestratorV3.sol
@@ -200,6 +200,7 @@ interface IOrchestratorV3 {
 
     function fulfillIntent(FulfillIntentParams calldata params) external;
 
+    /** @notice Manually releases an intent through risk settlement and its configured post-intent hook, if any. */
     function releaseFundsToPayer(bytes32 intentHash) external;
 
     /** @notice Clears durable recovery data after the failed risk hook completes reconciliation. */

--- a/contracts/interfaces/IOrchestratorV3.sol
+++ b/contracts/interfaces/IOrchestratorV3.sol
@@ -167,6 +167,7 @@ interface IOrchestratorV3 {
     error InvalidPostIntentHook(address hook);
     error InvalidPreIntentHook(address hook);
     error InvalidSignature();
+    error GatingSignatureAlreadyUsed(bytes32 digest);
     error SignatureExpired(uint256 expiration, uint256 currentTime);
 
     // Verification errors

--- a/contracts/interfaces/IOrchestratorV3.sol
+++ b/contracts/interfaces/IOrchestratorV3.sol
@@ -97,10 +97,11 @@ interface IOrchestratorV3 {
         bool isManualRelease
     );
 
-    event IntentReferralFeeDistributed(
+    event IntentFeeDistributed(
         bytes32 indexed intentHash,
-        address indexed feeRecipient,
-        uint256 feeAmount
+        IIntentRiskHook.FeeType feeType,
+        address indexed recipient,
+        uint256 amount
     );
     event IntentManagerFeeSnapshotted(bytes32 indexed intentHash, address indexed feeRecipient, uint256 fee);
     event DepositPreIntentHookSet(address indexed escrow, uint256 indexed depositId, address indexed hook, address setter);

--- a/contracts/interfaces/IStakeVault.sol
+++ b/contracts/interfaces/IStakeVault.sol
@@ -131,6 +131,18 @@ interface IStakeVault {
         uint256 amount,
         uint256 newClaimableBalance
     );
+    event DeferredFeeContingent(
+        bytes32 indexed intentHash,
+        address indexed recipient,
+        IIntentRiskHook.FeeType indexed feeType,
+        uint256 amount
+    );
+    event DeferredFeeCancelled(
+        bytes32 indexed intentHash,
+        address indexed recipient,
+        IIntentRiskHook.FeeType indexed feeType,
+        uint256 amount
+    );
     event FeeClaimWithdrawn(
         address indexed beneficiary,
         address indexed recipient,

--- a/contracts/interfaces/IStakeVault.sol
+++ b/contracts/interfaces/IStakeVault.sol
@@ -183,6 +183,10 @@ interface IStakeVault {
      * @dev `_amount` may be zero so cumulative-rounding steps still enforce admission gates.
      */
     function increaseReservation(bytes32 _positionId, uint256 _amount, uint64 _releaseTime) external;
+    /**
+     * @notice Decreases a reservation amount and updates its maturity after settlement accounting.
+     * @dev Increases must use `increaseReservation` so its admission gates apply.
+     */
     function updateReservation(bytes32 _intentHash, uint256 _newAmount, uint64 _releaseTime) external;
     function releaseReservation(bytes32 _intentHash) external;
     function slashReservation(bytes32 _intentHash, address _maker, uint256 _amount) external;

--- a/contracts/lib/FeeSettlementLib.sol
+++ b/contracts/lib/FeeSettlementLib.sol
@@ -72,11 +72,6 @@ library FeeSettlementLib {
         if (fundsConsumed) return (address(_riskHook), netAmount);
 
         _transferFeeAllocations(_token, _intentHash, feeAllocations);
-        if (_isManualRelease) {
-            PostIntentHookExecutor.transferTo(_token, _intent.to, netAmount);
-            return (_intent.to, netAmount);
-        }
-
         fundsTransferredTo = PostIntentHookExecutor.transferOrExecute(
             _token,
             _intentHash,

--- a/contracts/lib/FeeSettlementLib.sol
+++ b/contracts/lib/FeeSettlementLib.sol
@@ -36,6 +36,11 @@ library FeeSettlementLib {
         uint256 managerFee;
     }
 
+    /**
+     * @notice Executes risk settlement or distributes the fee plan and remaining funds.
+     * @return fundsTransferredTo Recipient of the settlement funds.
+     * @return reportedAmount Net amount for ordinary distribution, or gross amount when the risk hook consumes funds.
+     */
     function executeSettlement(
         IERC20 _token,
         IIntentRiskHook _riskHook,
@@ -46,12 +51,12 @@ library FeeSettlementLib {
         FeeConfig memory _feeConfig,
         bool _isManualRelease,
         uint256 _riskCallbackGasLimit
-    ) public returns (address fundsTransferredTo, uint256 netAmount) {
+    ) public returns (address fundsTransferredTo, uint256 reportedAmount) {
         (
             IIntentRiskHook.FeeAllocation[] memory feeAllocations,
             uint256 totalFees
         ) = _calculateFeeAllocations(_intent, _releaseAmount, _feeConfig);
-        netAmount = _releaseAmount - totalFees;
+        uint256 netAmount = _releaseAmount - totalFees;
 
         bool fundsConsumed = RiskSettlementExecutor.execute(
             _riskHook,
@@ -69,7 +74,7 @@ library FeeSettlementLib {
             MAX_RISK_CALLBACK_RETURN_DATA
         );
 
-        if (fundsConsumed) return (address(_riskHook), netAmount);
+        if (fundsConsumed) return (address(_riskHook), _releaseAmount);
 
         _transferFeeAllocations(_token, _intentHash, feeAllocations);
         fundsTransferredTo = PostIntentHookExecutor.transferOrExecute(
@@ -79,6 +84,7 @@ library FeeSettlementLib {
             netAmount,
             _postIntentHookData
         );
+        return (fundsTransferredTo, netAmount);
     }
 
     function _calculateFeeAllocations(

--- a/contracts/lib/FeeSettlementLib.sol
+++ b/contracts/lib/FeeSettlementLib.sol
@@ -22,8 +22,9 @@ library FeeSettlementLib {
     uint256 internal constant PRECISE_UNIT = 1e18;
     uint256 internal constant MAX_RISK_CALLBACK_RETURN_DATA = 2_048;
 
-    event IntentReferralFeeDistributed(
+    event IntentFeeDistributed(
         bytes32 indexed intentHash,
+        IIntentRiskHook.FeeType feeType,
         address indexed recipient,
         uint256 amount
     );
@@ -139,9 +140,12 @@ library FeeSettlementLib {
         for (uint256 allocationIndex = 0; allocationIndex < _allocations.length; allocationIndex++) {
             IIntentRiskHook.FeeAllocation memory allocation = _allocations[allocationIndex];
             _token.safeTransfer(allocation.recipient, allocation.amount);
-            if (allocation.feeType == IIntentRiskHook.FeeType.REFERRAL) {
-                emit IntentReferralFeeDistributed(_intentHash, allocation.recipient, allocation.amount);
-            }
+            emit IntentFeeDistributed(
+                _intentHash,
+                allocation.feeType,
+                allocation.recipient,
+                allocation.amount
+            );
         }
     }
 }

--- a/contracts/lib/PostIntentHookExecutor.sol
+++ b/contracts/lib/PostIntentHookExecutor.sol
@@ -64,9 +64,4 @@ library PostIntentHookExecutor {
         _token.safeApprove(address(_intent.postIntentHook), 0);
         return address(_intent.postIntentHook);
     }
-
-    /** @notice Safely transfers a manual-release payout without executing its optional post hook. */
-    function transferTo(IERC20 _token, address _recipient, uint256 _amount) public {
-        _token.safeTransfer(_recipient, _amount);
-    }
 }

--- a/contracts/mocks/PostIntentHookV2Mock.sol
+++ b/contracts/mocks/PostIntentHookV2Mock.sol
@@ -15,6 +15,7 @@ contract PostIntentHookV2Mock is IPostIntentHookV2 {
 
     IERC20 public immutable usdc;
     address public immutable orchestrator;
+    bytes public lastPostIntentHookData;
 
     /* ============ Constructor ============ */
 
@@ -29,8 +30,10 @@ contract PostIntentHookV2Mock is IPostIntentHookV2 {
      */
     function execute(
         HookExecutionContext calldata _ctx,
-        bytes calldata /*_fulfillHookData*/
+        bytes calldata _postIntentHookData
     ) external override {
+        lastPostIntentHookData = _postIntentHookData;
+
         // Decode target address from intent data
         address targetAddress = abi.decode(_ctx.intent.signalHookData, (address));
 

--- a/test-foundry/deterministic/helpers/OrchestratorV2LegacyFixture.sol
+++ b/test-foundry/deterministic/helpers/OrchestratorV2LegacyFixture.sol
@@ -274,25 +274,51 @@ abstract contract OrchestratorV2LegacyFixture is Test {
         IOrchestratorV2.SignalIntentParams memory params,
         uint256 expiration
     ) internal view returns (bytes memory) {
-        bytes32 messageHash = keccak256(
-            abi.encodePacked(
-                address(orchestrator),
-                params.escrow,
-                params.depositId,
-                params.amount,
-                signedCaller,
-                params.to,
-                params.paymentMethod,
-                params.fiatCurrency,
-                params.conversionRate,
-                _referralHash(params.referralFees),
-                expiration,
-                CHAIN_ID
-            )
-        );
+        bytes32 messageHash;
+        if (_usesStandaloneV3Format()) {
+            messageHash = keccak256(
+                abi.encodePacked(
+                    address(orchestrator),
+                    params.escrow,
+                    params.depositId,
+                    params.amount,
+                    signedCaller,
+                    params.to,
+                    params.paymentMethod,
+                    params.fiatCurrency,
+                    params.conversionRate,
+                    _referralHash(params.referralFees),
+                    address(params.postIntentHook),
+                    keccak256(params.data),
+                    expiration,
+                    CHAIN_ID
+                )
+            );
+        } else {
+            messageHash = keccak256(
+                abi.encodePacked(
+                    address(orchestrator),
+                    params.escrow,
+                    params.depositId,
+                    params.amount,
+                    signedCaller,
+                    params.to,
+                    params.paymentMethod,
+                    params.fiatCurrency,
+                    params.conversionRate,
+                    _referralHash(params.referralFees),
+                    expiration,
+                    CHAIN_ID
+                )
+            );
+        }
         bytes32 digest = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerKey, digest);
         return abi.encodePacked(r, s, v);
+    }
+
+    function _usesStandaloneV3Format() internal pure virtual returns (bool) {
+        return false;
     }
 
     function _gatedParams(uint256 gatedDepositId, uint256 signerKey, address signedCaller, uint256 expiration)

--- a/test-foundry/deterministic/libs/RiskCallbackLibrariesParity.t.sol
+++ b/test-foundry/deterministic/libs/RiskCallbackLibrariesParity.t.sol
@@ -142,7 +142,8 @@ contract RiskCallbackLibrariesParityTest is Test {
         assertEq(token.balanceOf(address(postIntentHook)), 10e6);
         assertEq(token.allowance(address(this), address(postIntentHook)), 0);
 
-        PostIntentHookExecutor.transferTo(token, recipient, 1e6);
+        intent.postIntentHook = IPostIntentHookV2(address(0));
+        assertEq(PostIntentHookExecutor.transferOrExecute(token, INTENT_HASH, intent, 1e6, ""), recipient);
         assertEq(token.balanceOf(recipient), 11e6);
     }
 

--- a/test-foundry/deterministic/orchestrator/OrchestratorV2HooksGovernanceParity.t.sol
+++ b/test-foundry/deterministic/orchestrator/OrchestratorV2HooksGovernanceParity.t.sol
@@ -9,6 +9,7 @@ import {IOrchestratorV2} from "contracts/interfaces/IOrchestratorV2.sol";
 import {IPostIntentHookV2} from "contracts/interfaces/IPostIntentHookV2.sol";
 import {IPreIntentHook} from "contracts/interfaces/IPreIntentHook.sol";
 import {IReferralFee} from "contracts/interfaces/IReferralFee.sol";
+import {IIntentRiskHook} from "contracts/interfaces/IIntentRiskHook.sol";
 
 contract OrchestratorV2HooksGovernanceParityTest is OrchestratorV2LegacyFixture {
     event DepositPreIntentHookSet(
@@ -22,6 +23,12 @@ contract OrchestratorV2HooksGovernanceParityTest is OrchestratorV2LegacyFixture 
     event AllowMultipleIntentsUpdated(bool allowMultiple);
     event ProtocolFeeUpdated(uint256 fee);
     event ProtocolFeeRecipientUpdated(address indexed recipient);
+    event IntentFeeDistributed(
+        bytes32 indexed intentHash,
+        IIntentRiskHook.FeeType feeType,
+        address indexed recipient,
+        uint256 amount
+    );
     event IntentReferralFeeDistributed(bytes32 indexed intentHash, address indexed recipient, uint256 amount);
     event ReentrancyAttempted(bool success);
 
@@ -261,10 +268,17 @@ contract OrchestratorV2HooksGovernanceParityTest is OrchestratorV2LegacyFixture 
         IOrchestratorV2.SignalIntentParams memory params = _defaultParams();
         params.referralFees = _twoReferralFees();
         bytes32 intentHash = _signal(taker, params);
-        vm.expectEmit(true, true, false, true, address(orchestrator));
-        emit IntentReferralFeeDistributed(intentHash, referrer, 150_000);
-        vm.expectEmit(true, true, false, true, address(orchestrator));
-        emit IntentReferralFeeDistributed(intentHash, other, 100_000);
+        if (_usesStandaloneV3Format()) {
+            vm.expectEmit(true, true, false, true, address(orchestrator));
+            emit IntentFeeDistributed(intentHash, IIntentRiskHook.FeeType.REFERRAL, referrer, 150_000);
+            vm.expectEmit(true, true, false, true, address(orchestrator));
+            emit IntentFeeDistributed(intentHash, IIntentRiskHook.FeeType.REFERRAL, other, 100_000);
+        } else {
+            vm.expectEmit(true, true, false, true, address(orchestrator));
+            emit IntentReferralFeeDistributed(intentHash, referrer, 150_000);
+            vm.expectEmit(true, true, false, true, address(orchestrator));
+            emit IntentReferralFeeDistributed(intentHash, other, 100_000);
+        }
         vm.prank(depositor);
         orchestrator.releaseFundsToPayer(intentHash);
     }

--- a/test-foundry/deterministic/orchestrator/OrchestratorV3StandaloneParity.t.sol
+++ b/test-foundry/deterministic/orchestrator/OrchestratorV3StandaloneParity.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.18;
 import {OrchestratorV2} from "contracts/OrchestratorV2.sol";
 import {OrchestratorV3} from "contracts/OrchestratorV3.sol";
 import {EscrowRegistry} from "contracts/registries/EscrowRegistry.sol";
+import {IOrchestratorV2} from "contracts/interfaces/IOrchestratorV2.sol";
 import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
 
 import {OrchestratorV2LifecycleParityTest} from "./OrchestratorV2LifecycleParity.t.sol";
@@ -18,9 +19,17 @@ contract OrchestratorV3LifecycleParityTest is OrchestratorV2LifecycleParityTest 
 }
 
 contract OrchestratorV3HooksGovernanceParityTest is OrchestratorV2HooksGovernanceParityTest {
+    event IntentFulfilled(
+        bytes32 indexed intentHash, address indexed fundsTransferredTo, uint256 amount, bool manual
+    );
+
     function setUp() public override {
         super.setUp();
         _replaceOrchestratorWithStandaloneV3();
+    }
+
+    function _usesStandaloneV3Format() internal pure override returns (bool) {
+        return true;
     }
 
     function test_GovernanceUpdatesRegistriesFeesAndPauseState() public override {
@@ -71,6 +80,69 @@ contract OrchestratorV3HooksGovernanceParityTest is OrchestratorV2HooksGovernanc
         assertEq(accountIntents.length, 2);
         assertEq(accountIntents[0], first);
         assertEq(accountIntents[1], second);
+    }
+
+    function test_GatingRejectsReusedSignature() public {
+        uint256 gatedDepositId = _newGatedDeposit();
+        IOrchestratorV2.SignalIntentParams memory params =
+            _gatedParams(gatedDepositId, gatingServiceKey, taker, block.timestamp + 1 days);
+        _signal(taker, params);
+        vm.expectPartialRevert(IOrchestratorV3.GatingSignatureAlreadyUsed.selector);
+        _signalCall(taker, params);
+    }
+
+    function test_GatingAcceptsFreshSignatureWithDifferentExpiration() public {
+        uint256 gatedDepositId = _newGatedDeposit();
+        IOrchestratorV2.SignalIntentParams memory first =
+            _gatedParams(gatedDepositId, gatingServiceKey, taker, block.timestamp + 1 days);
+        _signal(taker, first);
+        IOrchestratorV2.SignalIntentParams memory second =
+            _gatedParams(gatedDepositId, gatingServiceKey, taker, block.timestamp + 2 days);
+        assertNotEq(_signal(taker, second), bytes32(0));
+    }
+
+    function test_GatingRejectsUnsignedPostIntentHook() public {
+        uint256 gatedDepositId = _newGatedDeposit();
+        uint256 expiration = block.timestamp + 1 days;
+        IOrchestratorV2.SignalIntentParams memory params =
+            _gatedParams(gatedDepositId, gatingServiceKey, taker, expiration);
+        params.postIntentHook = postIntentHook;
+        vm.expectRevert(IOrchestratorV3.InvalidSignature.selector);
+        _signalCall(taker, params);
+    }
+
+    function test_GatingRejectsUnsignedData() public {
+        uint256 gatedDepositId = _newGatedDeposit();
+        uint256 expiration = block.timestamp + 1 days;
+        IOrchestratorV2.SignalIntentParams memory params =
+            _gatedParams(gatedDepositId, gatingServiceKey, taker, expiration);
+        params.data = "different data";
+        vm.expectRevert(IOrchestratorV3.InvalidSignature.selector);
+        _signalCall(taker, params);
+    }
+
+    function test_ManualReleaseRoutesNetThroughConfiguredPostIntentHook() public {
+        orchestrator.setProtocolFee(1e16);
+        IOrchestratorV2.SignalIntentParams memory params = _defaultParams();
+        params.postIntentHook = postIntentHook;
+        params.data = abi.encode(other);
+        bytes32 intentHash = _signal(taker, params);
+        uint256 recipientBefore = token.balanceOf(other);
+        vm.expectEmit(true, true, false, true, address(orchestrator));
+        emit IntentFulfilled(intentHash, address(postIntentHook), 49.5e6, true);
+        vm.prank(depositor);
+        orchestrator.releaseFundsToPayer(intentHash);
+        assertEq(token.balanceOf(other) - recipientBefore, 49.5e6);
+    }
+
+    function test_ManualReleaseWithoutPostIntentHookTransfersDirectlyToIntentRecipient() public {
+        bytes32 intentHash = _signalDefault();
+        uint256 recipientBefore = token.balanceOf(taker);
+        vm.expectEmit(true, true, false, true, address(orchestrator));
+        emit IntentFulfilled(intentHash, taker, INTENT_AMOUNT, true);
+        vm.prank(depositor);
+        orchestrator.releaseFundsToPayer(intentHash);
+        assertEq(token.balanceOf(taker) - recipientBefore, INTENT_AMOUNT);
     }
 }
 

--- a/test-foundry/deterministic/staking/OrchestratorV3ControlRecoveryParity.t.sol
+++ b/test-foundry/deterministic/staking/OrchestratorV3ControlRecoveryParity.t.sol
@@ -14,6 +14,22 @@ import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
 contract OrchestratorV3ControlRecoveryParityTest is RiskManagerBoundaryFixture {
     event RiskCallbackGasLimitUpdated(uint256 gasLimit);
 
+    function test_DepositorCanSetAndClearRiskHookButRegisteredDelegateCannot() public {
+        assertEq(escrow.getDeposit(0).delegate, makerDelegate);
+        IntentRiskHookMock hook = new IntentRiskHookMock();
+        vm.prank(maker);
+        orchestrator.setDepositRiskHook(address(escrow), 0, IIntentRiskHook(address(hook)));
+        assertEq(address(orchestrator.getDepositRiskHook(address(escrow), 0)), address(hook));
+
+        vm.expectRevert(abi.encodeWithSelector(IOrchestratorV3.UnauthorizedCaller.selector, makerDelegate, maker));
+        vm.prank(makerDelegate);
+        orchestrator.setDepositRiskHook(address(escrow), 0, IIntentRiskHook(address(0)));
+
+        vm.prank(maker);
+        orchestrator.setDepositRiskHook(address(escrow), 0, IIntentRiskHook(address(0)));
+        assertEq(address(orchestrator.getDepositRiskHook(address(escrow), 0)), address(0));
+    }
+
     function test_OrchestratorV3ExposesHookSnapshotsAndGuardedGovernance() public {
         assertEq(address(orchestrator.getDepositRiskHook(address(escrow), 0)), address(manager));
         vm.expectRevert(bytes("Ownable: caller is not the owner"));
@@ -25,7 +41,7 @@ contract OrchestratorV3ControlRecoveryParityTest is RiskManagerBoundaryFixture {
         emit RiskCallbackGasLimitUpdated(1_000_000);
         orchestrator.setRiskCallbackGasLimit(1_000_000);
 
-        vm.expectPartialRevert(IOrchestratorV2.UnauthorizedCallerOrDelegate.selector);
+        vm.expectRevert(abi.encodeWithSelector(IOrchestratorV3.UnauthorizedCaller.selector, other, maker));
         vm.prank(other);
         orchestrator.setDepositRiskHook(address(escrow), 0, IIntentRiskHook(address(0)));
         vm.expectRevert(IOrchestratorV2.ZeroAddress.selector);

--- a/test-foundry/deterministic/staking/RiskManagerSettlementRoutingParity.t.sol
+++ b/test-foundry/deterministic/staking/RiskManagerSettlementRoutingParity.t.sol
@@ -5,9 +5,18 @@ import {RiskManagerBoundaryFixture} from "../helpers/RiskManagerBoundaryFixture.
 import {PostIntentHookV2Mock} from "contracts/mocks/PostIntentHookV2Mock.sol";
 import {IPostIntentHookV2} from "contracts/interfaces/IPostIntentHookV2.sol";
 import {IRiskManager} from "contracts/interfaces/IRiskManager.sol";
+import {IIntentRiskHook} from "contracts/interfaces/IIntentRiskHook.sol";
 
 contract RiskManagerSettlementRoutingParityTest is RiskManagerBoundaryFixture {
-    event IntentReferralFeeDistributed(bytes32 indexed intentHash, address indexed recipient, uint256 feeAmount);
+    event IntentFulfilled(
+        bytes32 indexed intentHash, address indexed fundsTransferredTo, uint256 amount, bool manual
+    );
+    event IntentFeeDistributed(
+        bytes32 indexed intentHash,
+        IIntentRiskHook.FeeType feeType,
+        address indexed recipient,
+        uint256 amount
+    );
 
     function test_ManualReleaseUsesDeferredCustodyAndSkipsOrdinaryPostHook() public {
         _enableDeferred();
@@ -22,6 +31,8 @@ contract RiskManagerSettlementRoutingParityTest is RiskManagerBoundaryFixture {
             abi.encode(recipient)
         );
         uint256 recipientBefore = token.balanceOf(recipient);
+        vm.expectEmit(true, true, false, true, address(orchestrator));
+        emit IntentFulfilled(intentHash, address(manager), 100e6, true);
         vm.prank(maker);
         orchestrator.releaseFundsToPayer(intentHash);
         assertEq(vault.getDeferredStake(intentHash).grossAmount, 100e6);
@@ -69,7 +80,13 @@ contract RiskManagerSettlementRoutingParityTest is RiskManagerBoundaryFixture {
         uint256 managerBefore = token.balanceOf(recipient);
         uint256 takerBefore = token.balanceOf(taker);
         vm.expectEmit(true, true, false, true, address(orchestrator));
-        emit IntentReferralFeeDistributed(intentHash, other, 0.2e6);
+        emit IntentFeeDistributed(intentHash, IIntentRiskHook.FeeType.PROTOCOL, address(this), 0.2e6);
+        vm.expectEmit(true, true, false, true, address(orchestrator));
+        emit IntentFeeDistributed(intentHash, IIntentRiskHook.FeeType.REFERRAL, other, 0.2e6);
+        vm.expectEmit(true, true, false, true, address(orchestrator));
+        emit IntentFeeDistributed(intentHash, IIntentRiskHook.FeeType.MANAGER, recipient, 0.2e6);
+        vm.expectEmit(true, true, false, true, address(orchestrator));
+        emit IntentFulfilled(intentHash, taker, 19.4e6, false);
         _fulfill(intentHash, 20e6);
         assertEq(token.balanceOf(address(this)), protocolBefore + 0.2e6);
         assertEq(token.balanceOf(other), referrerBefore + 0.2e6);

--- a/test-foundry/deterministic/staking/StakeVaultDeferredParity.t.sol
+++ b/test-foundry/deterministic/staking/StakeVaultDeferredParity.t.sol
@@ -38,6 +38,25 @@ contract StakeVaultDeferredParityTest is StakeVaultLegacyFixture {
         uint256 vestedFeeAmount,
         uint256 netStakeReleased
     );
+    event DeferredFeeVested(
+        bytes32 indexed intentHash,
+        address indexed recipient,
+        IIntentRiskHook.FeeType indexed feeType,
+        uint256 amount,
+        uint256 newClaimableBalance
+    );
+    event DeferredFeeContingent(
+        bytes32 indexed intentHash,
+        address indexed recipient,
+        IIntentRiskHook.FeeType indexed feeType,
+        uint256 amount
+    );
+    event DeferredFeeCancelled(
+        bytes32 indexed intentHash,
+        address indexed recipient,
+        IIntentRiskHook.FeeType indexed feeType,
+        uint256 amount
+    );
 
     function _fees(address protocol, uint256 protocolAmount, address referrer, uint256 referrerAmount)
         internal
@@ -244,12 +263,19 @@ contract StakeVaultDeferredParityTest is StakeVaultLegacyFixture {
         bytes32 intentHash = keccak256("zero-rounded-deferred-fee");
         uint64 releaseTime = uint64(block.timestamp + DAY);
         _authorize(intentHash, releaseTime);
-        _fund(intentHash, 100e6, releaseTime, _fees(maker, 0, recipient, 1e6));
+        IIntentRiskHook.FeeAllocation[] memory fees = _fees(maker, 0, recipient, 1e6);
+        token.transfer(address(vault), 100e6);
+        vm.expectEmit(true, true, true, true, address(vault));
+        emit DeferredFeeContingent(intentHash, recipient, IIntentRiskHook.FeeType.REFERRAL, 1e6);
+        vm.prank(controller);
+        vault.recordDeferredStake(intentHash, staker, 100e6, releaseTime, fees);
         IIntentRiskHook.FeeAllocation[] memory stored = vault.getDeferredFeeAllocations(intentHash);
         assertEq(stored.length, 1);
         assertEq(stored[0].recipient, recipient);
         assertEq(vault.getDeferredStake(intentHash).feeAmount, 1e6);
         vm.warp(releaseTime);
+        vm.expectEmit(true, true, true, true, address(vault));
+        emit DeferredFeeVested(intentHash, recipient, IIntentRiskHook.FeeType.REFERRAL, 1e6, 1e6);
         vm.recordLogs();
         vm.prank(controller);
         vault.releaseDeferredStake(intentHash);
@@ -271,6 +297,8 @@ contract StakeVaultDeferredParityTest is StakeVaultLegacyFixture {
         bytes32 intentHash = keccak256("deferred");
         _authorize(intentHash, 0);
         _fund(intentHash, 100e6, 0, _fees(recipient, 2e6, maker, 0));
+        vm.expectEmit(true, true, true, true, address(vault));
+        emit DeferredFeeCancelled(intentHash, recipient, IIntentRiskHook.FeeType.PROTOCOL, 2e6);
         vm.prank(controller);
         vault.slashDeferredStake(intentHash, maker);
         assertEq(vault.getDeferredStake(intentHash).grossAmount, 0);

--- a/test-foundry/deterministic/staking/StakeVaultReservationParity.t.sol
+++ b/test-foundry/deterministic/staking/StakeVaultReservationParity.t.sol
@@ -86,6 +86,37 @@ contract StakeVaultReservationParityTest is StakeVaultLegacyFixture {
         vault.updateReservation(intentHash, 0, 0);
     }
 
+    function test_UpdateReservationRejectsIncreaseDespiteAmpleFreeStake() public {
+        bytes32 intentHash = keccak256("decrease-only");
+        _deposit(1_000e6);
+        _reserve(intentHash, 100e6, 100);
+        vm.expectRevert(abi.encodeWithSelector(StakeVault.InvalidReservationAmount.selector, 200e6, 100e6));
+        vm.prank(controller);
+        vault.updateReservation(intentHash, 200e6, 200);
+    }
+
+    function test_UpdateReservationEqualAmountRefreshesMaturity() public {
+        bytes32 intentHash = keccak256("equal-refresh");
+        _deposit(100e6);
+        _reserve(intentHash, 50e6, 100);
+        vm.expectEmit(true, true, false, true, address(vault));
+        emit StakeReservationUpdated(intentHash, staker, 50e6, 50e6, 50e6, 200);
+        vm.prank(controller);
+        vault.updateReservation(intentHash, 50e6, 200);
+        assertEq(_reservation(intentHash).releaseTime, 200);
+    }
+
+    function test_UpdateReservationCanDecreaseWhileReservationsPaused() public {
+        bytes32 intentHash = keccak256("paused-decrease");
+        _deposit(100e6);
+        _reserve(intentHash, 50e6, 100);
+        vault.setStakeOperationsPaused(false, true);
+        vm.prank(controller);
+        vault.updateReservation(intentHash, 20e6, 200);
+        assertEq(_reservation(intentHash).amount, 20e6);
+        assertEq(vault.freeStake(staker), 80e6);
+    }
+
     function test_IncreaseReservationUsesAdmissionGatedPath() public {
         bytes32 positionId = keccak256("extension-top-up");
         _deposit(10e6);

--- a/test-foundry/invariant/handlers/StakeVaultHandler.sol
+++ b/test-foundry/invariant/handlers/StakeVaultHandler.sol
@@ -156,12 +156,7 @@ contract StakeVaultHandler is Test {
     function update(uint256 slotSeed, uint256 rawAmount, uint64 rawDuration) external {
         bytes32 position = _position(slotSeed);
         IStakeVault.Reservation memory beforeReservation = vault.getReservation(position);
-        uint256 capacity;
-        if (beforeReservation.active) {
-            capacity = vault.eligibleStake(beforeReservation.staker)
-                - (vault.reservedStake(beforeReservation.staker) - beforeReservation.amount);
-        }
-        uint256 newAmount = capacity == 0 ? 1 : bound(rawAmount, 1, capacity);
+        uint256 newAmount = beforeReservation.active ? bound(rawAmount, 1, beforeReservation.amount) : 1;
         uint64 releaseTime = uint64(block.timestamp) + uint64(bound(uint256(rawDuration), 1, 30 days));
         bytes4 expectedRevert = beforeReservation.active ? bytes4(0) : StakeVault.ReservationNotFound.selector;
         bool success = _call(
@@ -171,11 +166,7 @@ contract StakeVaultHandler is Test {
             expectedRevert
         );
         if (success) {
-            if (newAmount >= beforeReservation.amount) {
-                ghostReserved[beforeReservation.staker] += newAmount - beforeReservation.amount;
-            } else {
-                ghostReserved[beforeReservation.staker] -= beforeReservation.amount - newAmount;
-            }
+            ghostReserved[beforeReservation.staker] -= beforeReservation.amount - newAmount;
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes 7 issues found in review of the V3 staking/settlement system (FeeSettlementLib, StakeVault, RiskManager, OrchestratorV3).
- One commit per issue; every commit was independently reviewed (Claude + Codex convergence) and returned green before the next landed.

## Fixes
1. ✅ `FeeSettlementLib._transferFeeAllocations` only emitted `IntentReferralFeeDistributed` — replaced with unified `IntentFeeDistributed(intentHash, feeType, recipient, amount)` for every protocol/referral/manager allocation. (`ff8b8c8`)
2. ✅ Gating signature replay + omitted `postIntentHook` / persisted data hash — digest now binds hook + `keccak256(data)` and is single-use (`GatingSignatureAlreadyUsed`). (`0f8dfbb`)
3. ✅ `setDepositRiskHook` callable by delegates — now depositor-only (`UnauthorizedCaller`). (`79cc04d`)
4. ✅ Post-intent hook not executed during manual release — `releaseFundsToPayer` now settles through `transferOrExecute` (empty ephemeral hook data, persisted signal data intact; fail-closed on hook revert). (`6958948`)
5. ✅ Missing per-allocation deferred fee events — added `DeferredFeeContingent` (funding) and `DeferredFeeCancelled` (chargeback) mirroring `DeferredFeeVested`. (`0d7f044`)
6. ✅ `StakeVault.updateReservation` allowed increases bypassing pause/exit/current-controller gates — now decrease-only (`InvalidReservationAmount` on increase; equal-amount maturity refresh kept). (`5ea441f`)
7. ✅ `IntentFulfilled` reported net when deferred settlement moved gross to StakeVault — funds-consumed path now reports gross (recipient stays the consuming hook; `IntentRiskSettlementExecuted` carries the full breakdown). (`642d84c`)

## Breaking / Integration Notes
- **Off-chain gating services** signing for OrchestratorV3 deposits must adopt the V3 message format (adds `postIntentHook` and `keccak256(data)`) and issue a fresh signature per authorized take (vary `signatureExpiration` for repeat authorizations).
- **Before wiring AcrossBridgeHookV2 (or any strict-length hook) to V3 in production**: it reverts on empty `postIntentHookData`, so manual release on bridged intents fails closed until the hook accepts empty ephemeral data (no funds stranded — cancel/expiry remain live).
- Indexers: `IntentFulfilled.amount` is net on ordinary distribution (sum with `IntentFeeDistributed` events for total outflow) and gross when a risk hook consumed the settlement (no fee events; fees deferred inside StakeVault).

## Rebase Note
Rebased onto main after the Hardhat-to-Foundry test migration (#194). Contract changes were unaffected; Hardhat test edits to migration-deleted specs were dropped, and a final commit (`12361de`) reconciles the Foundry suite: flips parity assertions translated from pre-fix behavior, clamps the invariant handler to decrease-only reservation updates, and ports the lost coverage for all 7 fixes into Foundry.

## Companion PR
- Indexer alignment: https://github.com/zkp2p/zkp2p-indexer/pull/205

## Test Plan
- [x] Pre-rebase: per-commit Hardhat V3 + staking suites green at every step; V2 suites unaffected
- [x] Post-rebase: full Foundry suite (`forge test` — now the canonical CI gate): 1538 passing, 0 failing
- [x] Each commit reviewed green via review-pr (Claude + Codex) before the next landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KfpZ5N6ftLycX4pKqBXFj9

