### PR TITLE
feat: add standalone prepaid IntentGuardian

### DIFF
--- a/contracts/IntentGuardian.sol
+++ b/contracts/IntentGuardian.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import {IEscrow} from "./interfaces/IEscrow.sol";
+import {IEscrowRegistry} from "./interfaces/IEscrowRegistry.sol";
+import {IIntentGuardian} from "./interfaces/IIntentGuardian.sol";
+
+/**
+ * @title IntentGuardian
+ * @notice Extends live Escrow intents in exchange for a prepaid, non-refundable fee.
+ * @dev Escrow and EscrowV2 expose the same Deposit and Intent ABI used here. A deposit opts into a
+ *      specific guardian address, so the constructor-fixed fee cannot be changed beneath its maker.
+ *      A different fee requires a new guardian deployment and an explicit opt-in on a new deposit.
+ */
+contract IntentGuardian is IIntentGuardian, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+    uint256 public constant SECONDS_PER_HOUR = 1 hours;
+    uint256 public constant EXTENSION_FEE_DENOMINATOR = BPS_DENOMINATOR * SECONDS_PER_HOUR;
+    uint256 public constant MAX_TOTAL_INTENT_LIFETIME = 5 days;
+    uint256 public constant MAX_EXTENSION_FEE_BPS_PER_HOUR = EXTENSION_FEE_DENOMINATOR / MAX_TOTAL_INTENT_LIFETIME;
+
+    IEscrowRegistry public immutable override escrowRegistry;
+    uint256 public immutable override extensionFeeBpsPerHour;
+
+    constructor(IEscrowRegistry _escrowRegistry, uint256 _extensionFeeBpsPerHour) {
+        if (address(_escrowRegistry) == address(0)) revert ZeroAddress();
+        if (_extensionFeeBpsPerHour > MAX_EXTENSION_FEE_BPS_PER_HOUR) {
+            revert ExtensionFeeExceedsIntentAmount(_extensionFeeBpsPerHour);
+        }
+
+        escrowRegistry = _escrowRegistry;
+        extensionFeeBpsPerHour = _extensionFeeBpsPerHour;
+    }
+
+    /**
+     * @inheritdoc IIntentGuardian
+     * @dev The compatible Escrow enforces guardian authorization, non-zero time, and the cumulative
+     *      five-day lifetime cap. All state and token movements revert atomically on payment failure.
+     */
+    function extendIntent(
+        address _escrow,
+        uint256 _depositId,
+        bytes32 _intentHash,
+        uint256 _additionalTime,
+        uint256 _maxCost
+    ) external override nonReentrant {
+        uint256 feeBpsPerHour = extensionFeeBpsPerHour;
+        if (feeBpsPerHour == 0) revert ExtensionsDisabled();
+
+        if (!escrowRegistry.isAcceptingAllEscrows() && !escrowRegistry.isWhitelistedEscrow(_escrow)) {
+            revert EscrowNotWhitelisted(_escrow);
+        }
+
+        IEscrow escrow = IEscrow(_escrow);
+        IEscrow.Deposit memory deposit = escrow.getDeposit(_depositId);
+        IEscrow.Intent memory intent = escrow.getDepositIntent(_depositId, _intentHash);
+
+        if (block.timestamp >= intent.expiryTime) {
+            revert IntentAlreadyExpired(_intentHash, intent.expiryTime, block.timestamp);
+        }
+
+        escrow.extendIntentExpiry(_depositId, _intentHash, _additionalTime);
+
+        uint256 cost = _quoteExtensionCost(intent.amount, _additionalTime, feeBpsPerHour);
+        if (cost > _maxCost) revert ExtensionCostExceedsMax(cost, _maxCost);
+
+        deposit.token.safeTransferFrom(msg.sender, deposit.depositor, cost);
+
+        emit IntentExtended(_escrow, _depositId, _intentHash, msg.sender, _additionalTime, cost);
+    }
+
+    /// @inheritdoc IIntentGuardian
+    function quoteExtensionCost(uint256 _intentAmount, uint256 _additionalTime)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        return _quoteExtensionCost(_intentAmount, _additionalTime, extensionFeeBpsPerHour);
+    }
+
+    function _quoteExtensionCost(uint256 _intentAmount, uint256 _additionalTime, uint256 _feeBpsPerHour)
+        internal
+        pure
+        returns (uint256)
+    {
+        return Math.mulDiv(_intentAmount, _feeBpsPerHour * _additionalTime, EXTENSION_FEE_DENOMINATOR, Math.Rounding.Up);
+    }
+}

--- a/contracts/interfaces/IIntentGuardian.sol
+++ b/contracts/interfaces/IIntentGuardian.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {IEscrowRegistry} from "./IEscrowRegistry.sol";
+
+/**
+ * @title IIntentGuardian
+ * @notice Permissionless prepaid intent extensions for compatible Escrow deposits.
+ */
+interface IIntentGuardian {
+    event IntentExtended(
+        address indexed escrow,
+        uint256 indexed depositId,
+        bytes32 indexed intentHash,
+        address payer,
+        uint256 additionalTime,
+        uint256 cost
+    );
+
+    error ZeroAddress();
+    error ExtensionsDisabled();
+    error IntentAlreadyExpired(bytes32 intentHash, uint256 expiryTime, uint256 currentTime);
+    error ExtensionCostExceedsMax(uint256 cost, uint256 maxCost);
+    error ExtensionFeeExceedsIntentAmount(uint256 extensionFeeBpsPerHour);
+    error EscrowNotWhitelisted(address escrow);
+
+    /**
+     * @notice Prepays a deposit's maker and extends a live intent.
+     * @param _escrow Whitelisted Escrow or EscrowV2 holding the deposit and intent.
+     * @param _depositId Deposit containing the intent.
+     * @param _intentHash Intent to extend.
+     * @param _additionalTime Seconds to add to the current expiry.
+     * @param _maxCost Maximum fee the payer authorizes.
+     */
+    function extendIntent(
+        address _escrow,
+        uint256 _depositId,
+        bytes32 _intentHash,
+        uint256 _additionalTime,
+        uint256 _maxCost
+    ) external;
+
+    /// @notice Quotes the exact upward-rounded prepaid extension cost.
+    function quoteExtensionCost(uint256 _intentAmount, uint256 _additionalTime) external view returns (uint256);
+
+    /// @notice Escrow registry used to authorize compatible escrows.
+    function escrowRegistry() external view returns (IEscrowRegistry);
+
+    /// @notice Immutable hourly extension fee in basis points of the locked intent amount.
+    function extensionFeeBpsPerHour() external view returns (uint256);
+}

