### PR TITLE
feat(hooks): add group-based whitelisting via AddressGroupRegistry

### DIFF
--- a/contracts/hooks/WhitelistPreIntentHookV2.sol
+++ b/contracts/hooks/WhitelistPreIntentHookV2.sol
@@ -127,6 +127,61 @@ contract WhitelistPreIntentHookV2 is IPreIntentHook {
         revert TakerNotWhitelisted(_ctx.taker, _ctx.escrow, _ctx.depositId);
     }
 
+    /**
+     * @notice Attaches groups to a deposit. Idempotent: already-attached ids are skipped
+     * (no event). Validates each group exists in the registry (input validation only — not a
+     * trust guarantee about the group's governance).
+     * @param _escrow      Escrow address.
+     * @param _depositId   Deposit id.
+     * @param _groupIds    Group ids to attach (max MAX_GROUPS_PER_DEPOSIT attached in total).
+     */
+    function attachGroups(address _escrow, uint256 _depositId, uint256[] calldata _groupIds) external {
+        if (_escrow == address(0)) revert ZeroAddress();
+        if (_groupIds.length == 0) revert EmptyArray();
+
+        _validateDepositorOrDelegate(_escrow, _depositId);
+
+        uint256[] storage attached = attachedGroups[_escrow][_depositId];
+        for (uint256 i = 0; i < _groupIds.length; i++) {
+            uint256 groupId = _groupIds[i];
+            if (!groupRegistry.groupExists(groupId)) revert GroupDoesNotExist(groupId);
+            if (attachedGroupIndexPlusOne[_escrow][_depositId][groupId] != 0) continue;
+            if (attached.length >= MAX_GROUPS_PER_DEPOSIT) {
+                revert MaxGroupsExceeded(attached.length + 1, MAX_GROUPS_PER_DEPOSIT);
+            }
+            attached.push(groupId);
+            attachedGroupIndexPlusOne[_escrow][_depositId][groupId] = attached.length;
+            emit GroupAttached(_escrow, _depositId, groupId);
+        }
+    }
+
+    /**
+     * @notice Detaches groups from a deposit. Idempotent: ids not currently attached are
+     * skipped (no event). Detachment does not invalidate already-signaled intents.
+     * @param _escrow      Escrow address.
+     * @param _depositId   Deposit id.
+     * @param _groupIds    Group ids to detach.
+     */
+    function detachGroups(address _escrow, uint256 _depositId, uint256[] calldata _groupIds) external {
+        if (_escrow == address(0)) revert ZeroAddress();
+        if (_groupIds.length == 0) revert EmptyArray();
+
+        _validateDepositorOrDelegate(_escrow, _depositId);
+
+        uint256[] storage attached = attachedGroups[_escrow][_depositId];
+        for (uint256 i = 0; i < _groupIds.length; i++) {
+            uint256 groupId = _groupIds[i];
+            uint256 indexPlusOne = attachedGroupIndexPlusOne[_escrow][_depositId][groupId];
+            if (indexPlusOne == 0) continue;
+
+            uint256 lastId = attached[attached.length - 1];
+            attached[indexPlusOne - 1] = lastId;
+            attachedGroupIndexPlusOne[_escrow][_depositId][lastId] = indexPlusOne;
+            attached.pop();
+            delete attachedGroupIndexPlusOne[_escrow][_depositId][groupId];
+            emit GroupDetached(_escrow, _depositId, groupId);
+        }
+    }
     /* ============ External View Functions ============ */
 
     /**
@@ -139,6 +194,41 @@ contract WhitelistPreIntentHookV2 is IPreIntentHook {
         return whitelist[_escrow][_depositId][_taker];
     }
 
+    /**
+     * @notice Returns all group ids attached to a deposit.
+     * @param _escrow      Escrow address.
+     * @param _depositId   Deposit id.
+     */
+    function getAttachedGroups(address _escrow, uint256 _depositId) external view returns (uint256[] memory) {
+        return attachedGroups[_escrow][_depositId];
+    }
+
+    /**
+     * @notice Returns whether a group is attached to a deposit.
+     * @param _escrow      Escrow address.
+     * @param _depositId   Deposit id.
+     * @param _groupId     Group id.
+     */
+    function isGroupAttached(address _escrow, uint256 _depositId, uint256 _groupId) external view returns (bool) {
+        return attachedGroupIndexPlusOne[_escrow][_depositId][_groupId] != 0;
+    }
+
+    /**
+     * @notice Full effective admission check — same semantics as validateSignalIntent without
+     * the orchestrator gate or revert.
+     * @param _escrow      Escrow address.
+     * @param _depositId   Deposit id.
+     * @param _taker       Taker address to check.
+     */
+    function isAllowedTaker(address _escrow, uint256 _depositId, address _taker) external view returns (bool) {
+        if (whitelist[_escrow][_depositId][_taker]) return true;
+
+        uint256[] storage groupIds = attachedGroups[_escrow][_depositId];
+        for (uint256 i = 0; i < groupIds.length; i++) {
+            if (groupRegistry.isMember(groupIds[i], _taker)) return true;
+        }
+        return false;
+    }
     /* ============ Internal Functions ============ */
 
     function _validateDepositorOrDelegate(address _escrow, uint256 _depositId) internal view {

--- a/contracts/hooks/WhitelistPreIntentHookV2.sol
+++ b/contracts/hooks/WhitelistPreIntentHookV2.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { IAddressGroupRegistry } from "../interfaces/IAddressGroupRegistry.sol";
+import { IEscrow } from "../interfaces/IEscrow.sol";
+import { IOrchestratorRegistry } from "../interfaces/IOrchestratorRegistry.sol";
+import { IPreIntentHook } from "../interfaces/IPreIntentHook.sol";
+
+/**
+ * @title WhitelistPreIntentHookV2
+ * @notice Unified whitelist hook: a taker may signal against a deposit when they are directly
+ * whitelisted OR a member of any attached AddressGroupRegistry group. Allow-only; no blocklist.
+ * @dev Supersedes WhitelistPreIntentHook for new deposits. Configuration is keyed by
+ * (escrow, depositId) and persists if the deposit's orchestrator whitelist-hook slot is unset
+ * (whitelist paused) and later reattached (resumed). Membership is point-in-time admission
+ * authorization: removal does not invalidate already-signaled intents.
+ *
+ * TRUST MODEL: attaching a group delegates ongoing admission policy for the deposit to that
+ * group's controller set (current/future owner and resolver) — see AddressGroupRegistry.
+ */
+contract WhitelistPreIntentHookV2 is IPreIntentHook {
+
+    /* ============ Events ============ */
+
+    event TakerWhitelisted(address indexed escrow, uint256 indexed depositId, address indexed taker);
+    event TakerRemovedFromWhitelist(address indexed escrow, uint256 indexed depositId, address indexed taker);
+    event GroupAttached(address indexed escrow, uint256 indexed depositId, uint256 indexed groupId);
+    event GroupDetached(address indexed escrow, uint256 indexed depositId, uint256 indexed groupId);
+
+    /* ============ Errors ============ */
+
+    error ZeroAddress();
+    error EmptyArray();
+    error UnauthorizedCallerOrDelegate(address caller, address owner, address delegate);
+    error UnauthorizedOrchestratorCaller(address caller);
+    error TakerNotWhitelisted(address taker, address escrow, uint256 depositId);
+    error GroupDoesNotExist(uint256 groupId);
+    error MaxGroupsExceeded(uint256 attempted, uint256 max);
+
+    /* ============ Constants ============ */
+
+    uint256 public constant MAX_GROUPS_PER_DEPOSIT = 10;
+
+    /* ============ State Variables ============ */
+
+    IOrchestratorRegistry public immutable orchestratorRegistry;
+    IAddressGroupRegistry public immutable groupRegistry;
+
+    // escrow => depositId => taker => whitelisted
+    mapping(address => mapping(uint256 => mapping(address => bool))) public whitelist;
+    // escrow => depositId => attached group ids (enumerable, max MAX_GROUPS_PER_DEPOSIT)
+    mapping(address => mapping(uint256 => uint256[])) internal attachedGroups;
+    // escrow => depositId => groupId => index+1 in attachedGroups (0 = not attached)
+    mapping(address => mapping(uint256 => mapping(uint256 => uint256))) internal attachedGroupIndexPlusOne;
+
+    /* ============ Constructor ============ */
+
+    constructor(address _orchestratorRegistry, address _groupRegistry) {
+        if (_orchestratorRegistry == address(0) || _groupRegistry == address(0)) revert ZeroAddress();
+
+        orchestratorRegistry = IOrchestratorRegistry(_orchestratorRegistry);
+        groupRegistry = IAddressGroupRegistry(_groupRegistry);
+    }
+
+    /* ============ External Functions ============ */
+
+    /**
+     * @notice Adds takers to a deposit's direct whitelist. Idempotent: already-whitelisted
+     * takers are skipped (no event).
+     * @param _escrow      Escrow address.
+     * @param _depositId   Deposit id.
+     * @param _takers      Taker addresses to whitelist.
+     */
+    function addToWhitelist(address _escrow, uint256 _depositId, address[] calldata _takers) external {
+        if (_escrow == address(0)) revert ZeroAddress();
+        if (_takers.length == 0) revert EmptyArray();
+
+        _validateDepositorOrDelegate(_escrow, _depositId);
+
+        for (uint256 i = 0; i < _takers.length; i++) {
+            address taker = _takers[i];
+            if (taker == address(0)) revert ZeroAddress();
+            if (!whitelist[_escrow][_depositId][taker]) {
+                whitelist[_escrow][_depositId][taker] = true;
+                emit TakerWhitelisted(_escrow, _depositId, taker);
+            }
+        }
+    }
+
+    /**
+     * @notice Removes takers from a deposit's direct whitelist. Idempotent: absent takers are
+     * skipped (no event). Removal does not invalidate already-signaled intents.
+     * @param _escrow      Escrow address.
+     * @param _depositId   Deposit id.
+     * @param _takers      Taker addresses to remove.
+     */
+    function removeFromWhitelist(address _escrow, uint256 _depositId, address[] calldata _takers) external {
+        if (_escrow == address(0)) revert ZeroAddress();
+        if (_takers.length == 0) revert EmptyArray();
+
+        _validateDepositorOrDelegate(_escrow, _depositId);
+
+        for (uint256 i = 0; i < _takers.length; i++) {
+            address taker = _takers[i];
+            if (taker == address(0)) revert ZeroAddress();
+            if (whitelist[_escrow][_depositId][taker]) {
+                whitelist[_escrow][_depositId][taker] = false;
+                emit TakerRemovedFromWhitelist(_escrow, _depositId, taker);
+            }
+        }
+    }
+
+    /**
+     * @inheritdoc IPreIntentHook
+     */
+    function validateSignalIntent(PreIntentContext calldata _ctx) external view override {
+        if (!orchestratorRegistry.isOrchestrator(msg.sender)) revert UnauthorizedOrchestratorCaller(msg.sender);
+
+        if (whitelist[_ctx.escrow][_ctx.depositId][_ctx.taker]) return;
+
+        uint256[] storage groupIds = attachedGroups[_ctx.escrow][_ctx.depositId];
+        for (uint256 i = 0; i < groupIds.length; i++) {
+            if (groupRegistry.isMember(groupIds[i], _ctx.taker)) return;
+        }
+
+        revert TakerNotWhitelisted(_ctx.taker, _ctx.escrow, _ctx.depositId);
+    }
+
+    /* ============ External View Functions ============ */
+
+    /**
+     * @notice Returns whether a taker is on the deposit's direct whitelist (groups excluded).
+     * @param _escrow      Escrow address.
+     * @param _depositId   Deposit id.
+     * @param _taker       Taker address to check.
+     */
+    function isWhitelisted(address _escrow, uint256 _depositId, address _taker) external view returns (bool) {
+        return whitelist[_escrow][_depositId][_taker];
+    }
+
+    /* ============ Internal Functions ============ */
+
+    function _validateDepositorOrDelegate(address _escrow, uint256 _depositId) internal view {
+        IEscrow.Deposit memory deposit = IEscrow(_escrow).getDeposit(_depositId);
+        bool isDepositorOrDelegate = msg.sender == deposit.depositor
+            || (deposit.delegate != address(0) && msg.sender == deposit.delegate);
+        if (!isDepositorOrDelegate) {
+            revert UnauthorizedCallerOrDelegate(msg.sender, deposit.depositor, deposit.delegate);
+        }
+    }
+}

--- a/contracts/interfaces/IAddressGroupRegistry.sol
+++ b/contracts/interfaces/IAddressGroupRegistry.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+/**
+ * @title IAddressGroupRegistry
+ * @notice Permissionless registry of owner-managed address groups with optional resolvers.
+ */
+interface IAddressGroupRegistry {
+    /**
+     * @notice Creates a new group owned by the caller; the name is emitted, not stored.
+     */
+    function createGroup(string calldata _name) external returns (uint256 groupId);
+
+    /**
+     * @notice Starts a two-step ownership transfer; replaces any existing pending owner.
+     */
+    function transferGroupOwnership(uint256 _groupId, address _newOwner) external;
+
+    /**
+     * @notice Cancels a pending ownership transfer.
+     */
+    function cancelGroupOwnershipTransfer(uint256 _groupId) external;
+
+    /**
+     * @notice Completes a pending ownership transfer; callable only by the pending owner.
+     */
+    function acceptGroupOwnership(uint256 _groupId) external;
+
+    /**
+     * @notice Adds members to a group (owner only; idempotent).
+     */
+    function addMembers(uint256 _groupId, address[] calldata _members) external;
+
+    /**
+     * @notice Removes members from a group (owner only; idempotent).
+     */
+    function removeMembers(uint256 _groupId, address[] calldata _members) external;
+
+    /**
+     * @notice Sets or clears the group's resolver (owner only; nonzero resolver must have code).
+     */
+    function setResolver(uint256 _groupId, address _resolver) external;
+
+    /**
+     * @notice Returns whether an account is a member (curated OR resolver; fail-closed).
+     */
+    function isMember(uint256 _groupId, address _account) external view returns (bool);
+
+    /**
+     * @notice Returns whether a group exists (input validation only, not a trust guarantee).
+     */
+    function groupExists(uint256 _groupId) external view returns (bool);
+
+    /**
+     * @notice Returns a group's governance state for atomic inspection.
+     */
+    function getGroup(uint256 _groupId)
+        external
+        view
+        returns (address owner, address pendingOwner, address resolver, bool exists);
+
+    /**
+     * @notice Returns the last assigned group id (ids start at 1).
+     */
+    function groupCount() external view returns (uint256);
+}

--- a/contracts/interfaces/IWhitelistResolver.sol
+++ b/contracts/interfaces/IWhitelistResolver.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+/**
+ * @title IWhitelistResolver
+ * @notice Optional programmatic membership source for an AddressGroupRegistry group.
+ * @dev Called by the registry via a gas-capped staticcall with bounded returndata handling.
+ * Implementations MUST be view and return true only for members.
+ */
+interface IWhitelistResolver {
+    /**
+     * @notice Returns whether an account is a member of a group.
+     * @param _groupId    Group id in the calling registry.
+     * @param _account    Account to check.
+     */
+    function isMember(uint256 _groupId, address _account) external view returns (bool);
+}

--- a/contracts/mocks/AddressGroupRegistryGasHarness.sol
+++ b/contracts/mocks/AddressGroupRegistryGasHarness.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { AddressGroupRegistry } from "../registries/AddressGroupRegistry.sol";
+
+// Test-only subclass that raises the resolver gas limit so the bounded-returndata copy can be
+// demonstrated with payloads far larger than the production stipend permits (harness-level
+// proof; production stipend cannot construct such payloads by design).
+contract AddressGroupRegistryGasHarness is AddressGroupRegistry {
+    uint256 internal resolverGasLimitOverride = RESOLVER_GAS_LIMIT;
+
+    function setResolverGasLimit(uint256 _limit) external {
+        resolverGasLimitOverride = _limit;
+    }
+
+    function _resolverGasLimit() internal view override returns (uint256) {
+        return resolverGasLimitOverride;
+    }
+}

--- a/contracts/mocks/WhitelistResolverMock.sol
+++ b/contracts/mocks/WhitelistResolverMock.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { IWhitelistResolver } from "../interfaces/IWhitelistResolver.sol";
+
+contract WhitelistResolverMock is IWhitelistResolver {
+    enum Mode {
+        MembershipMap,        // honest resolver backed by memberOf mapping
+        ReturnTrue,
+        ReturnFalse,
+        ReturnTwo,            // 32-byte word == 2
+        ReturnMax,            // 32-byte word == type(uint256).max
+        ReturnShort,          // fewer than 32 bytes of returndata
+        Revert,
+        BurnGas,              // consume the entire forwarded gas
+        PayloadReturnNotOne,  // `payloadSize` bytes of returndata, first word == 2
+        PayloadReturnTrue,    // `payloadSize` bytes of returndata, first word == 1
+        PayloadRevert         // revert with `payloadSize` bytes of revert data
+    }
+
+    Mode public mode;
+    uint256 public payloadSize;
+    mapping(uint256 => mapping(address => bool)) public memberOf;
+
+    function setMode(Mode _mode) external {
+        mode = _mode;
+    }
+
+    function setPayloadSize(uint256 _payloadSize) external {
+        payloadSize = _payloadSize;
+    }
+
+    function setMemberOf(uint256 _groupId, address _account, bool _isMember) external {
+        memberOf[_groupId][_account] = _isMember;
+    }
+
+    function isMember(uint256 _groupId, address _account) external view override returns (bool) {
+        Mode currentMode = mode;
+        if (currentMode == Mode.MembershipMap) return memberOf[_groupId][_account];
+        if (currentMode == Mode.ReturnTrue) return true;
+        if (currentMode == Mode.ReturnFalse) return false;
+        if (currentMode == Mode.ReturnTwo) {
+            assembly { mstore(0x00, 2) return(0x00, 0x20) }
+        }
+        if (currentMode == Mode.ReturnMax) {
+            assembly { mstore(0x00, not(0)) return(0x00, 0x20) }
+        }
+        if (currentMode == Mode.ReturnShort) {
+            assembly { mstore(0x00, 1) return(0x00, 0x10) }
+        }
+        if (currentMode == Mode.Revert) {
+            revert("resolver failed");
+        }
+        if (currentMode == Mode.BurnGas) {
+            assembly {
+                for { } 1 { } { pop(keccak256(0x00, 0x20)) }
+            }
+        }
+        uint256 size = payloadSize;
+        if (currentMode == Mode.PayloadReturnNotOne) {
+            assembly { mstore(0x00, 2) return(0x00, size) }
+        }
+        if (currentMode == Mode.PayloadReturnTrue) {
+            assembly { mstore(0x00, 1) return(0x00, size) }
+        }
+        // Mode.PayloadRevert
+        assembly { revert(0x00, size) }
+    }
+}

--- a/contracts/registries/AddressGroupRegistry.sol
+++ b/contracts/registries/AddressGroupRegistry.sol
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { IAddressGroupRegistry } from "../interfaces/IAddressGroupRegistry.sol";
+import { IWhitelistResolver } from "../interfaces/IWhitelistResolver.sol";
+
+/**
+ * @title AddressGroupRegistry
+ * @notice Permissionless registry of owner-managed address groups. Groups are identified by a
+ * sequential uint256 id (starting at 1) and are never deleted. Only the group owner mutates
+ * members and the resolver; shared control is achieved by using a multisig as the owner.
+ * @dev The integer id is only unique within one registry deployment on one chain — off-chain
+ * consumers must key groups by (chainId, registryAddress, groupId).
+ *
+ * TRUST MODEL: attaching a group to any consumer (e.g. WhitelistPreIntentHookV2) delegates
+ * ongoing admission policy to the group's controller set: the current owner, any future owner
+ * after transfer, and the current and any future resolver. Any of these can admit arbitrary
+ * accounts at any time.
+ */
+contract AddressGroupRegistry is IAddressGroupRegistry {
+
+    /* ============ Structs ============ */
+
+    struct Group {
+        address owner;
+        address pendingOwner;
+        address resolver;
+    }
+
+    /* ============ Events ============ */
+
+    event GroupCreated(uint256 indexed groupId, address indexed owner, string name);
+    event GroupOwnershipTransferStarted(uint256 indexed groupId, address indexed owner, address indexed pendingOwner);
+    event GroupOwnershipTransferCancelled(uint256 indexed groupId, address indexed cancelledPendingOwner);
+    event GroupOwnershipTransferred(uint256 indexed groupId, address indexed previousOwner, address indexed newOwner);
+    event MemberAdded(uint256 indexed groupId, address indexed member);
+    event MemberRemoved(uint256 indexed groupId, address indexed member);
+    event ResolverSet(uint256 indexed groupId, address indexed oldResolver, address indexed newResolver);
+
+    /* ============ Errors ============ */
+
+    error GroupDoesNotExist(uint256 groupId);
+    error UnauthorizedGroupOwner(address caller, address owner);
+    error UnauthorizedPendingOwner(address caller, address pendingOwner);
+    error NoPendingTransfer(uint256 groupId);
+    error ZeroAddress();
+    error EmptyArray();
+    error ResolverNotContract(address resolver);
+
+    /* ============ Constants ============ */
+
+    // Gas forwarded to resolver staticcalls. Sized so mapping- or balanceOf-style checks fit
+    // comfortably while bounding the cost a malicious resolver can impose on callers.
+    uint256 public constant RESOLVER_GAS_LIMIT = 50_000;
+
+    /* ============ State Variables ============ */
+
+    uint256 public override groupCount;                                 // last assigned id; ids start at 1
+
+    mapping(uint256 => Group) internal groups;
+    // groupId => account => curated membership
+    mapping(uint256 => mapping(address => bool)) public members;
+
+    /* ============ External Functions ============ */
+
+    /**
+     * @notice Creates a new group owned by the caller.
+     * @param _name    Human-readable label, emitted in the event only (not stored).
+     */
+    function createGroup(string calldata _name) external override returns (uint256 groupId) {
+        groupId = ++groupCount;
+        groups[groupId].owner = msg.sender;
+        emit GroupCreated(groupId, msg.sender, _name);
+    }
+
+    /**
+     * @notice Starts a two-step ownership transfer. Replaces any existing pending owner.
+     * @param _groupId    Group id.
+     * @param _newOwner   Proposed new owner (must be nonzero; cancellation is a dedicated function).
+     */
+    function transferGroupOwnership(uint256 _groupId, address _newOwner) external override {
+        Group storage group = _requireGroupOwner(_groupId);
+        if (_newOwner == address(0)) revert ZeroAddress();
+
+        group.pendingOwner = _newOwner;
+        emit GroupOwnershipTransferStarted(_groupId, msg.sender, _newOwner);
+    }
+
+    /**
+     * @notice Cancels a pending ownership transfer.
+     * @param _groupId    Group id.
+     */
+    function cancelGroupOwnershipTransfer(uint256 _groupId) external override {
+        Group storage group = _requireGroupOwner(_groupId);
+        address pendingOwner = group.pendingOwner;
+        if (pendingOwner == address(0)) revert NoPendingTransfer(_groupId);
+
+        delete group.pendingOwner;
+        emit GroupOwnershipTransferCancelled(_groupId, pendingOwner);
+    }
+
+    /**
+     * @notice Completes a pending ownership transfer. Callable only by the pending owner.
+     * The previous owner retains no access after acceptance.
+     * @param _groupId    Group id.
+     */
+    function acceptGroupOwnership(uint256 _groupId) external override {
+        Group storage group = groups[_groupId];
+        if (group.owner == address(0)) revert GroupDoesNotExist(_groupId);
+        if (msg.sender != group.pendingOwner) revert UnauthorizedPendingOwner(msg.sender, group.pendingOwner);
+
+        address previousOwner = group.owner;
+        group.owner = msg.sender;
+        delete group.pendingOwner;
+        emit GroupOwnershipTransferred(_groupId, previousOwner, msg.sender);
+    }
+
+    /**
+     * @notice Adds members to a group. Idempotent: already-present members are skipped (no event).
+     * @param _groupId    Group id.
+     * @param _members    Members to add.
+     */
+    function addMembers(uint256 _groupId, address[] calldata _members) external override {
+        _requireGroupOwner(_groupId);
+        if (_members.length == 0) revert EmptyArray();
+
+        for (uint256 i = 0; i < _members.length; i++) {
+            address member = _members[i];
+            if (member == address(0)) revert ZeroAddress();
+            if (!members[_groupId][member]) {
+                members[_groupId][member] = true;
+                emit MemberAdded(_groupId, member);
+            }
+        }
+    }
+
+    /**
+     * @notice Removes members from a group. Idempotent: absent members are skipped (no event).
+     * @param _groupId    Group id.
+     * @param _members    Members to remove.
+     */
+    function removeMembers(uint256 _groupId, address[] calldata _members) external override {
+        _requireGroupOwner(_groupId);
+        if (_members.length == 0) revert EmptyArray();
+
+        for (uint256 i = 0; i < _members.length; i++) {
+            address member = _members[i];
+            if (member == address(0)) revert ZeroAddress();
+            if (members[_groupId][member]) {
+                members[_groupId][member] = false;
+                emit MemberRemoved(_groupId, member);
+            }
+        }
+    }
+
+    /**
+     * @notice Sets or clears the group's resolver. A nonzero resolver must have code; note this
+     * does not make upgradeable or malicious resolvers safe — the resolver is part of the
+     * group's trust surface.
+     * @param _groupId    Group id.
+     * @param _resolver   Resolver contract (address(0) to clear).
+     */
+    function setResolver(uint256 _groupId, address _resolver) external override {
+        Group storage group = _requireGroupOwner(_groupId);
+        if (_resolver != address(0) && _resolver.code.length == 0) revert ResolverNotContract(_resolver);
+
+        emit ResolverSet(_groupId, group.resolver, _resolver);
+        group.resolver = _resolver;
+    }
+
+    /* ============ External View Functions ============ */
+
+    /**
+     * @notice Returns whether an account is a member of a group (curated OR resolver).
+     * Returns false for nonexistent groups. Resolver failures fail closed for that resolver
+     * only — they never revert this call.
+     * @param _groupId    Group id.
+     * @param _account    Account to check.
+     */
+    function isMember(uint256 _groupId, address _account) public view override returns (bool) {
+        if (members[_groupId][_account]) return true;
+
+        address resolver = groups[_groupId].resolver;
+        if (resolver == address(0)) return false;
+
+        return _resolverSaysYes(resolver, _groupId, _account);
+    }
+
+    /**
+     * @notice Returns whether a group exists (input validation only — not a trust guarantee).
+     * @param _groupId    Group id.
+     */
+    function groupExists(uint256 _groupId) external view override returns (bool) {
+        return groups[_groupId].owner != address(0);
+    }
+
+    /**
+     * @notice Returns a group's governance state for atomic inspection.
+     * @param _groupId    Group id.
+     */
+    function getGroup(uint256 _groupId)
+        external
+        view
+        override
+        returns (address owner, address pendingOwner, address resolver, bool exists)
+    {
+        Group storage group = groups[_groupId];
+        return (group.owner, group.pendingOwner, group.resolver, group.owner != address(0));
+    }
+
+    /* ============ Internal Functions ============ */
+
+    function _requireGroupOwner(uint256 _groupId) internal view returns (Group storage group) {
+        group = groups[_groupId];
+        if (group.owner == address(0)) revert GroupDoesNotExist(_groupId);
+        if (msg.sender != group.owner) revert UnauthorizedGroupOwner(msg.sender, group.owner);
+    }
+
+    /**
+     * @dev Task 2 replaces this stub with the hardened staticcall. Curated-only until then.
+     */
+    function _resolverSaysYes(address _resolver, uint256 _groupId, address _account) internal view returns (bool) {
+        _resolver; _groupId; _account;
+        return false;
+    }
+
+    /**
+     * @dev Virtual so the gas-harness mock can raise the limit for the bounded-copy proof test.
+     */
+    function _resolverGasLimit() internal view virtual returns (uint256) {
+        return RESOLVER_GAS_LIMIT;
+    }
+}

--- a/contracts/registries/AddressGroupRegistry.sol
+++ b/contracts/registries/AddressGroupRegistry.sol
@@ -218,11 +218,21 @@ contract AddressGroupRegistry is IAddressGroupRegistry {
     }
 
     /**
-     * @dev Task 2 replaces this stub with the hardened staticcall. Curated-only until then.
+     * @dev Invokes the resolver with a fixed gas stipend and bounded returndata handling.
+     * Uses the 0x00-0x3f scratch space as the 32-byte output buffer; never copies
+     * attacker-controlled returndata sizes. Success requires the call to succeed, at least
+     * 32 bytes of returndata, and the first word to be exactly 1. Any failure (revert,
+     * out-of-gas, short or malformed return, no code at call time) evaluates to false.
      */
-    function _resolverSaysYes(address _resolver, uint256 _groupId, address _account) internal view returns (bool) {
-        _resolver; _groupId; _account;
-        return false;
+    function _resolverSaysYes(address _resolver, uint256 _groupId, address _account) internal view returns (bool result) {
+        bytes memory callData = abi.encodeWithSelector(IWhitelistResolver.isMember.selector, _groupId, _account);
+        uint256 gasLimit = _resolverGasLimit();
+        assembly ("memory-safe") {
+            let success := staticcall(gasLimit, _resolver, add(callData, 0x20), mload(callData), 0x00, 0x20)
+            if and(success, gt(returndatasize(), 0x1f)) {
+                result := eq(mload(0x00), 1)
+            }
+        }
     }
 
     /**

--- a/deploy/29_deploy_whitelist_groups.ts
+++ b/deploy/29_deploy_whitelist_groups.ts
@@ -1,0 +1,52 @@
+import "module-alias/register";
+
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+import {
+  getDeployedContractAddress,
+  waitForDeploymentDelay,
+} from "../deployments/helpers";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deploy } = await hre.deployments;
+  const network = hre.deployments.getNetworkName();
+
+  const [deployer] = await hre.getUnnamedAccounts();
+
+  const orchestratorRegistryAddress = getDeployedContractAddress(network, "OrchestratorRegistry");
+
+  console.log("=== Deploying AddressGroupRegistry + WhitelistPreIntentHookV2 ===");
+
+  const addressGroupRegistry = await deploy("AddressGroupRegistry", {
+    from: deployer,
+    args: [],
+  });
+  console.log("AddressGroupRegistry deployed at", addressGroupRegistry.address);
+  await waitForDeploymentDelay(hre);
+
+  const whitelistPreIntentHookV2 = await deploy("WhitelistPreIntentHookV2", {
+    from: deployer,
+    args: [orchestratorRegistryAddress, addressGroupRegistry.address],
+  });
+  console.log("WhitelistPreIntentHookV2 deployed at", whitelistPreIntentHookV2.address);
+  await waitForDeploymentDelay(hre);
+
+  console.log("=== Deployment finished ===");
+  console.log("NOTE: neither contract is owned or registered anywhere — depositors opt in via setDepositWhitelistHook");
+};
+
+func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> => {
+  const network = hre.network.name;
+  try {
+    getDeployedContractAddress(network, "WhitelistPreIntentHookV2");
+    return true; // already deployed
+  } catch (e) {
+    return false;
+  }
+};
+
+func.tags = ["29_deploy_whitelist_groups"];
+func.dependencies = ["14_deploy_v2_system"];
+
+export default func;

--- a/packages/contracts/scripts/extractors/abis.ts
+++ b/packages/contracts/scripts/extractors/abis.ts
@@ -26,6 +26,8 @@ const SOURCE_ABI_ARTIFACTS: Record<string, string> = {
   NullifierRegistryV2: 'contracts/registries/NullifierRegistryV2.sol/NullifierRegistryV2.json',
   UnifiedPaymentVerifierV3:
     'contracts/unifiedVerifier/UnifiedPaymentVerifierV3.sol/UnifiedPaymentVerifierV3.json',
+  AddressGroupRegistry: 'contracts/registries/AddressGroupRegistry.sol/AddressGroupRegistry.json',
+  WhitelistPreIntentHookV2: 'contracts/hooks/WhitelistPreIntentHookV2.sol/WhitelistPreIntentHookV2.json',
 };
 
 function ensureDir(dir: string) {

--- a/test-foundry/deterministic/hooks/WhitelistPreIntentHookV2.t.sol
+++ b/test-foundry/deterministic/hooks/WhitelistPreIntentHookV2.t.sol
@@ -329,4 +329,263 @@ contract WhitelistPreIntentHookV2Test is Test {
         vm.prank(taker);
         hook.validateSignalIntent(context);
     }
+    /* ============ group attachment ============ */
+
+    function _newGroup(address groupOwner) internal returns (uint256 groupId) {
+        vm.prank(groupOwner);
+        groupId = groupRegistry.createGroup("g");
+    }
+
+    function _attach(address caller, uint256[] memory ids) internal {
+        vm.prank(caller);
+        hook.attachGroups(address(escrow), 0, ids);
+    }
+
+    function _detach(address caller, uint256[] memory ids) internal {
+        vm.prank(caller);
+        hook.detachGroups(address(escrow), 0, ids);
+    }
+
+    function test_DepositorAttachesGroupAndEmits() public {
+        uint256 groupId = _newGroup(depositor);
+        vm.expectEmit(true, true, true, true, address(hook));
+        emit GroupAttached(address(escrow), 0, groupId);
+        _attach(depositor, _groupIds(groupId));
+        assertTrue(hook.isGroupAttached(address(escrow), 0, groupId));
+        uint256[] memory attached = hook.getAttachedGroups(address(escrow), 0);
+        assertEq(attached.length, 1);
+        assertEq(attached[0], groupId);
+    }
+
+    function test_DelegateCanAttachGroups() public {
+        uint256 groupId = _newGroup(depositor);
+        _attach(delegate, _groupIds(groupId));
+        assertTrue(hook.isGroupAttached(address(escrow), 0, groupId));
+    }
+
+    function test_UnauthorizedCannotAttachGroups() public {
+        uint256 groupId = _newGroup(depositor);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                WhitelistPreIntentHookV2.UnauthorizedCallerOrDelegate.selector, unauthorized, depositor, delegate
+            )
+        );
+        _attach(unauthorized, _groupIds(groupId));
+    }
+
+    function test_AttachNonexistentGroupReverts() public {
+        vm.expectRevert(abi.encodeWithSelector(WhitelistPreIntentHookV2.GroupDoesNotExist.selector, 42));
+        _attach(depositor, _groupIds(42));
+    }
+
+    function test_AttachGroupZeroReverts() public {
+        vm.expectRevert(abi.encodeWithSelector(WhitelistPreIntentHookV2.GroupDoesNotExist.selector, 0));
+        _attach(depositor, _groupIds(0));
+    }
+
+    function test_AttachEmptyArrayReverts() public {
+        vm.expectRevert(WhitelistPreIntentHookV2.EmptyArray.selector);
+        _attach(depositor, new uint256[](0));
+    }
+
+    function test_NonexistentIdInBatchRevertsWholeAttach() public {
+        uint256 valid = _newGroup(depositor);
+        uint256[] memory mixed = new uint256[](2);
+        mixed[0] = valid;
+        mixed[1] = 999; // nonexistent
+        vm.expectRevert(abi.encodeWithSelector(WhitelistPreIntentHookV2.GroupDoesNotExist.selector, 999));
+        _attach(depositor, mixed);
+        assertFalse(hook.isGroupAttached(address(escrow), 0, valid)); // earlier element rolled back
+    }
+
+    function test_DetachEmptyArrayReverts() public {
+        vm.expectRevert(WhitelistPreIntentHookV2.EmptyArray.selector);
+        _detach(depositor, new uint256[](0));
+    }
+
+    function test_AttachAlreadyAttachedIsNoOpWithoutEvent() public {
+        uint256 groupId = _newGroup(depositor);
+        _attach(depositor, _groupIds(groupId));
+        vm.recordLogs();
+        _attach(depositor, _groupIds(groupId));
+        assertEq(vm.getRecordedLogs().length, 0);
+        assertEq(hook.getAttachedGroups(address(escrow), 0).length, 1);
+    }
+
+    function test_DetachAbsentGroupIsNoOpWithoutEvent() public {
+        vm.recordLogs();
+        _detach(depositor, _groupIds(7));
+        assertEq(vm.getRecordedLogs().length, 0);
+    }
+
+    function test_DetachGroupZeroIsNoOp() public {
+        vm.recordLogs();
+        _detach(depositor, _groupIds(0));
+        assertEq(vm.getRecordedLogs().length, 0);
+    }
+
+    function test_MaxGroupsCapEnforced() public {
+        uint256[] memory ids = new uint256[](11);
+        for (uint256 i = 0; i < 11; i++) {
+            ids[i] = _newGroup(depositor);
+        }
+        uint256[] memory firstTen = new uint256[](10);
+        for (uint256 i = 0; i < 10; i++) {
+            firstTen[i] = ids[i];
+        }
+        _attach(depositor, firstTen);
+        vm.expectRevert(abi.encodeWithSelector(WhitelistPreIntentHookV2.MaxGroupsExceeded.selector, 11, 10));
+        _attach(depositor, _groupIds(ids[10]));
+    }
+
+    function test_DetachSwapAndPopKeepsIndexIntegrity() public {
+        uint256 a = _newGroup(depositor);
+        uint256 b = _newGroup(depositor);
+        uint256 c = _newGroup(depositor);
+        uint256[] memory all = new uint256[](3);
+        all[0] = a; all[1] = b; all[2] = c;
+        _attach(depositor, all);
+
+        vm.expectEmit(true, true, true, true, address(hook));
+        emit GroupDetached(address(escrow), 0, a);
+        _detach(depositor, _groupIds(a));
+
+        uint256[] memory attached = hook.getAttachedGroups(address(escrow), 0);
+        assertEq(attached.length, 2);
+        assertEq(attached[0], c); // last element swapped into a's slot
+        assertEq(attached[1], b);
+        assertFalse(hook.isGroupAttached(address(escrow), 0, a));
+        assertTrue(hook.isGroupAttached(address(escrow), 0, b));
+        assertTrue(hook.isGroupAttached(address(escrow), 0, c));
+
+        // detach the (moved) last element too
+        _detach(depositor, _groupIds(b));
+        attached = hook.getAttachedGroups(address(escrow), 0);
+        assertEq(attached.length, 1);
+        assertEq(attached[0], c);
+    }
+
+    function test_DetachedGroupCanBeReattached() public {
+        uint256 groupId = _newGroup(depositor);
+        _attach(depositor, _groupIds(groupId));
+        _detach(depositor, _groupIds(groupId));
+        _attach(depositor, _groupIds(groupId));
+        assertTrue(hook.isGroupAttached(address(escrow), 0, groupId));
+    }
+
+    /* ============ validateSignalIntent — group path ============ */
+
+    function test_CuratedGroupMemberCanSignal() public {
+        uint256 groupId = _newGroup(depositor);
+        vm.prank(depositor);
+        groupRegistry.addMembers(groupId, _address(taker));
+        _attach(depositor, _groupIds(groupId));
+        _signalCall();
+        assertEq(orchestrator.getAccountIntents(taker).length, 1);
+    }
+
+    function test_ThirdPartyGroupMemberCanSignal() public {
+        address thirdParty = makeAddr("thirdParty");
+        uint256 groupId = _newGroup(thirdParty);
+        vm.prank(thirdParty);
+        groupRegistry.addMembers(groupId, _address(taker));
+        _attach(depositor, _groupIds(groupId));
+        _signalCall();
+        assertEq(orchestrator.getAccountIntents(taker).length, 1);
+    }
+
+    function test_ResolverGroupMemberCanSignal() public {
+        uint256 groupId = _newGroup(depositor);
+        vm.prank(depositor);
+        groupRegistry.setResolver(groupId, address(resolverMock));
+        resolverMock.setMemberOf(groupId, taker, true);
+        _attach(depositor, _groupIds(groupId));
+        _signalCall();
+        assertEq(orchestrator.getAccountIntents(taker).length, 1);
+    }
+
+    function test_NonMemberOfAttachedGroupsCannotSignal() public {
+        uint256 groupId = _newGroup(depositor);
+        _attach(depositor, _groupIds(groupId));
+        _expectNotWhitelistedRevert();
+        _signalCall();
+    }
+
+    function test_MatchInLastOfTenGroupsSignals() public {
+        uint256[] memory ids = new uint256[](10);
+        for (uint256 i = 0; i < 10; i++) {
+            ids[i] = _newGroup(depositor);
+        }
+        _attach(depositor, ids);
+        vm.prank(depositor);
+        groupRegistry.addMembers(ids[9], _address(taker));
+        _signalCall();
+        assertEq(orchestrator.getAccountIntents(taker).length, 1);
+    }
+
+    function test_MatchInMiddleOfTenGroupsSignals() public {
+        uint256[] memory ids = new uint256[](10);
+        for (uint256 i = 0; i < 10; i++) {
+            ids[i] = _newGroup(depositor);
+        }
+        _attach(depositor, ids);
+        vm.prank(depositor);
+        groupRegistry.addMembers(ids[5], _address(taker));
+        _signalCall();
+        assertEq(orchestrator.getAccountIntents(taker).length, 1);
+    }
+
+    function test_DirectMatchShortCircuitsWithoutRegistryCalls() public {
+        uint256 groupId = _newGroup(depositor);
+        _attach(depositor, _groupIds(groupId));
+        _add(depositor, _address(taker));
+        vm.expectCall(address(groupRegistry), abi.encodeCall(groupRegistry.isMember, (groupId, taker)), 0);
+        _signalCall();
+        assertEq(orchestrator.getAccountIntents(taker).length, 1);
+    }
+
+    function test_GroupMatchShortCircuitsLaterGroupResolvers() public {
+        uint256 first = _newGroup(depositor);
+        uint256 second = _newGroup(depositor);
+        vm.prank(depositor);
+        groupRegistry.addMembers(first, _address(taker));
+        vm.prank(depositor);
+        groupRegistry.setResolver(second, address(resolverMock));
+        uint256[] memory both = new uint256[](2);
+        both[0] = first; both[1] = second;
+        _attach(depositor, both);
+        // match in the first group must not query the second group at all
+        vm.expectCall(address(groupRegistry), abi.encodeCall(groupRegistry.isMember, (second, taker)), 0);
+        vm.expectCall(address(resolverMock), abi.encodeCall(resolverMock.isMember, (second, taker)), 0);
+        _signalCall();
+        assertEq(orchestrator.getAccountIntents(taker).length, 1);
+    }
+
+    function test_RevertingResolverInEarlierGroupDoesNotBlockLaterGroupMatch() public {
+        uint256 broken = _newGroup(depositor);
+        uint256 good = _newGroup(depositor);
+        vm.prank(depositor);
+        groupRegistry.setResolver(broken, address(resolverMock));
+        resolverMock.setMode(WhitelistResolverMock.Mode.Revert);
+        vm.prank(depositor);
+        groupRegistry.addMembers(good, _address(taker));
+        uint256[] memory both = new uint256[](2);
+        both[0] = broken; both[1] = good;
+        _attach(depositor, both);
+        _signalCall();
+        assertEq(orchestrator.getAccountIntents(taker).length, 1);
+    }
+
+    function test_IsAllowedTakerMatchesValidateSemantics() public {
+        uint256 groupId = _newGroup(depositor);
+        _attach(depositor, _groupIds(groupId));
+        assertFalse(hook.isAllowedTaker(address(escrow), 0, taker));
+        vm.prank(depositor);
+        groupRegistry.addMembers(groupId, _address(taker));
+        assertTrue(hook.isAllowedTaker(address(escrow), 0, taker));
+        _detach(depositor, _groupIds(groupId));
+        assertFalse(hook.isAllowedTaker(address(escrow), 0, taker));
+        _add(depositor, _address(taker));
+        assertTrue(hook.isAllowedTaker(address(escrow), 0, taker));
+    }
 }

