### PR TITLE
feat: scope maker whitelist groups by payment method

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,19 +85,19 @@ owner-controlled global `lifecycleHook` for future intents:
 
 The first minimal global hook is the independent maker whitelist stack:
 
-- `AddressGroupRegistry`: governance registers stable public group IDs, manages metadata and active state,
-  and assigns curators. Curators add or remove members; membership is event-indexed rather than enumerable
-  onchain.
-- `WhitelistPolicy`: each maker owns a direct address whitelist and a bounded list of up to 10 allowed groups,
-  plus an explicit `enabled` switch. The policy survives global hook replacement.
+- `AddressGroupRegistry`: anyone may create a curator-managed group. Curators can add or remove members,
+  transfer control, configure an optional membership resolver, and opt into self-service membership.
+- `WhitelistPolicy`: each maker owns a maker-wide direct address whitelist plus a payment-method-specific
+  `enabled` switch and bounded list of up to 10 allowed groups. The policy survives global hook replacement.
 - `IntentLifecycleHookV1`: a stateless admission hook that delegates to `WhitelistPolicy`, allowing a taker when
-  the maker's policy is disabled, the taker is directly whitelisted, or the taker belongs to at least one
-  configured active group. Enabled policies with no matching address or group fail closed. Settlement and
-  cancellation are no-ops in this version.
+  enforcement is disabled for the intent's payment method, the taker is directly whitelisted by the maker, or
+  the taker belongs to at least one group enabled for that payment method. Enabled policies with no matching
+  address or group fail closed. Settlement and cancellation are no-ops in this version.
 
-Canonical deployment IDs are `keccak256` hashes of `peers`, `peer-pluses`, and `peer-merchants`. Group
-enforcement is maker-level, not payment-method- or deposit-level. These V3 changes do not modify
-`EscrowV2`, require an Escrow redeployment, or alter the production `OrchestratorV2` whitelist path.
+Group IDs are derived from the curator and registry group counter, and offchain consumers must key them by
+chain, registry address, and group ID. Group enforcement is scoped by maker and payment method, while direct
+address trust is maker-wide; neither is deposit-specific. These V3 changes do not modify `EscrowV2`, require
+an Escrow redeployment, or alter the production `OrchestratorV2` whitelist path.
 
 ## V2 Contract Inventory
 