--- a/deploy/31_deploy_intent_guardian.ts
+++ b/deploy/31_deploy_intent_guardian.ts
@@ -1,0 +1,49 @@
+import "module-alias/register";
+
+import {HardhatRuntimeEnvironment} from "hardhat/types";
+import {DeployFunction} from "hardhat-deploy/types";
+
+import {INTENT_GUARDIAN_EXTENSION_FEE_BPS_PER_HOUR} from "../deployments/parameters";
+import {
+  getDeployedContractAddress,
+  waitForDeploymentDelay,
+} from "../deployments/helpers";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const {deploy} = hre.deployments;
+  const network = hre.deployments.getNetworkName();
+  const [deployer] = await hre.getUnnamedAccounts();
+  const extensionFeeBpsPerHour = INTENT_GUARDIAN_EXTENSION_FEE_BPS_PER_HOUR[network];
+
+  if (extensionFeeBpsPerHour === undefined) {
+    throw new Error(`No immutable IntentGuardian fee configured for network: ${network}`);
+  }
+
+  const escrowRegistry = getDeployedContractAddress(network, "EscrowRegistry");
+  const guardian = await deploy("IntentGuardian", {
+    from: deployer,
+    args: [escrowRegistry, extensionFeeBpsPerHour],
+    log: true,
+  });
+
+  if (guardian.newlyDeployed) {
+    console.log(
+      "IntentGuardian deployed at",
+      guardian.address,
+      "with immutable fee",
+      extensionFeeBpsPerHour,
+      "bps/hour",
+    );
+    await waitForDeploymentDelay(hre);
+  }
+};
+
+func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> => {
+  const network = hre.deployments.getNetworkName();
+  return INTENT_GUARDIAN_EXTENSION_FEE_BPS_PER_HOUR[network] === undefined;
+};
+
+func.tags = ["31_deploy_intent_guardian", "IntentGuardian"];
+func.dependencies = ["14_deploy_v2_system"];
+
+export default func;

--- a/deploy/deploy_summary.ts
+++ b/deploy/deploy_summary.ts
@@ -57,6 +57,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     ChainlinkOracleAdapter:             ${tryGetAddress(network, "ChainlinkOracleAdapter")}
     PythOracleAdapter:                  ${tryGetAddress(network, "PythOracleAdapter")}
     ProtocolViewerV2:                   ${tryGetAddress(network, "ProtocolViewerV2")}
+    IntentGuardian:                     ${tryGetAddress(network, "IntentGuardian")}
     ----------------------------------------------------------------------
     Stake Risk Contracts:
     BoundedCall:                        ${tryGetAddress(network, "BoundedCall")}

--- a/deployments/parameters.ts
+++ b/deployments/parameters.ts
@@ -162,6 +162,16 @@ export const STAKE_RISK_PLATFORM_POLICY: any = {
   base_staging: INITIAL_STAKE_RISK_PLATFORM_POLICY,
 };
 