--- a/test-foundry/deterministic/hooks/WhitelistPreIntentHookV2.t.sol
+++ b/test-foundry/deterministic/hooks/WhitelistPreIntentHookV2.t.sol
@@ -588,4 +588,112 @@ contract WhitelistPreIntentHookV2Test is Test {
         _add(depositor, _address(taker));
         assertTrue(hook.isAllowedTaker(address(escrow), 0, taker));
     }
+    /* ============ configuration persistence and lifecycle ============ */
+
+    function test_ConfigPersistsAcrossHookUnsetAndReattach() public {
+        uint256 groupId = _newGroup(depositor);
+        _attach(depositor, _groupIds(groupId));
+        _add(depositor, _address(taker));
+
+        // unset hook slot => whitelist paused, anyone can signal
+        vm.prank(depositor);
+        orchestrator.setDepositWhitelistHook(address(escrow), 0, IPreIntentHook(address(0)));
+        vm.prank(unauthorized);
+        orchestrator.signalIntent(_paramsFor(unauthorized));
+        assertEq(orchestrator.getAccountIntents(unauthorized).length, 1);
+
+        // reattach => dormant config resumes: direct entry and attached group intact
+        vm.prank(depositor);
+        orchestrator.setDepositWhitelistHook(address(escrow), 0, IPreIntentHook(address(hook)));
+        assertTrue(hook.isWhitelisted(address(escrow), 0, taker));
+        assertTrue(hook.isGroupAttached(address(escrow), 0, groupId));
+        _expectNotWhitelistedRevertFor(takerTwo);
+        vm.prank(takerTwo);
+        orchestrator.signalIntent(_paramsFor(takerTwo));
+    }
+
+    function test_MembershipRemovalDoesNotInvalidateSignaledIntent() public {
+        uint256 groupId = _newGroup(depositor);
+        vm.prank(depositor);
+        groupRegistry.addMembers(groupId, _address(taker));
+        _attach(depositor, _groupIds(groupId));
+        _signalCall();
+        bytes32[] memory intents = orchestrator.getAccountIntents(taker);
+        assertEq(intents.length, 1);
+
+        vm.prank(depositor);
+        groupRegistry.removeMembers(groupId, _address(taker));
+        // the already-signaled intent still exists and is untouched
+        assertEq(orchestrator.getAccountIntents(taker).length, 1);
+        // but a new signal is rejected (point-in-time admission)
+        _expectNotWhitelistedRevert();
+        _signalCall();
+    }
+
+    function test_SetupRaceWindowIsRealBeforeHookAttachment() public {
+        // Demonstrates the documented limitation: a second deposit (id 1) accepts intents
+        // between createDeposit and setDepositWhitelistHook.
+        vm.startPrank(depositor);
+        token.approve(address(escrow), 10_000e6);
+        _createDeposit(); // deposit id 1, no hook configured yet
+        vm.stopPrank();
+
+        IOrchestratorV3.SignalIntentParams memory params = _paramsFor(unauthorized);
+        params.depositId = 1;
+        vm.prank(unauthorized);
+        orchestrator.signalIntent(params); // succeeds — window is open
+        assertEq(orchestrator.getAccountIntents(unauthorized).length, 1);
+    }
+
+    function test_HookRejectionPrecedesLiquidityCheck() public {
+        // Validation order under test: OrchestratorV3.signalIntent runs _validateSignalIntent
+        // (no liquidity check), then the hooks, and only locks funds afterwards — so a
+        // non-member must get TakerNotWhitelisted even when the deposit is drained, while a
+        // whitelisted taker passes the hook and then hits InsufficientDepositLiquidity.
+        _add(depositor, _address(taker));
+        IOrchestratorV3.SignalIntentParams memory params = _signalParams();
+        params.amount = 100e6; // drain the entire deposit
+        vm.prank(taker);
+        orchestrator.signalIntent(params);
+
+        _expectNotWhitelistedRevertFor(takerTwo);
+        vm.prank(takerTwo);
+        orchestrator.signalIntent(_paramsFor(takerTwo));
+
+        _add(depositor, _address(takerTwo));
+        vm.expectRevert(
+            abi.encodeWithSelector(IEscrowV2.InsufficientDepositLiquidity.selector, 0, 0, INTENT_AMOUNT)
+        );
+        vm.prank(takerTwo);
+        orchestrator.signalIntent(_paramsFor(takerTwo));
+    }
+
+    function test_NewDelegateGainsConfigRightsOldDelegateLosesThem() public {
+        address newDelegate = makeAddr("newDelegate");
+        vm.prank(depositor);
+        escrow.setDelegate(0, newDelegate);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                WhitelistPreIntentHookV2.UnauthorizedCallerOrDelegate.selector, delegate, depositor, newDelegate
+            )
+        );
+        _add(delegate, _address(taker));
+
+        _add(newDelegate, _address(taker));
+        assertTrue(hook.isWhitelisted(address(escrow), 0, taker));
+    }
+
+    /* ============ helpers for the above ============ */
+
+    function _paramsFor(address signaler) internal view returns (IOrchestratorV3.SignalIntentParams memory params) {
+        params = _signalParams();
+        params.to = signaler;
+    }
+
+    function _expectNotWhitelistedRevertFor(address who) internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(WhitelistPreIntentHookV2.TakerNotWhitelisted.selector, who, address(escrow), 0)
+        );
+    }
 }