--- a/contracts/hooks/IntentLifecycleHookV1.sol
+++ b/contracts/hooks/IntentLifecycleHookV1.sol
@@ -11,8 +11,9 @@ import {IWhitelistPolicy} from "../interfaces/IWhitelistPolicy.sol";
 /**
  * @title IntentLifecycleHookV1
  * @notice Stateless lifecycle hook admitting any orchestrator registered in OrchestratorRegistry and enforcing
- * maker-owned whitelist policies. A taker is admitted when enforcement is disabled or when the policy allows the
- * taker directly or through an allowed group. Settlement and cancellation are no-ops in this version.
+ * maker-owned whitelist policies. A taker is admitted when enforcement is disabled for the intent's payment method
+ * or when the policy allows the taker through the maker-wide direct whitelist or a payment-method group.
+ * Settlement and cancellation are no-ops in this version.
  * @dev Reads intent context from the calling orchestrator and delegates admission to WhitelistPolicy.
  */
 contract IntentLifecycleHookV1 is IIntentLifecycleHook {
@@ -27,7 +28,7 @@ contract IntentLifecycleHookV1 is IIntentLifecycleHook {
     error InvalidDependency(address dependency);
     error UnauthorizedOrchestrator(address caller);
     error IntentNotFound(bytes32 intentHash);
-    error TakerNotWhitelisted(address maker, address taker);
+    error TakerNotWhitelisted(address maker, bytes32 paymentMethod, address taker);
 
     /* ============ Constructor ============ */
 
@@ -49,8 +50,8 @@ contract IntentLifecycleHookV1 is IIntentLifecycleHook {
         if (intent.owner == address(0)) revert IntentNotFound(_intentHash);
 
         address maker = IEscrow(intent.escrow).getDeposit(intent.depositId).depositor;
-        if (!whitelistPolicy.isTakerAllowed(maker, intent.owner)) {
-            revert TakerNotWhitelisted(maker, intent.owner);
+        if (!whitelistPolicy.isTakerAllowed(maker, intent.paymentMethod, intent.owner)) {
+            revert TakerNotWhitelisted(maker, intent.paymentMethod, intent.owner);
         }
     }
 

--- a/contracts/hooks/WhitelistPolicy.sol
+++ b/contracts/hooks/WhitelistPolicy.sol
@@ -8,29 +8,29 @@ import {IWhitelistPolicy} from "../interfaces/IWhitelistPolicy.sol";
 /**
  * @title WhitelistPolicy
  * @notice Persistent maker-owned taker admission settings, independent from any lifecycle-hook deployment.
- * Each maker can allow direct addresses or members of a bounded list of curated groups.
- * @dev Enabling an empty policy is allowed and intentionally fails closed when evaluated.
+ * Each maker can trust direct addresses globally and configure a bounded list of curated groups per payment method.
+ * @dev Enabling an empty payment-method policy is allowed and intentionally fails closed when evaluated.
  */
 contract WhitelistPolicy is IWhitelistPolicy {
     /* ============ Constants ============ */
 
-    uint256 public constant MAX_GROUPS_PER_MAKER = 10;
+    uint256 public constant MAX_GROUPS_PER_PAYMENT_METHOD = 10;
 
     /* ============ State Variables ============ */
 
     IAddressGroupRegistry public immutable override groupRegistry;
 
-    mapping(address => bool) public override enabled;
+    mapping(address => mapping(bytes32 => bool)) public override enabled;
     mapping(address => mapping(address => bool)) public override isWhitelisted;
-    mapping(address => bytes32[]) internal allowedGroups;
+    mapping(address => mapping(bytes32 => bytes32[])) internal allowedGroups;
 
     /* ============ Events ============ */
 
-    event EnabledUpdated(address indexed maker, bool enabled);
+    event EnabledUpdated(address indexed maker, bytes32 indexed paymentMethod, bool enabled);
     event AddressWhitelisted(address indexed maker, address indexed taker);
     event AddressRemovedFromWhitelist(address indexed maker, address indexed taker);
-    event AllowedGroupAdded(address indexed maker, bytes32 indexed groupId);
-    event AllowedGroupRemoved(address indexed maker, bytes32 indexed groupId);
+    event AllowedGroupAdded(address indexed maker, bytes32 indexed paymentMethod, bytes32 indexed groupId);
+    event AllowedGroupRemoved(address indexed maker, bytes32 indexed paymentMethod, bytes32 indexed groupId);
 
     /* ============ Errors ============ */
 
@@ -55,9 +55,9 @@ contract WhitelistPolicy is IWhitelistPolicy {
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function setEnabled(bool _enabled) external override {
-        enabled[msg.sender] = _enabled;
-        emit EnabledUpdated(msg.sender, _enabled);
+    function setEnabled(bytes32 _paymentMethod, bool _enabled) external override {
+        enabled[msg.sender][_paymentMethod] = _enabled;
+        emit EnabledUpdated(msg.sender, _paymentMethod, _enabled);
     }
 
     /**
@@ -94,38 +94,38 @@ contract WhitelistPolicy is IWhitelistPolicy {
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function addAllowedGroups(bytes32[] calldata _groupIds) external override {
+    function addAllowedGroups(bytes32 _paymentMethod, bytes32[] calldata _groupIds) external override {
         if (_groupIds.length == 0) revert EmptyArray();
 
-        bytes32[] storage makerGroups = allowedGroups[msg.sender];
+        bytes32[] storage paymentMethodGroups = allowedGroups[msg.sender][_paymentMethod];
         for (uint256 i = 0; i < _groupIds.length; ++i) {
             bytes32 groupId = _groupIds[i];
             if (!groupRegistry.groupExists(groupId)) revert GroupDoesNotExist(groupId);
-            if (_containsGroup(makerGroups, groupId)) continue;
-            if (makerGroups.length == MAX_GROUPS_PER_MAKER) {
-                revert TooManyGroups(makerGroups.length + 1, MAX_GROUPS_PER_MAKER);
+            if (_containsGroup(paymentMethodGroups, groupId)) continue;
+            if (paymentMethodGroups.length == MAX_GROUPS_PER_PAYMENT_METHOD) {
+                revert TooManyGroups(paymentMethodGroups.length + 1, MAX_GROUPS_PER_PAYMENT_METHOD);
             }
 
-            makerGroups.push(groupId);
-            emit AllowedGroupAdded(msg.sender, groupId);
+            paymentMethodGroups.push(groupId);
+            emit AllowedGroupAdded(msg.sender, _paymentMethod, groupId);
         }
     }
 
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function removeAllowedGroups(bytes32[] calldata _groupIds) external override {
+    function removeAllowedGroups(bytes32 _paymentMethod, bytes32[] calldata _groupIds) external override {
         if (_groupIds.length == 0) revert EmptyArray();
 
-        bytes32[] storage makerGroups = allowedGroups[msg.sender];
+        bytes32[] storage paymentMethodGroups = allowedGroups[msg.sender][_paymentMethod];
         for (uint256 i = 0; i < _groupIds.length; ++i) {
             bytes32 groupId = _groupIds[i];
-            uint256 groupIndex = _findGroupIndex(makerGroups, groupId);
-            if (groupIndex == makerGroups.length) continue;
+            uint256 groupIndex = _findGroupIndex(paymentMethodGroups, groupId);
+            if (groupIndex == paymentMethodGroups.length) continue;
 
-            makerGroups[groupIndex] = makerGroups[makerGroups.length - 1];
-            makerGroups.pop();
-            emit AllowedGroupRemoved(msg.sender, groupId);
+            paymentMethodGroups[groupIndex] = paymentMethodGroups[paymentMethodGroups.length - 1];
+            paymentMethodGroups.pop();
+            emit AllowedGroupRemoved(msg.sender, _paymentMethod, groupId);
         }
     }
 
@@ -134,27 +134,42 @@ contract WhitelistPolicy is IWhitelistPolicy {
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function getAllowedGroups(address _maker) external view override returns (bytes32[] memory) {
-        return allowedGroups[_maker];
+    function getAllowedGroups(address _maker, bytes32 _paymentMethod)
+        external
+        view
+        override
+        returns (bytes32[] memory)
+    {
+        return allowedGroups[_maker][_paymentMethod];
     }
 
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function isGroupAllowed(address _maker, bytes32 _groupId) external view override returns (bool) {
-        return _containsGroup(allowedGroups[_maker], _groupId);
+    function isGroupAllowed(address _maker, bytes32 _paymentMethod, bytes32 _groupId)
+        external
+        view
+        override
+        returns (bool)
+    {
+        return _containsGroup(allowedGroups[_maker][_paymentMethod], _groupId);
     }
 
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function isTakerAllowed(address _maker, address _taker) external view override returns (bool) {
-        if (!enabled[_maker]) return true;
+    function isTakerAllowed(address _maker, bytes32 _paymentMethod, address _taker)
+        external
+        view
+        override
+        returns (bool)
+    {
+        if (!enabled[_maker][_paymentMethod]) return true;
         if (isWhitelisted[_maker][_taker]) return true;
 
-        bytes32[] storage makerGroups = allowedGroups[_maker];
-        for (uint256 i = 0; i < makerGroups.length; ++i) {
-            if (groupRegistry.isMember(makerGroups[i], _taker)) return true;
+        bytes32[] storage paymentMethodGroups = allowedGroups[_maker][_paymentMethod];
+        for (uint256 i = 0; i < paymentMethodGroups.length; ++i) {
+            if (groupRegistry.isMember(paymentMethodGroups[i], _taker)) return true;
         }
         return false;
     }

--- a/contracts/interfaces/IWhitelistPolicy.sol
+++ b/contracts/interfaces/IWhitelistPolicy.sol
@@ -6,15 +6,15 @@ import {IAddressGroupRegistry} from "./IAddressGroupRegistry.sol";
 
 interface IWhitelistPolicy {
     function groupRegistry() external view returns (IAddressGroupRegistry);
-    function enabled(address maker) external view returns (bool);
+    function enabled(address maker, bytes32 paymentMethod) external view returns (bool);
     function isWhitelisted(address maker, address taker) external view returns (bool);
-    function getAllowedGroups(address maker) external view returns (bytes32[] memory);
-    function isGroupAllowed(address maker, bytes32 groupId) external view returns (bool);
-    function isTakerAllowed(address maker, address taker) external view returns (bool);
+    function getAllowedGroups(address maker, bytes32 paymentMethod) external view returns (bytes32[] memory);
+    function isGroupAllowed(address maker, bytes32 paymentMethod, bytes32 groupId) external view returns (bool);
+    function isTakerAllowed(address maker, bytes32 paymentMethod, address taker) external view returns (bool);
 
-    function setEnabled(bool enabled) external;
+    function setEnabled(bytes32 paymentMethod, bool enabled) external;
     function addWhitelistedAddresses(address[] calldata takers) external;
     function removeWhitelistedAddresses(address[] calldata takers) external;
-    function addAllowedGroups(bytes32[] calldata groupIds) external;
-    function removeAllowedGroups(bytes32[] calldata groupIds) external;
+    function addAllowedGroups(bytes32 paymentMethod, bytes32[] calldata groupIds) external;
+    function removeAllowedGroups(bytes32 paymentMethod, bytes32[] calldata groupIds) external;
 }

--- a/deploy/29_deploy_maker_group_risk_system.ts
+++ b/deploy/29_deploy_maker_group_risk_system.ts
@@ -55,6 +55,11 @@ async function systemFullyWired(network: string): Promise<boolean> {
   const orchestratorRegistry = await ethers.getContractAt("OrchestratorRegistry", orchestratorRegistryAddress);
   const escrowRegistry = await ethers.getContractAt("EscrowRegistry", escrowRegistryAddress);
 
+  // Capability probe for the payment-method-scoped policy schema. The previous
+  // maker-wide policy does not implement this selector, so the call fails and
+  // forces hardhat-deploy to process the changed policy/hook bytecode and wiring.
+  await policy.enabled(ethers.constants.AddressZero, ethers.constants.HashZero);
+
   if ((await policy.groupRegistry()).toLowerCase() !== registryAddress.toLowerCase()) return false;
   if ((await hook.whitelistPolicy()).toLowerCase() !== policyAddress.toLowerCase()) return false;
   if ((await hook.orchestratorRegistry()).toLowerCase() !== orchestratorRegistryAddress.toLowerCase()) return false;

--- a/test-foundry/deterministic/hooks/WhitelistPolicy.t.sol
+++ b/test-foundry/deterministic/hooks/WhitelistPolicy.t.sol
@@ -8,6 +8,9 @@ import {WhitelistPolicy} from "contracts/hooks/WhitelistPolicy.sol";
 import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
 
 contract WhitelistPolicyTest is Test {
+    bytes32 internal constant VENMO = keccak256("venmo");
+    bytes32 internal constant ZELLE = keccak256("zelle");
+
     bytes32 internal PEERS;
     bytes32 internal PEER_PLUSES;
     bytes32 internal PEER_MERCHANTS;
@@ -20,11 +23,11 @@ contract WhitelistPolicyTest is Test {
     AddressGroupRegistry internal registry;
     WhitelistPolicy internal policy;
 
-    event EnabledUpdated(address indexed maker, bool enabled);
+    event EnabledUpdated(address indexed maker, bytes32 indexed paymentMethod, bool enabled);
     event AddressWhitelisted(address indexed maker, address indexed taker);
     event AddressRemovedFromWhitelist(address indexed maker, address indexed taker);
-    event AllowedGroupAdded(address indexed maker, bytes32 indexed groupId);
-    event AllowedGroupRemoved(address indexed maker, bytes32 indexed groupId);
+    event AllowedGroupAdded(address indexed maker, bytes32 indexed paymentMethod, bytes32 indexed groupId);
+    event AllowedGroupRemoved(address indexed maker, bytes32 indexed paymentMethod, bytes32 indexed groupId);
 
     function setUp() public {
         maker = makeAddr("maker");
@@ -46,18 +49,19 @@ contract WhitelistPolicyTest is Test {
         new WhitelistPolicy(AddressGroupRegistry(maker));
     }
 
-    function test_SetEnabledIsScopedToMaker() public {
-        vm.expectEmit(true, false, false, true, address(policy));
-        emit EnabledUpdated(maker, true);
+    function test_SetEnabledIsScopedToMakerAndPaymentMethod() public {
+        vm.expectEmit(true, true, false, true, address(policy));
+        emit EnabledUpdated(maker, VENMO, true);
         vm.prank(maker);
-        policy.setEnabled(true);
+        policy.setEnabled(VENMO, true);
 
-        assertTrue(policy.enabled(maker));
-        assertFalse(policy.enabled(otherMaker));
+        assertTrue(policy.enabled(maker, VENMO));
+        assertFalse(policy.enabled(maker, ZELLE));
+        assertFalse(policy.enabled(otherMaker, VENMO));
 
         vm.prank(maker);
-        policy.setEnabled(false);
-        assertFalse(policy.enabled(maker));
+        policy.setEnabled(VENMO, false);
+        assertFalse(policy.enabled(maker, VENMO));
     }
 
     function test_AddWhitelistedAddressesIsIdempotentAndEnumerableByGetter() public {
@@ -119,36 +123,38 @@ contract WhitelistPolicyTest is Test {
     function test_AddAllowedGroupsSupportsViewsAndDeduplicates() public {
         bytes32[] memory groups = _groupIds(PEERS, PEER_PLUSES);
 
-        vm.expectEmit(true, true, false, true, address(policy));
-        emit AllowedGroupAdded(maker, PEERS);
-        vm.expectEmit(true, true, false, true, address(policy));
-        emit AllowedGroupAdded(maker, PEER_PLUSES);
+        vm.expectEmit(true, true, true, true, address(policy));
+        emit AllowedGroupAdded(maker, VENMO, PEERS);
+        vm.expectEmit(true, true, true, true, address(policy));
+        emit AllowedGroupAdded(maker, VENMO, PEER_PLUSES);
         vm.prank(maker);
-        policy.addAllowedGroups(groups);
+        policy.addAllowedGroups(VENMO, groups);
 
-        assertEq(policy.getAllowedGroups(maker), groups);
-        assertTrue(policy.isGroupAllowed(maker, PEERS));
-        assertTrue(policy.isGroupAllowed(maker, PEER_PLUSES));
-        assertFalse(policy.isGroupAllowed(otherMaker, PEERS));
+        assertEq(policy.getAllowedGroups(maker, VENMO), groups);
+        assertEq(policy.getAllowedGroups(maker, ZELLE).length, 0);
+        assertTrue(policy.isGroupAllowed(maker, VENMO, PEERS));
+        assertTrue(policy.isGroupAllowed(maker, VENMO, PEER_PLUSES));
+        assertFalse(policy.isGroupAllowed(maker, ZELLE, PEERS));
+        assertFalse(policy.isGroupAllowed(otherMaker, VENMO, PEERS));
 
         vm.recordLogs();
         vm.prank(maker);
-        policy.addAllowedGroups(groups);
+        policy.addAllowedGroups(VENMO, groups);
         assertEq(vm.getRecordedLogs().length, 0);
-        assertEq(policy.getAllowedGroups(maker).length, 2);
+        assertEq(policy.getAllowedGroups(maker, VENMO).length, 2);
     }
 
     function test_AddAllowedGroupsRejectsEmptyAndUnknownGroups() public {
         vm.expectRevert(WhitelistPolicy.EmptyArray.selector);
         vm.prank(maker);
-        policy.addAllowedGroups(new bytes32[](0));
+        policy.addAllowedGroups(VENMO, new bytes32[](0));
 
         bytes32 unknownGroup = bytes32(uint256(999));
         vm.expectRevert(abi.encodeWithSelector(WhitelistPolicy.GroupDoesNotExist.selector, unknownGroup));
         vm.prank(maker);
-        policy.addAllowedGroups(_groupIds(unknownGroup));
+        policy.addAllowedGroups(VENMO, _groupIds(unknownGroup));
 
-        assertEq(policy.getAllowedGroups(maker).length, 0);
+        assertEq(policy.getAllowedGroups(maker, VENMO).length, 0);
     }
 
     function test_AddAllowedGroupsRejectsEleventhUniqueGroup() public {
@@ -158,85 +164,96 @@ contract WhitelistPolicyTest is Test {
         }
 
         vm.prank(maker);
-        policy.addAllowedGroups(firstTen);
-        assertEq(policy.getAllowedGroups(maker).length, policy.MAX_GROUPS_PER_MAKER());
+        policy.addAllowedGroups(VENMO, firstTen);
+        assertEq(policy.getAllowedGroups(maker, VENMO).length, policy.MAX_GROUPS_PER_PAYMENT_METHOD());
 
         bytes32 eleventh = registry.createGroup("Eleventh Group");
         vm.expectRevert(
             abi.encodeWithSelector(
-                WhitelistPolicy.TooManyGroups.selector, policy.MAX_GROUPS_PER_MAKER() + 1, policy.MAX_GROUPS_PER_MAKER()
+                WhitelistPolicy.TooManyGroups.selector,
+                policy.MAX_GROUPS_PER_PAYMENT_METHOD() + 1,
+                policy.MAX_GROUPS_PER_PAYMENT_METHOD()
             )
         );
         vm.prank(maker);
-        policy.addAllowedGroups(_groupIds(eleventh));
+        policy.addAllowedGroups(VENMO, _groupIds(eleventh));
+
+        vm.prank(maker);
+        policy.addAllowedGroups(ZELLE, _groupIds(eleventh));
+        assertTrue(policy.isGroupAllowed(maker, ZELLE, eleventh));
     }
 
     function test_RemoveAllowedGroupsUsesSwapAndPopAndIsIdempotent() public {
         vm.prank(maker);
-        policy.addAllowedGroups(_groupIds(PEERS, PEER_PLUSES, PEER_MERCHANTS));
+        policy.addAllowedGroups(VENMO, _groupIds(PEERS, PEER_PLUSES, PEER_MERCHANTS));
 
-        vm.expectEmit(true, true, false, true, address(policy));
-        emit AllowedGroupRemoved(maker, PEERS);
+        vm.expectEmit(true, true, true, true, address(policy));
+        emit AllowedGroupRemoved(maker, VENMO, PEERS);
         vm.prank(maker);
-        policy.removeAllowedGroups(_groupIds(PEERS));
+        policy.removeAllowedGroups(VENMO, _groupIds(PEERS));
 
-        bytes32[] memory remaining = policy.getAllowedGroups(maker);
+        bytes32[] memory remaining = policy.getAllowedGroups(maker, VENMO);
         assertEq(remaining.length, 2);
         assertEq(remaining[0], PEER_MERCHANTS);
         assertEq(remaining[1], PEER_PLUSES);
-        assertFalse(policy.isGroupAllowed(maker, PEERS));
-        assertTrue(policy.isGroupAllowed(maker, PEER_PLUSES));
-        assertTrue(policy.isGroupAllowed(maker, PEER_MERCHANTS));
+        assertFalse(policy.isGroupAllowed(maker, VENMO, PEERS));
+        assertTrue(policy.isGroupAllowed(maker, VENMO, PEER_PLUSES));
+        assertTrue(policy.isGroupAllowed(maker, VENMO, PEER_MERCHANTS));
 
         vm.recordLogs();
         vm.prank(maker);
-        policy.removeAllowedGroups(_groupIds(PEERS));
+        policy.removeAllowedGroups(VENMO, _groupIds(PEERS));
         assertEq(vm.getRecordedLogs().length, 0);
     }
 
     function test_RemoveAllowedGroupsRejectsEmptyArray() public {
         vm.expectRevert(WhitelistPolicy.EmptyArray.selector);
         vm.prank(maker);
-        policy.removeAllowedGroups(new bytes32[](0));
+        policy.removeAllowedGroups(VENMO, new bytes32[](0));
     }
 
     function test_IsTakerAllowedReturnsTrueWhenPolicyDisabled() public view {
-        assertTrue(policy.isTakerAllowed(maker, taker));
+        assertTrue(policy.isTakerAllowed(maker, VENMO, taker));
     }
 
-    function test_IsTakerAllowedReturnsTrueForDirectWhitelist() public {
+    function test_DirectWhitelistIsMakerWideAcrossEnabledPaymentMethods() public {
         vm.startPrank(maker);
-        policy.setEnabled(true);
+        policy.setEnabled(VENMO, true);
+        policy.setEnabled(ZELLE, true);
         policy.addWhitelistedAddresses(_addresses(taker));
         vm.stopPrank();
 
-        assertTrue(policy.isTakerAllowed(maker, taker));
+        assertTrue(policy.isTakerAllowed(maker, VENMO, taker));
+        assertTrue(policy.isTakerAllowed(maker, ZELLE, taker));
     }
 
-    function test_IsTakerAllowedReturnsTrueForGroupMember() public {
+    function test_GroupAdmissionIsScopedToPaymentMethod() public {
         vm.startPrank(maker);
-        policy.setEnabled(true);
-        policy.addAllowedGroups(_groupIds(PEERS));
+        policy.setEnabled(VENMO, true);
+        policy.setEnabled(ZELLE, true);
+        policy.addAllowedGroups(VENMO, _groupIds(PEERS));
         vm.stopPrank();
         registry.addMembers(PEERS, _addresses(taker));
 
-        assertTrue(policy.isTakerAllowed(maker, taker));
+        assertTrue(policy.isTakerAllowed(maker, VENMO, taker));
+        assertFalse(policy.isTakerAllowed(maker, ZELLE, taker));
     }
 
     function test_IsTakerAllowedReturnsFalseForEnabledEmptyPolicy() public {
         vm.prank(maker);
-        policy.setEnabled(true);
+        policy.setEnabled(VENMO, true);
 
-        assertFalse(policy.isTakerAllowed(maker, taker));
+        assertFalse(policy.isTakerAllowed(maker, VENMO, taker));
+        assertTrue(policy.isTakerAllowed(maker, ZELLE, taker));
     }
 
     function test_IsTakerAllowedReturnsFalseForNonMember() public {
         vm.startPrank(maker);
-        policy.setEnabled(true);
-        policy.addAllowedGroups(_groupIds(PEERS));
+        policy.setEnabled(VENMO, true);
+        policy.addAllowedGroups(VENMO, _groupIds(PEERS));
         vm.stopPrank();
 
-        assertFalse(policy.isTakerAllowed(maker, taker));
+        assertFalse(policy.isTakerAllowed(maker, VENMO, taker));
     }
 
     function _groupIds(bytes32 _first) internal pure returns (bytes32[] memory groupIds) {

--- a/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.18;
 
 import {IIntentLifecycleHook} from "contracts/interfaces/IIntentLifecycleHook.sol";
+import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
 import {IOrchestratorV2} from "contracts/interfaces/IOrchestratorV2.sol";
 import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
 import {IntentLifecycleHookV1} from "contracts/hooks/IntentLifecycleHookV1.sol";
@@ -14,6 +15,8 @@ import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.so
 import {OrchestratorV2LegacyFixture} from "../helpers/OrchestratorV2LegacyFixture.sol";
 
 contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture {
+    bytes32 internal constant OTHER_METHOD = keccak256("zelle");
+
     bytes32 internal PEERS;
     bytes32 internal PEER_PLUSES;
     bytes32 internal PEER_MERCHANTS;
@@ -47,14 +50,14 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
 
     function test_EnabledEmptyPolicyFailsClosedBeforeEscrowLock() public {
         vm.prank(depositor);
-        policy.setEnabled(true);
+        policy.setEnabled(METHOD, true);
 
         uint256 counterBefore = orchestrator.intentCounter();
         bytes32 rejectedIntent = _intentHash(counterBefore);
         uint256 availableBefore = escrow.getDeposit(depositId).remainingDeposits;
 
         bytes memory emptyPolicyRevert =
-            abi.encodeWithSelector(IntentLifecycleHookV1.TakerNotWhitelisted.selector, depositor, taker);
+            abi.encodeWithSelector(IntentLifecycleHookV1.TakerNotWhitelisted.selector, depositor, METHOD, taker);
         vm.expectRevert(
             abi.encodeWithSelector(
                 BoundedCall.LifecycleHookAdmissionFailed.selector,
@@ -73,13 +76,13 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
 
     function test_NonMemberRejectedAndMemberAccepted() public {
         vm.startPrank(depositor);
-        policy.addAllowedGroups(_groupIds(PEERS));
-        policy.setEnabled(true);
+        policy.addAllowedGroups(METHOD, _groupIds(PEERS));
+        policy.setEnabled(METHOD, true);
         vm.stopPrank();
 
         bytes32 rejectedIntent = _intentHash(orchestrator.intentCounter());
         bytes memory nonMemberRevert =
-            abi.encodeWithSelector(IntentLifecycleHookV1.TakerNotWhitelisted.selector, depositor, taker);
+            abi.encodeWithSelector(IntentLifecycleHookV1.TakerNotWhitelisted.selector, depositor, METHOD, taker);
         vm.expectRevert(
             abi.encodeWithSelector(
                 BoundedCall.LifecycleHookAdmissionFailed.selector,
@@ -98,16 +101,36 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
     function test_DirectAddressWhitelistAllowsTaker() public {
         vm.startPrank(depositor);
         policy.addWhitelistedAddresses(_addresses(taker));
-        policy.setEnabled(true);
+        policy.setEnabled(METHOD, true);
         vm.stopPrank();
 
         assertNotEq(_signalDefault(), bytes32(0));
     }
 
+    function test_PaymentMethodGroupScopeAndMakerWideDirectWhitelist() public {
+        _addPaymentMethod(OTHER_METHOD);
+
+        vm.startPrank(depositor);
+        policy.addAllowedGroups(METHOD, _groupIds(PEERS));
+        policy.setEnabled(METHOD, true);
+        policy.setEnabled(OTHER_METHOD, true);
+        vm.stopPrank();
+        _addMembers(PEERS, taker);
+
+        IOrchestratorV2.SignalIntentParams memory otherMethodParams = _defaultParams();
+        otherMethodParams.paymentMethod = OTHER_METHOD;
+        vm.expectPartialRevert(BoundedCall.LifecycleHookAdmissionFailed.selector);
+        _signalCall(taker, otherMethodParams);
+
+        vm.prank(depositor);
+        policy.addWhitelistedAddresses(_addresses(taker));
+        assertNotEq(_signal(taker, otherMethodParams), bytes32(0));
+    }
+
     function test_MultipleGroupsUseOrSemantics() public {
         vm.startPrank(depositor);
-        policy.addAllowedGroups(_groupIds(PEERS, PEER_PLUSES, PEER_MERCHANTS));
-        policy.setEnabled(true);
+        policy.addAllowedGroups(METHOD, _groupIds(PEERS, PEER_PLUSES, PEER_MERCHANTS));
+        policy.setEnabled(METHOD, true);
         vm.stopPrank();
 
         _addMembers(PEER_PLUSES, taker);
@@ -116,8 +139,8 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
 
     function test_MakerPolicyAppliesAcrossMakerDeposits() public {
         vm.startPrank(depositor);
-        policy.addAllowedGroups(_groupIds(PEERS));
-        policy.setEnabled(true);
+        policy.addAllowedGroups(METHOD, _groupIds(PEERS));
+        policy.setEnabled(METHOD, true);
         uint256 secondDepositId = _createDeposit(address(0), delegate);
         vm.stopPrank();
 
@@ -184,8 +207,8 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
         }
 
         vm.startPrank(depositor);
-        policy.addAllowedGroups(groups);
-        policy.setEnabled(true);
+        policy.addAllowedGroups(METHOD, groups);
+        policy.setEnabled(METHOD, true);
         vm.stopPrank();
         _addMembers(groups[groups.length - 1], taker);
 
@@ -226,10 +249,29 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
 
     function _enablePeerPolicyAndAddTaker() internal {
         vm.startPrank(depositor);
-        policy.addAllowedGroups(_groupIds(PEERS));
-        policy.setEnabled(true);
+        policy.addAllowedGroups(METHOD, _groupIds(PEERS));
+        policy.setEnabled(METHOD, true);
         vm.stopPrank();
         _addMembers(PEERS, taker);
+    }
+
+    function _addPaymentMethod(bytes32 _paymentMethod) internal {
+        bytes32[] memory supportedCurrencies = new bytes32[](1);
+        supportedCurrencies[0] = USD;
+        paymentVerifierRegistry.addPaymentMethod(_paymentMethod, address(verifier), supportedCurrencies);
+
+        bytes32[] memory paymentMethods = new bytes32[](1);
+        paymentMethods[0] = _paymentMethod;
+        IEscrowV2.DepositPaymentMethodData[] memory paymentMethodData = new IEscrowV2.DepositPaymentMethodData[](1);
+        paymentMethodData[0] =
+            IEscrowV2.DepositPaymentMethodData({intentGatingService: address(0), payeeDetails: PAYEE, data: ""});
+        IEscrowV2.Currency[][] memory currencies = new IEscrowV2.Currency[][](1);
+        currencies[0] = new IEscrowV2.Currency[](1);
+        currencies[0][0] =
+            IEscrowV2.Currency({code: USD, minConversionRate: CONVERSION_RATE, oracleRateConfig: _emptyOracle()});
+
+        vm.prank(depositor);
+        escrow.addPaymentMethods(depositId, paymentMethods, paymentMethodData, currencies);
     }
 
     function _addMembers(bytes32 _groupId, address _member) internal {


### PR DESCRIPTION
## Summary

- scope whitelist enforcement and allowed groups by `maker × paymentMethod`
- keep direct taker addresses maker-wide across payment methods
- pass the intent payment method from `IntentLifecycleHookV1` into whitelist admission
- update focused unit/integration coverage and the V3 architecture documentation

## Policy model

- `enabled[maker][paymentMethod]` controls whether that payment method is restricted
- `allowedGroups[maker][paymentMethod]` selects the curated groups admitted for that payment method
- `isWhitelisted[maker][taker]` remains a maker-wide trust decision
- an enabled payment method with no matching direct address or group fails closed

## Verification

- `forge test --match-path 'test-foundry/deterministic/hooks/WhitelistPolicy.t.sol'` (16 passed)
- `forge test --match-path 'test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol'` (13 passed)
- `forge fmt --check` on changed Solidity files
- `git diff --check`
- `yarn compile` with the documented local development key (132 Solidity files compiled; typings generated)

## Deployment impact

This changes the `WhitelistPolicy` ABI/state shape and the `IntentLifecycleHookV1` admission call/error ABI. The staging-only policy and lifecycle hook must be redeployed and rewired when this change is deployed. No `EscrowV2` change or redeployment is required, and production `OrchestratorV2` is unaffected.
