### PR TITLE
feat: make IntentGuardian fee governable

### DIFF
--- a/contracts/IntentGuardian.sol
+++ b/contracts/IntentGuardian.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.18;
 
+import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -14,11 +15,10 @@ import {IIntentGuardian} from "./interfaces/IIntentGuardian.sol";
 /**
  * @title IntentGuardian
  * @notice Extends live Escrow intents in exchange for a prepaid, non-refundable fee.
- * @dev Escrow and EscrowV2 expose the same Deposit and Intent ABI used here. A deposit opts into a
- *      specific guardian address, so the constructor-fixed fee cannot be changed beneath its maker.
- *      A different fee requires a new guardian deployment and an explicit opt-in on a new deposit.
+ * @dev Escrow and EscrowV2 expose the same Deposit and Intent ABI used here. Governance can update
+ *      the extension fee for every deposit using this guardian address.
  */
-contract IntentGuardian is IIntentGuardian, ReentrancyGuard {
+contract IntentGuardian is IIntentGuardian, Ownable2Step, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     uint256 public constant BPS_DENOMINATOR = 10_000;
@@ -28,16 +28,20 @@ contract IntentGuardian is IIntentGuardian, ReentrancyGuard {
     uint256 public constant MAX_EXTENSION_FEE_BPS_PER_HOUR = EXTENSION_FEE_DENOMINATOR / MAX_TOTAL_INTENT_LIFETIME;
 
     IEscrowRegistry public immutable override escrowRegistry;
-    uint256 public immutable override extensionFeeBpsPerHour;
+    uint256 public override extensionFeeBpsPerHour;
 
-    constructor(IEscrowRegistry _escrowRegistry, uint256 _extensionFeeBpsPerHour) {
+    constructor(address _owner, IEscrowRegistry _escrowRegistry, uint256 _extensionFeeBpsPerHour) {
+        if (_owner == address(0)) revert ZeroAddress();
         if (address(_escrowRegistry) == address(0)) revert ZeroAddress();
-        if (_extensionFeeBpsPerHour > MAX_EXTENSION_FEE_BPS_PER_HOUR) {
-            revert ExtensionFeeExceedsIntentAmount(_extensionFeeBpsPerHour);
-        }
 
         escrowRegistry = _escrowRegistry;
-        extensionFeeBpsPerHour = _extensionFeeBpsPerHour;
+        _transferOwnership(_owner);
+        _setExtensionFeeBpsPerHour(_extensionFeeBpsPerHour);
+    }
+
+    /// @inheritdoc IIntentGuardian
+    function setExtensionFeeBpsPerHour(uint256 _extensionFeeBpsPerHour) external override onlyOwner {
+        _setExtensionFeeBpsPerHour(_extensionFeeBpsPerHour);
     }
 
     /**
@@ -93,5 +97,15 @@ contract IntentGuardian is IIntentGuardian, ReentrancyGuard {
         returns (uint256)
     {
         return Math.mulDiv(_intentAmount, _feeBpsPerHour * _additionalTime, EXTENSION_FEE_DENOMINATOR, Math.Rounding.Up);
+    }
+
+    function _setExtensionFeeBpsPerHour(uint256 _extensionFeeBpsPerHour) internal {
+        if (_extensionFeeBpsPerHour > MAX_EXTENSION_FEE_BPS_PER_HOUR) {
+            revert ExtensionFeeExceedsIntentAmount(_extensionFeeBpsPerHour);
+        }
+
+        uint256 previousFeeBpsPerHour = extensionFeeBpsPerHour;
+        extensionFeeBpsPerHour = _extensionFeeBpsPerHour;
+        emit ExtensionFeeBpsPerHourUpdated(previousFeeBpsPerHour, _extensionFeeBpsPerHour);
     }
 }

--- a/contracts/interfaces/IIntentGuardian.sol
+++ b/contracts/interfaces/IIntentGuardian.sol
@@ -9,6 +9,8 @@ import {IEscrowRegistry} from "./IEscrowRegistry.sol";
  * @notice Permissionless prepaid intent extensions for compatible Escrow deposits.
  */
 interface IIntentGuardian {
+    event ExtensionFeeBpsPerHourUpdated(uint256 previousFeeBpsPerHour, uint256 newFeeBpsPerHour);
+
     event IntentExtended(
         address indexed escrow,
         uint256 indexed depositId,
@@ -41,12 +43,18 @@ interface IIntentGuardian {
         uint256 _maxCost
     ) external;
 
+    /**
+     * @notice Updates the hourly extension fee for all deposits using this guardian.
+     * @dev A zero fee disables extensions until governance configures a non-zero fee.
+     */
+    function setExtensionFeeBpsPerHour(uint256 _extensionFeeBpsPerHour) external;
+
     /// @notice Quotes the exact upward-rounded prepaid extension cost.
     function quoteExtensionCost(uint256 _intentAmount, uint256 _additionalTime) external view returns (uint256);
 
     /// @notice Escrow registry used to authorize compatible escrows.
     function escrowRegistry() external view returns (IEscrowRegistry);
 
-    /// @notice Immutable hourly extension fee in basis points of the locked intent amount.
+    /// @notice Governance-configured hourly extension fee in basis points of the locked intent amount.
     function extensionFeeBpsPerHour() external view returns (uint256);
 }

--- a/deploy/31_deploy_intent_guardian.ts
+++ b/deploy/31_deploy_intent_guardian.ts
@@ -3,7 +3,10 @@ import "module-alias/register";
 import {HardhatRuntimeEnvironment} from "hardhat/types";
 import {DeployFunction} from "hardhat-deploy/types";
 
-import {INTENT_GUARDIAN_EXTENSION_FEE_BPS_PER_HOUR} from "../deployments/parameters";
+import {
+  INTENT_GUARDIAN_EXTENSION_FEE_BPS_PER_HOUR,
+  MULTI_SIG,
+} from "../deployments/parameters";
 import {
   getDeployedContractAddress,
   waitForDeploymentDelay,
@@ -13,16 +16,17 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const {deploy} = hre.deployments;
   const network = hre.deployments.getNetworkName();
   const [deployer] = await hre.getUnnamedAccounts();
+  const owner = MULTI_SIG[network] || deployer;
   const extensionFeeBpsPerHour = INTENT_GUARDIAN_EXTENSION_FEE_BPS_PER_HOUR[network];
 
   if (extensionFeeBpsPerHour === undefined) {
-    throw new Error(`No immutable IntentGuardian fee configured for network: ${network}`);
+    throw new Error(`No initial IntentGuardian fee configured for network: ${network}`);
   }
 
   const escrowRegistry = getDeployedContractAddress(network, "EscrowRegistry");
   const guardian = await deploy("IntentGuardian", {
     from: deployer,
-    args: [escrowRegistry, extensionFeeBpsPerHour],
+    args: [owner, escrowRegistry, extensionFeeBpsPerHour],
     log: true,
   });
 
@@ -30,7 +34,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     console.log(
       "IntentGuardian deployed at",
       guardian.address,
-      "with immutable fee",
+      "with governance owner",
+      owner,
+      "and initial fee",
       extensionFeeBpsPerHour,
       "bps/hour",
     );

--- a/deployments/parameters.ts
+++ b/deployments/parameters.ts
@@ -162,10 +162,9 @@ export const STAKE_RISK_PLATFORM_POLICY: any = {
   base_staging: INITIAL_STAKE_RISK_PLATFORM_POLICY,
 };
 
-// Immutable hourly fee for the standalone IntentGuardian, denominated in basis points of the
-// locked intent amount. Changing this value deploys a new guardian version; makers that opted
-// into an earlier guardian keep that deployment's constructor-fixed economics. Production is
-// intentionally absent until governance ratifies a fee and deployment.
+// Initial hourly fee for the standalone IntentGuardian, denominated in basis points of the
+// locked intent amount. Governance can update this value on the deployed guardian. Production
+// is intentionally absent until governance ratifies a fee and deployment.
 export const INTENT_GUARDIAN_EXTENSION_FEE_BPS_PER_HOUR: Record<string, number> = {
   localhost: 2,
   hardhat: 2,

--- a/test-foundry/deterministic/guardian/IntentGuardian.t.sol
+++ b/test-foundry/deterministic/guardian/IntentGuardian.t.sol
@@ -69,6 +69,8 @@ contract GuardianEscrowMock {
 }
 
 contract IntentGuardianTest is Test {
+    event ExtensionFeeBpsPerHourUpdated(uint256 previousFeeBpsPerHour, uint256 newFeeBpsPerHour);
+
     event IntentExtended(
         address indexed escrow,
         uint256 indexed depositId,
@@ -96,33 +98,76 @@ contract IntentGuardianTest is Test {
         escrow = new GuardianEscrowMock();
         escrowRegistry = new EscrowRegistry();
         escrowRegistry.addEscrow(address(escrow));
-        guardian = new IntentGuardian(escrowRegistry, EXTENSION_FEE_BPS_PER_HOUR);
+        guardian = new IntentGuardian(address(this), escrowRegistry, EXTENSION_FEE_BPS_PER_HOUR);
         escrow.configureDeposit(depositor, token, address(guardian));
         _setLiveIntent(escrow, INTENT_HASH, INTENT_AMOUNT, 1 days);
         token.mint(payer, INTENT_AMOUNT);
     }
 
-    function test_ConstructorFixesFeeAndRejectsInvalidConfiguration() public {
+    function test_ConstructorSetsGovernanceAndRejectsInvalidConfiguration() public {
         assertEq(guardian.extensionFeeBpsPerHour(), EXTENSION_FEE_BPS_PER_HOUR);
         assertEq(address(guardian.escrowRegistry()), address(escrowRegistry));
+        assertEq(guardian.owner(), address(this));
         assertEq(guardian.MAX_EXTENSION_FEE_BPS_PER_HOUR(), 83);
 
         vm.expectRevert(IIntentGuardian.ZeroAddress.selector);
-        new IntentGuardian(IEscrowRegistry(address(0)), EXTENSION_FEE_BPS_PER_HOUR);
+        new IntentGuardian(address(0), escrowRegistry, EXTENSION_FEE_BPS_PER_HOUR);
+
+        vm.expectRevert(IIntentGuardian.ZeroAddress.selector);
+        new IntentGuardian(address(this), IEscrowRegistry(address(0)), EXTENSION_FEE_BPS_PER_HOUR);
 
         vm.expectRevert(abi.encodeWithSelector(IIntentGuardian.ExtensionFeeExceedsIntentAmount.selector, 84));
-        new IntentGuardian(escrowRegistry, 84);
+        new IntentGuardian(address(this), escrowRegistry, 84);
     }
 
-    function test_ThereIsNoFeeMutationSurface() public {
-        (bool success,) = address(guardian).call(abi.encodeWithSignature("setExtensionFeeBpsPerHour(uint256)", 1));
+    function test_OwnerUpdatesFeeAndQuoteWhileNonOwnerCannot() public {
+        vm.prank(payer);
+        vm.expectRevert("Ownable: caller is not the owner");
+        guardian.setExtensionFeeBpsPerHour(1);
 
-        assertFalse(success);
+        uint256 previousQuote = guardian.quoteExtensionCost(INTENT_AMOUNT, 1 hours);
+        vm.expectEmit(false, false, false, true, address(guardian));
+        emit ExtensionFeeBpsPerHourUpdated(EXTENSION_FEE_BPS_PER_HOUR, 20);
+        guardian.setExtensionFeeBpsPerHour(20);
+
+        assertEq(guardian.extensionFeeBpsPerHour(), 20);
+        assertEq(guardian.quoteExtensionCost(INTENT_AMOUNT, 1 hours), previousQuote * 2);
+    }
+
+    function test_FeeUpdateRejectsAboveMaximumAndCanDisableExtensions() public {
+        vm.expectRevert(abi.encodeWithSelector(IIntentGuardian.ExtensionFeeExceedsIntentAmount.selector, 84));
+        guardian.setExtensionFeeBpsPerHour(84);
         assertEq(guardian.extensionFeeBpsPerHour(), EXTENSION_FEE_BPS_PER_HOUR);
+
+        vm.expectEmit(false, false, false, true, address(guardian));
+        emit ExtensionFeeBpsPerHourUpdated(EXTENSION_FEE_BPS_PER_HOUR, 0);
+        guardian.setExtensionFeeBpsPerHour(0);
+
+        vm.expectRevert(IIntentGuardian.ExtensionsDisabled.selector);
+        guardian.extendIntent(address(escrow), DEPOSIT_ID, INTENT_HASH, 1 hours, type(uint256).max);
+    }
+
+    function test_TwoStepOwnershipTransferMovesFeeAuthority() public {
+        address nextOwner = makeAddr("nextOwner");
+        guardian.transferOwnership(nextOwner);
+        assertEq(guardian.owner(), address(this));
+        assertEq(guardian.pendingOwner(), nextOwner);
+
+        vm.prank(nextOwner);
+        guardian.acceptOwnership();
+        assertEq(guardian.owner(), nextOwner);
+        assertEq(guardian.pendingOwner(), address(0));
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        guardian.setExtensionFeeBpsPerHour(20);
+
+        vm.prank(nextOwner);
+        guardian.setExtensionFeeBpsPerHour(20);
+        assertEq(guardian.extensionFeeBpsPerHour(), 20);
     }
 
     function test_ZeroFeeDeploymentDisablesExtensions() public {
-        IntentGuardian disabledGuardian = new IntentGuardian(escrowRegistry, 0);
+        IntentGuardian disabledGuardian = new IntentGuardian(address(this), escrowRegistry, 0);
         escrow.configureDeposit(depositor, token, address(disabledGuardian));
 
         vm.expectRevert(IIntentGuardian.ExtensionsDisabled.selector);
@@ -197,7 +242,7 @@ contract IntentGuardianTest is Test {
     }
 
     function test_QuoteRoundsUpToNextTokenUnit() public {
-        IntentGuardian oneBpsGuardian = new IntentGuardian(escrowRegistry, 1);
+        IntentGuardian oneBpsGuardian = new IntentGuardian(address(this), escrowRegistry, 1);
         assertEq(oneBpsGuardian.quoteExtensionCost(1, 1), 1);
 
         uint256 amount = 1_000_003;

--- a/test-foundry/deterministic/guardian/IntentGuardianEscrowCompatibility.t.sol
+++ b/test-foundry/deterministic/guardian/IntentGuardianEscrowCompatibility.t.sol
@@ -27,7 +27,7 @@ abstract contract IntentGuardianCompatibilityTestBase is Test {
     function setUp() public virtual {
         token = new GuardianTokenMock();
         escrowRegistry = new EscrowRegistry();
-        guardian = new IntentGuardian(escrowRegistry, 10);
+        guardian = new IntentGuardian(address(this), escrowRegistry, 10);
         token.mint(payer, INTENT_AMOUNT);
     }
 

--- a/test-foundry/fuzz/IntentGuardianFuzz.t.sol
+++ b/test-foundry/fuzz/IntentGuardianFuzz.t.sol
@@ -53,7 +53,7 @@ contract IntentGuardianFuzzTest is Test {
         uint256 amount = bound(uint256(rawAmount), 1, type(uint96).max);
         uint256 additionalTime = bound(uint256(rawTime), 1, 5 days);
         uint256 fee = bound(uint256(rawFee), 1, 83);
-        IntentGuardian guardian = new IntentGuardian(escrowRegistry, fee);
+        IntentGuardian guardian = new IntentGuardian(address(this), escrowRegistry, fee);
 
         assertLe(guardian.quoteExtensionCost(amount, additionalTime), amount);
     }
@@ -82,7 +82,7 @@ contract IntentGuardianFuzzTest is Test {
     }
 
     function _configureGuardian(uint256 _amount, uint256 _fee) internal returns (IntentGuardian guardian) {
-        guardian = new IntentGuardian(escrowRegistry, _fee);
+        guardian = new IntentGuardian(address(this), escrowRegistry, _fee);
         escrow.configureDeposit(depositor, token, address(guardian));
         escrow.setIntent(INTENT_HASH, _amount, block.timestamp, block.timestamp + 1 hours);
         token.mint(payer, _amount);


### PR DESCRIPTION
## Summary
- replace the constructor-immutable guardian fee with an owner-governed `setExtensionFeeBpsPerHour` setter
- use `Ownable2Step` for safer future governance handoffs and require an explicit non-zero governance owner at deployment
- emit `ExtensionFeeBpsPerHourUpdated(previous, next)` at construction and on every governance update
- keep the existing 83 bps/hour maximum; setting the fee to zero disables extensions
- initialize ownership from the configured multisig, falling back to the deployer on local/staging networks without a multisig

## Economic tradeoff
This intentionally changes the guarantee introduced in #206: a maker opting into this guardian is now exposed to governance raising or lowering the fee for the shared guardian address. Payers retain `maxCost` slippage protection, but makers do not have a per-deposit minimum fee.

## Compatibility and deployment impact
- constructor is now `(owner, escrowRegistry, initialFeeBpsPerHour)`
- packaged ABI includes the setter plus `Ownable2Step` governance events
- no onchain deployment or live deployment artifacts
- `Escrow.sol` and `EscrowV2.sol` remain untouched
- companion indexer PR will audit fee and ownership changes

## Validation
- focused guardian deterministic/compatibility tests: 17 passed
- guardian fuzz tests: 3 properties, 512 runs each
- `yarn build`: passed; 134 Solidity files compiled and 290 typings generated
- `yarn pkg:build`: passed; 9 contract-source ABIs
- `yarn pkg:test`: 3 suites / 9 tests passed
- full Foundry suite: 98 suites / 1,556 passed / 0 failed / 0 skipped
- focused `forge fmt --check` and `git diff --check`: passed

Coverage was not rerun because this repository requires explicit coverage requests for the heavy workflow; every new setter branch is directly exercised by focused tests.