--- a/test-foundry/deterministic/hooks/WhitelistPreIntentHookV2.t.sol
+++ b/test-foundry/deterministic/hooks/WhitelistPreIntentHookV2.t.sol
@@ -252,6 +252,15 @@ contract WhitelistPreIntentHookV2Test is Test {
         vm.expectRevert(WhitelistPreIntentHookV2.ZeroAddress.selector);
         vm.prank(depositor);
         hook.addToWhitelist(address(0), 0, _address(taker));
+        vm.expectRevert(WhitelistPreIntentHookV2.ZeroAddress.selector);
+        vm.prank(depositor);
+        hook.removeFromWhitelist(address(0), 0, _address(taker));
+        vm.expectRevert(WhitelistPreIntentHookV2.ZeroAddress.selector);
+        vm.prank(depositor);
+        hook.attachGroups(address(0), 0, _groupIds(0));
+        vm.expectRevert(WhitelistPreIntentHookV2.ZeroAddress.selector);
+        vm.prank(depositor);
+        hook.detachGroups(address(0), 0, _groupIds(0));
     }
 
     function test_EmptyBatchReverts() public {

--- a/test-foundry/deterministic/hooks/WhitelistPreIntentHookV2.t.sol
+++ b/test-foundry/deterministic/hooks/WhitelistPreIntentHookV2.t.sol
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {EscrowV2} from "contracts/EscrowV2.sol";
+import {OrchestratorV3} from "contracts/OrchestratorV3.sol";
+import {WhitelistPreIntentHookV2} from "contracts/hooks/WhitelistPreIntentHookV2.sol";
+import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
+import {WhitelistResolverMock} from "contracts/mocks/WhitelistResolverMock.sol";
+import {PaymentVerifierMock} from "contracts/mocks/PaymentVerifierMock.sol";
+import {USDCMock} from "contracts/mocks/USDCMock.sol";
+import {EscrowRegistry} from "contracts/registries/EscrowRegistry.sol";
+import {OrchestratorRegistry} from "contracts/registries/OrchestratorRegistry.sol";
+import {PaymentVerifierRegistry} from "contracts/registries/PaymentVerifierRegistry.sol";
+import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
+import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
+import {IPostIntentHookV2} from "contracts/interfaces/IPostIntentHookV2.sol";
+import {IPreIntentHook} from "contracts/interfaces/IPreIntentHook.sol";
+import {IReferralFee} from "contracts/interfaces/IReferralFee.sol";
+
+contract WhitelistPreIntentHookV2Test is Test {
+    event TakerWhitelisted(address indexed escrow, uint256 indexed depositId, address indexed taker);
+    event TakerRemovedFromWhitelist(address indexed escrow, uint256 indexed depositId, address indexed taker);
+    event GroupAttached(address indexed escrow, uint256 indexed depositId, uint256 indexed groupId);
+    event GroupDetached(address indexed escrow, uint256 indexed depositId, uint256 indexed groupId);
+
+    uint256 internal constant CHAIN_ID = 1;
+    uint256 internal constant INTENT_AMOUNT = 50e6;
+    uint256 internal constant CONVERSION_RATE = 1.02e18;
+    bytes32 internal constant METHOD = keccak256("venmo");
+    bytes32 internal constant USD = keccak256("USD");
+    bytes32 internal constant PAYEE = keccak256("payeeDetails");
+
+    address internal depositor;
+    address internal delegate;
+    address internal taker;
+    address internal takerTwo;
+    address internal unauthorized;
+    USDCMock internal token;
+    EscrowV2 internal escrow;
+    OrchestratorV3 internal orchestrator;
+    OrchestratorRegistry internal orchestratorRegistry;
+    AddressGroupRegistry internal groupRegistry;
+    WhitelistPreIntentHookV2 internal hook;
+    WhitelistResolverMock internal resolverMock;
+
+    function setUp() public {
+        depositor = makeAddr("depositor");
+        delegate = makeAddr("delegate");
+        taker = makeAddr("taker");
+        takerTwo = makeAddr("takerTwo");
+        unauthorized = makeAddr("unauthorized");
+        token = new USDCMock(1_000_000_000e6, "USDC", "USDC");
+        token.transfer(depositor, 10_000e6);
+
+        EscrowRegistry escrowRegistry = new EscrowRegistry();
+        PaymentVerifierRegistry paymentVerifierRegistry = new PaymentVerifierRegistry();
+        orchestratorRegistry = new OrchestratorRegistry();
+        PaymentVerifierMock verifier = new PaymentVerifierMock();
+        bytes32[] memory currencies = new bytes32[](1);
+        currencies[0] = USD;
+        paymentVerifierRegistry.addPaymentMethod(METHOD, address(verifier), currencies);
+
+        escrow = new EscrowV2(
+            address(this),
+            CHAIN_ID,
+            address(orchestratorRegistry),
+            address(paymentVerifierRegistry),
+            address(0),
+            0,
+            10,
+            1 hours
+        );
+        escrowRegistry.addEscrow(address(escrow));
+        orchestrator = new OrchestratorV3(
+            address(this),
+            CHAIN_ID,
+            address(escrowRegistry),
+            address(paymentVerifierRegistry),
+            0,
+            address(this),
+            2_000_000 // risk callback gas limit (min 750k); no risk hooks are set in these tests
+        );
+        orchestratorRegistry.addOrchestrator(address(orchestrator));
+        verifier.setVerificationContext(address(orchestrator), address(escrow));
+
+        groupRegistry = new AddressGroupRegistry();
+        hook = new WhitelistPreIntentHookV2(address(orchestratorRegistry), address(groupRegistry));
+        resolverMock = new WhitelistResolverMock();
+
+        vm.startPrank(depositor);
+        token.approve(address(escrow), 10_000e6);
+        _createDeposit();
+        vm.stopPrank();
+
+        vm.prank(depositor);
+        orchestrator.setDepositWhitelistHook(address(escrow), 0, IPreIntentHook(address(hook)));
+    }
+
+    function _createDeposit() internal {
+        bytes32[] memory methods = new bytes32[](1);
+        methods[0] = METHOD;
+        IEscrowV2.DepositPaymentMethodData[] memory methodData = new IEscrowV2.DepositPaymentMethodData[](1);
+        methodData[0] =
+            IEscrowV2.DepositPaymentMethodData({intentGatingService: address(0), payeeDetails: PAYEE, data: ""});
+        IEscrowV2.Currency[][] memory currencies = new IEscrowV2.Currency[][](1);
+        currencies[0] = new IEscrowV2.Currency[](1);
+        currencies[0][0] = IEscrowV2.Currency({
+            code: USD,
+            minConversionRate: 1.01e18,
+            oracleRateConfig: IEscrowV2.OracleRateConfig({
+                adapter: address(0), adapterConfig: "", spreadBps: 0, maxStaleness: 0
+            })
+        });
+        escrow.createDeposit(
+            IEscrowV2.CreateDepositParams({
+                token: IERC20(address(token)),
+                amount: 100e6,
+                intentAmountRange: IEscrowV2.Range({min: 10e6, max: 200e6}),
+                paymentMethods: methods,
+                paymentMethodData: methodData,
+                currencies: currencies,
+                delegate: delegate,
+                intentGuardian: address(0),
+                retainOnEmpty: false
+            })
+        );
+    }
+
+    function _address(address value) internal pure returns (address[] memory values) {
+        values = new address[](1);
+        values[0] = value;
+    }
+
+    function _addresses(address first, address second) internal pure returns (address[] memory values) {
+        values = new address[](2);
+        values[0] = first;
+        values[1] = second;
+    }
+
+    function _groupIds(uint256 value) internal pure returns (uint256[] memory values) {
+        values = new uint256[](1);
+        values[0] = value;
+    }
+
+    function _add(address caller, address[] memory takers) internal {
+        vm.prank(caller);
+        hook.addToWhitelist(address(escrow), 0, takers);
+    }
+
+    function _remove(address caller, address[] memory takers) internal {
+        vm.prank(caller);
+        hook.removeFromWhitelist(address(escrow), 0, takers);
+    }
+
+    function _signalParams() internal view returns (IOrchestratorV3.SignalIntentParams memory params) {
+        IReferralFee.ReferralFee[] memory referralFees = new IReferralFee.ReferralFee[](0);
+        params = IOrchestratorV3.SignalIntentParams({
+            escrow: address(escrow),
+            depositId: 0,
+            amount: INTENT_AMOUNT,
+            to: taker,
+            paymentMethod: METHOD,
+            fiatCurrency: USD,
+            conversionRate: CONVERSION_RATE,
+            referralFees: referralFees,
+            gatingServiceSignature: "",
+            signatureExpiration: 0,
+            postIntentHook: IPostIntentHookV2(address(0)),
+            preIntentHookData: "",
+            data: ""
+        });
+    }
+
+    function _signalCall() internal {
+        vm.prank(taker);
+        orchestrator.signalIntent(_signalParams());
+    }
+
+    function _expectNotWhitelistedRevert() internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(WhitelistPreIntentHookV2.TakerNotWhitelisted.selector, taker, address(escrow), 0)
+        );
+    }
+
+    /* ============ constructor ============ */
+
+    function test_ConstructorRejectsZeroAddresses() public {
+        vm.expectRevert(WhitelistPreIntentHookV2.ZeroAddress.selector);
+        new WhitelistPreIntentHookV2(address(0), address(groupRegistry));
+        vm.expectRevert(WhitelistPreIntentHookV2.ZeroAddress.selector);
+        new WhitelistPreIntentHookV2(address(orchestratorRegistry), address(0));
+    }
+
+    function test_ConstructorStoresImmutables() public view {
+        assertEq(address(hook.orchestratorRegistry()), address(orchestratorRegistry));
+        assertEq(address(hook.groupRegistry()), address(groupRegistry));
+    }
+
+    /* ============ direct whitelist management ============ */
+
+    function test_DepositorAddsTakersAndEmitsPerTaker() public {
+        vm.expectEmit(true, true, true, true, address(hook));
+        emit TakerWhitelisted(address(escrow), 0, taker);
+        vm.expectEmit(true, true, true, true, address(hook));
+        emit TakerWhitelisted(address(escrow), 0, takerTwo);
+        _add(depositor, _addresses(taker, takerTwo));
+        assertTrue(hook.isWhitelisted(address(escrow), 0, taker));
+        assertTrue(hook.isWhitelisted(address(escrow), 0, takerTwo));
+    }
+
+    function test_DelegateCanAddTakers() public {
+        _add(delegate, _address(taker));
+        assertTrue(hook.isWhitelisted(address(escrow), 0, taker));
+    }
+
+    function test_UnauthorizedCannotAddTakers() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                WhitelistPreIntentHookV2.UnauthorizedCallerOrDelegate.selector, unauthorized, depositor, delegate
+            )
+        );
+        _add(unauthorized, _address(taker));
+    }
+
+    function test_AddExistingTakerIsNoOpWithoutEvent() public {
+        _add(depositor, _address(taker));
+        vm.recordLogs();
+        _add(depositor, _address(taker));
+        assertEq(vm.getRecordedLogs().length, 0);
+        assertTrue(hook.isWhitelisted(address(escrow), 0, taker));
+    }
+
+    function test_RemoveAbsentTakerIsNoOpWithoutEvent() public {
+        vm.recordLogs();
+        _remove(depositor, _address(taker));
+        assertEq(vm.getRecordedLogs().length, 0);
+    }
+
+    function test_DepositorRemovesTakerAndEmits() public {
+        _add(depositor, _addresses(taker, takerTwo));
+        vm.expectEmit(true, true, true, true, address(hook));
+        emit TakerRemovedFromWhitelist(address(escrow), 0, taker);
+        _remove(depositor, _address(taker));
+        assertFalse(hook.isWhitelisted(address(escrow), 0, taker));
+        assertTrue(hook.isWhitelisted(address(escrow), 0, takerTwo));
+    }
+
+    function test_ZeroEscrowReverts() public {
+        vm.expectRevert(WhitelistPreIntentHookV2.ZeroAddress.selector);
+        vm.prank(depositor);
+        hook.addToWhitelist(address(0), 0, _address(taker));
+    }
+
+    function test_EmptyBatchReverts() public {
+        vm.expectRevert(WhitelistPreIntentHookV2.EmptyArray.selector);
+        vm.prank(depositor);
+        hook.addToWhitelist(address(escrow), 0, new address[](0));
+        vm.expectRevert(WhitelistPreIntentHookV2.EmptyArray.selector);
+        vm.prank(depositor);
+        hook.removeFromWhitelist(address(escrow), 0, new address[](0));
+    }
+
+    function test_ZeroTakerReverts() public {
+        vm.expectRevert(WhitelistPreIntentHookV2.ZeroAddress.selector);
+        _add(depositor, _address(address(0)));
+        vm.expectRevert(WhitelistPreIntentHookV2.ZeroAddress.selector);
+        _remove(depositor, _address(address(0)));
+    }
+
+    function test_ZeroTakerInBatchRevertsWholeTransaction() public {
+        vm.expectRevert(WhitelistPreIntentHookV2.ZeroAddress.selector);
+        _add(depositor, _addresses(taker, address(0)));
+        assertFalse(hook.isWhitelisted(address(escrow), 0, taker)); // earlier element rolled back
+
+        _add(depositor, _address(taker));
+        vm.expectRevert(WhitelistPreIntentHookV2.ZeroAddress.selector);
+        _remove(depositor, _addresses(taker, address(0)));
+        assertTrue(hook.isWhitelisted(address(escrow), 0, taker)); // removal rolled back
+    }
+
+    function test_MixedBatchEmitsOnlyForStateChanges() public {
+        _add(depositor, _address(taker));
+        vm.recordLogs();
+        _add(depositor, _addresses(taker, takerTwo)); // taker existing, takerTwo new
+        assertEq(vm.getRecordedLogs().length, 1); // only takerTwo's TakerWhitelisted
+        assertTrue(hook.isWhitelisted(address(escrow), 0, takerTwo));
+    }
+
+    /* ============ validateSignalIntent — direct path ============ */
+
+    function test_DirectlyWhitelistedTakerCanSignal() public {
+        _add(depositor, _address(taker));
+        _signalCall();
+        assertEq(orchestrator.getAccountIntents(taker).length, 1);
+    }
+
+    function test_UnknownTakerCannotSignal() public {
+        _expectNotWhitelistedRevert();
+        _signalCall();
+    }
+
+    function test_RemovedTakerCannotSignal() public {
+        _add(depositor, _address(taker));
+        _remove(depositor, _address(taker));
+        _expectNotWhitelistedRevert();
+        _signalCall();
+    }
+
+    function test_DirectValidateCallRejectsNonOrchestrator() public {
+        IReferralFee.ReferralFee[] memory referralFees = new IReferralFee.ReferralFee[](0);
+        IPreIntentHook.PreIntentContext memory context = IPreIntentHook.PreIntentContext({
+            taker: taker,
+            escrow: address(escrow),
+            depositId: 0,
+            amount: INTENT_AMOUNT,
+            to: taker,
+            paymentMethod: METHOD,
+            fiatCurrency: USD,
+            conversionRate: CONVERSION_RATE,
+            referralFees: referralFees,
+            preIntentHookData: ""
+        });
+        vm.expectRevert(
+            abi.encodeWithSelector(WhitelistPreIntentHookV2.UnauthorizedOrchestratorCaller.selector, taker)
+        );
+        vm.prank(taker);
+        hook.validateSignalIntent(context);
+    }
+}

