### PR TITLE
docs: explain Foundry CI cache behavior

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -82,3 +82,9 @@ There are no fork-dependent tests. Chain-dependent behavior was replaced with de
 ## Expected local runtimes
 
 On the recorded Apple M5 Max / Foundry v1.7.1 host, deterministic tests take about 0.8s warm and the complete suite takes about 5.6s warm. Deterministic coverage takes about 5 minutes locally: roughly 288 seconds for the complete minimal-IR pass and about 12 seconds for all exact-source mapping shards. PR #197 measured the equivalent deterministic coverage producer at 8m46s on a fresh GitHub-hosted runner. Subsequent normal test runs use Foundry's content-addressed cache, while correctness never depends on cache state.
+
+## CI cache behavior
+
+The complete-suite job caches `out/` and `cache_forge/`. Its exact key includes the pinned Foundry version, `foundry.toml`, production Solidity, Foundry tests, and Forge Standard Library sources. A documentation-only change therefore restores the exact cache produced by `main`; changing any Solidity test or compiler input intentionally creates a new key and may require a cold compile once.
+
+Pull-request caches are scoped to the pull request. After a large source-path change lands, allow the resulting push-to-`main` workflow to finish so it can publish the new cache for later branches. Coverage still compiles with its dedicated instrumentation settings and is measured separately from the incremental complete-suite cache.


### PR DESCRIPTION
## Summary

- document which inputs determine the complete-suite Foundry cache key
- explain why pull-request caches cannot seed later branches directly
- document the required post-merge main cache-seeding step

## Validation design

This PR is intentionally documentation-only. It does not change foundry.toml, production Solidity, Foundry tests, or Forge Standard Library sources, so the complete-suite job restored the exact cache published by the post-merge main run for PR #197.

- cold main seed: https://github.com/zkp2p/zkp2p-contracts/actions/runs/29907261009
- warm validation: https://github.com/zkp2p/zkp2p-contracts/actions/runs/29909605866
- exact cache key was published under refs/heads/main and accessed by this PR

## Measured result

| Measurement | Cold main seed | Warm PR #198 | Improvement |
|---|---:|---:|---:|
| Complete-suite test command | 33m58s | 28s | 72.8x faster |
| Complete-suite job with setup | 34m25s | 59s | 35.0x faster |
| Build/package/deployment job | 2m51s | 2m49s | unchanged |
| Coverage + Codecov job | 9m04s | 8m34s | effectively unchanged |
| Workflow wall time | 34m28s | 8m38s | 4.0x faster |

The improvement came from restoring compiled Foundry artifacts for unchanged Solidity and test inputs. Coverage remains intentionally uncached because it recompiles with separate instrumentation settings; it is now the approximately nine-minute critical path for normal PRs.

## Verification

- all three CI jobs passed
- complete Foundry suite: 59s job, 28s actual test command
- deterministic coverage and Codecov: 8m34s
- build, package, and localhost deployment: 2m49s
- no Solidity, test, Foundry configuration, or workflow changes