+// Immutable hourly fee for the standalone IntentGuardian, denominated in basis points of the
+// locked intent amount. Changing this value deploys a new guardian version; makers that opted
+// into an earlier guardian keep that deployment's constructor-fixed economics. Production is
+// intentionally absent until governance ratifies a fee and deployment.
+export const INTENT_GUARDIAN_EXTENSION_FEE_BPS_PER_HOUR: Record<string, number> = {
+  localhost: 2,
+  hardhat: 2,
+  base_staging: 2,
+};
+
 // Pyth Network contract addresses
 export const PYTH_CONTRACT: any = {
   "localhost": "",

--- a/packages/contracts/scripts/extractors/abis.ts
+++ b/packages/contracts/scripts/extractors/abis.ts
@@ -19,6 +19,7 @@ const PKG_ROOT = path.resolve(__dirname, '../..');
 const ABIS_DIR = path.join(PKG_ROOT, 'abis');
 
 const SOURCE_ABI_ARTIFACTS: Record<string, string> = {
+  IntentGuardian: 'contracts/IntentGuardian.sol/IntentGuardian.json',
   RiskManager: 'contracts/RiskManager.sol/RiskManager.json',
   StakeVault: 'contracts/StakeVault.sol/StakeVault.json',
   OrchestratorV3: 'contracts/OrchestratorV3.sol/OrchestratorV3.json',

--- a/packages/contracts/test/riskMath.spec.ts
+++ b/packages/contracts/test/riskMath.spec.ts
@@ -3,6 +3,7 @@ import {
   calculateIntentExtensionPenalty,
   calculateRequiredCoverage,
   calculateStakeBackedCapacity,
+  quoteIntentGuardianExtensionCost,
   selectRiskMode,
 } from "../../../utils/riskMath";
 
@@ -13,6 +14,12 @@ describe("risk math", () => {
     expect(calculateIntentExtensionCost(1_000_000_000n, 23n * HOUR, 10n)).toBe(23_000_000n);
     expect(calculateIntentExtensionCost(1n, 1n, 1n)).toBe(1n);
     expect(calculateIntentExtensionCost(1_000_000n, HOUR, 0n)).toBe(0n);
+  });
+
+  it("quotes the guardian's prepaid cost with the exact onchain rounding", () => {
+    expect(quoteIntentGuardianExtensionCost(1_000_000_000n, 2n * HOUR, 10n)).toBe(2_000_000n);
+    expect(quoteIntentGuardianExtensionCost(1n, 1n, 1n)).toBe(1n);
+    expect(quoteIntentGuardianExtensionCost(1_000_000n, HOUR, 0n)).toBe(0n);
   });
 
   it("charges only elapsed purchased time after the original expiry", () => {
@@ -43,6 +50,7 @@ describe("risk math", () => {
 
   it("rejects unsafe numbers", () => {
     expect(() => calculateIntentExtensionCost(Number.MAX_SAFE_INTEGER + 1, HOUR, 1)).toThrow(RangeError);
+    expect(() => quoteIntentGuardianExtensionCost(1, HOUR, -1)).toThrow(RangeError);
     expect(() => calculateRequiredCoverage(-1, true)).toThrow(RangeError);
   });
 });

--- a/scripts/run-foundry-coverage.cjs
+++ b/scripts/run-foundry-coverage.cjs
@@ -61,6 +61,11 @@ const deterministicCoverageRuns = [
         test: "test-foundry/deterministic/hooks",
     },
     {
+        name: "deterministic-guardian",
+        irMinimum: true,
+        test: "test-foundry/deterministic/guardian",
+    },
+    {
         name: "deterministic-integration",
         irMinimum: true,
         test: "test-foundry/deterministic/integration",
@@ -138,6 +143,11 @@ const exactSourceCoverageRuns = [
         source: "contracts/lib/BoundedCall.sol",
         test: "test-foundry/deterministic/libs",
     },
+    {
+        name: "intent-guardian",
+        source: "contracts/IntentGuardian.sol",
+        test: "test-foundry/deterministic/guardian",
+    },
     ...legacyOrchestratorTests.map((test, index) => ({
         name: `legacy-orchestrator-${index}`,
         source: "contracts/Orchestrator.sol",
@@ -153,6 +163,7 @@ const coverageLanes = new Map([
         "remaining",
         [
             "deterministic-deployment",
+            "deterministic-guardian",
             "deterministic-hooks",
             "deterministic-oracles",
             "deterministic-periphery",

--- a/test-foundry/deterministic/guardian/IntentGuardian.t.sol
+++ b/test-foundry/deterministic/guardian/IntentGuardian.t.sol
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {IntentGuardian} from "../../../contracts/IntentGuardian.sol";
+import {IEscrow} from "../../../contracts/interfaces/IEscrow.sol";
+import {IEscrowRegistry} from "../../../contracts/interfaces/IEscrowRegistry.sol";
+import {IIntentGuardian} from "../../../contracts/interfaces/IIntentGuardian.sol";
+import {EscrowRegistry} from "../../../contracts/registries/EscrowRegistry.sol";
+
+contract GuardianTokenMock is ERC20 {
+    constructor() ERC20("Guardian Token", "GUARD") {}
+
+    function mint(address _account, uint256 _amount) external {
+        _mint(_account, _amount);
+    }
+}
+
+contract GuardianEscrowMock {
+    IEscrow.Deposit internal deposit;
+    mapping(bytes32 => IEscrow.Intent) internal intents;
+
+    function configureDeposit(address _depositor, IERC20 _token, address _guardian) external {
+        deposit.depositor = _depositor;
+        deposit.token = _token;
+        deposit.intentGuardian = _guardian;
+    }
+
+    function setIntent(bytes32 _intentHash, uint256 _amount, uint256 _timestamp, uint256 _expiryTime) external {
+        intents[_intentHash] =
+            IEscrow.Intent({intentHash: _intentHash, amount: _amount, timestamp: _timestamp, expiryTime: _expiryTime});
+    }
+
+    function deleteIntent(bytes32 _intentHash) external {
+        delete intents[_intentHash];
+    }
+
+    function getDeposit(uint256 _depositId) external view returns (IEscrow.Deposit memory) {
+        _depositId;
+        return deposit;
+    }
+
+    function getDepositIntent(uint256 _depositId, bytes32 _intentHash) external view returns (IEscrow.Intent memory) {
+        _depositId;
+        return intents[_intentHash];
+    }
+
+    function extendIntentExpiry(uint256 _depositId, bytes32 _intentHash, uint256 _additionalTime) external {
+        IEscrow.Deposit storage storedDeposit = deposit;
+        IEscrow.Intent storage intent = intents[_intentHash];
+
+        if (storedDeposit.depositor == address(0)) revert IEscrow.DepositNotFound(_depositId);
+        if (intent.intentHash == bytes32(0)) revert IEscrow.IntentNotFound(_intentHash);
+        if (storedDeposit.intentGuardian != msg.sender) {
+            revert IEscrow.UnauthorizedCaller(msg.sender, storedDeposit.intentGuardian);
+        }
+        if (_additionalTime == 0) revert IEscrow.ZeroValue();
+        if (intent.expiryTime + _additionalTime > intent.timestamp + 5 days) {
+            revert IEscrow.AmountAboveMax(_additionalTime, 5 days);
+        }
+
+        intent.expiryTime += _additionalTime;
+    }
+}
+
+contract IntentGuardianTest is Test {
+    event IntentExtended(
+        address indexed escrow,
+        uint256 indexed depositId,
+        bytes32 indexed intentHash,
+        address payer,
+        uint256 additionalTime,
+        uint256 cost
+    );
+
+    uint256 internal constant DEPOSIT_ID = 1;
+    uint256 internal constant INTENT_AMOUNT = 1_000e6;
+    uint256 internal constant EXTENSION_FEE_BPS_PER_HOUR = 10;
+    bytes32 internal constant INTENT_HASH = keccak256("intent");
+
+    address internal depositor = makeAddr("depositor");
+    address internal payer = makeAddr("payer");
+
+    GuardianTokenMock internal token;
+    GuardianEscrowMock internal escrow;
+    EscrowRegistry internal escrowRegistry;
+    IntentGuardian internal guardian;
+
+    function setUp() public {
+        token = new GuardianTokenMock();
+        escrow = new GuardianEscrowMock();
+        escrowRegistry = new EscrowRegistry();
+        escrowRegistry.addEscrow(address(escrow));
+        guardian = new IntentGuardian(escrowRegistry, EXTENSION_FEE_BPS_PER_HOUR);
+        escrow.configureDeposit(depositor, token, address(guardian));
+        _setLiveIntent(escrow, INTENT_HASH, INTENT_AMOUNT, 1 days);
+        token.mint(payer, INTENT_AMOUNT);
+    }
+
+    function test_ConstructorFixesFeeAndRejectsInvalidConfiguration() public {
+        assertEq(guardian.extensionFeeBpsPerHour(), EXTENSION_FEE_BPS_PER_HOUR);
+        assertEq(address(guardian.escrowRegistry()), address(escrowRegistry));
+        assertEq(guardian.MAX_EXTENSION_FEE_BPS_PER_HOUR(), 83);
+
+        vm.expectRevert(IIntentGuardian.ZeroAddress.selector);
+        new IntentGuardian(IEscrowRegistry(address(0)), EXTENSION_FEE_BPS_PER_HOUR);
+
+        vm.expectRevert(abi.encodeWithSelector(IIntentGuardian.ExtensionFeeExceedsIntentAmount.selector, 84));
+        new IntentGuardian(escrowRegistry, 84);
+    }
+
+    function test_ThereIsNoFeeMutationSurface() public {
+        (bool success,) = address(guardian).call(abi.encodeWithSignature("setExtensionFeeBpsPerHour(uint256)", 1));
+
+        assertFalse(success);
+        assertEq(guardian.extensionFeeBpsPerHour(), EXTENSION_FEE_BPS_PER_HOUR);
+    }
+
+    function test_ZeroFeeDeploymentDisablesExtensions() public {
+        IntentGuardian disabledGuardian = new IntentGuardian(escrowRegistry, 0);
+        escrow.configureDeposit(depositor, token, address(disabledGuardian));
+
+        vm.expectRevert(IIntentGuardian.ExtensionsDisabled.selector);
+        disabledGuardian.extendIntent(address(escrow), DEPOSIT_ID, INTENT_HASH, 1 hours, type(uint256).max);
+    }
+
+    function test_UnrelatedPayerPrepaysDepositorAndExtendsIntentImmediately() public {
+        uint256 additionalTime = 2 hours;
+        uint256 cost = guardian.quoteExtensionCost(INTENT_AMOUNT, additionalTime);
+        uint256 expiryBefore = escrow.getDepositIntent(DEPOSIT_ID, INTENT_HASH).expiryTime;
+        uint256 payerBalanceBefore = token.balanceOf(payer);
+        uint256 depositorBalanceBefore = token.balanceOf(depositor);
+
+        _approveGuardian(cost);
+        vm.prank(payer);
+        vm.expectEmit(true, true, true, true, address(guardian));
+        emit IntentExtended(address(escrow), DEPOSIT_ID, INTENT_HASH, payer, additionalTime, cost);
+        guardian.extendIntent(address(escrow), DEPOSIT_ID, INTENT_HASH, additionalTime, cost);
+
+        assertEq(escrow.getDepositIntent(DEPOSIT_ID, INTENT_HASH).expiryTime, expiryBefore + additionalTime);
+        assertEq(token.balanceOf(payer), payerBalanceBefore - cost);
+        assertEq(token.balanceOf(depositor), depositorBalanceBefore + cost);
+        assertEq(token.balanceOf(address(guardian)), 0);
+    }
+
+    function test_RemovedOrUnknownEscrowCannotBeUsed() public {
+        escrowRegistry.removeEscrow(address(escrow));
+
+        vm.expectRevert(abi.encodeWithSelector(IIntentGuardian.EscrowNotWhitelisted.selector, address(escrow)));
+        guardian.extendIntent(address(escrow), DEPOSIT_ID, INTENT_HASH, 1 hours, type(uint256).max);
+    }
+
+    function test_AcceptAllRegistryModeSupportsCompatibleUnlistedEscrow() public {
+        GuardianEscrowMock otherEscrow = new GuardianEscrowMock();
+        otherEscrow.configureDeposit(depositor, token, address(guardian));
+        _setLiveIntent(otherEscrow, INTENT_HASH, INTENT_AMOUNT, 1 days);
+        escrowRegistry.setAcceptAllEscrows(true);
+
+        uint256 additionalTime = 1 hours;
+        uint256 cost = guardian.quoteExtensionCost(INTENT_AMOUNT, additionalTime);
+        uint256 expiryBefore = otherEscrow.getDepositIntent(DEPOSIT_ID, INTENT_HASH).expiryTime;
+
+        _approveGuardian(cost);
+        vm.prank(payer);
+        guardian.extendIntent(address(otherEscrow), DEPOSIT_ID, INTENT_HASH, additionalTime, cost);
+
+        assertEq(otherEscrow.getDepositIntent(DEPOSIT_ID, INTENT_HASH).expiryTime, expiryBefore + additionalTime);
+    }
+
+    function test_OneGuardianSupportsMultipleWhitelistedEscrows() public {
+        GuardianEscrowMock secondEscrow = new GuardianEscrowMock();
+        escrowRegistry.addEscrow(address(secondEscrow));
+        secondEscrow.configureDeposit(depositor, token, address(guardian));
+        bytes32 secondIntent = keccak256("second-intent");
+        _setLiveIntent(secondEscrow, secondIntent, INTENT_AMOUNT, 1 days);
+
+        uint256 additionalTime = 1 hours;
+        uint256 cost = guardian.quoteExtensionCost(INTENT_AMOUNT, additionalTime);
+        uint256 firstExpiryBefore = escrow.getDepositIntent(DEPOSIT_ID, INTENT_HASH).expiryTime;
+        uint256 secondExpiryBefore = secondEscrow.getDepositIntent(DEPOSIT_ID, secondIntent).expiryTime;
+        _approveGuardian(cost * 2);
+
+        vm.startPrank(payer);
+        guardian.extendIntent(address(escrow), DEPOSIT_ID, INTENT_HASH, additionalTime, cost);
+        guardian.extendIntent(address(secondEscrow), DEPOSIT_ID, secondIntent, additionalTime, cost);
+        vm.stopPrank();
+
+        assertEq(escrow.getDepositIntent(DEPOSIT_ID, INTENT_HASH).expiryTime, firstExpiryBefore + additionalTime);
+        assertEq(
+            secondEscrow.getDepositIntent(DEPOSIT_ID, secondIntent).expiryTime, secondExpiryBefore + additionalTime
+        );
+    }
+
+    function test_QuoteRoundsUpToNextTokenUnit() public {
+        IntentGuardian oneBpsGuardian = new IntentGuardian(escrowRegistry, 1);
+        assertEq(oneBpsGuardian.quoteExtensionCost(1, 1), 1);
+
+        uint256 amount = 1_000_003;
+        uint256 additionalTime = 333;
+        uint256 numerator = amount * additionalTime;
+        assertEq(oneBpsGuardian.quoteExtensionCost(amount, additionalTime), (numerator + 36_000_000 - 1) / 36_000_000);
+    }
+
+    function test_MaxCostRevertsAtomicallyThenAcceptsExactQuote() public {
+        uint256 additionalTime = 1 hours;
+        uint256 cost = guardian.quoteExtensionCost(INTENT_AMOUNT, additionalTime);
+        uint256 expiryBefore = escrow.getDepositIntent(DEPOSIT_ID, INTENT_HASH).expiryTime;
+        _approveGuardian(cost);
+
+        vm.prank(payer);
+        vm.expectRevert(abi.encodeWithSelector(IIntentGuardian.ExtensionCostExceedsMax.selector, cost, cost - 1));
+        guardian.extendIntent(address(escrow), DEPOSIT_ID, INTENT_HASH, additionalTime, cost - 1);
+
+        assertEq(escrow.getDepositIntent(DEPOSIT_ID, INTENT_HASH).expiryTime, expiryBefore);
+
+        vm.prank(payer);
+        guardian.extendIntent(address(escrow), DEPOSIT_ID, INTENT_HASH, additionalTime, cost);
+        assertEq(escrow.getDepositIntent(DEPOSIT_ID, INTENT_HASH).expiryTime, expiryBefore + additionalTime);
+    }
+
+    function test_ExpiredAndUnknownIntentsCannotBeExtended() public {
+        uint256 expiryTime = escrow.getDepositIntent(DEPOSIT_ID, INTENT_HASH).expiryTime;
+        vm.warp(expiryTime);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentGuardian.IntentAlreadyExpired.selector, INTENT_HASH, expiryTime, block.timestamp
+            )
+        );
+        guardian.extendIntent(address(escrow), DEPOSIT_ID, INTENT_HASH, 1 hours, type(uint256).max);
+
+        bytes32 unknownIntentHash = keccak256("unknown");
+        vm.expectRevert(
+            abi.encodeWithSelector(IIntentGuardian.IntentAlreadyExpired.selector, unknownIntentHash, 0, block.timestamp)
+        );
+        guardian.extendIntent(address(escrow), DEPOSIT_ID, unknownIntentHash, 1 hours, type(uint256).max);
+    }
+
+    function test_EscrowEnforcesZeroTimeAndCumulativeFiveDayLifetimeCap() public {
+        vm.expectRevert(IEscrow.ZeroValue.selector);
+        guardian.extendIntent(address(escrow), DEPOSIT_ID, INTENT_HASH, 0, type(uint256).max);
+
+        vm.expectRevert(abi.encodeWithSelector(IEscrow.AmountAboveMax.selector, 5 days, 5 days));
+        guardian.extendIntent(address(escrow), DEPOSIT_ID, INTENT_HASH, 5 days, type(uint256).max);
+
+        _approveGuardian(type(uint256).max);
+        vm.startPrank(payer);
+        guardian.extendIntent(address(escrow), DEPOSIT_ID, INTENT_HASH, 2 days, type(uint256).max);
+        guardian.extendIntent(address(escrow), DEPOSIT_ID, INTENT_HASH, 2 days, type(uint256).max);
+        vm.expectRevert(abi.encodeWithSelector(IEscrow.AmountAboveMax.selector, 1, 5 days));
+        guardian.extendIntent(address(escrow), DEPOSIT_ID, INTENT_HASH, 1, type(uint256).max);
+        vm.stopPrank();
+    }
+
+    function test_FailedSafeTransferRevertsEscrowExtensionAtomically() public {
+        uint256 expiryBefore = escrow.getDepositIntent(DEPOSIT_ID, INTENT_HASH).expiryTime;
+
+        vm.prank(payer);
+        vm.expectRevert();
+        guardian.extendIntent(address(escrow), DEPOSIT_ID, INTENT_HASH, 1 hours, type(uint256).max);
+
+        assertEq(escrow.getDepositIntent(DEPOSIT_ID, INTENT_HASH).expiryTime, expiryBefore);
+        assertEq(token.balanceOf(depositor), 0);
+    }
+
+    function test_PrepaidExtensionIsNotRefundedWhenIntentTerminatesImmediately() public {
+        uint256 cost = guardian.quoteExtensionCost(INTENT_AMOUNT, 1 hours);
+        _approveGuardian(cost);
+        vm.prank(payer);
+        guardian.extendIntent(address(escrow), DEPOSIT_ID, INTENT_HASH, 1 hours, cost);
+        uint256 payerBalanceAfterExtension = token.balanceOf(payer);
+        uint256 depositorBalanceAfterExtension = token.balanceOf(depositor);
+
+        escrow.deleteIntent(INTENT_HASH);
+
+        assertEq(token.balanceOf(payer), payerBalanceAfterExtension);
+        assertEq(token.balanceOf(depositor), depositorBalanceAfterExtension);
+        assertEq(token.balanceOf(address(guardian)), 0);
+    }
+
+    function _setLiveIntent(GuardianEscrowMock _escrow, bytes32 _intentHash, uint256 _amount, uint256 _duration)
+        internal
+    {
+        _escrow.setIntent(_intentHash, _amount, block.timestamp, block.timestamp + _duration);
+    }
+
+    function _approveGuardian(uint256 _amount) internal {
+        vm.prank(payer);
+        token.approve(address(guardian), _amount);
+    }
+}

--- a/test-foundry/deterministic/guardian/IntentGuardianEscrowCompatibility.t.sol
+++ b/test-foundry/deterministic/guardian/IntentGuardianEscrowCompatibility.t.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+
+import {Escrow} from "../../../contracts/Escrow.sol";
+import {EscrowV2} from "../../../contracts/EscrowV2.sol";
+import {IntentGuardian} from "../../../contracts/IntentGuardian.sol";
+import {IEscrow} from "../../../contracts/interfaces/IEscrow.sol";
+import {IEscrowV2} from "../../../contracts/interfaces/IEscrowV2.sol";
+import {EscrowRegistry} from "../../../contracts/registries/EscrowRegistry.sol";
+import {OrchestratorRegistry} from "../../../contracts/registries/OrchestratorRegistry.sol";
+import {GuardianTokenMock} from "./IntentGuardian.t.sol";
+
+abstract contract IntentGuardianCompatibilityTestBase is Test {
+    uint256 internal constant INTENT_AMOUNT = 1_000e6;
+    bytes32 internal constant INTENT_HASH = keccak256("compatibility-intent");
+
+    address internal depositor = makeAddr("depositor");
+    address internal payer = makeAddr("payer");
+
+    GuardianTokenMock internal token;
+    EscrowRegistry internal escrowRegistry;
+    IntentGuardian internal guardian;
+
+    function setUp() public virtual {
+        token = new GuardianTokenMock();
+        escrowRegistry = new EscrowRegistry();
+        guardian = new IntentGuardian(escrowRegistry, 10);
+        token.mint(payer, INTENT_AMOUNT);
+    }
+
+    function _extend(address _escrow) internal {
+        uint256 cost = guardian.quoteExtensionCost(INTENT_AMOUNT, 1 hours);
+        vm.prank(payer);
+        token.approve(address(guardian), cost);
+        vm.prank(payer);
+        guardian.extendIntent(_escrow, 0, INTENT_HASH, 1 hours, cost);
+    }
+}
+
+contract IntentGuardianEscrowCompatibilityTest is IntentGuardianCompatibilityTestBase {
+    function test_CompatibleWithFrozenEscrow() public {
+        Escrow frozenEscrow = new Escrow(address(this), block.chainid, address(1), depositor, 0, 10, 1 days);
+        frozenEscrow.setOrchestrator(address(this));
+        escrowRegistry.addEscrow(address(frozenEscrow));
+
+        token.mint(depositor, INTENT_AMOUNT * 2);
+        vm.startPrank(depositor);
+        token.approve(address(frozenEscrow), INTENT_AMOUNT * 2);
+        frozenEscrow.createDeposit(
+            IEscrow.CreateDepositParams({
+                token: token,
+                amount: INTENT_AMOUNT * 2,
+                intentAmountRange: IEscrow.Range({min: INTENT_AMOUNT, max: INTENT_AMOUNT}),
+                paymentMethods: new bytes32[](0),
+                paymentMethodData: new IEscrow.DepositPaymentMethodData[](0),
+                currencies: new IEscrow.Currency[][](0),
+                delegate: address(0),
+                intentGuardian: address(guardian),
+                retainOnEmpty: true
+            })
+        );
+        vm.stopPrank();
+        frozenEscrow.lockFunds(0, INTENT_HASH, INTENT_AMOUNT);
+
+        uint256 expiryBefore = frozenEscrow.getDepositIntent(0, INTENT_HASH).expiryTime;
+        _extend(address(frozenEscrow));
+
+        assertEq(frozenEscrow.getDepositIntent(0, INTENT_HASH).expiryTime, expiryBefore + 1 hours);
+    }
+}
+
+contract IntentGuardianEscrowV2CompatibilityTest is IntentGuardianCompatibilityTestBase {
+    function test_CompatibleWithFrozenEscrowV2AndCurrentOrchestratorAuthorization() public {
+        OrchestratorRegistry orchestratorRegistry = new OrchestratorRegistry();
+        orchestratorRegistry.addOrchestrator(address(this));
+        EscrowV2 frozenEscrowV2 = new EscrowV2(
+            address(this), block.chainid, address(orchestratorRegistry), address(1), depositor, 0, 10, 1 days
+        );
+        escrowRegistry.addEscrow(address(frozenEscrowV2));
+
+        token.mint(depositor, INTENT_AMOUNT * 2);
+        vm.startPrank(depositor);
+        token.approve(address(frozenEscrowV2), INTENT_AMOUNT * 2);
+        frozenEscrowV2.createDeposit(
+            IEscrowV2.CreateDepositParams({
+                token: token,
+                amount: INTENT_AMOUNT * 2,
+                intentAmountRange: IEscrowV2.Range({min: INTENT_AMOUNT, max: INTENT_AMOUNT}),
+                paymentMethods: new bytes32[](0),
+                paymentMethodData: new IEscrowV2.DepositPaymentMethodData[](0),
+                currencies: new IEscrowV2.Currency[][](0),
+                delegate: address(0),
+                intentGuardian: address(guardian),
+                retainOnEmpty: true
+            })
+        );
+        vm.stopPrank();
+        frozenEscrowV2.lockFunds(0, INTENT_HASH, INTENT_AMOUNT);
+
+        uint256 expiryBefore = frozenEscrowV2.getDepositIntent(0, INTENT_HASH).expiryTime;
+        _extend(address(frozenEscrowV2));
+
+        assertEq(frozenEscrowV2.getDepositIntent(0, INTENT_HASH).expiryTime, expiryBefore + 1 hours);
+    }
+}

--- a/test-foundry/fuzz/IntentGuardianFuzz.t.sol
+++ b/test-foundry/fuzz/IntentGuardianFuzz.t.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IntentGuardian} from "../../contracts/IntentGuardian.sol";
+import {IIntentGuardian} from "../../contracts/interfaces/IIntentGuardian.sol";
+import {EscrowRegistry} from "../../contracts/registries/EscrowRegistry.sol";
+import {GuardianEscrowMock, GuardianTokenMock} from "../deterministic/guardian/IntentGuardian.t.sol";
+
+contract IntentGuardianFuzzTest is Test {
+    uint256 internal constant DEPOSIT_ID = 1;
+    bytes32 internal constant INTENT_HASH = keccak256("fuzz-intent");
+    uint256 internal constant FEE_DENOMINATOR = 36_000_000;
+
+    address internal depositor = makeAddr("depositor");
+    address internal payer = makeAddr("payer");
+
+    GuardianTokenMock internal token;
+    GuardianEscrowMock internal escrow;
+    EscrowRegistry internal escrowRegistry;
+
+    function setUp() public {
+        token = new GuardianTokenMock();
+        escrow = new GuardianEscrowMock();
+        escrowRegistry = new EscrowRegistry();
+        escrowRegistry.addEscrow(address(escrow));
+    }
+
+    function testFuzz_QuoteMatchesChargedCostAndRoundsUp(uint96 rawAmount, uint32 rawAdditionalTime, uint8 rawFee)
+        public
+    {
+        uint256 amount = bound(uint256(rawAmount), 1, type(uint96).max);
+        uint256 additionalTime = bound(uint256(rawAdditionalTime), 1, 5 days - 1 hours);
+        uint256 fee = bound(uint256(rawFee), 1, 83);
+        IntentGuardian guardian = _configureGuardian(amount, fee);
+        uint256 quote = guardian.quoteExtensionCost(amount, additionalTime);
+
+        vm.prank(payer);
+        token.approve(address(guardian), quote);
+        vm.prank(payer);
+        guardian.extendIntent(address(escrow), DEPOSIT_ID, INTENT_HASH, additionalTime, quote);
+
+        uint256 numerator = amount * fee * additionalTime;
+        assertEq(token.balanceOf(depositor), quote);
+        assertEq(token.balanceOf(payer), amount - quote);
+        assertGe(quote * FEE_DENOMINATOR, numerator);
+        assertLt((quote - 1) * FEE_DENOMINATOR, numerator);
+    }
+
+    function testFuzz_CostNeverExceedsIntentAmount(uint96 rawAmount, uint32 rawTime, uint8 rawFee) public {
+        uint256 amount = bound(uint256(rawAmount), 1, type(uint96).max);
+        uint256 additionalTime = bound(uint256(rawTime), 1, 5 days);
+        uint256 fee = bound(uint256(rawFee), 1, 83);
+        IntentGuardian guardian = new IntentGuardian(escrowRegistry, fee);
+
+        assertLe(guardian.quoteExtensionCost(amount, additionalTime), amount);
+    }
+
+    function testFuzz_MaxCostFailureLeavesExpiryAndBalancesUntouched(
+        uint96 rawAmount,
+        uint32 rawAdditionalTime,
+        uint8 rawFee
+    ) public {
+        uint256 amount = bound(uint256(rawAmount), 1, type(uint96).max);
+        uint256 additionalTime = bound(uint256(rawAdditionalTime), 1, 5 days - 1 hours);
+        uint256 fee = bound(uint256(rawFee), 1, 83);
+        IntentGuardian guardian = _configureGuardian(amount, fee);
+        uint256 quote = guardian.quoteExtensionCost(amount, additionalTime);
+        uint256 expiryBefore = escrow.getDepositIntent(DEPOSIT_ID, INTENT_HASH).expiryTime;
+
+        vm.prank(payer);
+        token.approve(address(guardian), quote);
+        vm.prank(payer);
+        vm.expectRevert(abi.encodeWithSelector(IIntentGuardian.ExtensionCostExceedsMax.selector, quote, quote - 1));
+        guardian.extendIntent(address(escrow), DEPOSIT_ID, INTENT_HASH, additionalTime, quote - 1);
+
+        assertEq(escrow.getDepositIntent(DEPOSIT_ID, INTENT_HASH).expiryTime, expiryBefore);
+        assertEq(token.balanceOf(payer), amount);
+        assertEq(token.balanceOf(depositor), 0);
+    }
+
+    function _configureGuardian(uint256 _amount, uint256 _fee) internal returns (IntentGuardian guardian) {
+        guardian = new IntentGuardian(escrowRegistry, _fee);
+        escrow.configureDeposit(depositor, token, address(guardian));
+        escrow.setIntent(INTENT_HASH, _amount, block.timestamp, block.timestamp + 1 hours);
+        token.mint(payer, _amount);
+    }
+}

--- a/utils/riskMath.ts
+++ b/utils/riskMath.ts
@@ -1,4 +1,4 @@
-/** Exact client-side counterparts of RiskManager's integer formulas. */
+/** Exact client-side counterparts of IntentGuardian and RiskManager integer formulas. */
 
 export type IntegerLike = bigint | number | string | { toString(): string };
 
@@ -28,16 +28,29 @@ function ceilDiv(numerator: bigint, denominator: bigint): bigint {
   return ((numerator - 1n) / denominator) + 1n;
 }
 
-/** ceil(A * s * T / (10_000 * 1 hour)); returns zero when the curve is disabled. */
+/** Exact counterpart of IntentGuardian's ceil(A * s * T / (10_000 * 1 hour)) quote. */
+export function quoteIntentGuardianExtensionCost(
+  intentAmount: IntegerLike,
+  extensionTime: IntegerLike,
+  extensionFeeBpsPerHour: IntegerLike,
+): bigint {
+  const amount = integer(intentAmount, "intentAmount");
+  const duration = integer(extensionTime, "extensionTime");
+  const fee = integer(extensionFeeBpsPerHour, "extensionFeeBpsPerHour");
+  return ceilDiv(amount * fee * duration, RISK_EXTENSION_DENOMINATOR);
+}
+
+/** Backwards-compatible RiskManager name for the same integer pricing formula. */
 export function calculateIntentExtensionCost(
   intentAmount: IntegerLike,
   extensionTime: IntegerLike,
   extensionPenaltyBpsPerHour: IntegerLike,
 ): bigint {
-  const amount = integer(intentAmount, "intentAmount");
-  const duration = integer(extensionTime, "extensionTime");
-  const slope = integer(extensionPenaltyBpsPerHour, "extensionPenaltyBpsPerHour");
-  return ceilDiv(amount * slope * duration, RISK_EXTENSION_DENOMINATOR);
+  return quoteIntentGuardianExtensionCost(
+    intentAmount,
+    extensionTime,
+    extensionPenaltyBpsPerHour,
+  );
 }
 
 /** Charges elapsed post-expiry time, capped by the exact duration purchased. */


### PR DESCRIPTION
## Summary
- add a standalone prepaid `IntentGuardian` compatible with the frozen `Escrow`, `EscrowV2`, current `OrchestratorV2`, and future orchestrators that use the shared Escrow ABI
- use a constructor-fixed immutable fee; changing price requires a new guardian deployment and maker opt-in, so governance cannot lower economics beneath existing opt-ins
- add deploy/config plumbing, packaged ABI extraction, and an exact upward-rounded client quote helper
- add focused deterministic, compatibility, and 512-run fuzz tests

## Economics and security
- permissionless payer
- only live intents can be extended
- prepaid, non-refundable fee transfers directly from payer to deposit owner
- caller-supplied `maxCost` protects against slippage
- the Escrow remains the authority for guardian authorization, non-zero extensions, and cumulative five-day lifetime cap
- Escrow registry allowlisting and `SafeERC20` transfers
- no owner or fee-mutation surface; a new fee means a new deployment/version

## Compatibility and deployment impact
- **`contracts/Escrow.sol` and `contracts/EscrowV2.sol` are untouched**
- no `RiskManager`, `StakeVault`, or `OrchestratorV3` dependency
- fresh `31_deploy_intent_guardian.ts`; local/hardhat/staging use 2 bps/hour, while production is intentionally unconfigured
- no onchain deployment and no live deployment artifacts in this PR
- follow-up: deploy the chosen immutable version, authorize its address on maker deposits, publish the contracts package, and activate the corresponding indexer address

## Validation
- `yarn compile` — 134 Solidity files compiled; 137 artifacts / 290 typings
- `yarn build` — pass
- `yarn pkg:build` — pass; 9 source ABIs including `IntentGuardian`
- `yarn pkg:test` — 3 suites / 9 tests passed
- `forge test --summary` with documented deterministic test keys — 98 suites / 1,554 passed / 0 failed / 0 skipped
- guardian deterministic tests — 15 passed
- guardian fuzz tests — 3 properties, 512 runs each
- `yarn coverage` — 99.87% lines, 99.76% statements, 98.70% branches, 100% functions
- `contracts/IntentGuardian.sol` — 25/25 lines, 32/32 statements, 6/6 branches, 4/4 functions
- focused `forge fmt --check` and `git diff --check` — pass

## Reference
The standalone guardian behavior was informed by #205, without taking its bundled RiskManager, StakeVault, OrchestratorV3, or maker-protection changes.