--- a/test-foundry/deterministic/hooks/WhitelistPreIntentHookV2Gas.t.sol
+++ b/test-foundry/deterministic/hooks/WhitelistPreIntentHookV2Gas.t.sol
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {EscrowV2} from "contracts/EscrowV2.sol";
+import {OrchestratorV3} from "contracts/OrchestratorV3.sol";
+import {WhitelistPreIntentHookV2} from "contracts/hooks/WhitelistPreIntentHookV2.sol";
+import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
+import {WhitelistResolverMock} from "contracts/mocks/WhitelistResolverMock.sol";
+import {PaymentVerifierMock} from "contracts/mocks/PaymentVerifierMock.sol";
+import {USDCMock} from "contracts/mocks/USDCMock.sol";
+import {EscrowRegistry} from "contracts/registries/EscrowRegistry.sol";
+import {OrchestratorRegistry} from "contracts/registries/OrchestratorRegistry.sol";
+import {PaymentVerifierRegistry} from "contracts/registries/PaymentVerifierRegistry.sol";
+import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
+import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
+import {IPostIntentHookV2} from "contracts/interfaces/IPostIntentHookV2.sol";
+import {IPreIntentHook} from "contracts/interfaces/IPreIntentHook.sol";
+import {IReferralFee} from "contracts/interfaces/IReferralFee.sol";
+
+// Benchmark protocol (from the design spec): deposit 0 attaches 10 groups, each with a
+// DISTINCT malicious resolver instance (a reused address would be warm after the first call
+// under EIP-2929 and understate worst-case gas). Deposit 1 is identically shaped with zero
+// groups. Foundry keeps EIP-2929 warmth across an entire test function, so `vm.cool` is
+// applied to every participating contract before EACH measurement — both measurements run
+// with all account and storage accesses cold, matching the spec's acceptance criterion.
+// Setup gas is excluded by measuring only the signalIntent call. Acceptance: delta of
+// (ten-malicious-group rejection) - (zero-group rejection) <= 700_000. Tuning order if
+// exceeded: RESOLVER_GAS_LIMIT first, MAX_GROUPS_PER_DEPOSIT second.
+contract WhitelistPreIntentHookV2GasTest is Test {
+    uint256 internal constant CHAIN_ID = 1;
+    uint256 internal constant INTENT_AMOUNT = 50e6;
+    uint256 internal constant CONVERSION_RATE = 1.02e18;
+    bytes32 internal constant METHOD = keccak256("venmo");
+    bytes32 internal constant USD = keccak256("USD");
+    bytes32 internal constant PAYEE = keccak256("payeeDetails");
+    uint256 internal constant MAX_REJECTION_DELTA = 700_000;
+
+    address internal depositor;
+    address internal taker;
+    USDCMock internal token;
+    EscrowV2 internal escrow;
+    OrchestratorV3 internal orchestrator;
+    OrchestratorRegistry internal orchestratorRegistry;
+    EscrowRegistry internal escrowRegistry;
+    PaymentVerifierRegistry internal paymentVerifierRegistry;
+    PaymentVerifierMock internal verifier;
+    AddressGroupRegistry internal groupRegistry;
+    WhitelistPreIntentHookV2 internal hook;
+    address[] internal contractsToCool;
+
+    function setUp() public {
+        depositor = makeAddr("depositor");
+        taker = makeAddr("taker");
+        token = new USDCMock(1_000_000_000e6, "USDC", "USDC");
+        token.transfer(depositor, 10_000e6);
+
+        escrowRegistry = new EscrowRegistry();
+        paymentVerifierRegistry = new PaymentVerifierRegistry();
+        orchestratorRegistry = new OrchestratorRegistry();
+        verifier = new PaymentVerifierMock();
+        bytes32[] memory currencies = new bytes32[](1);
+        currencies[0] = USD;
+        paymentVerifierRegistry.addPaymentMethod(METHOD, address(verifier), currencies);
+
+        escrow = new EscrowV2(
+            address(this),
+            CHAIN_ID,
+            address(orchestratorRegistry),
+            address(paymentVerifierRegistry),
+            address(0),
+            0,
+            10,
+            1 hours
+        );
+        escrowRegistry.addEscrow(address(escrow));
+        orchestrator = new OrchestratorV3(
+            address(this),
+            CHAIN_ID,
+            address(escrowRegistry),
+            address(paymentVerifierRegistry),
+            0,
+            address(this),
+            2_000_000 // risk callback gas limit (min 750k); no risk hooks are set in these tests
+        );
+        orchestratorRegistry.addOrchestrator(address(orchestrator));
+        verifier.setVerificationContext(address(orchestrator), address(escrow));
+
+        groupRegistry = new AddressGroupRegistry();
+        hook = new WhitelistPreIntentHookV2(address(orchestratorRegistry), address(groupRegistry));
+
+        vm.startPrank(depositor);
+        token.approve(address(escrow), 10_000e6);
+        _createDeposit(); // deposit 0
+        _createDeposit(); // deposit 1 (identical shape)
+        vm.stopPrank();
+
+        vm.prank(depositor);
+        orchestrator.setDepositWhitelistHook(address(escrow), 0, IPreIntentHook(address(hook)));
+        vm.prank(depositor);
+        orchestrator.setDepositWhitelistHook(address(escrow), 1, IPreIntentHook(address(hook)));
+
+        contractsToCool.push(address(token));
+        contractsToCool.push(address(escrowRegistry));
+        contractsToCool.push(address(paymentVerifierRegistry));
+        contractsToCool.push(address(orchestratorRegistry));
+        contractsToCool.push(address(verifier));
+        contractsToCool.push(address(escrow));
+        contractsToCool.push(address(orchestrator));
+        contractsToCool.push(address(groupRegistry));
+        contractsToCool.push(address(hook));
+    }
+
+    function _createDeposit() internal {
+        bytes32[] memory methods = new bytes32[](1);
+        methods[0] = METHOD;
+        IEscrowV2.DepositPaymentMethodData[] memory methodData = new IEscrowV2.DepositPaymentMethodData[](1);
+        methodData[0] =
+            IEscrowV2.DepositPaymentMethodData({intentGatingService: address(0), payeeDetails: PAYEE, data: ""});
+        IEscrowV2.Currency[][] memory currencies = new IEscrowV2.Currency[][](1);
+        currencies[0] = new IEscrowV2.Currency[](1);
+        currencies[0][0] = IEscrowV2.Currency({
+            code: USD,
+            minConversionRate: 1.01e18,
+            oracleRateConfig: IEscrowV2.OracleRateConfig({
+                adapter: address(0), adapterConfig: "", spreadBps: 0, maxStaleness: 0
+            })
+        });
+        escrow.createDeposit(
+            IEscrowV2.CreateDepositParams({
+                token: IERC20(address(token)),
+                amount: 100e6,
+                intentAmountRange: IEscrowV2.Range({min: 10e6, max: 200e6}),
+                paymentMethods: methods,
+                paymentMethodData: methodData,
+                currencies: currencies,
+                delegate: address(0),
+                intentGuardian: address(0),
+                retainOnEmpty: false
+            })
+        );
+    }
+
+    function _signalParams(uint256 depositId) internal view returns (IOrchestratorV3.SignalIntentParams memory params) {
+        IReferralFee.ReferralFee[] memory referralFees = new IReferralFee.ReferralFee[](0);
+        params = IOrchestratorV3.SignalIntentParams({
+            escrow: address(escrow),
+            depositId: depositId,
+            amount: INTENT_AMOUNT,
+            to: taker,
+            paymentMethod: METHOD,
+            fiatCurrency: USD,
+            conversionRate: CONVERSION_RATE,
+            referralFees: referralFees,
+            gatingServiceSignature: "",
+            signatureExpiration: 0,
+            postIntentHook: IPostIntentHookV2(address(0)),
+            preIntentHookData: "",
+            data: ""
+        });
+    }
+
+    function _setupTenMaliciousGroups(WhitelistResolverMock.Mode mode, uint256 payloadSize) internal {
+        uint256[] memory ids = new uint256[](10);
+        for (uint256 i = 0; i < 10; i++) {
+            WhitelistResolverMock malicious = new WhitelistResolverMock();
+            malicious.setMode(mode);
+            if (payloadSize > 0) malicious.setPayloadSize(payloadSize);
+            vm.prank(depositor);
+            ids[i] = groupRegistry.createGroup("malicious");
+            vm.prank(depositor);
+            groupRegistry.setResolver(ids[i], address(malicious));
+            contractsToCool.push(address(malicious));
+        }
+        vm.prank(depositor);
+        hook.attachGroups(address(escrow), 0, ids);
+    }
+
+    function _coolAll() internal {
+        for (uint256 i = 0; i < contractsToCool.length; i++) {
+            vm.cool(contractsToCool[i]);
+        }
+    }
+
+    function _measureRejection(uint256 depositId) internal returns (uint256 gasUsed) {
+        IOrchestratorV3.SignalIntentParams memory params = _signalParams(depositId);
+        _coolAll();
+        vm.prank(taker);
+        uint256 gasBefore = gasleft();
+        try orchestrator.signalIntent(params) {
+            revert("signal should have been rejected");
+        } catch (bytes memory reason) {
+            gasUsed = gasBefore - gasleft();
+            // Both measurements must be rejected by the whitelist hook specifically — a
+            // setup failure (payment method, rate, liquidity, ...) would otherwise be
+            // silently measured as if it were the path under test.
+            assertEq(bytes4(reason), WhitelistPreIntentHookV2.TakerNotWhitelisted.selector);
+        }
+    }
+
+    function _assertDeltaWithinBudget(string memory label) internal {
+        uint256 tenGroupGas = _measureRejection(0);
+        uint256 zeroGroupGas = _measureRejection(1);
+        uint256 delta = tenGroupGas - zeroGroupGas;
+        emit log_named_uint(label, delta);
+        assertLe(delta, MAX_REJECTION_DELTA);
+    }
+
+    function test_TenStipendBurnerResolversRejectionDeltaWithinBudget() public {
+        _setupTenMaliciousGroups(WhitelistResolverMock.Mode.BurnGas, 0);
+        _assertDeltaWithinBudget("ten-burner delta");
+    }
+
+    function test_TenMaxPayloadResolversRejectionDeltaWithinBudget() public {
+        // Max payload constructible under the 50k stipend; first word != 1 so the path rejects.
+        _setupTenMaliciousGroups(WhitelistResolverMock.Mode.PayloadReturnNotOne, 96_000);
+        _assertDeltaWithinBudget("ten-payload delta");
+    }
+
+    function test_TenPayloadRevertResolversRejectionDeltaWithinBudget() public {
+        _setupTenMaliciousGroups(WhitelistResolverMock.Mode.PayloadRevert, 96_000);
+        _assertDeltaWithinBudget("ten-revert delta");
+    }
+}

--- a/test-foundry/deterministic/registries/AddressGroupRegistry.t.sol
+++ b/test-foundry/deterministic/registries/AddressGroupRegistry.t.sol
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+
+import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
+
+contract AddressGroupRegistryTest is Test {
+    event GroupCreated(uint256 indexed groupId, address indexed owner, string name);
+    event GroupOwnershipTransferStarted(uint256 indexed groupId, address indexed owner, address indexed pendingOwner);
+    event GroupOwnershipTransferCancelled(uint256 indexed groupId, address indexed cancelledPendingOwner);
+    event GroupOwnershipTransferred(uint256 indexed groupId, address indexed previousOwner, address indexed newOwner);
+    event MemberAdded(uint256 indexed groupId, address indexed member);
+    event MemberRemoved(uint256 indexed groupId, address indexed member);
+
+    AddressGroupRegistry internal registry;
+    address internal alice;
+    address internal bob;
+    address internal carol;
+
+    function setUp() public {
+        registry = new AddressGroupRegistry();
+        alice = makeAddr("alice");
+        bob = makeAddr("bob");
+        carol = makeAddr("carol");
+    }
+
+    function _members(address first) internal pure returns (address[] memory values) {
+        values = new address[](1);
+        values[0] = first;
+    }
+
+    function _members(address first, address second) internal pure returns (address[] memory values) {
+        values = new address[](2);
+        values[0] = first;
+        values[1] = second;
+    }
+
+    function _createGroup(address owner) internal returns (uint256 groupId) {
+        vm.prank(owner);
+        groupId = registry.createGroup("test-group");
+    }
+
+    /* ============ createGroup ============ */
+
+    function test_CreateGroupAssignsSequentialIdsFromOne() public {
+        vm.expectEmit(true, true, true, true, address(registry));
+        emit GroupCreated(1, alice, "test-group");
+        uint256 first = _createGroup(alice);
+        uint256 second = _createGroup(bob);
+        assertEq(first, 1);
+        assertEq(second, 2);
+        assertEq(registry.groupCount(), 2);
+    }
+
+    function test_CreateGroupSetsCallerAsOwner() public {
+        uint256 groupId = _createGroup(alice);
+        (address owner, address pendingOwner, address resolver, bool exists) = registry.getGroup(groupId);
+        assertEq(owner, alice);
+        assertEq(pendingOwner, address(0));
+        assertEq(resolver, address(0));
+        assertTrue(exists);
+    }
+
+    function test_GroupZeroDoesNotExist() public view {
+        assertFalse(registry.groupExists(0));
+        (,,, bool exists) = registry.getGroup(0);
+        assertFalse(exists);
+    }
+
+    function test_UnknownGroupDoesNotExist() public view {
+        assertFalse(registry.groupExists(42));
+    }
+
+    /* ============ ownership lifecycle ============ */
+
+    function test_OwnerStartsTransferAndEmits() public {
+        uint256 groupId = _createGroup(alice);
+        vm.expectEmit(true, true, true, true, address(registry));
+        emit GroupOwnershipTransferStarted(groupId, alice, bob);
+        vm.prank(alice);
+        registry.transferGroupOwnership(groupId, bob);
+        (address owner, address pendingOwner,,) = registry.getGroup(groupId);
+        assertEq(owner, alice);
+        assertEq(pendingOwner, bob);
+    }
+
+    function test_NewTransferReplacesPendingOwner() public {
+        uint256 groupId = _createGroup(alice);
+        vm.prank(alice);
+        registry.transferGroupOwnership(groupId, bob);
+        vm.prank(alice);
+        registry.transferGroupOwnership(groupId, carol);
+        (, address pendingOwner,,) = registry.getGroup(groupId);
+        assertEq(pendingOwner, carol);
+    }
+
+    function test_TransferToZeroReverts() public {
+        uint256 groupId = _createGroup(alice);
+        vm.expectRevert(AddressGroupRegistry.ZeroAddress.selector);
+        vm.prank(alice);
+        registry.transferGroupOwnership(groupId, address(0));
+    }
+
+    function test_NonOwnerCannotStartTransfer() public {
+        uint256 groupId = _createGroup(alice);
+        vm.expectRevert(abi.encodeWithSelector(AddressGroupRegistry.UnauthorizedGroupOwner.selector, bob, alice));
+        vm.prank(bob);
+        registry.transferGroupOwnership(groupId, bob);
+    }
+
+    function test_TransferOnNonexistentGroupReverts() public {
+        vm.expectRevert(abi.encodeWithSelector(AddressGroupRegistry.GroupDoesNotExist.selector, 7));
+        vm.prank(alice);
+        registry.transferGroupOwnership(7, bob);
+    }
+
+    function test_OwnerCancelsPendingTransferAndEmits() public {
+        uint256 groupId = _createGroup(alice);
+        vm.prank(alice);
+        registry.transferGroupOwnership(groupId, bob);
+        vm.expectEmit(true, true, true, true, address(registry));
+        emit GroupOwnershipTransferCancelled(groupId, bob);
+        vm.prank(alice);
+        registry.cancelGroupOwnershipTransfer(groupId);
+        (, address pendingOwner,,) = registry.getGroup(groupId);
+        assertEq(pendingOwner, address(0));
+    }
+
+    function test_CancelWithoutPendingTransferReverts() public {
+        uint256 groupId = _createGroup(alice);
+        vm.expectRevert(abi.encodeWithSelector(AddressGroupRegistry.NoPendingTransfer.selector, groupId));
+        vm.prank(alice);
+        registry.cancelGroupOwnershipTransfer(groupId);
+    }
+
+    function test_PendingOwnerAcceptsAndEmits() public {
+        uint256 groupId = _createGroup(alice);
+        vm.prank(alice);
+        registry.transferGroupOwnership(groupId, bob);
+        vm.expectEmit(true, true, true, true, address(registry));
+        emit GroupOwnershipTransferred(groupId, alice, bob);
+        vm.prank(bob);
+        registry.acceptGroupOwnership(groupId);
+        (address owner, address pendingOwner,,) = registry.getGroup(groupId);
+        assertEq(owner, bob);
+        assertEq(pendingOwner, address(0));
+    }
+
+    function test_NonPendingOwnerCannotAccept() public {
+        uint256 groupId = _createGroup(alice);
+        vm.prank(alice);
+        registry.transferGroupOwnership(groupId, bob);
+        vm.expectRevert(abi.encodeWithSelector(AddressGroupRegistry.UnauthorizedPendingOwner.selector, carol, bob));
+        vm.prank(carol);
+        registry.acceptGroupOwnership(groupId);
+    }
+
+    function test_PendingOwnerHasNoAdminRightsBeforeAcceptance() public {
+        uint256 groupId = _createGroup(alice);
+        vm.prank(alice);
+        registry.transferGroupOwnership(groupId, bob);
+        vm.expectRevert(abi.encodeWithSelector(AddressGroupRegistry.UnauthorizedGroupOwner.selector, bob, alice));
+        vm.prank(bob);
+        registry.addMembers(groupId, _members(carol));
+    }
+
+    function test_PreviousOwnerHasNoAdminRightsAfterTransfer() public {
+        uint256 groupId = _createGroup(alice);
+        vm.prank(alice);
+        registry.transferGroupOwnership(groupId, bob);
+        vm.prank(bob);
+        registry.acceptGroupOwnership(groupId);
+        vm.expectRevert(abi.encodeWithSelector(AddressGroupRegistry.UnauthorizedGroupOwner.selector, alice, bob));
+        vm.prank(alice);
+        registry.addMembers(groupId, _members(carol));
+    }
+
+    /* ============ member batches ============ */
+
+    function test_OwnerAddsMembersAndEmitsPerMember() public {
+        uint256 groupId = _createGroup(alice);
+        vm.expectEmit(true, true, true, true, address(registry));
+        emit MemberAdded(groupId, bob);
+        vm.expectEmit(true, true, true, true, address(registry));
+        emit MemberAdded(groupId, carol);
+        vm.prank(alice);
+        registry.addMembers(groupId, _members(bob, carol));
+        assertTrue(registry.isMember(groupId, bob));
+        assertTrue(registry.isMember(groupId, carol));
+        assertFalse(registry.isMember(groupId, alice));
+    }
+
+    function test_AddExistingMemberIsNoOpWithoutEvent() public {
+        uint256 groupId = _createGroup(alice);
+        vm.prank(alice);
+        registry.addMembers(groupId, _members(bob));
+        vm.recordLogs();
+        vm.prank(alice);
+        registry.addMembers(groupId, _members(bob));
+        assertEq(vm.getRecordedLogs().length, 0);
+        assertTrue(registry.isMember(groupId, bob));
+    }
+
+    function test_OwnerRemovesMemberAndEmits() public {
+        uint256 groupId = _createGroup(alice);
+        vm.prank(alice);
+        registry.addMembers(groupId, _members(bob, carol));
+        vm.expectEmit(true, true, true, true, address(registry));
+        emit MemberRemoved(groupId, bob);
+        vm.prank(alice);
+        registry.removeMembers(groupId, _members(bob));
+        assertFalse(registry.isMember(groupId, bob));
+        assertTrue(registry.isMember(groupId, carol));
+    }
+
+    function test_RemoveAbsentMemberIsNoOpWithoutEvent() public {
+        uint256 groupId = _createGroup(alice);
+        vm.recordLogs();
+        vm.prank(alice);
+        registry.removeMembers(groupId, _members(bob));
+        assertEq(vm.getRecordedLogs().length, 0);
+    }
+
+    function test_EmptyMemberBatchReverts() public {
+        uint256 groupId = _createGroup(alice);
+        vm.expectRevert(AddressGroupRegistry.EmptyArray.selector);
+        vm.prank(alice);
+        registry.addMembers(groupId, new address[](0));
+        vm.expectRevert(AddressGroupRegistry.EmptyArray.selector);
+        vm.prank(alice);
+        registry.removeMembers(groupId, new address[](0));
+    }
+
+    function test_ZeroMemberReverts() public {
+        uint256 groupId = _createGroup(alice);
+        vm.expectRevert(AddressGroupRegistry.ZeroAddress.selector);
+        vm.prank(alice);
+        registry.addMembers(groupId, _members(address(0)));
+        vm.expectRevert(AddressGroupRegistry.ZeroAddress.selector);
+        vm.prank(alice);
+        registry.removeMembers(groupId, _members(address(0)));
+    }
+
+    function test_NonOwnerCannotMutateMembers() public {
+        uint256 groupId = _createGroup(alice);
+        vm.expectRevert(abi.encodeWithSelector(AddressGroupRegistry.UnauthorizedGroupOwner.selector, bob, alice));
+        vm.prank(bob);
+        registry.addMembers(groupId, _members(carol));
+        vm.expectRevert(abi.encodeWithSelector(AddressGroupRegistry.UnauthorizedGroupOwner.selector, bob, alice));
+        vm.prank(bob);
+        registry.removeMembers(groupId, _members(carol));
+    }
+
+    function test_IsMemberOnNonexistentGroupReturnsFalse() public view {
+        assertFalse(registry.isMember(99, bob));
+    }
+
+    /* ============ batch atomicity and mixed batches ============ */
+
+    function test_ZeroInBatchRevertsWholeTransaction() public {
+        uint256 groupId = _createGroup(alice);
+        vm.expectRevert(AddressGroupRegistry.ZeroAddress.selector);
+        vm.prank(alice);
+        registry.addMembers(groupId, _members(bob, address(0)));
+        assertFalse(registry.isMember(groupId, bob)); // earlier element rolled back
+
+        vm.prank(alice);
+        registry.addMembers(groupId, _members(bob));
+        vm.expectRevert(AddressGroupRegistry.ZeroAddress.selector);
+        vm.prank(alice);
+        registry.removeMembers(groupId, _members(bob, address(0)));
+        assertTrue(registry.isMember(groupId, bob)); // removal rolled back
+    }
+
+    function test_MixedBatchEmitsOnlyForStateChanges() public {
+        uint256 groupId = _createGroup(alice);
+        vm.prank(alice);
+        registry.addMembers(groupId, _members(bob));
+        vm.recordLogs();
+        vm.prank(alice);
+        registry.addMembers(groupId, _members(bob, carol)); // bob existing, carol new
+        assertEq(vm.getRecordedLogs().length, 1); // only carol's MemberAdded
+        assertTrue(registry.isMember(groupId, carol));
+    }
+
+    /* ============ full admin-surface auth after ownership changes ============ */
+
+    function test_PreviousOwnerCannotSetResolverOrRemoveMembersOrTransfer() public {
+        uint256 groupId = _createGroup(alice);
+        vm.prank(alice);
+        registry.addMembers(groupId, _members(carol));
+        vm.prank(alice);
+        registry.transferGroupOwnership(groupId, bob);
+        vm.prank(bob);
+        registry.acceptGroupOwnership(groupId);
+
+        bytes memory expected =
+            abi.encodeWithSelector(AddressGroupRegistry.UnauthorizedGroupOwner.selector, alice, bob);
+        vm.expectRevert(expected);
+        vm.prank(alice);
+        registry.removeMembers(groupId, _members(carol));
+        vm.expectRevert(expected);
+        vm.prank(alice);
+        registry.setResolver(groupId, address(registry)); // any contract address suffices for the auth check
+        vm.expectRevert(expected);
+        vm.prank(alice);
+        registry.transferGroupOwnership(groupId, alice);
+        vm.expectRevert(expected);
+        vm.prank(alice);
+        registry.cancelGroupOwnershipTransfer(groupId);
+    }
+
+    function test_PendingOwnerCannotRemoveMembersOrSetResolver() public {
+        uint256 groupId = _createGroup(alice);
+        vm.prank(alice);
+        registry.addMembers(groupId, _members(carol));
+        vm.prank(alice);
+        registry.transferGroupOwnership(groupId, bob);
+
+        bytes memory expected =
+            abi.encodeWithSelector(AddressGroupRegistry.UnauthorizedGroupOwner.selector, bob, alice);
+        vm.expectRevert(expected);
+        vm.prank(bob);
+        registry.removeMembers(groupId, _members(carol));
+        vm.expectRevert(expected);
+        vm.prank(bob);
+        registry.setResolver(groupId, address(registry));
+    }
+}

--- a/test-foundry/deterministic/registries/AddressGroupRegistry.t.sol
+++ b/test-foundry/deterministic/registries/AddressGroupRegistry.t.sol
@@ -147,6 +147,12 @@ contract AddressGroupRegistryTest is Test {
         assertEq(pendingOwner, address(0));
     }
 
+    function test_CannotAcceptOwnershipOfNonexistentGroup() public {
+        uint256 groupId = 42;
+        vm.expectRevert(abi.encodeWithSelector(AddressGroupRegistry.GroupDoesNotExist.selector, groupId));
+        registry.acceptGroupOwnership(groupId);
+    }
+
     function test_NonPendingOwnerCannotAccept() public {
         uint256 groupId = _createGroup(alice);
         vm.prank(alice);

--- a/test-foundry/deterministic/registries/AddressGroupRegistryResolver.t.sol
+++ b/test-foundry/deterministic/registries/AddressGroupRegistryResolver.t.sol
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+
+import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
+import {AddressGroupRegistryGasHarness} from "contracts/mocks/AddressGroupRegistryGasHarness.sol";
+import {WhitelistResolverMock} from "contracts/mocks/WhitelistResolverMock.sol";
+
+contract AddressGroupRegistryResolverTest is Test {
+    event ResolverSet(uint256 indexed groupId, address indexed oldResolver, address indexed newResolver);
+
+    AddressGroupRegistry internal registry;
+    WhitelistResolverMock internal resolver;
+    address internal alice;
+    address internal bob;
+    uint256 internal groupId;
+
+    function setUp() public {
+        registry = new AddressGroupRegistry();
+        resolver = new WhitelistResolverMock();
+        alice = makeAddr("alice");
+        bob = makeAddr("bob");
+        vm.prank(alice);
+        groupId = registry.createGroup("resolver-group");
+    }
+
+    function _setResolver(address newResolver) internal {
+        vm.prank(alice);
+        registry.setResolver(groupId, newResolver);
+    }
+
+    /* ============ setResolver ============ */
+
+    function test_OwnerSetsResolverAndEmitsOldAndNew() public {
+        vm.expectEmit(true, true, true, true, address(registry));
+        emit ResolverSet(groupId, address(0), address(resolver));
+        _setResolver(address(resolver));
+        (,, address stored,) = registry.getGroup(groupId);
+        assertEq(stored, address(resolver));
+    }
+
+    function test_ZeroClearsResolver() public {
+        _setResolver(address(resolver));
+        vm.expectEmit(true, true, true, true, address(registry));
+        emit ResolverSet(groupId, address(resolver), address(0));
+        _setResolver(address(0));
+        (,, address stored,) = registry.getGroup(groupId);
+        assertEq(stored, address(0));
+    }
+
+    function test_EoaResolverReverts() public {
+        vm.expectRevert(abi.encodeWithSelector(AddressGroupRegistry.ResolverNotContract.selector, bob));
+        _setResolver(bob);
+    }
+
+    function test_NonOwnerCannotSetResolver() public {
+        vm.expectRevert(abi.encodeWithSelector(AddressGroupRegistry.UnauthorizedGroupOwner.selector, bob, alice));
+        vm.prank(bob);
+        registry.setResolver(groupId, address(resolver));
+    }
+
+    /* ============ effective membership ============ */
+
+    function test_ResolverMembershipGrantsAccess() public {
+        _setResolver(address(resolver));
+        resolver.setMemberOf(groupId, bob, true);
+        assertTrue(registry.isMember(groupId, bob));
+    }
+
+    function test_CuratedMembershipWorksAlongsideResolver() public {
+        _setResolver(address(resolver));
+        address[] memory batch = new address[](1);
+        batch[0] = bob;
+        vm.prank(alice);
+        registry.addMembers(groupId, batch);
+        // curated hit short-circuits before the resolver
+        vm.expectCall(address(resolver), abi.encodeCall(resolver.isMember, (groupId, bob)), 0);
+        assertTrue(registry.isMember(groupId, bob));
+    }
+
+    function test_NoResolverNoCuratedMeansFalse() public view {
+        assertFalse(registry.isMember(groupId, bob));
+    }
+
+    /* ============ fail-closed matrix ============ */
+
+    function _assertFailClosed(WhitelistResolverMock.Mode mode) internal {
+        _setResolver(address(resolver));
+        resolver.setMode(mode);
+        assertFalse(registry.isMember(groupId, bob));
+    }
+
+    function test_ResolverReturnTrueGrants() public {
+        _setResolver(address(resolver));
+        resolver.setMode(WhitelistResolverMock.Mode.ReturnTrue);
+        assertTrue(registry.isMember(groupId, bob));
+    }
+
+    function test_ResolverReturnFalseDenies() public {
+        _assertFailClosed(WhitelistResolverMock.Mode.ReturnFalse);
+    }
+
+    function test_ResolverWordTwoDenies() public {
+        _assertFailClosed(WhitelistResolverMock.Mode.ReturnTwo);
+    }
+
+    function test_ResolverWordMaxDenies() public {
+        _assertFailClosed(WhitelistResolverMock.Mode.ReturnMax);
+    }
+
+    function test_ResolverShortReturndataDenies() public {
+        _assertFailClosed(WhitelistResolverMock.Mode.ReturnShort);
+    }
+
+    function test_ResolverRevertDenies() public {
+        _assertFailClosed(WhitelistResolverMock.Mode.Revert);
+    }
+
+    function test_ResolverGasBurnDeniesAndDoesNotRevertCaller() public {
+        _assertFailClosed(WhitelistResolverMock.Mode.BurnGas);
+    }
+
+    function test_ResolverDestroyedAfterSetDenies() public {
+        _setResolver(address(resolver));
+        // simulate code disappearing after setResolver's code check
+        vm.etch(address(resolver), "");
+        assertFalse(registry.isMember(groupId, bob));
+    }
+
+    function test_OversizedPayloadUnderStipendDenies() public {
+        _setResolver(address(resolver));
+        resolver.setMode(WhitelistResolverMock.Mode.PayloadReturnNotOne);
+        resolver.setPayloadSize(96_000); // empirically constructible within the 50k stipend
+        assertFalse(registry.isMember(groupId, bob));
+    }
+
+    function test_OversizedRevertUnderStipendDenies() public {
+        _setResolver(address(resolver));
+        resolver.setMode(WhitelistResolverMock.Mode.PayloadRevert);
+        resolver.setPayloadSize(96_000);
+        assertFalse(registry.isMember(groupId, bob));
+    }
+
+    function test_OversizedPayloadWithWordOneGrants() public {
+        // trailing bytes beyond the first word are intentionally ignored
+        _setResolver(address(resolver));
+        resolver.setMode(WhitelistResolverMock.Mode.PayloadReturnTrue);
+        resolver.setPayloadSize(96_000);
+        assertTrue(registry.isMember(groupId, bob));
+    }
+
+    /* ============ harness-level bounded-copy proof (exceeds stipend by construction) ============ */
+
+    function test_HarnessOneMegabyteReturndataCopiesOnlyBoundedResult() public {
+        AddressGroupRegistryGasHarness harness = new AddressGroupRegistryGasHarness();
+        vm.prank(alice);
+        uint256 harnessGroup = harness.createGroup("harness");
+        vm.prank(alice);
+        harness.setResolver(harnessGroup, address(resolver));
+        harness.setResolverGasLimit(30_000_000);
+        resolver.setMode(WhitelistResolverMock.Mode.PayloadReturnTrue);
+        resolver.setPayloadSize(1_048_576); // 1 MB — only constructible with the raised harness limit
+        // Bounded copy: the call succeeds, evaluates the first word only, and does not revert
+        // or balloon caller memory despite 1 MB of returndata.
+        assertTrue(harness.isMember(harnessGroup, bob));
+
+        resolver.setMode(WhitelistResolverMock.Mode.PayloadReturnNotOne);
+        assertFalse(harness.isMember(harnessGroup, bob));
+
+        resolver.setMode(WhitelistResolverMock.Mode.PayloadRevert);
+        assertFalse(harness.isMember(harnessGroup, bob));
+    }
+}

--- a/test-foundry/fuzz/WhitelistHookV2AttachFuzz.t.sol
+++ b/test-foundry/fuzz/WhitelistHookV2AttachFuzz.t.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+
+import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
+import {WhitelistPreIntentHookV2} from "contracts/hooks/WhitelistPreIntentHookV2.sol";
+import {OrchestratorRegistry} from "contracts/registries/OrchestratorRegistry.sol";
+import {IEscrow} from "contracts/interfaces/IEscrow.sol";
+
+// Minimal escrow stand-in: the hook's config functions only read depositor/delegate.
+contract EscrowGetDepositMock {
+    address public depositor;
+
+    constructor(address _depositor) {
+        depositor = _depositor;
+    }
+
+    function getDeposit(uint256) external view returns (IEscrow.Deposit memory deposit) {
+        deposit.depositor = depositor;
+        deposit.delegate = address(0);
+    }
+}
+
+contract WhitelistHookV2AttachFuzzTest is Test {
+    uint256 internal constant GROUP_POOL = 15; // > MAX_GROUPS_PER_DEPOSIT to exercise the cap
+
+    AddressGroupRegistry internal registry;
+    WhitelistPreIntentHookV2 internal hook;
+    EscrowGetDepositMock internal escrow;
+    address internal depositor;
+    uint256[] internal pool;
+
+    function setUp() public {
+        depositor = makeAddr("depositor");
+        registry = new AddressGroupRegistry();
+        hook = new WhitelistPreIntentHookV2(address(new OrchestratorRegistry()), address(registry));
+        escrow = new EscrowGetDepositMock(depositor);
+        for (uint256 i = 0; i < GROUP_POOL; i++) {
+            vm.prank(depositor);
+            pool.push(registry.createGroup("pool"));
+        }
+    }
+
+    function _one(uint256 id) internal pure returns (uint256[] memory values) {
+        values = new uint256[](1);
+        values[0] = id;
+    }
+
+    /// forge-config: default.fuzz.runs = 512
+    function testFuzz_AttachDetachSequencePreservesIndexIntegrity(uint8[] calldata ops) public {
+        vm.assume(ops.length <= 64);
+        bool[] memory expectedAttached = new bool[](GROUP_POOL);
+        uint256 expectedCount;
+
+        for (uint256 i = 0; i < ops.length; i++) {
+            uint256 poolIndex = uint256(ops[i] % GROUP_POOL);
+            bool isAttach = (ops[i] & 0x80) == 0;
+            uint256 groupId = pool[poolIndex];
+
+            if (isAttach) {
+                if (!expectedAttached[poolIndex] && expectedCount >= hook.MAX_GROUPS_PER_DEPOSIT()) {
+                    vm.expectRevert(
+                        abi.encodeWithSelector(
+                            WhitelistPreIntentHookV2.MaxGroupsExceeded.selector,
+                            expectedCount + 1,
+                            hook.MAX_GROUPS_PER_DEPOSIT()
+                        )
+                    );
+                    vm.prank(depositor);
+                    hook.attachGroups(address(escrow), 0, _one(groupId));
+                } else {
+                    vm.prank(depositor);
+                    hook.attachGroups(address(escrow), 0, _one(groupId));
+                    if (!expectedAttached[poolIndex]) {
+                        expectedAttached[poolIndex] = true;
+                        expectedCount++;
+                    }
+                }
+            } else {
+                vm.prank(depositor);
+                hook.detachGroups(address(escrow), 0, _one(groupId));
+                if (expectedAttached[poolIndex]) {
+                    expectedAttached[poolIndex] = false;
+                    expectedCount--;
+                }
+            }
+
+            _assertIntegrity(expectedAttached, expectedCount);
+        }
+    }
+
+    function _assertIntegrity(bool[] memory expectedAttached, uint256 expectedCount) internal view {
+        uint256[] memory attached = hook.getAttachedGroups(address(escrow), 0);
+
+        // count matches the model and never exceeds the cap
+        assertEq(attached.length, expectedCount);
+        assertLe(attached.length, hook.MAX_GROUPS_PER_DEPOSIT());
+
+        // no duplicates, and every array entry reports attached
+        for (uint256 i = 0; i < attached.length; i++) {
+            assertTrue(hook.isGroupAttached(address(escrow), 0, attached[i]));
+            for (uint256 j = i + 1; j < attached.length; j++) {
+                assertTrue(attached[i] != attached[j]);
+            }
+        }
+
+        // model agreement in both directions
+        for (uint256 p = 0; p < GROUP_POOL; p++) {
+            assertEq(hook.isGroupAttached(address(escrow), 0, pool[p]), expectedAttached[p]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds **AddressGroupRegistry**: a permissionless registry of owner-managed address groups (sequential ids from 1, two-step ownership transfer, idempotent member batches) so depositors can whitelist a single group identifier instead of individual addresses; both Peer and third parties can maintain groups.
- Adds **WhitelistPreIntentHookV2**: unified whitelist hook — a taker may signal when directly whitelisted OR a member of any of up to 10 attached groups. Supersedes the V1 hook for new deposits; V1 deposits keep working.
- Groups optionally delegate membership to a **resolver** contract (NFT holders, stakers, KYC, ...) via a hardened staticcall: 50k gas stipend, fixed 32-byte returndata copy, strict `== 1` check, fail-closed per resolver — a broken/malicious resolver can never brick a deposit or bypass other admission paths.
- **Zero orchestrator/escrow changes**: the hook plugs into the existing per-deposit `depositWhitelistHooks` slot; integration targets **OrchestratorV3** (works with any orchestrator registered in OrchestratorRegistry).

## Changes
- `contracts/registries/AddressGroupRegistry.sol` + `contracts/interfaces/IAddressGroupRegistry.sol`, `IWhitelistResolver.sol`
- `contracts/hooks/WhitelistPreIntentHookV2.sol`
- Mocks: `WhitelistResolverMock` (11-mode malicious-resolver matrix), `AddressGroupRegistryGasHarness`
- Tests (1,562 lines): registry unit + resolver fail-closed matrix (incl. 1 MB bounded-copy harness proof), hook unit + OrchestratorV3 integration (config persistence across hook unset/reattach, point-in-time admission, setup-race-window demonstration, hook-before-liquidity ordering), adversarial gas benchmark, attach/detach fuzz
- `deploy/29_deploy_whitelist_groups.ts` — **prepared and localhost-validated only; NOT deployed to staging/prod**
- Package ABI exports for both contracts in `packages/contracts/scripts/extractors/abis.ts`

## Spec Alignment
- Design spec + implementation plan were developed with a 5-round adversarial convergence review; they live in gitignored `docs/superpowers/` (this repo ignores `docs/`), so they are not part of this diff.
- Key documented decisions: owner-only group administration (no manager role — shared control via multisig owner); allow-only semantics (no blocklist); config persists across hook unset/reattach (pause/resume); membership is point-in-time admission (removal does not invalidate signaled intents); the create-deposit → set-hook race window is a documented pre-existing limitation with an atomic setup router deferred.

## Test Plan
- [x] Full Foundry suite: **1,637 tests passing, 0 failed** (109 suites)
- [x] Malicious-resolver matrix: revert, out-of-gas burn, short/malformed return, wrong word, no code at call time, oversized (96KB) return + revert payloads under the stipend
- [x] Adversarial gas benchmark (cold-state via `vm.cool`, 10 distinct resolver addresses): worst delta **586,149 gas** vs zero-group rejection (budget ≤ 700k)
- [x] Fuzz: attach/detach index integrity over 512 runs (no dup ids, index↔array agreement, cap ≤ 10)
- [x] Deploy script validated on ephemeral localhost node (both contracts deployed and readable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxzGTRdk5D3vzM3WZjdeST