### PR TITLE
feat: scope whitelist policy to deposits

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,19 +85,19 @@ owner-controlled global `lifecycleHook` for future intents:
 
 The first minimal global hook is the independent maker whitelist stack:
 
-- `AddressGroupRegistry`: governance registers stable public group IDs, manages metadata and active state,
-  and assigns curators. Curators add or remove members; membership is event-indexed rather than enumerable
-  onchain.
-- `WhitelistPolicy`: each maker owns a direct address whitelist and a bounded list of up to 10 allowed groups,
-  plus an explicit `enabled` switch. The policy survives global hook replacement.
+- `AddressGroupRegistry`: anyone may create a curator-managed group. Curators can add or remove members,
+  transfer control, configure an optional membership resolver, and opt into self-service membership.
+- `WhitelistPolicy`: each maker owns a maker-wide direct address whitelist plus a payment-method-specific
+  `enabled` switch and bounded list of up to 10 allowed groups. The policy survives global hook replacement.
 - `IntentLifecycleHookV1`: a stateless admission hook that delegates to `WhitelistPolicy`, allowing a taker when
-  the maker's policy is disabled, the taker is directly whitelisted, or the taker belongs to at least one
-  configured active group. Enabled policies with no matching address or group fail closed. Settlement and
-  cancellation are no-ops in this version.
+  enforcement is disabled for the intent's payment method, the taker is directly whitelisted by the maker, or
+  the taker belongs to at least one group enabled for that payment method. Enabled policies with no matching
+  address or group fail closed. Settlement and cancellation are no-ops in this version.
 
-Canonical deployment IDs are `keccak256` hashes of `peers`, `peer-pluses`, and `peer-merchants`. Group
-enforcement is maker-level, not payment-method- or deposit-level. These V3 changes do not modify
-`EscrowV2`, require an Escrow redeployment, or alter the production `OrchestratorV2` whitelist path.
+Group IDs are derived from the curator and registry group counter, and offchain consumers must key them by
+chain, registry address, and group ID. Group enforcement is scoped by maker and payment method, while direct
+address trust is maker-wide; neither is deposit-specific. These V3 changes do not modify `EscrowV2`, require
+an Escrow redeployment, or alter the production `OrchestratorV2` whitelist path.
 
 ## V2 Contract Inventory
 

--- a/README.md
+++ b/README.md
@@ -83,21 +83,23 @@ owner-controlled global `lifecycleHook` for future intents:
 - The existing generic per-deposit pre-intent hook remains available. V3 has no dedicated per-deposit
   whitelist slot and no maker- or deposit-selected lifecycle hook.
 
-The first minimal global hook is the independent maker whitelist stack:
+The first minimal global hook is the independent deposit whitelist stack:
 
 - `AddressGroupRegistry`: anyone may create a curator-managed group. Curators can add or remove members,
   transfer control, configure an optional membership resolver, and opt into self-service membership.
-- `WhitelistPolicy`: each maker owns a maker-wide direct address whitelist plus a payment-method-specific
-  `enabled` switch and bounded list of up to 10 allowed groups. The policy survives global hook replacement.
+- `WhitelistPolicy`: each deposit owns an `enabled` switch, a direct address whitelist, and a bounded list of
+  up to 10 allowed groups. Only the escrow's recorded depositor may configure a deposit, and
+  `configureDeposit` sets all three in one transaction. The policy survives global hook replacement.
 - `IntentLifecycleHookV1`: a stateless admission hook that delegates to `WhitelistPolicy`, allowing a taker when
-  enforcement is disabled for the intent's payment method, the taker is directly whitelisted by the maker, or
-  the taker belongs to at least one group enabled for that payment method. Enabled policies with no matching
-  address or group fail closed. Settlement and cancellation are no-ops in this version.
+  enforcement is disabled for the intent's deposit, the taker is directly whitelisted on that deposit, or the
+  taker belongs to at least one group allowed by that deposit. Enabled policies with no matching address or
+  group fail closed. Settlement and cancellation are no-ops in this version.
 
 Group IDs are derived from the curator and registry group counter, and offchain consumers must key them by
-chain, registry address, and group ID. Group enforcement is scoped by maker and payment method, while direct
-address trust is maker-wide; neither is deposit-specific. These V3 changes do not modify `EscrowV2`, require
-an Escrow redeployment, or alter the production `OrchestratorV2` whitelist path.
+chain, registry address, and group ID. All three admission settings are scoped to the `(escrow, depositId)`
+pair, so one maker can run gated and open deposits at the same time and nothing is shared across a maker's
+deposits. These V3 changes do not modify `EscrowV2`, require an Escrow redeployment, or alter the production
+`OrchestratorV2` whitelist path.
 
 ## V2 Contract Inventory
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ The first minimal global hook is the independent deposit whitelist stack:
 - `WhitelistPolicy`: each deposit owns an `enabled` switch, a direct address whitelist, and a bounded list of
   up to 10 allowed groups. Only the escrow's recorded depositor may configure a deposit, and
   `configureDeposit` sets all three in one transaction. The policy survives global hook replacement.
+  A governance owner may rotate the escrow registry that gates those writes via `setEscrowRegistry`, and must
+  keep it in sync with `OrchestratorV3.setEscrowRegistry` — if the two diverge, deposits on an escrow admitted
+  by only one of them can be neither gated nor revoked while the orchestrator keeps admitting intents. The
+  owner cannot admit or reject a taker: `isTakerAllowed` never reads the escrow registry.
 - `IntentLifecycleHookV1`: a stateless admission hook that delegates to `WhitelistPolicy`, allowing a taker when
   enforcement is disabled for the intent's deposit, the taker is directly whitelisted on that deposit, or the
   taker belongs to at least one group allowed by that deposit. Enabled policies with no matching address or

--- a/contracts/hooks/IntentLifecycleHookV1.sol
+++ b/contracts/hooks/IntentLifecycleHookV1.sol
@@ -2,7 +2,6 @@
 
 pragma solidity ^0.8.18;
 
-import {IEscrow} from "../interfaces/IEscrow.sol";
 import {IIntentLifecycleHook} from "../interfaces/IIntentLifecycleHook.sol";
 import {IOrchestratorRegistry} from "../interfaces/IOrchestratorRegistry.sol";
 import {IOrchestratorV3} from "../interfaces/IOrchestratorV3.sol";
@@ -11,8 +10,8 @@ import {IWhitelistPolicy} from "../interfaces/IWhitelistPolicy.sol";
 /**
  * @title IntentLifecycleHookV1
  * @notice Stateless lifecycle hook admitting any orchestrator registered in OrchestratorRegistry and enforcing
- * maker-owned whitelist policies. A taker is admitted when enforcement is disabled for the intent's payment method
- * or when the policy allows the taker through the maker-wide direct whitelist or a payment-method group.
+ * deposit-scoped whitelist policies. A taker is admitted when enforcement is disabled for the intent's deposit
+ * or when the policy allows the taker through that deposit's direct whitelist or one of its allowed groups.
  * Settlement and cancellation are no-ops in this version.
  * @dev Reads intent context from the calling orchestrator and delegates admission to WhitelistPolicy.
  */
@@ -28,7 +27,7 @@ contract IntentLifecycleHookV1 is IIntentLifecycleHook {
     error InvalidDependency(address dependency);
     error UnauthorizedOrchestrator(address caller);
     error IntentNotFound(bytes32 intentHash);
-    error TakerNotWhitelisted(address maker, bytes32 paymentMethod, address taker);
+    error TakerNotWhitelisted(address escrow, uint256 depositId, address taker);
 
     /* ============ Constructor ============ */
 
@@ -49,9 +48,8 @@ contract IntentLifecycleHookV1 is IIntentLifecycleHook {
         IOrchestratorV3.IntentContext memory intent = IOrchestratorV3(msg.sender).getIntentContext(_intentHash);
         if (intent.owner == address(0)) revert IntentNotFound(_intentHash);
 
-        address maker = IEscrow(intent.escrow).getDeposit(intent.depositId).depositor;
-        if (!whitelistPolicy.isTakerAllowed(maker, intent.paymentMethod, intent.owner)) {
-            revert TakerNotWhitelisted(maker, intent.paymentMethod, intent.owner);
+        if (!whitelistPolicy.isTakerAllowed(intent.escrow, intent.depositId, intent.owner)) {
+            revert TakerNotWhitelisted(intent.escrow, intent.depositId, intent.owner);
         }
     }
 

--- a/contracts/hooks/IntentLifecycleHookV1.sol
+++ b/contracts/hooks/IntentLifecycleHookV1.sol
@@ -11,8 +11,9 @@ import {IWhitelistPolicy} from "../interfaces/IWhitelistPolicy.sol";
 /**
  * @title IntentLifecycleHookV1
  * @notice Stateless lifecycle hook admitting any orchestrator registered in OrchestratorRegistry and enforcing
- * maker-owned whitelist policies. A taker is admitted when enforcement is disabled or when the policy allows the
- * taker directly or through an allowed group. Settlement and cancellation are no-ops in this version.
+ * maker-owned whitelist policies. A taker is admitted when enforcement is disabled for the intent's payment method
+ * or when the policy allows the taker through the maker-wide direct whitelist or a payment-method group.
+ * Settlement and cancellation are no-ops in this version.
  * @dev Reads intent context from the calling orchestrator and delegates admission to WhitelistPolicy.
  */
 contract IntentLifecycleHookV1 is IIntentLifecycleHook {
@@ -27,7 +28,7 @@ contract IntentLifecycleHookV1 is IIntentLifecycleHook {
     error InvalidDependency(address dependency);
     error UnauthorizedOrchestrator(address caller);
     error IntentNotFound(bytes32 intentHash);
-    error TakerNotWhitelisted(address maker, address taker);
+    error TakerNotWhitelisted(address maker, bytes32 paymentMethod, address taker);
 
     /* ============ Constructor ============ */
 
@@ -49,8 +50,8 @@ contract IntentLifecycleHookV1 is IIntentLifecycleHook {
         if (intent.owner == address(0)) revert IntentNotFound(_intentHash);
 
         address maker = IEscrow(intent.escrow).getDeposit(intent.depositId).depositor;
-        if (!whitelistPolicy.isTakerAllowed(maker, intent.owner)) {
-            revert TakerNotWhitelisted(maker, intent.owner);
+        if (!whitelistPolicy.isTakerAllowed(maker, intent.paymentMethod, intent.owner)) {
+            revert TakerNotWhitelisted(maker, intent.paymentMethod, intent.owner);
         }
     }
 

--- a/contracts/hooks/WhitelistPolicy.sol
+++ b/contracts/hooks/WhitelistPolicy.sol
@@ -8,29 +8,29 @@ import {IWhitelistPolicy} from "../interfaces/IWhitelistPolicy.sol";
 /**
  * @title WhitelistPolicy
  * @notice Persistent maker-owned taker admission settings, independent from any lifecycle-hook deployment.
- * Each maker can allow direct addresses or members of a bounded list of curated groups.
- * @dev Enabling an empty policy is allowed and intentionally fails closed when evaluated.
+ * Each maker can trust direct addresses globally and configure a bounded list of curated groups per payment method.
+ * @dev Enabling an empty payment-method policy is allowed and intentionally fails closed when evaluated.
  */
 contract WhitelistPolicy is IWhitelistPolicy {
     /* ============ Constants ============ */
 
-    uint256 public constant MAX_GROUPS_PER_MAKER = 10;
+    uint256 public constant MAX_GROUPS_PER_PAYMENT_METHOD = 10;
 
     /* ============ State Variables ============ */
 
     IAddressGroupRegistry public immutable override groupRegistry;
 
-    mapping(address => bool) public override enabled;
+    mapping(address => mapping(bytes32 => bool)) public override enabled;
     mapping(address => mapping(address => bool)) public override isWhitelisted;
-    mapping(address => bytes32[]) internal allowedGroups;
+    mapping(address => mapping(bytes32 => bytes32[])) internal allowedGroups;
 
     /* ============ Events ============ */
 
-    event EnabledUpdated(address indexed maker, bool enabled);
+    event EnabledUpdated(address indexed maker, bytes32 indexed paymentMethod, bool enabled);
     event AddressWhitelisted(address indexed maker, address indexed taker);
     event AddressRemovedFromWhitelist(address indexed maker, address indexed taker);
-    event AllowedGroupAdded(address indexed maker, bytes32 indexed groupId);
-    event AllowedGroupRemoved(address indexed maker, bytes32 indexed groupId);
+    event AllowedGroupAdded(address indexed maker, bytes32 indexed paymentMethod, bytes32 indexed groupId);
+    event AllowedGroupRemoved(address indexed maker, bytes32 indexed paymentMethod, bytes32 indexed groupId);
 
     /* ============ Errors ============ */
 
@@ -55,9 +55,9 @@ contract WhitelistPolicy is IWhitelistPolicy {
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function setEnabled(bool _enabled) external override {
-        enabled[msg.sender] = _enabled;
-        emit EnabledUpdated(msg.sender, _enabled);
+    function setEnabled(bytes32 _paymentMethod, bool _enabled) external override {
+        enabled[msg.sender][_paymentMethod] = _enabled;
+        emit EnabledUpdated(msg.sender, _paymentMethod, _enabled);
     }
 
     /**
@@ -94,38 +94,38 @@ contract WhitelistPolicy is IWhitelistPolicy {
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function addAllowedGroups(bytes32[] calldata _groupIds) external override {
+    function addAllowedGroups(bytes32 _paymentMethod, bytes32[] calldata _groupIds) external override {
         if (_groupIds.length == 0) revert EmptyArray();
 
-        bytes32[] storage makerGroups = allowedGroups[msg.sender];
+        bytes32[] storage paymentMethodGroups = allowedGroups[msg.sender][_paymentMethod];
         for (uint256 i = 0; i < _groupIds.length; ++i) {
             bytes32 groupId = _groupIds[i];
             if (!groupRegistry.groupExists(groupId)) revert GroupDoesNotExist(groupId);
-            if (_containsGroup(makerGroups, groupId)) continue;
-            if (makerGroups.length == MAX_GROUPS_PER_MAKER) {
-                revert TooManyGroups(makerGroups.length + 1, MAX_GROUPS_PER_MAKER);
+            if (_containsGroup(paymentMethodGroups, groupId)) continue;
+            if (paymentMethodGroups.length == MAX_GROUPS_PER_PAYMENT_METHOD) {
+                revert TooManyGroups(paymentMethodGroups.length + 1, MAX_GROUPS_PER_PAYMENT_METHOD);
             }
 
-            makerGroups.push(groupId);
-            emit AllowedGroupAdded(msg.sender, groupId);
+            paymentMethodGroups.push(groupId);
+            emit AllowedGroupAdded(msg.sender, _paymentMethod, groupId);
         }
     }
 
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function removeAllowedGroups(bytes32[] calldata _groupIds) external override {
+    function removeAllowedGroups(bytes32 _paymentMethod, bytes32[] calldata _groupIds) external override {
         if (_groupIds.length == 0) revert EmptyArray();
 
-        bytes32[] storage makerGroups = allowedGroups[msg.sender];
+        bytes32[] storage paymentMethodGroups = allowedGroups[msg.sender][_paymentMethod];
         for (uint256 i = 0; i < _groupIds.length; ++i) {
             bytes32 groupId = _groupIds[i];
-            uint256 groupIndex = _findGroupIndex(makerGroups, groupId);
-            if (groupIndex == makerGroups.length) continue;
+            uint256 groupIndex = _findGroupIndex(paymentMethodGroups, groupId);
+            if (groupIndex == paymentMethodGroups.length) continue;
 
-            makerGroups[groupIndex] = makerGroups[makerGroups.length - 1];
-            makerGroups.pop();
-            emit AllowedGroupRemoved(msg.sender, groupId);
+            paymentMethodGroups[groupIndex] = paymentMethodGroups[paymentMethodGroups.length - 1];
+            paymentMethodGroups.pop();
+            emit AllowedGroupRemoved(msg.sender, _paymentMethod, groupId);
         }
     }
 
@@ -134,27 +134,42 @@ contract WhitelistPolicy is IWhitelistPolicy {
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function getAllowedGroups(address _maker) external view override returns (bytes32[] memory) {
-        return allowedGroups[_maker];
+    function getAllowedGroups(address _maker, bytes32 _paymentMethod)
+        external
+        view
+        override
+        returns (bytes32[] memory)
+    {
+        return allowedGroups[_maker][_paymentMethod];
     }
 
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function isGroupAllowed(address _maker, bytes32 _groupId) external view override returns (bool) {
-        return _containsGroup(allowedGroups[_maker], _groupId);
+    function isGroupAllowed(address _maker, bytes32 _paymentMethod, bytes32 _groupId)
+        external
+        view
+        override
+        returns (bool)
+    {
+        return _containsGroup(allowedGroups[_maker][_paymentMethod], _groupId);
     }
 
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function isTakerAllowed(address _maker, address _taker) external view override returns (bool) {
-        if (!enabled[_maker]) return true;
+    function isTakerAllowed(address _maker, bytes32 _paymentMethod, address _taker)
+        external
+        view
+        override
+        returns (bool)
+    {
+        if (!enabled[_maker][_paymentMethod]) return true;
         if (isWhitelisted[_maker][_taker]) return true;
 
-        bytes32[] storage makerGroups = allowedGroups[_maker];
-        for (uint256 i = 0; i < makerGroups.length; ++i) {
-            if (groupRegistry.isMember(makerGroups[i], _taker)) return true;
+        bytes32[] storage paymentMethodGroups = allowedGroups[_maker][_paymentMethod];
+        for (uint256 i = 0; i < paymentMethodGroups.length; ++i) {
+            if (groupRegistry.isMember(paymentMethodGroups[i], _taker)) return true;
         }
         return false;
     }

--- a/contracts/hooks/WhitelistPolicy.sol
+++ b/contracts/hooks/WhitelistPolicy.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.18;
 
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
 import {IAddressGroupRegistry} from "../interfaces/IAddressGroupRegistry.sol";
 import {IEscrow} from "../interfaces/IEscrow.sol";
 import {IEscrowRegistry} from "../interfaces/IEscrowRegistry.sol";
@@ -17,8 +19,11 @@ import {IWhitelistPolicy} from "../interfaces/IWhitelistPolicy.sol";
  * While EscrowRegistry is in accept-all mode the registry check passes for any address, so passing an EOA or a
  * contract without `getDeposit` reverts inside the escrow call with no reason data rather than a policy error.
  * That path is a caller mistake on a governance-gated mode, and is not worth a per-write code-length check.
+ * `escrowRegistry` is governance-settable via `setEscrowRegistry` and MUST be kept in sync with the orchestrator's
+ * escrow registry (`OrchestratorV3.setEscrowRegistry`), because if the two diverge, deposits on an escrow admitted
+ * by only one of them can be neither gated nor revoked while the orchestrator keeps admitting intents for them.
  */
-contract WhitelistPolicy is IWhitelistPolicy {
+contract WhitelistPolicy is Ownable, IWhitelistPolicy {
     /* ============ Constants ============ */
 
     uint256 public constant MAX_GROUPS_PER_DEPOSIT = 10;
@@ -26,7 +31,7 @@ contract WhitelistPolicy is IWhitelistPolicy {
     /* ============ State Variables ============ */
 
     IAddressGroupRegistry public immutable override groupRegistry;
-    IEscrowRegistry public immutable override escrowRegistry;
+    IEscrowRegistry public override escrowRegistry;
 
     mapping(address => mapping(uint256 => bool)) public override enabled;
     mapping(address => mapping(uint256 => mapping(address => bool))) public override isWhitelisted;
@@ -39,6 +44,7 @@ contract WhitelistPolicy is IWhitelistPolicy {
     event AddressRemovedFromWhitelist(address indexed escrow, uint256 indexed depositId, address indexed taker);
     event AllowedGroupAdded(address indexed escrow, uint256 indexed depositId, bytes32 indexed groupId);
     event AllowedGroupRemoved(address indexed escrow, uint256 indexed depositId, bytes32 indexed groupId);
+    event EscrowRegistryUpdated(address indexed escrowRegistry);
 
     /* ============ Errors ============ */
 
@@ -53,7 +59,7 @@ contract WhitelistPolicy is IWhitelistPolicy {
 
     /* ============ Constructor ============ */
 
-    constructor(IAddressGroupRegistry _groupRegistry, IEscrowRegistry _escrowRegistry) {
+    constructor(IAddressGroupRegistry _groupRegistry, IEscrowRegistry _escrowRegistry) Ownable() {
         _validateDependency(address(_groupRegistry));
         _validateDependency(address(_escrowRegistry));
 
@@ -72,6 +78,18 @@ contract WhitelistPolicy is IWhitelistPolicy {
         if (depositor == address(0)) revert DepositNotFound(_escrow, _depositId);
         if (msg.sender != depositor) revert NotDepositor(_escrow, _depositId, msg.sender);
         _;
+    }
+
+    /* ============ Governance Functions ============ */
+
+    /**
+     * @inheritdoc IWhitelistPolicy
+     */
+    function setEscrowRegistry(IEscrowRegistry _escrowRegistry) external override onlyOwner {
+        _validateDependency(address(_escrowRegistry));
+
+        escrowRegistry = _escrowRegistry;
+        emit EscrowRegistryUpdated(address(_escrowRegistry));
     }
 
     /* ============ Depositor Functions ============ */

--- a/contracts/hooks/WhitelistPolicy.sol
+++ b/contracts/hooks/WhitelistPolicy.sol
@@ -3,129 +3,171 @@
 pragma solidity ^0.8.18;
 
 import {IAddressGroupRegistry} from "../interfaces/IAddressGroupRegistry.sol";
+import {IEscrow} from "../interfaces/IEscrow.sol";
+import {IEscrowRegistry} from "../interfaces/IEscrowRegistry.sol";
 import {IWhitelistPolicy} from "../interfaces/IWhitelistPolicy.sol";
 
 /**
  * @title WhitelistPolicy
- * @notice Persistent maker-owned taker admission settings, independent from any lifecycle-hook deployment.
- * Each maker can trust direct addresses globally and configure a bounded list of curated groups per payment method.
- * @dev Enabling an empty payment-method policy is allowed and intentionally fails closed when evaluated.
+ * @notice Persistent deposit-scoped taker admission settings, independent from any lifecycle-hook deployment.
+ * Each deposit carries its own enforcement switch, direct address whitelist, and bounded list of curated groups,
+ * so one maker can run gated and open deposits side by side. The policy survives global hook replacement.
+ * @dev Enabling a deposit with no groups and no whitelisted addresses is allowed and intentionally fails closed
+ * when evaluated. Writes are authorized against the escrow's recorded depositor, so the deposit must already exist.
+ * While EscrowRegistry is in accept-all mode the registry check passes for any address, so passing an EOA or a
+ * contract without `getDeposit` reverts inside the escrow call with no reason data rather than a policy error.
+ * That path is a caller mistake on a governance-gated mode, and is not worth a per-write code-length check.
  */
 contract WhitelistPolicy is IWhitelistPolicy {
     /* ============ Constants ============ */
 
-    uint256 public constant MAX_GROUPS_PER_PAYMENT_METHOD = 10;
+    uint256 public constant MAX_GROUPS_PER_DEPOSIT = 10;
 
     /* ============ State Variables ============ */
 
     IAddressGroupRegistry public immutable override groupRegistry;
+    IEscrowRegistry public immutable override escrowRegistry;
 
-    mapping(address => mapping(bytes32 => bool)) public override enabled;
-    mapping(address => mapping(address => bool)) public override isWhitelisted;
-    mapping(address => mapping(bytes32 => bytes32[])) internal allowedGroups;
+    mapping(address => mapping(uint256 => bool)) public override enabled;
+    mapping(address => mapping(uint256 => mapping(address => bool))) public override isWhitelisted;
+    mapping(address => mapping(uint256 => bytes32[])) internal allowedGroups;
 
     /* ============ Events ============ */
 
-    event EnabledUpdated(address indexed maker, bytes32 indexed paymentMethod, bool enabled);
-    event AddressWhitelisted(address indexed maker, address indexed taker);
-    event AddressRemovedFromWhitelist(address indexed maker, address indexed taker);
-    event AllowedGroupAdded(address indexed maker, bytes32 indexed paymentMethod, bytes32 indexed groupId);
-    event AllowedGroupRemoved(address indexed maker, bytes32 indexed paymentMethod, bytes32 indexed groupId);
+    event EnabledUpdated(address indexed escrow, uint256 indexed depositId, bool enabled);
+    event AddressWhitelisted(address indexed escrow, uint256 indexed depositId, address indexed taker);
+    event AddressRemovedFromWhitelist(address indexed escrow, uint256 indexed depositId, address indexed taker);
+    event AllowedGroupAdded(address indexed escrow, uint256 indexed depositId, bytes32 indexed groupId);
+    event AllowedGroupRemoved(address indexed escrow, uint256 indexed depositId, bytes32 indexed groupId);
 
     /* ============ Errors ============ */
 
     error ZeroAddress();
     error EmptyArray();
-    error InvalidGroupRegistry(address registry);
+    error InvalidDependency(address dependency);
     error GroupDoesNotExist(bytes32 groupId);
     error TooManyGroups(uint256 attempted, uint256 maximum);
+    error EscrowNotWhitelisted(address escrow);
+    error DepositNotFound(address escrow, uint256 depositId);
+    error NotDepositor(address escrow, uint256 depositId, address caller);
 
     /* ============ Constructor ============ */
 
-    constructor(IAddressGroupRegistry _groupRegistry) {
-        address registryAddress = address(_groupRegistry);
-        if (registryAddress == address(0)) revert ZeroAddress();
-        if (registryAddress.code.length == 0) revert InvalidGroupRegistry(registryAddress);
+    constructor(IAddressGroupRegistry _groupRegistry, IEscrowRegistry _escrowRegistry) {
+        _validateDependency(address(_groupRegistry));
+        _validateDependency(address(_escrowRegistry));
 
         groupRegistry = _groupRegistry;
+        escrowRegistry = _escrowRegistry;
     }
 
-    /* ============ Maker Functions ============ */
+    /* ============ Modifiers ============ */
+
+    modifier onlyDepositor(address _escrow, uint256 _depositId) {
+        if (!escrowRegistry.isWhitelistedEscrow(_escrow) && !escrowRegistry.isAcceptingAllEscrows()) {
+            revert EscrowNotWhitelisted(_escrow);
+        }
+
+        address depositor = IEscrow(_escrow).getDeposit(_depositId).depositor;
+        if (depositor == address(0)) revert DepositNotFound(_escrow, _depositId);
+        if (msg.sender != depositor) revert NotDepositor(_escrow, _depositId, msg.sender);
+        _;
+    }
+
+    /* ============ Depositor Functions ============ */
 
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function setEnabled(bytes32 _paymentMethod, bool _enabled) external override {
-        enabled[msg.sender][_paymentMethod] = _enabled;
-        emit EnabledUpdated(msg.sender, _paymentMethod, _enabled);
+    function configureDeposit(
+        address _escrow,
+        uint256 _depositId,
+        bool _enabled,
+        bytes32[] calldata _groupIds,
+        address[] calldata _takers
+    )
+        external
+        override
+        onlyDepositor(_escrow, _depositId)
+    {
+        _setEnabled(_escrow, _depositId, _enabled);
+        _addGroups(_escrow, _depositId, _groupIds);
+        _addTakers(_escrow, _depositId, _takers);
     }
 
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function addWhitelistedAddresses(address[] calldata _takers) external override {
+    function setEnabled(address _escrow, uint256 _depositId, bool _enabled)
+        external
+        override
+        onlyDepositor(_escrow, _depositId)
+    {
+        _setEnabled(_escrow, _depositId, _enabled);
+    }
+
+    /**
+     * @inheritdoc IWhitelistPolicy
+     */
+    function addWhitelistedAddresses(address _escrow, uint256 _depositId, address[] calldata _takers)
+        external
+        override
+        onlyDepositor(_escrow, _depositId)
+    {
+        if (_takers.length == 0) revert EmptyArray();
+        _addTakers(_escrow, _depositId, _takers);
+    }
+
+    /**
+     * @inheritdoc IWhitelistPolicy
+     */
+    function removeWhitelistedAddresses(address _escrow, uint256 _depositId, address[] calldata _takers)
+        external
+        override
+        onlyDepositor(_escrow, _depositId)
+    {
         if (_takers.length == 0) revert EmptyArray();
 
         for (uint256 i = 0; i < _takers.length; ++i) {
             address taker = _takers[i];
-            if (taker == address(0)) revert ZeroAddress();
-            if (isWhitelisted[msg.sender][taker]) continue;
+            if (!isWhitelisted[_escrow][_depositId][taker]) continue;
 
-            isWhitelisted[msg.sender][taker] = true;
-            emit AddressWhitelisted(msg.sender, taker);
+            isWhitelisted[_escrow][_depositId][taker] = false;
+            emit AddressRemovedFromWhitelist(_escrow, _depositId, taker);
         }
     }
 
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function removeWhitelistedAddresses(address[] calldata _takers) external override {
-        if (_takers.length == 0) revert EmptyArray();
-
-        for (uint256 i = 0; i < _takers.length; ++i) {
-            address taker = _takers[i];
-            if (!isWhitelisted[msg.sender][taker]) continue;
-
-            isWhitelisted[msg.sender][taker] = false;
-            emit AddressRemovedFromWhitelist(msg.sender, taker);
-        }
+    function addAllowedGroups(address _escrow, uint256 _depositId, bytes32[] calldata _groupIds)
+        external
+        override
+        onlyDepositor(_escrow, _depositId)
+    {
+        if (_groupIds.length == 0) revert EmptyArray();
+        _addGroups(_escrow, _depositId, _groupIds);
     }
 
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function addAllowedGroups(bytes32 _paymentMethod, bytes32[] calldata _groupIds) external override {
+    function removeAllowedGroups(address _escrow, uint256 _depositId, bytes32[] calldata _groupIds)
+        external
+        override
+        onlyDepositor(_escrow, _depositId)
+    {
         if (_groupIds.length == 0) revert EmptyArray();
 
-        bytes32[] storage paymentMethodGroups = allowedGroups[msg.sender][_paymentMethod];
+        bytes32[] storage depositGroups = allowedGroups[_escrow][_depositId];
         for (uint256 i = 0; i < _groupIds.length; ++i) {
             bytes32 groupId = _groupIds[i];
-            if (!groupRegistry.groupExists(groupId)) revert GroupDoesNotExist(groupId);
-            if (_containsGroup(paymentMethodGroups, groupId)) continue;
-            if (paymentMethodGroups.length == MAX_GROUPS_PER_PAYMENT_METHOD) {
-                revert TooManyGroups(paymentMethodGroups.length + 1, MAX_GROUPS_PER_PAYMENT_METHOD);
-            }
+            uint256 groupIndex = _findGroupIndex(depositGroups, groupId);
+            if (groupIndex == depositGroups.length) continue;
 
-            paymentMethodGroups.push(groupId);
-            emit AllowedGroupAdded(msg.sender, _paymentMethod, groupId);
-        }
-    }
-
-    /**
-     * @inheritdoc IWhitelistPolicy
-     */
-    function removeAllowedGroups(bytes32 _paymentMethod, bytes32[] calldata _groupIds) external override {
-        if (_groupIds.length == 0) revert EmptyArray();
-
-        bytes32[] storage paymentMethodGroups = allowedGroups[msg.sender][_paymentMethod];
-        for (uint256 i = 0; i < _groupIds.length; ++i) {
-            bytes32 groupId = _groupIds[i];
-            uint256 groupIndex = _findGroupIndex(paymentMethodGroups, groupId);
-            if (groupIndex == paymentMethodGroups.length) continue;
-
-            paymentMethodGroups[groupIndex] = paymentMethodGroups[paymentMethodGroups.length - 1];
-            paymentMethodGroups.pop();
-            emit AllowedGroupRemoved(msg.sender, _paymentMethod, groupId);
+            depositGroups[groupIndex] = depositGroups[depositGroups.length - 1];
+            depositGroups.pop();
+            emit AllowedGroupRemoved(_escrow, _depositId, groupId);
         }
     }
 
@@ -134,47 +176,73 @@ contract WhitelistPolicy is IWhitelistPolicy {
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function getAllowedGroups(address _maker, bytes32 _paymentMethod)
-        external
-        view
-        override
-        returns (bytes32[] memory)
-    {
-        return allowedGroups[_maker][_paymentMethod];
+    function getAllowedGroups(address _escrow, uint256 _depositId) external view override returns (bytes32[] memory) {
+        return allowedGroups[_escrow][_depositId];
     }
 
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function isGroupAllowed(address _maker, bytes32 _paymentMethod, bytes32 _groupId)
+    function isGroupAllowed(address _escrow, uint256 _depositId, bytes32 _groupId)
         external
         view
         override
         returns (bool)
     {
-        return _containsGroup(allowedGroups[_maker][_paymentMethod], _groupId);
+        return _containsGroup(allowedGroups[_escrow][_depositId], _groupId);
     }
 
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function isTakerAllowed(address _maker, bytes32 _paymentMethod, address _taker)
+    function isTakerAllowed(address _escrow, uint256 _depositId, address _taker)
         external
         view
         override
         returns (bool)
     {
-        if (!enabled[_maker][_paymentMethod]) return true;
-        if (isWhitelisted[_maker][_taker]) return true;
+        if (!enabled[_escrow][_depositId]) return true;
+        if (isWhitelisted[_escrow][_depositId][_taker]) return true;
 
-        bytes32[] storage paymentMethodGroups = allowedGroups[_maker][_paymentMethod];
-        for (uint256 i = 0; i < paymentMethodGroups.length; ++i) {
-            if (groupRegistry.isMember(paymentMethodGroups[i], _taker)) return true;
+        bytes32[] storage depositGroups = allowedGroups[_escrow][_depositId];
+        for (uint256 i = 0; i < depositGroups.length; ++i) {
+            if (groupRegistry.isMember(depositGroups[i], _taker)) return true;
         }
         return false;
     }
 
     /* ============ Internal Functions ============ */
+
+    function _setEnabled(address _escrow, uint256 _depositId, bool _enabled) internal {
+        enabled[_escrow][_depositId] = _enabled;
+        emit EnabledUpdated(_escrow, _depositId, _enabled);
+    }
+
+    function _addTakers(address _escrow, uint256 _depositId, address[] calldata _takers) internal {
+        for (uint256 i = 0; i < _takers.length; ++i) {
+            address taker = _takers[i];
+            if (taker == address(0)) revert ZeroAddress();
+            if (isWhitelisted[_escrow][_depositId][taker]) continue;
+
+            isWhitelisted[_escrow][_depositId][taker] = true;
+            emit AddressWhitelisted(_escrow, _depositId, taker);
+        }
+    }
+
+    function _addGroups(address _escrow, uint256 _depositId, bytes32[] calldata _groupIds) internal {
+        bytes32[] storage depositGroups = allowedGroups[_escrow][_depositId];
+        for (uint256 i = 0; i < _groupIds.length; ++i) {
+            bytes32 groupId = _groupIds[i];
+            if (!groupRegistry.groupExists(groupId)) revert GroupDoesNotExist(groupId);
+            if (_containsGroup(depositGroups, groupId)) continue;
+            if (depositGroups.length == MAX_GROUPS_PER_DEPOSIT) {
+                revert TooManyGroups(depositGroups.length + 1, MAX_GROUPS_PER_DEPOSIT);
+            }
+
+            depositGroups.push(groupId);
+            emit AllowedGroupAdded(_escrow, _depositId, groupId);
+        }
+    }
 
     function _containsGroup(bytes32[] storage _groups, bytes32 _groupId) internal view returns (bool) {
         return _findGroupIndex(_groups, _groupId) != _groups.length;
@@ -185,5 +253,10 @@ contract WhitelistPolicy is IWhitelistPolicy {
             if (_groups[i] == _groupId) return i;
         }
         return _groups.length;
+    }
+
+    function _validateDependency(address _dependency) internal view {
+        if (_dependency == address(0)) revert ZeroAddress();
+        if (_dependency.code.length == 0) revert InvalidDependency(_dependency);
     }
 }

--- a/contracts/interfaces/IWhitelistPolicy.sol
+++ b/contracts/interfaces/IWhitelistPolicy.sol
@@ -33,6 +33,17 @@ interface IWhitelistPolicy {
         bytes32[] calldata groupIds,
         address[] calldata takers
     ) external;
+
+    /**
+     * @notice Updates the escrow registry used to authorize deposit configuration.
+     * @dev Governance-only (owner). The new registry must be a non-zero address with deployed code, else this call
+     * reverts. This value MUST be kept in sync with the orchestrator's escrow registry
+     * (`OrchestratorV3.setEscrowRegistry`), because if they diverge, deposits on an escrow admitted by only one
+     * registry can be neither gated nor revoked here while the orchestrator keeps admitting intents for them.
+     * @param escrowRegistry New escrow registry used to authorize deposit configuration.
+     */
+    function setEscrowRegistry(IEscrowRegistry escrowRegistry) external;
+
     function setEnabled(address escrow, uint256 depositId, bool enabled) external;
     function addWhitelistedAddresses(address escrow, uint256 depositId, address[] calldata takers) external;
     function removeWhitelistedAddresses(address escrow, uint256 depositId, address[] calldata takers) external;

--- a/contracts/interfaces/IWhitelistPolicy.sol
+++ b/contracts/interfaces/IWhitelistPolicy.sol
@@ -3,18 +3,27 @@
 pragma solidity ^0.8.18;
 
 import {IAddressGroupRegistry} from "./IAddressGroupRegistry.sol";
+import {IEscrowRegistry} from "./IEscrowRegistry.sol";
 
 interface IWhitelistPolicy {
     function groupRegistry() external view returns (IAddressGroupRegistry);
-    function enabled(address maker, bytes32 paymentMethod) external view returns (bool);
-    function isWhitelisted(address maker, address taker) external view returns (bool);
-    function getAllowedGroups(address maker, bytes32 paymentMethod) external view returns (bytes32[] memory);
-    function isGroupAllowed(address maker, bytes32 paymentMethod, bytes32 groupId) external view returns (bool);
-    function isTakerAllowed(address maker, bytes32 paymentMethod, address taker) external view returns (bool);
+    function escrowRegistry() external view returns (IEscrowRegistry);
+    function enabled(address escrow, uint256 depositId) external view returns (bool);
+    function isWhitelisted(address escrow, uint256 depositId, address taker) external view returns (bool);
+    function getAllowedGroups(address escrow, uint256 depositId) external view returns (bytes32[] memory);
+    function isGroupAllowed(address escrow, uint256 depositId, bytes32 groupId) external view returns (bool);
+    function isTakerAllowed(address escrow, uint256 depositId, address taker) external view returns (bool);
 
-    function setEnabled(bytes32 paymentMethod, bool enabled) external;
-    function addWhitelistedAddresses(address[] calldata takers) external;
-    function removeWhitelistedAddresses(address[] calldata takers) external;
-    function addAllowedGroups(bytes32 paymentMethod, bytes32[] calldata groupIds) external;
-    function removeAllowedGroups(bytes32 paymentMethod, bytes32[] calldata groupIds) external;
+    function configureDeposit(
+        address escrow,
+        uint256 depositId,
+        bool enabled,
+        bytes32[] calldata groupIds,
+        address[] calldata takers
+    ) external;
+    function setEnabled(address escrow, uint256 depositId, bool enabled) external;
+    function addWhitelistedAddresses(address escrow, uint256 depositId, address[] calldata takers) external;
+    function removeWhitelistedAddresses(address escrow, uint256 depositId, address[] calldata takers) external;
+    function addAllowedGroups(address escrow, uint256 depositId, bytes32[] calldata groupIds) external;
+    function removeAllowedGroups(address escrow, uint256 depositId, bytes32[] calldata groupIds) external;
 }

--- a/contracts/interfaces/IWhitelistPolicy.sol
+++ b/contracts/interfaces/IWhitelistPolicy.sol
@@ -6,15 +6,15 @@ import {IAddressGroupRegistry} from "./IAddressGroupRegistry.sol";
 
 interface IWhitelistPolicy {
     function groupRegistry() external view returns (IAddressGroupRegistry);
-    function enabled(address maker) external view returns (bool);
+    function enabled(address maker, bytes32 paymentMethod) external view returns (bool);
     function isWhitelisted(address maker, address taker) external view returns (bool);
-    function getAllowedGroups(address maker) external view returns (bytes32[] memory);
-    function isGroupAllowed(address maker, bytes32 groupId) external view returns (bool);
-    function isTakerAllowed(address maker, address taker) external view returns (bool);
+    function getAllowedGroups(address maker, bytes32 paymentMethod) external view returns (bytes32[] memory);
+    function isGroupAllowed(address maker, bytes32 paymentMethod, bytes32 groupId) external view returns (bool);
+    function isTakerAllowed(address maker, bytes32 paymentMethod, address taker) external view returns (bool);
 
-    function setEnabled(bool enabled) external;
+    function setEnabled(bytes32 paymentMethod, bool enabled) external;
     function addWhitelistedAddresses(address[] calldata takers) external;
     function removeWhitelistedAddresses(address[] calldata takers) external;
-    function addAllowedGroups(bytes32[] calldata groupIds) external;
-    function removeAllowedGroups(bytes32[] calldata groupIds) external;
+    function addAllowedGroups(bytes32 paymentMethod, bytes32[] calldata groupIds) external;
+    function removeAllowedGroups(bytes32 paymentMethod, bytes32[] calldata groupIds) external;
 }

--- a/contracts/interfaces/IWhitelistPolicy.sol
+++ b/contracts/interfaces/IWhitelistPolicy.sol
@@ -14,6 +14,18 @@ interface IWhitelistPolicy {
     function isGroupAllowed(address escrow, uint256 depositId, bytes32 groupId) external view returns (bool);
     function isTakerAllowed(address escrow, uint256 depositId, address taker) external view returns (bool);
 
+    /**
+     * @notice Bundles enabling/disabling the deposit's gate with appending groups and takers in one call.
+     * @dev `enabled` REPLACES the deposit's current enforcement switch. `groupIds` and `takers` are APPENDED to
+     * the deposit's existing allowed-group list and direct whitelist; this call never removes or clears either
+     * list. Passing `enabled = false` disables enforcement on an already-gated deposit even while appending new
+     * groups or takers in the same call. Use `setEnabled` alone to toggle the gate without touching the lists.
+     * @param escrow Whitelisted Escrow or EscrowV2 holding the deposit.
+     * @param depositId Deposit to configure.
+     * @param enabled New value for the deposit's enforcement switch; replaces the prior value.
+     * @param groupIds Curated group ids to append to the deposit's allowed groups.
+     * @param takers Addresses to append to the deposit's direct whitelist.
+     */
     function configureDeposit(
         address escrow,
         uint256 depositId,

--- a/contracts/mocks/EscrowDepositorMock.sol
+++ b/contracts/mocks/EscrowDepositorMock.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {IEscrow} from "../interfaces/IEscrow.sol";
+
+/**
+ * @title EscrowDepositorMock
+ * @notice Minimal escrow stand-in exposing only the `getDeposit` call that WhitelistPolicy depends on.
+ * @dev Intentionally does not declare `is IEscrow`. WhitelistPolicy only ever reads `Deposit.depositor`,
+ * so implementing the full escrow surface would be dead weight. Every unset field is returned zeroed.
+ */
+contract EscrowDepositorMock {
+    mapping(uint256 => address) public depositors;
+
+    function setDepositor(uint256 _depositId, address _depositor) external {
+        depositors[_depositId] = _depositor;
+    }
+
+    function getDeposit(uint256 _depositId) external view returns (IEscrow.Deposit memory deposit) {
+        deposit.depositor = depositors[_depositId];
+    }
+}

--- a/deploy/29_deploy_maker_group_risk_system.ts
+++ b/deploy/29_deploy_maker_group_risk_system.ts
@@ -184,6 +184,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   await addOrchestratorToRegistry(hre, orchestratorRegistry, orchestratorV3.address);
   await addEscrowToRegistry(hre, escrowRegistry, escrowV2Address);
 
+  const whitelistPolicyContract = await ethers.getContractAt("WhitelistPolicy", whitelistPolicy.address);
+  await setNewOwner(hre, whitelistPolicyContract, governance);
   await setNewOwner(hre, orchestratorV3Contract, governance);
 
   console.log("=== Minimal V3 deposit whitelist risk system deployment prepared ===");

--- a/deploy/29_deploy_maker_group_risk_system.ts
+++ b/deploy/29_deploy_maker_group_risk_system.ts
@@ -56,9 +56,9 @@ async function systemFullyWired(network: string): Promise<boolean> {
   const orchestratorRegistry = await ethers.getContractAt("OrchestratorRegistry", orchestratorRegistryAddress);
   const escrowRegistry = await ethers.getContractAt("EscrowRegistry", escrowRegistryAddress);
 
-  // Capability probe for the deposit-scoped policy schema. The previous payment-method-scoped policy
-  // exposes enabled(address,bytes32) rather than enabled(address,uint256), so this call reverts against
-  // stale bytecode and forces hardhat-deploy to process the changed policy/hook wiring.
+  // Capability probe for the deposit-scoped policy schema. The currently deployed policy is maker-scoped and
+  // exposes enabled(address) rather than enabled(address,uint256), so this call reverts against stale bytecode
+  // (argument-count mismatch) and forces hardhat-deploy to process the changed policy/hook wiring.
   await policy.enabled(ethers.constants.AddressZero, 0);
 
   if ((await policy.groupRegistry()).toLowerCase() !== registryAddress.toLowerCase()) return false;

--- a/deploy/29_deploy_maker_group_risk_system.ts
+++ b/deploy/29_deploy_maker_group_risk_system.ts
@@ -184,6 +184,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   await addOrchestratorToRegistry(hre, orchestratorRegistry, orchestratorV3.address);
   await addEscrowToRegistry(hre, escrowRegistry, escrowV2Address);
 
+  // Ownership handoff. Any policy configuration added below this point must go through
+  // executeOrQueueGovernanceCall -- the deployer is no longer the owner on networks with a real MULTI_SIG.
   const whitelistPolicyContract = await ethers.getContractAt("WhitelistPolicy", whitelistPolicy.address);
   await setNewOwner(hre, whitelistPolicyContract, governance);
   await setNewOwner(hre, orchestratorV3Contract, governance);

--- a/deploy/29_deploy_maker_group_risk_system.ts
+++ b/deploy/29_deploy_maker_group_risk_system.ts
@@ -18,6 +18,7 @@ import {
   waitForDeploymentDelay,
 } from "../deployments/helpers";
 import { safeBatchCollector } from "../deployments/safeBatchCollector";
+import type { WhitelistPolicy__factory } from "../typechain";
 
 async function executeOrQueueGovernanceCall(
   hre: HardhatRuntimeEnvironment,
@@ -55,12 +56,13 @@ async function systemFullyWired(network: string): Promise<boolean> {
   const orchestratorRegistry = await ethers.getContractAt("OrchestratorRegistry", orchestratorRegistryAddress);
   const escrowRegistry = await ethers.getContractAt("EscrowRegistry", escrowRegistryAddress);
 
-  // Capability probe for the payment-method-scoped policy schema. The previous
-  // maker-wide policy does not implement this selector, so the call fails and
-  // forces hardhat-deploy to process the changed policy/hook bytecode and wiring.
-  await policy.enabled(ethers.constants.AddressZero, ethers.constants.HashZero);
+  // Capability probe for the deposit-scoped policy schema. The previous payment-method-scoped policy
+  // exposes enabled(address,bytes32) rather than enabled(address,uint256), so this call reverts against
+  // stale bytecode and forces hardhat-deploy to process the changed policy/hook wiring.
+  await policy.enabled(ethers.constants.AddressZero, 0);
 
   if ((await policy.groupRegistry()).toLowerCase() !== registryAddress.toLowerCase()) return false;
+  if ((await policy.escrowRegistry()).toLowerCase() !== escrowRegistryAddress.toLowerCase()) return false;
   if ((await hook.whitelistPolicy()).toLowerCase() !== policyAddress.toLowerCase()) return false;
   if ((await hook.orchestratorRegistry()).toLowerCase() !== orchestratorRegistryAddress.toLowerCase()) return false;
   if ((await orchestrator.lifecycleHook()).toLowerCase() !== hookAddress.toLowerCase()) return false;
@@ -82,7 +84,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const orchestratorRegistryAddress = getDeployedContractAddress(network, "OrchestratorRegistry");
   const escrowV2Address = getDeployedContractAddress(network, "EscrowV2");
 
-  console.log("=== Deploying minimal OrchestratorV3 maker whitelist risk system ===");
+  console.log("=== Deploying minimal OrchestratorV3 deposit whitelist risk system ===");
 
   const boundedCall = await deploy("BoundedCall", {
     from: deployer,
@@ -143,9 +145,14 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     await waitForDeploymentDelay(hre);
   }
 
+  const whitelistPolicyArgs: Parameters<WhitelistPolicy__factory["deploy"]> = [
+    addressGroupRegistry.address,
+    escrowRegistryAddress,
+  ];
+
   const whitelistPolicy = await deploy("WhitelistPolicy", {
     from: deployer,
-    args: [addressGroupRegistry.address],
+    args: whitelistPolicyArgs,
   });
   if (whitelistPolicy.newlyDeployed) {
     console.log("WhitelistPolicy deployed at", whitelistPolicy.address);
@@ -179,7 +186,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   await setNewOwner(hre, orchestratorV3Contract, governance);
 
-  console.log("=== Minimal V3 risk system deployment prepared ===");
+  console.log("=== Minimal V3 deposit whitelist risk system deployment prepared ===");
   console.log("OrchestratorV3:", orchestratorV3.address);
   console.log("AddressGroupRegistry:", addressGroupRegistry.address);
   console.log("WhitelistPolicy:", whitelistPolicy.address);

--- a/deploy/29_deploy_maker_group_risk_system.ts
+++ b/deploy/29_deploy_maker_group_risk_system.ts
@@ -55,6 +55,11 @@ async function systemFullyWired(network: string): Promise<boolean> {
   const orchestratorRegistry = await ethers.getContractAt("OrchestratorRegistry", orchestratorRegistryAddress);
   const escrowRegistry = await ethers.getContractAt("EscrowRegistry", escrowRegistryAddress);
 
+  // Capability probe for the payment-method-scoped policy schema. The previous
+  // maker-wide policy does not implement this selector, so the call fails and
+  // forces hardhat-deploy to process the changed policy/hook bytecode and wiring.
+  await policy.enabled(ethers.constants.AddressZero, ethers.constants.HashZero);
+
   if ((await policy.groupRegistry()).toLowerCase() !== registryAddress.toLowerCase()) return false;
   if ((await hook.whitelistPolicy()).toLowerCase() !== policyAddress.toLowerCase()) return false;
   if ((await hook.orchestratorRegistry()).toLowerCase() !== orchestratorRegistryAddress.toLowerCase()) return false;

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -33,7 +33,7 @@ import type { Escrow, Orchestrator } from "@zkp2p/contracts-v2/types"
 // Import utility functions
 import { getKeccak256Hash, calculateIntentHash } from "@zkp2p/contracts-v2/utils/protocolUtils"
 
-// Import stable source ABIs for the V3 lifecycle boundary and maker whitelist policy
+// Import stable source ABIs for the V3 lifecycle boundary and deposit-scoped whitelist policy
 import {
   AddressGroupRegistry,
   IIntentLifecycleHook,

--- a/test-foundry/deterministic/hooks/WhitelistPolicy.t.sol
+++ b/test-foundry/deterministic/hooks/WhitelistPolicy.t.sol
@@ -90,7 +90,37 @@ contract WhitelistPolicyTest is Test {
         assertFalse(policy.enabled(address(escrow), DEPOSIT_ONE));
     }
 
-    function test_ConfigureRevertsForUnknownDeposit() public {
+    function test_AllSixGatedEntryPointsRevertForNonDepositor() public {
+        bytes memory expectedRevert = abi.encodeWithSelector(
+            WhitelistPolicy.NotDepositor.selector, address(escrow), DEPOSIT_ONE, otherMaker
+        );
+
+        vm.expectRevert(expectedRevert);
+        vm.prank(otherMaker);
+        policy.setEnabled(address(escrow), DEPOSIT_ONE, true);
+
+        vm.expectRevert(expectedRevert);
+        vm.prank(otherMaker);
+        policy.configureDeposit(address(escrow), DEPOSIT_ONE, true, new bytes32[](0), new address[](0));
+
+        vm.expectRevert(expectedRevert);
+        vm.prank(otherMaker);
+        policy.addWhitelistedAddresses(address(escrow), DEPOSIT_ONE, _addresses(taker));
+
+        vm.expectRevert(expectedRevert);
+        vm.prank(otherMaker);
+        policy.removeWhitelistedAddresses(address(escrow), DEPOSIT_ONE, _addresses(taker));
+
+        vm.expectRevert(expectedRevert);
+        vm.prank(otherMaker);
+        policy.addAllowedGroups(address(escrow), DEPOSIT_ONE, _groupIds(PEERS));
+
+        vm.expectRevert(expectedRevert);
+        vm.prank(otherMaker);
+        policy.removeAllowedGroups(address(escrow), DEPOSIT_ONE, _groupIds(PEERS));
+    }
+
+    function test_SetEnabledRevertsForUnknownDeposit() public {
         vm.expectRevert(
             abi.encodeWithSelector(WhitelistPolicy.DepositNotFound.selector, address(escrow), UNKNOWN_DEPOSIT)
         );
@@ -98,7 +128,7 @@ contract WhitelistPolicyTest is Test {
         policy.setEnabled(address(escrow), UNKNOWN_DEPOSIT, true);
     }
 
-    function test_ConfigureRevertsForUnregisteredEscrow() public {
+    function test_SetEnabledRevertsForUnregisteredEscrow() public {
         vm.expectRevert(
             abi.encodeWithSelector(WhitelistPolicy.EscrowNotWhitelisted.selector, address(unregisteredEscrow))
         );
@@ -321,7 +351,7 @@ contract WhitelistPolicyTest is Test {
         assertTrue(policy.isWhitelisted(address(escrow), DEPOSIT_ONE, otherTaker));
     }
 
-    function test_ConfigureDepositEmitsTheSameEventsAsGranularSetters() public {
+    function test_ConfigureDepositEmitsGranularEvents() public {
         vm.expectEmit(true, true, false, true, address(policy));
         emit EnabledUpdated(address(escrow), DEPOSIT_ONE, true);
         vm.expectEmit(true, true, true, true, address(policy));
@@ -387,6 +417,24 @@ contract WhitelistPolicyTest is Test {
         );
         vm.prank(otherMaker);
         policy.configureDeposit(address(escrow), DEPOSIT_ONE, true, new bytes32[](0), new address[](0));
+    }
+
+    function test_ConfigureDepositWithEnabledFalseDisablesGateEvenWhenAppendingTakers() public {
+        vm.prank(maker);
+        policy.configureDeposit(address(escrow), DEPOSIT_ONE, true, _groupIds(PEERS), new address[](0));
+        assertTrue(policy.enabled(address(escrow), DEPOSIT_ONE));
+
+        vm.prank(maker);
+        policy.configureDeposit(address(escrow), DEPOSIT_ONE, false, new bytes32[](0), _addresses(taker));
+
+        assertFalse(policy.enabled(address(escrow), DEPOSIT_ONE));
+        assertTrue(policy.isWhitelisted(address(escrow), DEPOSIT_ONE, taker));
+
+        bytes32[] memory groups = policy.getAllowedGroups(address(escrow), DEPOSIT_ONE);
+        assertEq(groups.length, 1);
+        assertEq(groups[0], PEERS);
+
+        assertTrue(policy.isTakerAllowed(address(escrow), DEPOSIT_ONE, otherTaker));
     }
 
     /* ============ isTakerAllowed ============ */

--- a/test-foundry/deterministic/hooks/WhitelistPolicy.t.sol
+++ b/test-foundry/deterministic/hooks/WhitelistPolicy.t.sol
@@ -35,6 +35,7 @@ contract WhitelistPolicyTest is Test {
     event AddressRemovedFromWhitelist(address indexed escrow, uint256 indexed depositId, address indexed taker);
     event AllowedGroupAdded(address indexed escrow, uint256 indexed depositId, bytes32 indexed groupId);
     event AllowedGroupRemoved(address indexed escrow, uint256 indexed depositId, bytes32 indexed groupId);
+    event EscrowRegistryUpdated(address indexed escrowRegistry);
 
     function setUp() public {
         maker = makeAddr("maker");
@@ -76,6 +77,68 @@ contract WhitelistPolicyTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(WhitelistPolicy.InvalidDependency.selector, maker));
         new WhitelistPolicy(registry, EscrowRegistry(maker));
+    }
+
+    /* ============ Governance ============ */
+
+    function test_ConstructorSetsDeployerAsOwner() public {
+        assertEq(policy.owner(), address(this));
+    }
+
+    function test_SetEscrowRegistryUpdatesRegistryAndEmits() public {
+        EscrowRegistry newEscrowRegistry = new EscrowRegistry();
+
+        vm.expectEmit(true, false, false, true, address(policy));
+        emit EscrowRegistryUpdated(address(newEscrowRegistry));
+        policy.setEscrowRegistry(newEscrowRegistry);
+
+        assertEq(address(policy.escrowRegistry()), address(newEscrowRegistry));
+    }
+
+    function test_SetEscrowRegistryRejectsNonOwner() public {
+        vm.expectRevert(bytes("Ownable: caller is not the owner"));
+        vm.prank(maker);
+        policy.setEscrowRegistry(EscrowRegistry(address(otherEscrow)));
+
+        assertEq(address(policy.escrowRegistry()), address(escrowRegistry));
+    }
+
+    function test_SetEscrowRegistryRejectsZeroAndCodelessRegistry() public {
+        vm.expectRevert(WhitelistPolicy.ZeroAddress.selector);
+        policy.setEscrowRegistry(EscrowRegistry(address(0)));
+
+        vm.expectRevert(abi.encodeWithSelector(WhitelistPolicy.InvalidDependency.selector, maker));
+        policy.setEscrowRegistry(EscrowRegistry(maker));
+
+        assertEq(address(policy.escrowRegistry()), address(escrowRegistry));
+    }
+
+    function test_EscrowRegistryRotationRestoresRevocationAfterDivergence() public {
+        EscrowRegistry newEscrowRegistry = new EscrowRegistry();
+        newEscrowRegistry.addEscrow(address(escrow));
+
+        vm.prank(maker);
+        policy.configureDeposit(address(escrow), DEPOSIT_ONE, true, new bytes32[](0), _addresses(taker));
+
+        assertTrue(policy.isTakerAllowed(address(escrow), DEPOSIT_ONE, taker));
+
+        escrowRegistry.removeEscrow(address(escrow));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(WhitelistPolicy.EscrowNotWhitelisted.selector, address(escrow))
+        );
+        vm.prank(maker);
+        policy.removeWhitelistedAddresses(address(escrow), DEPOSIT_ONE, _addresses(taker));
+
+        assertTrue(policy.isTakerAllowed(address(escrow), DEPOSIT_ONE, taker));
+
+        policy.setEscrowRegistry(newEscrowRegistry);
+
+        vm.prank(maker);
+        policy.removeWhitelistedAddresses(address(escrow), DEPOSIT_ONE, _addresses(taker));
+
+        assertFalse(policy.isWhitelisted(address(escrow), DEPOSIT_ONE, taker));
+        assertFalse(policy.isTakerAllowed(address(escrow), DEPOSIT_ONE, taker));
     }
 
     /* ============ Authorization ============ */

--- a/test-foundry/deterministic/hooks/WhitelistPolicy.t.sol
+++ b/test-foundry/deterministic/hooks/WhitelistPolicy.t.sol
@@ -8,6 +8,9 @@ import {WhitelistPolicy} from "contracts/hooks/WhitelistPolicy.sol";
 import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
 
 contract WhitelistPolicyTest is Test {
+    bytes32 internal constant VENMO = keccak256("venmo");
+    bytes32 internal constant ZELLE = keccak256("zelle");
+
     bytes32 internal PEERS;
     bytes32 internal PEER_PLUSES;
     bytes32 internal PEER_MERCHANTS;
@@ -20,11 +23,11 @@ contract WhitelistPolicyTest is Test {
     AddressGroupRegistry internal registry;
     WhitelistPolicy internal policy;
 
-    event EnabledUpdated(address indexed maker, bool enabled);
+    event EnabledUpdated(address indexed maker, bytes32 indexed paymentMethod, bool enabled);
     event AddressWhitelisted(address indexed maker, address indexed taker);
     event AddressRemovedFromWhitelist(address indexed maker, address indexed taker);
-    event AllowedGroupAdded(address indexed maker, bytes32 indexed groupId);
-    event AllowedGroupRemoved(address indexed maker, bytes32 indexed groupId);
+    event AllowedGroupAdded(address indexed maker, bytes32 indexed paymentMethod, bytes32 indexed groupId);
+    event AllowedGroupRemoved(address indexed maker, bytes32 indexed paymentMethod, bytes32 indexed groupId);
 
     function setUp() public {
         maker = makeAddr("maker");
@@ -46,18 +49,19 @@ contract WhitelistPolicyTest is Test {
         new WhitelistPolicy(AddressGroupRegistry(maker));
     }
 
-    function test_SetEnabledIsScopedToMaker() public {
-        vm.expectEmit(true, false, false, true, address(policy));
-        emit EnabledUpdated(maker, true);
+    function test_SetEnabledIsScopedToMakerAndPaymentMethod() public {
+        vm.expectEmit(true, true, false, true, address(policy));
+        emit EnabledUpdated(maker, VENMO, true);
         vm.prank(maker);
-        policy.setEnabled(true);
+        policy.setEnabled(VENMO, true);
 
-        assertTrue(policy.enabled(maker));
-        assertFalse(policy.enabled(otherMaker));
+        assertTrue(policy.enabled(maker, VENMO));
+        assertFalse(policy.enabled(maker, ZELLE));
+        assertFalse(policy.enabled(otherMaker, VENMO));
 
         vm.prank(maker);
-        policy.setEnabled(false);
-        assertFalse(policy.enabled(maker));
+        policy.setEnabled(VENMO, false);
+        assertFalse(policy.enabled(maker, VENMO));
     }
 
     function test_AddWhitelistedAddressesIsIdempotentAndEnumerableByGetter() public {
@@ -119,36 +123,38 @@ contract WhitelistPolicyTest is Test {
     function test_AddAllowedGroupsSupportsViewsAndDeduplicates() public {
         bytes32[] memory groups = _groupIds(PEERS, PEER_PLUSES);
 
-        vm.expectEmit(true, true, false, true, address(policy));
-        emit AllowedGroupAdded(maker, PEERS);
-        vm.expectEmit(true, true, false, true, address(policy));
-        emit AllowedGroupAdded(maker, PEER_PLUSES);
+        vm.expectEmit(true, true, true, true, address(policy));
+        emit AllowedGroupAdded(maker, VENMO, PEERS);
+        vm.expectEmit(true, true, true, true, address(policy));
+        emit AllowedGroupAdded(maker, VENMO, PEER_PLUSES);
         vm.prank(maker);
-        policy.addAllowedGroups(groups);
+        policy.addAllowedGroups(VENMO, groups);
 
-        assertEq(policy.getAllowedGroups(maker), groups);
-        assertTrue(policy.isGroupAllowed(maker, PEERS));
-        assertTrue(policy.isGroupAllowed(maker, PEER_PLUSES));
-        assertFalse(policy.isGroupAllowed(otherMaker, PEERS));
+        assertEq(policy.getAllowedGroups(maker, VENMO), groups);
+        assertEq(policy.getAllowedGroups(maker, ZELLE).length, 0);
+        assertTrue(policy.isGroupAllowed(maker, VENMO, PEERS));
+        assertTrue(policy.isGroupAllowed(maker, VENMO, PEER_PLUSES));
+        assertFalse(policy.isGroupAllowed(maker, ZELLE, PEERS));
+        assertFalse(policy.isGroupAllowed(otherMaker, VENMO, PEERS));
 
         vm.recordLogs();
         vm.prank(maker);
-        policy.addAllowedGroups(groups);
+        policy.addAllowedGroups(VENMO, groups);
         assertEq(vm.getRecordedLogs().length, 0);
-        assertEq(policy.getAllowedGroups(maker).length, 2);
+        assertEq(policy.getAllowedGroups(maker, VENMO).length, 2);
     }
 
     function test_AddAllowedGroupsRejectsEmptyAndUnknownGroups() public {
         vm.expectRevert(WhitelistPolicy.EmptyArray.selector);
         vm.prank(maker);
-        policy.addAllowedGroups(new bytes32[](0));
+        policy.addAllowedGroups(VENMO, new bytes32[](0));
 
         bytes32 unknownGroup = bytes32(uint256(999));
         vm.expectRevert(abi.encodeWithSelector(WhitelistPolicy.GroupDoesNotExist.selector, unknownGroup));
         vm.prank(maker);
-        policy.addAllowedGroups(_groupIds(unknownGroup));
+        policy.addAllowedGroups(VENMO, _groupIds(unknownGroup));
 
-        assertEq(policy.getAllowedGroups(maker).length, 0);
+        assertEq(policy.getAllowedGroups(maker, VENMO).length, 0);
     }
 
     function test_AddAllowedGroupsRejectsEleventhUniqueGroup() public {
@@ -158,85 +164,96 @@ contract WhitelistPolicyTest is Test {
         }
 
         vm.prank(maker);
-        policy.addAllowedGroups(firstTen);
-        assertEq(policy.getAllowedGroups(maker).length, policy.MAX_GROUPS_PER_MAKER());
+        policy.addAllowedGroups(VENMO, firstTen);
+        assertEq(policy.getAllowedGroups(maker, VENMO).length, policy.MAX_GROUPS_PER_PAYMENT_METHOD());
 
         bytes32 eleventh = registry.createGroup("Eleventh Group");
         vm.expectRevert(
             abi.encodeWithSelector(
-                WhitelistPolicy.TooManyGroups.selector, policy.MAX_GROUPS_PER_MAKER() + 1, policy.MAX_GROUPS_PER_MAKER()
+                WhitelistPolicy.TooManyGroups.selector,
+                policy.MAX_GROUPS_PER_PAYMENT_METHOD() + 1,
+                policy.MAX_GROUPS_PER_PAYMENT_METHOD()
             )
         );
         vm.prank(maker);
-        policy.addAllowedGroups(_groupIds(eleventh));
+        policy.addAllowedGroups(VENMO, _groupIds(eleventh));
+
+        vm.prank(maker);
+        policy.addAllowedGroups(ZELLE, _groupIds(eleventh));
+        assertTrue(policy.isGroupAllowed(maker, ZELLE, eleventh));
     }
 
     function test_RemoveAllowedGroupsUsesSwapAndPopAndIsIdempotent() public {
         vm.prank(maker);
-        policy.addAllowedGroups(_groupIds(PEERS, PEER_PLUSES, PEER_MERCHANTS));
+        policy.addAllowedGroups(VENMO, _groupIds(PEERS, PEER_PLUSES, PEER_MERCHANTS));
 
-        vm.expectEmit(true, true, false, true, address(policy));
-        emit AllowedGroupRemoved(maker, PEERS);
+        vm.expectEmit(true, true, true, true, address(policy));
+        emit AllowedGroupRemoved(maker, VENMO, PEERS);
         vm.prank(maker);
-        policy.removeAllowedGroups(_groupIds(PEERS));
+        policy.removeAllowedGroups(VENMO, _groupIds(PEERS));
 
-        bytes32[] memory remaining = policy.getAllowedGroups(maker);
+        bytes32[] memory remaining = policy.getAllowedGroups(maker, VENMO);
         assertEq(remaining.length, 2);
         assertEq(remaining[0], PEER_MERCHANTS);
         assertEq(remaining[1], PEER_PLUSES);
-        assertFalse(policy.isGroupAllowed(maker, PEERS));
-        assertTrue(policy.isGroupAllowed(maker, PEER_PLUSES));
-        assertTrue(policy.isGroupAllowed(maker, PEER_MERCHANTS));
+        assertFalse(policy.isGroupAllowed(maker, VENMO, PEERS));
+        assertTrue(policy.isGroupAllowed(maker, VENMO, PEER_PLUSES));
+        assertTrue(policy.isGroupAllowed(maker, VENMO, PEER_MERCHANTS));
 
         vm.recordLogs();
         vm.prank(maker);
-        policy.removeAllowedGroups(_groupIds(PEERS));
+        policy.removeAllowedGroups(VENMO, _groupIds(PEERS));
         assertEq(vm.getRecordedLogs().length, 0);
     }
 
     function test_RemoveAllowedGroupsRejectsEmptyArray() public {
         vm.expectRevert(WhitelistPolicy.EmptyArray.selector);
         vm.prank(maker);
-        policy.removeAllowedGroups(new bytes32[](0));
+        policy.removeAllowedGroups(VENMO, new bytes32[](0));
     }
 
     function test_IsTakerAllowedReturnsTrueWhenPolicyDisabled() public view {
-        assertTrue(policy.isTakerAllowed(maker, taker));
+        assertTrue(policy.isTakerAllowed(maker, VENMO, taker));
     }
 
-    function test_IsTakerAllowedReturnsTrueForDirectWhitelist() public {
+    function test_DirectWhitelistIsMakerWideAcrossEnabledPaymentMethods() public {
         vm.startPrank(maker);
-        policy.setEnabled(true);
+        policy.setEnabled(VENMO, true);
+        policy.setEnabled(ZELLE, true);
         policy.addWhitelistedAddresses(_addresses(taker));
         vm.stopPrank();
 
-        assertTrue(policy.isTakerAllowed(maker, taker));
+        assertTrue(policy.isTakerAllowed(maker, VENMO, taker));
+        assertTrue(policy.isTakerAllowed(maker, ZELLE, taker));
     }
 
-    function test_IsTakerAllowedReturnsTrueForGroupMember() public {
+    function test_GroupAdmissionIsScopedToPaymentMethod() public {
         vm.startPrank(maker);
-        policy.setEnabled(true);
-        policy.addAllowedGroups(_groupIds(PEERS));
+        policy.setEnabled(VENMO, true);
+        policy.setEnabled(ZELLE, true);
+        policy.addAllowedGroups(VENMO, _groupIds(PEERS));
         vm.stopPrank();
         registry.addMembers(PEERS, _addresses(taker));
 
-        assertTrue(policy.isTakerAllowed(maker, taker));
+        assertTrue(policy.isTakerAllowed(maker, VENMO, taker));
+        assertFalse(policy.isTakerAllowed(maker, ZELLE, taker));
     }
 
     function test_IsTakerAllowedReturnsFalseForEnabledEmptyPolicy() public {
         vm.prank(maker);
-        policy.setEnabled(true);
+        policy.setEnabled(VENMO, true);
 
-        assertFalse(policy.isTakerAllowed(maker, taker));
+        assertFalse(policy.isTakerAllowed(maker, VENMO, taker));
+        assertTrue(policy.isTakerAllowed(maker, ZELLE, taker));
     }
 
     function test_IsTakerAllowedReturnsFalseForNonMember() public {
         vm.startPrank(maker);
-        policy.setEnabled(true);
-        policy.addAllowedGroups(_groupIds(PEERS));
+        policy.setEnabled(VENMO, true);
+        policy.addAllowedGroups(VENMO, _groupIds(PEERS));
         vm.stopPrank();
 
-        assertFalse(policy.isTakerAllowed(maker, taker));
+        assertFalse(policy.isTakerAllowed(maker, VENMO, taker));
     }
 
     function _groupIds(bytes32 _first) internal pure returns (bytes32[] memory groupIds) {

--- a/test-foundry/deterministic/hooks/WhitelistPolicy.t.sol
+++ b/test-foundry/deterministic/hooks/WhitelistPolicy.t.sol
@@ -4,12 +4,15 @@ pragma solidity ^0.8.18;
 
 import {Test} from "forge-std/Test.sol";
 
+import {EscrowDepositorMock} from "contracts/mocks/EscrowDepositorMock.sol";
 import {WhitelistPolicy} from "contracts/hooks/WhitelistPolicy.sol";
 import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
+import {EscrowRegistry} from "contracts/registries/EscrowRegistry.sol";
 
 contract WhitelistPolicyTest is Test {
-    bytes32 internal constant VENMO = keccak256("venmo");
-    bytes32 internal constant ZELLE = keccak256("zelle");
+    uint256 internal constant DEPOSIT_ONE = 1;
+    uint256 internal constant DEPOSIT_TWO = 2;
+    uint256 internal constant UNKNOWN_DEPOSIT = 99;
 
     bytes32 internal PEERS;
     bytes32 internal PEER_PLUSES;
@@ -21,240 +24,429 @@ contract WhitelistPolicyTest is Test {
     address internal otherTaker;
 
     AddressGroupRegistry internal registry;
+    EscrowRegistry internal escrowRegistry;
+    EscrowDepositorMock internal escrow;
+    EscrowDepositorMock internal otherEscrow;
+    EscrowDepositorMock internal unregisteredEscrow;
     WhitelistPolicy internal policy;
 
-    event EnabledUpdated(address indexed maker, bytes32 indexed paymentMethod, bool enabled);
-    event AddressWhitelisted(address indexed maker, address indexed taker);
-    event AddressRemovedFromWhitelist(address indexed maker, address indexed taker);
-    event AllowedGroupAdded(address indexed maker, bytes32 indexed paymentMethod, bytes32 indexed groupId);
-    event AllowedGroupRemoved(address indexed maker, bytes32 indexed paymentMethod, bytes32 indexed groupId);
+    event EnabledUpdated(address indexed escrow, uint256 indexed depositId, bool enabled);
+    event AddressWhitelisted(address indexed escrow, uint256 indexed depositId, address indexed taker);
+    event AddressRemovedFromWhitelist(address indexed escrow, uint256 indexed depositId, address indexed taker);
+    event AllowedGroupAdded(address indexed escrow, uint256 indexed depositId, bytes32 indexed groupId);
+    event AllowedGroupRemoved(address indexed escrow, uint256 indexed depositId, bytes32 indexed groupId);
 
     function setUp() public {
         maker = makeAddr("maker");
         otherMaker = makeAddr("otherMaker");
         taker = makeAddr("taker");
         otherTaker = makeAddr("otherTaker");
+
         registry = new AddressGroupRegistry();
         PEERS = registry.createGroup("Peers");
         PEER_PLUSES = registry.createGroup("Peer Pluses");
         PEER_MERCHANTS = registry.createGroup("Peer Merchants");
-        policy = new WhitelistPolicy(registry);
+
+        escrowRegistry = new EscrowRegistry();
+        escrow = new EscrowDepositorMock();
+        otherEscrow = new EscrowDepositorMock();
+        unregisteredEscrow = new EscrowDepositorMock();
+        escrowRegistry.addEscrow(address(escrow));
+        escrowRegistry.addEscrow(address(otherEscrow));
+
+        escrow.setDepositor(DEPOSIT_ONE, maker);
+        escrow.setDepositor(DEPOSIT_TWO, maker);
+        otherEscrow.setDepositor(DEPOSIT_ONE, otherMaker);
+        unregisteredEscrow.setDepositor(DEPOSIT_ONE, maker);
+
+        policy = new WhitelistPolicy(registry, escrowRegistry);
     }
 
-    function test_ConstructorRejectsZeroAndCodelessRegistry() public {
+    /* ============ Constructor ============ */
+
+    function test_ConstructorRejectsZeroAndCodelessDependencies() public {
         vm.expectRevert(WhitelistPolicy.ZeroAddress.selector);
-        new WhitelistPolicy(AddressGroupRegistry(address(0)));
+        new WhitelistPolicy(AddressGroupRegistry(address(0)), escrowRegistry);
 
-        vm.expectRevert(abi.encodeWithSelector(WhitelistPolicy.InvalidGroupRegistry.selector, maker));
-        new WhitelistPolicy(AddressGroupRegistry(maker));
+        vm.expectRevert(WhitelistPolicy.ZeroAddress.selector);
+        new WhitelistPolicy(registry, EscrowRegistry(address(0)));
+
+        vm.expectRevert(abi.encodeWithSelector(WhitelistPolicy.InvalidDependency.selector, maker));
+        new WhitelistPolicy(AddressGroupRegistry(maker), escrowRegistry);
+
+        vm.expectRevert(abi.encodeWithSelector(WhitelistPolicy.InvalidDependency.selector, maker));
+        new WhitelistPolicy(registry, EscrowRegistry(maker));
     }
 
-    function test_SetEnabledIsScopedToMakerAndPaymentMethod() public {
+    /* ============ Authorization ============ */
+
+    function test_OnlyDepositorMayConfigureDeposit() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(WhitelistPolicy.NotDepositor.selector, address(escrow), DEPOSIT_ONE, otherMaker)
+        );
+        vm.prank(otherMaker);
+        policy.setEnabled(address(escrow), DEPOSIT_ONE, true);
+
+        assertFalse(policy.enabled(address(escrow), DEPOSIT_ONE));
+    }
+
+    function test_ConfigureRevertsForUnknownDeposit() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(WhitelistPolicy.DepositNotFound.selector, address(escrow), UNKNOWN_DEPOSIT)
+        );
+        vm.prank(maker);
+        policy.setEnabled(address(escrow), UNKNOWN_DEPOSIT, true);
+    }
+
+    function test_ConfigureRevertsForUnregisteredEscrow() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(WhitelistPolicy.EscrowNotWhitelisted.selector, address(unregisteredEscrow))
+        );
+        vm.prank(maker);
+        policy.setEnabled(address(unregisteredEscrow), DEPOSIT_ONE, true);
+    }
+
+    function test_AcceptAllEscrowsModePermitsUnregisteredEscrow() public {
+        escrowRegistry.setAcceptAllEscrows(true);
+
+        vm.prank(maker);
+        policy.setEnabled(address(unregisteredEscrow), DEPOSIT_ONE, true);
+
+        assertTrue(policy.enabled(address(unregisteredEscrow), DEPOSIT_ONE));
+    }
+
+    /* ============ setEnabled ============ */
+
+    function test_SetEnabledIsScopedToDeposit() public {
         vm.expectEmit(true, true, false, true, address(policy));
-        emit EnabledUpdated(maker, VENMO, true);
+        emit EnabledUpdated(address(escrow), DEPOSIT_ONE, true);
         vm.prank(maker);
-        policy.setEnabled(VENMO, true);
+        policy.setEnabled(address(escrow), DEPOSIT_ONE, true);
 
-        assertTrue(policy.enabled(maker, VENMO));
-        assertFalse(policy.enabled(maker, ZELLE));
-        assertFalse(policy.enabled(otherMaker, VENMO));
+        assertTrue(policy.enabled(address(escrow), DEPOSIT_ONE));
+        assertFalse(policy.enabled(address(escrow), DEPOSIT_TWO));
+        assertFalse(policy.enabled(address(otherEscrow), DEPOSIT_ONE));
 
         vm.prank(maker);
-        policy.setEnabled(VENMO, false);
-        assertFalse(policy.enabled(maker, VENMO));
+        policy.setEnabled(address(escrow), DEPOSIT_ONE, false);
+        assertFalse(policy.enabled(address(escrow), DEPOSIT_ONE));
     }
 
-    function test_AddWhitelistedAddressesIsIdempotentAndEnumerableByGetter() public {
+    /* ============ Direct whitelist ============ */
+
+    function test_AddWhitelistedAddressesIsScopedToDepositAndIdempotent() public {
         address[] memory takers = _addresses(taker, otherTaker);
 
-        vm.expectEmit(true, true, false, true, address(policy));
-        emit AddressWhitelisted(maker, taker);
-        vm.expectEmit(true, true, false, true, address(policy));
-        emit AddressWhitelisted(maker, otherTaker);
+        vm.expectEmit(true, true, true, true, address(policy));
+        emit AddressWhitelisted(address(escrow), DEPOSIT_ONE, taker);
+        vm.expectEmit(true, true, true, true, address(policy));
+        emit AddressWhitelisted(address(escrow), DEPOSIT_ONE, otherTaker);
         vm.prank(maker);
-        policy.addWhitelistedAddresses(takers);
+        policy.addWhitelistedAddresses(address(escrow), DEPOSIT_ONE, takers);
 
-        assertTrue(policy.isWhitelisted(maker, taker));
-        assertTrue(policy.isWhitelisted(maker, otherTaker));
-        assertFalse(policy.isWhitelisted(otherMaker, taker));
+        assertTrue(policy.isWhitelisted(address(escrow), DEPOSIT_ONE, taker));
+        assertTrue(policy.isWhitelisted(address(escrow), DEPOSIT_ONE, otherTaker));
+        assertFalse(policy.isWhitelisted(address(escrow), DEPOSIT_TWO, taker));
+        assertFalse(policy.isWhitelisted(address(otherEscrow), DEPOSIT_ONE, taker));
 
         vm.recordLogs();
         vm.prank(maker);
-        policy.addWhitelistedAddresses(takers);
+        policy.addWhitelistedAddresses(address(escrow), DEPOSIT_ONE, takers);
         assertEq(vm.getRecordedLogs().length, 0);
     }
 
     function test_AddWhitelistedAddressesRejectsEmptyArrayAndZeroAddress() public {
         vm.expectRevert(WhitelistPolicy.EmptyArray.selector);
         vm.prank(maker);
-        policy.addWhitelistedAddresses(new address[](0));
+        policy.addWhitelistedAddresses(address(escrow), DEPOSIT_ONE, new address[](0));
 
         vm.expectRevert(WhitelistPolicy.ZeroAddress.selector);
         vm.prank(maker);
-        policy.addWhitelistedAddresses(_addresses(taker, address(0)));
+        policy.addWhitelistedAddresses(address(escrow), DEPOSIT_ONE, _addresses(taker, address(0)));
 
-        assertFalse(policy.isWhitelisted(maker, taker));
+        assertFalse(policy.isWhitelisted(address(escrow), DEPOSIT_ONE, taker));
     }
 
     function test_RemoveWhitelistedAddressesIsIdempotent() public {
         vm.prank(maker);
-        policy.addWhitelistedAddresses(_addresses(taker, otherTaker));
+        policy.addWhitelistedAddresses(address(escrow), DEPOSIT_ONE, _addresses(taker, otherTaker));
 
-        vm.expectEmit(true, true, false, true, address(policy));
-        emit AddressRemovedFromWhitelist(maker, taker);
+        vm.expectEmit(true, true, true, true, address(policy));
+        emit AddressRemovedFromWhitelist(address(escrow), DEPOSIT_ONE, taker);
         vm.prank(maker);
-        policy.removeWhitelistedAddresses(_addresses(taker));
+        policy.removeWhitelistedAddresses(address(escrow), DEPOSIT_ONE, _addresses(taker));
 
-        assertFalse(policy.isWhitelisted(maker, taker));
-        assertTrue(policy.isWhitelisted(maker, otherTaker));
+        assertFalse(policy.isWhitelisted(address(escrow), DEPOSIT_ONE, taker));
+        assertTrue(policy.isWhitelisted(address(escrow), DEPOSIT_ONE, otherTaker));
 
         vm.recordLogs();
         vm.prank(maker);
-        policy.removeWhitelistedAddresses(_addresses(taker));
+        policy.removeWhitelistedAddresses(address(escrow), DEPOSIT_ONE, _addresses(taker));
         assertEq(vm.getRecordedLogs().length, 0);
     }
 
     function test_RemoveWhitelistedAddressesRejectsEmptyArray() public {
         vm.expectRevert(WhitelistPolicy.EmptyArray.selector);
         vm.prank(maker);
-        policy.removeWhitelistedAddresses(new address[](0));
+        policy.removeWhitelistedAddresses(address(escrow), DEPOSIT_ONE, new address[](0));
     }
+
+    /* ============ Allowed groups ============ */
 
     function test_AddAllowedGroupsSupportsViewsAndDeduplicates() public {
         bytes32[] memory groups = _groupIds(PEERS, PEER_PLUSES);
 
         vm.expectEmit(true, true, true, true, address(policy));
-        emit AllowedGroupAdded(maker, VENMO, PEERS);
+        emit AllowedGroupAdded(address(escrow), DEPOSIT_ONE, PEERS);
         vm.expectEmit(true, true, true, true, address(policy));
-        emit AllowedGroupAdded(maker, VENMO, PEER_PLUSES);
+        emit AllowedGroupAdded(address(escrow), DEPOSIT_ONE, PEER_PLUSES);
         vm.prank(maker);
-        policy.addAllowedGroups(VENMO, groups);
+        policy.addAllowedGroups(address(escrow), DEPOSIT_ONE, groups);
 
-        assertEq(policy.getAllowedGroups(maker, VENMO), groups);
-        assertEq(policy.getAllowedGroups(maker, ZELLE).length, 0);
-        assertTrue(policy.isGroupAllowed(maker, VENMO, PEERS));
-        assertTrue(policy.isGroupAllowed(maker, VENMO, PEER_PLUSES));
-        assertFalse(policy.isGroupAllowed(maker, ZELLE, PEERS));
-        assertFalse(policy.isGroupAllowed(otherMaker, VENMO, PEERS));
+        assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE), groups);
+        assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_TWO).length, 0);
+        assertTrue(policy.isGroupAllowed(address(escrow), DEPOSIT_ONE, PEERS));
+        assertTrue(policy.isGroupAllowed(address(escrow), DEPOSIT_ONE, PEER_PLUSES));
+        assertFalse(policy.isGroupAllowed(address(escrow), DEPOSIT_TWO, PEERS));
+        assertFalse(policy.isGroupAllowed(address(otherEscrow), DEPOSIT_ONE, PEERS));
 
         vm.recordLogs();
         vm.prank(maker);
-        policy.addAllowedGroups(VENMO, groups);
+        policy.addAllowedGroups(address(escrow), DEPOSIT_ONE, groups);
         assertEq(vm.getRecordedLogs().length, 0);
-        assertEq(policy.getAllowedGroups(maker, VENMO).length, 2);
+        assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE).length, 2);
     }
 
     function test_AddAllowedGroupsRejectsEmptyAndUnknownGroups() public {
         vm.expectRevert(WhitelistPolicy.EmptyArray.selector);
         vm.prank(maker);
-        policy.addAllowedGroups(VENMO, new bytes32[](0));
+        policy.addAllowedGroups(address(escrow), DEPOSIT_ONE, new bytes32[](0));
 
         bytes32 unknownGroup = bytes32(uint256(999));
         vm.expectRevert(abi.encodeWithSelector(WhitelistPolicy.GroupDoesNotExist.selector, unknownGroup));
         vm.prank(maker);
-        policy.addAllowedGroups(VENMO, _groupIds(unknownGroup));
+        policy.addAllowedGroups(address(escrow), DEPOSIT_ONE, _groupIds(unknownGroup));
 
-        assertEq(policy.getAllowedGroups(maker, VENMO).length, 0);
+        assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE).length, 0);
     }
 
-    function test_AddAllowedGroupsRejectsEleventhUniqueGroup() public {
+    function test_GroupCapIsPerDeposit() public {
         bytes32[] memory firstTen = new bytes32[](10);
         for (uint256 i = 0; i < firstTen.length; ++i) {
             firstTen[i] = registry.createGroup("Curated Group");
         }
 
         vm.prank(maker);
-        policy.addAllowedGroups(VENMO, firstTen);
-        assertEq(policy.getAllowedGroups(maker, VENMO).length, policy.MAX_GROUPS_PER_PAYMENT_METHOD());
+        policy.addAllowedGroups(address(escrow), DEPOSIT_ONE, firstTen);
+        assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE).length, policy.MAX_GROUPS_PER_DEPOSIT());
 
         bytes32 eleventh = registry.createGroup("Eleventh Group");
         vm.expectRevert(
             abi.encodeWithSelector(
                 WhitelistPolicy.TooManyGroups.selector,
-                policy.MAX_GROUPS_PER_PAYMENT_METHOD() + 1,
-                policy.MAX_GROUPS_PER_PAYMENT_METHOD()
+                policy.MAX_GROUPS_PER_DEPOSIT() + 1,
+                policy.MAX_GROUPS_PER_DEPOSIT()
             )
         );
         vm.prank(maker);
-        policy.addAllowedGroups(VENMO, _groupIds(eleventh));
+        policy.addAllowedGroups(address(escrow), DEPOSIT_ONE, _groupIds(eleventh));
 
         vm.prank(maker);
-        policy.addAllowedGroups(ZELLE, _groupIds(eleventh));
-        assertTrue(policy.isGroupAllowed(maker, ZELLE, eleventh));
+        policy.addAllowedGroups(address(escrow), DEPOSIT_TWO, _groupIds(eleventh));
+        assertTrue(policy.isGroupAllowed(address(escrow), DEPOSIT_TWO, eleventh));
     }
 
     function test_RemoveAllowedGroupsUsesSwapAndPopAndIsIdempotent() public {
         vm.prank(maker);
-        policy.addAllowedGroups(VENMO, _groupIds(PEERS, PEER_PLUSES, PEER_MERCHANTS));
+        policy.addAllowedGroups(address(escrow), DEPOSIT_ONE, _groupIds(PEERS, PEER_PLUSES, PEER_MERCHANTS));
 
         vm.expectEmit(true, true, true, true, address(policy));
-        emit AllowedGroupRemoved(maker, VENMO, PEERS);
+        emit AllowedGroupRemoved(address(escrow), DEPOSIT_ONE, PEERS);
         vm.prank(maker);
-        policy.removeAllowedGroups(VENMO, _groupIds(PEERS));
+        policy.removeAllowedGroups(address(escrow), DEPOSIT_ONE, _groupIds(PEERS));
 
-        bytes32[] memory remaining = policy.getAllowedGroups(maker, VENMO);
+        bytes32[] memory remaining = policy.getAllowedGroups(address(escrow), DEPOSIT_ONE);
         assertEq(remaining.length, 2);
         assertEq(remaining[0], PEER_MERCHANTS);
         assertEq(remaining[1], PEER_PLUSES);
-        assertFalse(policy.isGroupAllowed(maker, VENMO, PEERS));
-        assertTrue(policy.isGroupAllowed(maker, VENMO, PEER_PLUSES));
-        assertTrue(policy.isGroupAllowed(maker, VENMO, PEER_MERCHANTS));
+        assertFalse(policy.isGroupAllowed(address(escrow), DEPOSIT_ONE, PEERS));
 
         vm.recordLogs();
         vm.prank(maker);
-        policy.removeAllowedGroups(VENMO, _groupIds(PEERS));
+        policy.removeAllowedGroups(address(escrow), DEPOSIT_ONE, _groupIds(PEERS));
         assertEq(vm.getRecordedLogs().length, 0);
     }
 
     function test_RemoveAllowedGroupsRejectsEmptyArray() public {
         vm.expectRevert(WhitelistPolicy.EmptyArray.selector);
         vm.prank(maker);
-        policy.removeAllowedGroups(VENMO, new bytes32[](0));
+        policy.removeAllowedGroups(address(escrow), DEPOSIT_ONE, new bytes32[](0));
     }
+
+    /* ============ configureDeposit ============ */
+
+    function test_ConfigureDepositSetsEnabledGroupsAndTakersInOneCall() public {
+        vm.prank(maker);
+        policy.configureDeposit(
+            address(escrow), DEPOSIT_ONE, true, _groupIds(PEERS, PEER_PLUSES), _addresses(taker)
+        );
+
+        assertTrue(policy.enabled(address(escrow), DEPOSIT_ONE));
+        assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE).length, 2);
+        assertTrue(policy.isWhitelisted(address(escrow), DEPOSIT_ONE, taker));
+        assertTrue(policy.isTakerAllowed(address(escrow), DEPOSIT_ONE, taker));
+    }
+
+    function test_ConfigureDepositAcceptsEmptyArrays() public {
+        vm.prank(maker);
+        policy.configureDeposit(address(escrow), DEPOSIT_ONE, true, new bytes32[](0), new address[](0));
+
+        assertTrue(policy.enabled(address(escrow), DEPOSIT_ONE));
+        assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE).length, 0);
+        assertFalse(policy.isTakerAllowed(address(escrow), DEPOSIT_ONE, taker));
+    }
+
+    function test_ConfigureDepositIsAdditive() public {
+        vm.startPrank(maker);
+        policy.configureDeposit(address(escrow), DEPOSIT_ONE, true, _groupIds(PEERS), _addresses(taker));
+        policy.configureDeposit(
+            address(escrow), DEPOSIT_ONE, true, _groupIds(PEER_PLUSES), _addresses(otherTaker)
+        );
+        vm.stopPrank();
+
+        assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE).length, 2);
+        assertTrue(policy.isGroupAllowed(address(escrow), DEPOSIT_ONE, PEERS));
+        assertTrue(policy.isGroupAllowed(address(escrow), DEPOSIT_ONE, PEER_PLUSES));
+        assertTrue(policy.isWhitelisted(address(escrow), DEPOSIT_ONE, taker));
+        assertTrue(policy.isWhitelisted(address(escrow), DEPOSIT_ONE, otherTaker));
+    }
+
+    function test_ConfigureDepositEmitsTheSameEventsAsGranularSetters() public {
+        vm.expectEmit(true, true, false, true, address(policy));
+        emit EnabledUpdated(address(escrow), DEPOSIT_ONE, true);
+        vm.expectEmit(true, true, true, true, address(policy));
+        emit AllowedGroupAdded(address(escrow), DEPOSIT_ONE, PEERS);
+        vm.expectEmit(true, true, true, true, address(policy));
+        emit AddressWhitelisted(address(escrow), DEPOSIT_ONE, taker);
+
+        vm.prank(maker);
+        policy.configureDeposit(address(escrow), DEPOSIT_ONE, true, _groupIds(PEERS), _addresses(taker));
+    }
+
+    function test_ConfigureDepositRollsBackPartialWritesOnValidationFailure() public {
+        bytes32 unknownGroup = bytes32(uint256(999));
+        vm.expectRevert(abi.encodeWithSelector(WhitelistPolicy.GroupDoesNotExist.selector, unknownGroup));
+        vm.prank(maker);
+        policy.configureDeposit(
+            address(escrow), DEPOSIT_ONE, true, _groupIds(PEERS, unknownGroup), _addresses(taker)
+        );
+
+        assertFalse(policy.enabled(address(escrow), DEPOSIT_ONE));
+        assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE).length, 0);
+        assertFalse(policy.isWhitelisted(address(escrow), DEPOSIT_ONE, taker));
+
+        vm.expectRevert(WhitelistPolicy.ZeroAddress.selector);
+        vm.prank(maker);
+        policy.configureDeposit(
+            address(escrow), DEPOSIT_ONE, true, _groupIds(PEERS), _addresses(taker, address(0))
+        );
+
+        assertFalse(policy.enabled(address(escrow), DEPOSIT_ONE));
+        assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE).length, 0);
+        assertFalse(policy.isWhitelisted(address(escrow), DEPOSIT_ONE, taker));
+    }
+
+    function test_ConfigureDepositEnforcesGroupCapAndRollsBack() public {
+        bytes32[] memory firstTen = new bytes32[](10);
+        for (uint256 i = 0; i < firstTen.length; ++i) {
+            firstTen[i] = registry.createGroup("Curated Group");
+        }
+        bytes32 eleventh = registry.createGroup("Eleventh Group");
+
+        vm.prank(maker);
+        policy.configureDeposit(address(escrow), DEPOSIT_ONE, true, firstTen, new address[](0));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                WhitelistPolicy.TooManyGroups.selector,
+                policy.MAX_GROUPS_PER_DEPOSIT() + 1,
+                policy.MAX_GROUPS_PER_DEPOSIT()
+            )
+        );
+        vm.prank(maker);
+        policy.configureDeposit(address(escrow), DEPOSIT_ONE, false, _groupIds(eleventh), _addresses(taker));
+
+        assertTrue(policy.enabled(address(escrow), DEPOSIT_ONE));
+        assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE).length, policy.MAX_GROUPS_PER_DEPOSIT());
+        assertFalse(policy.isWhitelisted(address(escrow), DEPOSIT_ONE, taker));
+    }
+
+    function test_ConfigureDepositRejectsNonDepositor() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(WhitelistPolicy.NotDepositor.selector, address(escrow), DEPOSIT_ONE, otherMaker)
+        );
+        vm.prank(otherMaker);
+        policy.configureDeposit(address(escrow), DEPOSIT_ONE, true, new bytes32[](0), new address[](0));
+    }
+
+    /* ============ isTakerAllowed ============ */
 
     function test_IsTakerAllowedReturnsTrueWhenPolicyDisabled() public view {
-        assertTrue(policy.isTakerAllowed(maker, VENMO, taker));
-    }
-
-    function test_DirectWhitelistIsMakerWideAcrossEnabledPaymentMethods() public {
-        vm.startPrank(maker);
-        policy.setEnabled(VENMO, true);
-        policy.setEnabled(ZELLE, true);
-        policy.addWhitelistedAddresses(_addresses(taker));
-        vm.stopPrank();
-
-        assertTrue(policy.isTakerAllowed(maker, VENMO, taker));
-        assertTrue(policy.isTakerAllowed(maker, ZELLE, taker));
-    }
-
-    function test_GroupAdmissionIsScopedToPaymentMethod() public {
-        vm.startPrank(maker);
-        policy.setEnabled(VENMO, true);
-        policy.setEnabled(ZELLE, true);
-        policy.addAllowedGroups(VENMO, _groupIds(PEERS));
-        vm.stopPrank();
-        registry.addMembers(PEERS, _addresses(taker));
-
-        assertTrue(policy.isTakerAllowed(maker, VENMO, taker));
-        assertFalse(policy.isTakerAllowed(maker, ZELLE, taker));
+        assertTrue(policy.isTakerAllowed(address(escrow), DEPOSIT_ONE, taker));
     }
 
     function test_IsTakerAllowedReturnsFalseForEnabledEmptyPolicy() public {
         vm.prank(maker);
-        policy.setEnabled(VENMO, true);
+        policy.setEnabled(address(escrow), DEPOSIT_ONE, true);
 
-        assertFalse(policy.isTakerAllowed(maker, VENMO, taker));
-        assertTrue(policy.isTakerAllowed(maker, ZELLE, taker));
+        assertFalse(policy.isTakerAllowed(address(escrow), DEPOSIT_ONE, taker));
+        assertTrue(policy.isTakerAllowed(address(escrow), DEPOSIT_TWO, taker));
     }
 
     function test_IsTakerAllowedReturnsFalseForNonMember() public {
         vm.startPrank(maker);
-        policy.setEnabled(VENMO, true);
-        policy.addAllowedGroups(VENMO, _groupIds(PEERS));
+        policy.setEnabled(address(escrow), DEPOSIT_ONE, true);
+        policy.addAllowedGroups(address(escrow), DEPOSIT_ONE, _groupIds(PEERS));
         vm.stopPrank();
 
-        assertFalse(policy.isTakerAllowed(maker, VENMO, taker));
+        assertFalse(policy.isTakerAllowed(address(escrow), DEPOSIT_ONE, taker));
     }
+
+    function test_DirectWhitelistIsScopedToDeposit() public {
+        vm.startPrank(maker);
+        policy.setEnabled(address(escrow), DEPOSIT_ONE, true);
+        policy.setEnabled(address(escrow), DEPOSIT_TWO, true);
+        policy.addWhitelistedAddresses(address(escrow), DEPOSIT_ONE, _addresses(taker));
+        vm.stopPrank();
+
+        assertTrue(policy.isTakerAllowed(address(escrow), DEPOSIT_ONE, taker));
+        assertFalse(policy.isTakerAllowed(address(escrow), DEPOSIT_TWO, taker));
+    }
+
+    function test_GroupAdmissionIsScopedToDeposit() public {
+        vm.startPrank(maker);
+        policy.setEnabled(address(escrow), DEPOSIT_ONE, true);
+        policy.setEnabled(address(escrow), DEPOSIT_TWO, true);
+        policy.addAllowedGroups(address(escrow), DEPOSIT_ONE, _groupIds(PEERS));
+        vm.stopPrank();
+        registry.addMembers(PEERS, _addresses(taker));
+
+        assertTrue(policy.isTakerAllowed(address(escrow), DEPOSIT_ONE, taker));
+        assertFalse(policy.isTakerAllowed(address(escrow), DEPOSIT_TWO, taker));
+    }
+
+    function test_PolicyIsIsolatedAcrossEscrowsWithSameDepositId() public {
+        vm.prank(maker);
+        policy.configureDeposit(address(escrow), DEPOSIT_ONE, true, new bytes32[](0), _addresses(taker));
+
+        vm.prank(otherMaker);
+        policy.setEnabled(address(otherEscrow), DEPOSIT_ONE, true);
+
+        assertTrue(policy.isTakerAllowed(address(escrow), DEPOSIT_ONE, taker));
+        assertFalse(policy.isTakerAllowed(address(otherEscrow), DEPOSIT_ONE, taker));
+    }
+
+    /* ============ Helpers ============ */
 
     function _groupIds(bytes32 _first) internal pure returns (bytes32[] memory groupIds) {
         groupIds = new bytes32[](1);

--- a/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.18;
 
 import {IIntentLifecycleHook} from "contracts/interfaces/IIntentLifecycleHook.sol";
+import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
 import {IOrchestratorV2} from "contracts/interfaces/IOrchestratorV2.sol";
 import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
 import {IntentLifecycleHookV1} from "contracts/hooks/IntentLifecycleHookV1.sol";
@@ -14,6 +15,8 @@ import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.so
 import {OrchestratorV2LegacyFixture} from "../helpers/OrchestratorV2LegacyFixture.sol";
 
 contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture {
+    bytes32 internal constant OTHER_METHOD = keccak256("zelle");
+
     bytes32 internal PEERS;
     bytes32 internal PEER_PLUSES;
     bytes32 internal PEER_MERCHANTS;
@@ -47,14 +50,14 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
 
     function test_EnabledEmptyPolicyFailsClosedBeforeEscrowLock() public {
         vm.prank(depositor);
-        policy.setEnabled(true);
+        policy.setEnabled(METHOD, true);
 
         uint256 counterBefore = orchestrator.intentCounter();
         bytes32 rejectedIntent = _intentHash(counterBefore);
         uint256 availableBefore = escrow.getDeposit(depositId).remainingDeposits;
 
         bytes memory emptyPolicyRevert =
-            abi.encodeWithSelector(IntentLifecycleHookV1.TakerNotWhitelisted.selector, depositor, taker);
+            abi.encodeWithSelector(IntentLifecycleHookV1.TakerNotWhitelisted.selector, depositor, METHOD, taker);
         vm.expectRevert(
             abi.encodeWithSelector(
                 BoundedCall.LifecycleHookAdmissionFailed.selector,
@@ -73,13 +76,13 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
 
     function test_NonMemberRejectedAndMemberAccepted() public {
         vm.startPrank(depositor);
-        policy.addAllowedGroups(_groupIds(PEERS));
-        policy.setEnabled(true);
+        policy.addAllowedGroups(METHOD, _groupIds(PEERS));
+        policy.setEnabled(METHOD, true);
         vm.stopPrank();
 
         bytes32 rejectedIntent = _intentHash(orchestrator.intentCounter());
         bytes memory nonMemberRevert =
-            abi.encodeWithSelector(IntentLifecycleHookV1.TakerNotWhitelisted.selector, depositor, taker);
+            abi.encodeWithSelector(IntentLifecycleHookV1.TakerNotWhitelisted.selector, depositor, METHOD, taker);
         vm.expectRevert(
             abi.encodeWithSelector(
                 BoundedCall.LifecycleHookAdmissionFailed.selector,
@@ -98,16 +101,36 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
     function test_DirectAddressWhitelistAllowsTaker() public {
         vm.startPrank(depositor);
         policy.addWhitelistedAddresses(_addresses(taker));
-        policy.setEnabled(true);
+        policy.setEnabled(METHOD, true);
         vm.stopPrank();
 
         assertNotEq(_signalDefault(), bytes32(0));
     }
 
+    function test_PaymentMethodGroupScopeAndMakerWideDirectWhitelist() public {
+        _addPaymentMethod(OTHER_METHOD);
+
+        vm.startPrank(depositor);
+        policy.addAllowedGroups(METHOD, _groupIds(PEERS));
+        policy.setEnabled(METHOD, true);
+        policy.setEnabled(OTHER_METHOD, true);
+        vm.stopPrank();
+        _addMembers(PEERS, taker);
+
+        IOrchestratorV2.SignalIntentParams memory otherMethodParams = _defaultParams();
+        otherMethodParams.paymentMethod = OTHER_METHOD;
+        vm.expectPartialRevert(BoundedCall.LifecycleHookAdmissionFailed.selector);
+        _signalCall(taker, otherMethodParams);
+
+        vm.prank(depositor);
+        policy.addWhitelistedAddresses(_addresses(taker));
+        assertNotEq(_signal(taker, otherMethodParams), bytes32(0));
+    }
+
     function test_MultipleGroupsUseOrSemantics() public {
         vm.startPrank(depositor);
-        policy.addAllowedGroups(_groupIds(PEERS, PEER_PLUSES, PEER_MERCHANTS));
-        policy.setEnabled(true);
+        policy.addAllowedGroups(METHOD, _groupIds(PEERS, PEER_PLUSES, PEER_MERCHANTS));
+        policy.setEnabled(METHOD, true);
         vm.stopPrank();
 
         _addMembers(PEER_PLUSES, taker);
@@ -116,8 +139,8 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
 
     function test_MakerPolicyAppliesAcrossMakerDeposits() public {
         vm.startPrank(depositor);
-        policy.addAllowedGroups(_groupIds(PEERS));
-        policy.setEnabled(true);
+        policy.addAllowedGroups(METHOD, _groupIds(PEERS));
+        policy.setEnabled(METHOD, true);
         uint256 secondDepositId = _createDeposit(address(0), delegate);
         vm.stopPrank();
 
@@ -184,8 +207,8 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
         }
 
         vm.startPrank(depositor);
-        policy.addAllowedGroups(groups);
-        policy.setEnabled(true);
+        policy.addAllowedGroups(METHOD, groups);
+        policy.setEnabled(METHOD, true);
         vm.stopPrank();
         _addMembers(groups[groups.length - 1], taker);
 
@@ -226,10 +249,29 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
 
     function _enablePeerPolicyAndAddTaker() internal {
         vm.startPrank(depositor);
-        policy.addAllowedGroups(_groupIds(PEERS));
-        policy.setEnabled(true);
+        policy.addAllowedGroups(METHOD, _groupIds(PEERS));
+        policy.setEnabled(METHOD, true);
         vm.stopPrank();
         _addMembers(PEERS, taker);
+    }
+
+    function _addPaymentMethod(bytes32 _paymentMethod) internal {
+        bytes32[] memory supportedCurrencies = new bytes32[](1);
+        supportedCurrencies[0] = USD;
+        paymentVerifierRegistry.addPaymentMethod(_paymentMethod, address(verifier), supportedCurrencies);
+
+        bytes32[] memory paymentMethods = new bytes32[](1);
+        paymentMethods[0] = _paymentMethod;
+        IEscrowV2.DepositPaymentMethodData[] memory paymentMethodData = new IEscrowV2.DepositPaymentMethodData[](1);
+        paymentMethodData[0] =
+            IEscrowV2.DepositPaymentMethodData({intentGatingService: address(0), payeeDetails: PAYEE, data: ""});
+        IEscrowV2.Currency[][] memory currencies = new IEscrowV2.Currency[][](1);
+        currencies[0] = new IEscrowV2.Currency[](1);
+        currencies[0][0] =
+            IEscrowV2.Currency({code: USD, minConversionRate: CONVERSION_RATE, oracleRateConfig: _emptyOracle()});
+
+        vm.prank(depositor);
+        escrow.addPaymentMethods(depositId, paymentMethods, paymentMethodData, currencies);
     }
 
     function _addMembers(bytes32 _groupId, address _member) internal {

--- a/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
@@ -34,7 +34,7 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
         PEER_PLUSES = groupRegistry.createGroup("Peer Pluses");
         PEER_MERCHANTS = groupRegistry.createGroup("Peer Merchants");
 
-        policy = new WhitelistPolicy(groupRegistry);
+        policy = new WhitelistPolicy(groupRegistry, escrowRegistry);
         lifecycleHook = new IntentLifecycleHookV1(orchestratorRegistry, policy);
         IOrchestratorV3(address(orchestrator)).setLifecycleHook(lifecycleHook);
     }
@@ -50,14 +50,15 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
 
     function test_EnabledEmptyPolicyFailsClosedBeforeEscrowLock() public {
         vm.prank(depositor);
-        policy.setEnabled(METHOD, true);
+        policy.setEnabled(address(escrow), depositId, true);
 
         uint256 counterBefore = orchestrator.intentCounter();
         bytes32 rejectedIntent = _intentHash(counterBefore);
         uint256 availableBefore = escrow.getDeposit(depositId).remainingDeposits;
 
-        bytes memory emptyPolicyRevert =
-            abi.encodeWithSelector(IntentLifecycleHookV1.TakerNotWhitelisted.selector, depositor, METHOD, taker);
+        bytes memory emptyPolicyRevert = abi.encodeWithSelector(
+            IntentLifecycleHookV1.TakerNotWhitelisted.selector, address(escrow), depositId, taker
+        );
         vm.expectRevert(
             abi.encodeWithSelector(
                 BoundedCall.LifecycleHookAdmissionFailed.selector,
@@ -75,14 +76,13 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
     }
 
     function test_NonMemberRejectedAndMemberAccepted() public {
-        vm.startPrank(depositor);
-        policy.addAllowedGroups(METHOD, _groupIds(PEERS));
-        policy.setEnabled(METHOD, true);
-        vm.stopPrank();
+        vm.prank(depositor);
+        policy.configureDeposit(address(escrow), depositId, true, _groupIds(PEERS), new address[](0));
 
         bytes32 rejectedIntent = _intentHash(orchestrator.intentCounter());
-        bytes memory nonMemberRevert =
-            abi.encodeWithSelector(IntentLifecycleHookV1.TakerNotWhitelisted.selector, depositor, METHOD, taker);
+        bytes memory nonMemberRevert = abi.encodeWithSelector(
+            IntentLifecycleHookV1.TakerNotWhitelisted.selector, address(escrow), depositId, taker
+        );
         vm.expectRevert(
             abi.encodeWithSelector(
                 BoundedCall.LifecycleHookAdmissionFailed.selector,
@@ -99,58 +99,55 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
     }
 
     function test_DirectAddressWhitelistAllowsTaker() public {
-        vm.startPrank(depositor);
-        policy.addWhitelistedAddresses(_addresses(taker));
-        policy.setEnabled(METHOD, true);
-        vm.stopPrank();
+        vm.prank(depositor);
+        policy.configureDeposit(address(escrow), depositId, true, new bytes32[](0), _addresses(taker));
 
         assertNotEq(_signalDefault(), bytes32(0));
     }
 
-    function test_PaymentMethodGroupScopeAndMakerWideDirectWhitelist() public {
+    function test_DepositPolicyAppliesAcrossAllPaymentMethodsOfTheDeposit() public {
         _addPaymentMethod(OTHER_METHOD);
 
-        vm.startPrank(depositor);
-        policy.addAllowedGroups(METHOD, _groupIds(PEERS));
-        policy.setEnabled(METHOD, true);
-        policy.setEnabled(OTHER_METHOD, true);
-        vm.stopPrank();
-        _addMembers(PEERS, taker);
+        vm.prank(depositor);
+        policy.configureDeposit(address(escrow), depositId, true, _groupIds(PEERS), new address[](0));
 
         IOrchestratorV2.SignalIntentParams memory otherMethodParams = _defaultParams();
         otherMethodParams.paymentMethod = OTHER_METHOD;
         vm.expectPartialRevert(BoundedCall.LifecycleHookAdmissionFailed.selector);
         _signalCall(taker, otherMethodParams);
 
-        vm.prank(depositor);
-        policy.addWhitelistedAddresses(_addresses(taker));
+        _addMembers(PEERS, taker);
         assertNotEq(_signal(taker, otherMethodParams), bytes32(0));
+        assertNotEq(_signalDefault(), bytes32(0));
     }
 
     function test_MultipleGroupsUseOrSemantics() public {
-        vm.startPrank(depositor);
-        policy.addAllowedGroups(METHOD, _groupIds(PEERS, PEER_PLUSES, PEER_MERCHANTS));
-        policy.setEnabled(METHOD, true);
-        vm.stopPrank();
+        vm.prank(depositor);
+        policy.configureDeposit(
+            address(escrow), depositId, true, _groupIds(PEERS, PEER_PLUSES, PEER_MERCHANTS), new address[](0)
+        );
 
         _addMembers(PEER_PLUSES, taker);
         assertNotEq(_signalDefault(), bytes32(0));
     }
 
-    function test_MakerPolicyAppliesAcrossMakerDeposits() public {
+    function test_PolicyIsScopedToDepositNotMaker() public {
         vm.startPrank(depositor);
-        policy.addAllowedGroups(METHOD, _groupIds(PEERS));
-        policy.setEnabled(METHOD, true);
+        policy.configureDeposit(address(escrow), depositId, true, _groupIds(PEERS), new address[](0));
         uint256 secondDepositId = _createDeposit(address(0), delegate);
         vm.stopPrank();
 
+        vm.expectPartialRevert(BoundedCall.LifecycleHookAdmissionFailed.selector);
+        _signalCall(taker, _defaultParams());
+
         IOrchestratorV2.SignalIntentParams memory secondDepositParams = _defaultParams();
         secondDepositParams.depositId = secondDepositId;
+        assertNotEq(_signal(taker, secondDepositParams), bytes32(0));
+
+        vm.prank(depositor);
+        policy.configureDeposit(address(escrow), secondDepositId, true, _groupIds(PEERS), new address[](0));
         vm.expectPartialRevert(BoundedCall.LifecycleHookAdmissionFailed.selector);
         _signalCall(taker, secondDepositParams);
-
-        _addMembers(PEERS, taker);
-        assertNotEq(_signal(taker, secondDepositParams), bytes32(0));
     }
 
     function test_MembershipRemovalOnlyAffectsFutureAdmissionAndCancellationRemainsLive() public {
@@ -206,10 +203,8 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
             groups[i] = groupRegistry.createGroup("Bounded Group");
         }
 
-        vm.startPrank(depositor);
-        policy.addAllowedGroups(METHOD, groups);
-        policy.setEnabled(METHOD, true);
-        vm.stopPrank();
+        vm.prank(depositor);
+        policy.configureDeposit(address(escrow), depositId, true, groups, new address[](0));
         _addMembers(groups[groups.length - 1], taker);
 
         IOrchestratorV3(address(orchestrator)).setCallbackGasLimit(750_000);
@@ -248,10 +243,8 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
     }
 
     function _enablePeerPolicyAndAddTaker() internal {
-        vm.startPrank(depositor);
-        policy.addAllowedGroups(METHOD, _groupIds(PEERS));
-        policy.setEnabled(METHOD, true);
-        vm.stopPrank();
+        vm.prank(depositor);
+        policy.configureDeposit(address(escrow), depositId, true, _groupIds(PEERS), new address[](0));
         _addMembers(PEERS, taker);
     }
 

--- a/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
@@ -105,6 +105,18 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
         assertNotEq(_signalDefault(), bytes32(0));
     }
 
+    function test_DelegateIsNotAuthorizedToConfigureDeposit() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(WhitelistPolicy.NotDepositor.selector, address(escrow), depositId, delegate)
+        );
+        vm.prank(delegate);
+        policy.configureDeposit(address(escrow), depositId, true, new bytes32[](0), new address[](0));
+
+        vm.prank(depositor);
+        policy.configureDeposit(address(escrow), depositId, true, new bytes32[](0), new address[](0));
+        assertTrue(policy.enabled(address(escrow), depositId));
+    }
+
     function test_DepositPolicyAppliesAcrossAllPaymentMethodsOfTheDeposit() public {
         _addPaymentMethod(OTHER_METHOD);
 


### PR DESCRIPTION
## Summary

Re-scopes `WhitelistPolicy` taker admission from `(maker, paymentMethod)` keys to `(escrow, depositId)` keys, so a single maker can run gated and open deposits at the same time. The payment-method dimension is removed entirely.

| Setting | Before | After |
|---|---|---|
| `enabled` | `(maker, paymentMethod)` | `(escrow, depositId)` |
| `allowedGroups` | `(maker, paymentMethod)` | `(escrow, depositId)` |
| `isWhitelisted` | `(maker, taker)` — maker-wide | `(escrow, depositId, taker)` |

**Supersedes #211.** This branch contains #211's two commits (`ee341f9`, `2c1eb3f`) and then replaces the payment-method scoping they added. #211 should be closed rather than merged — merging both is redundant.

_Replaces #212, which GitHub auto-closed when the source branch was renamed from `kartik/jagged-continent` to `kartik/deposit-scoped-whitelist-policy`. Same commits, same content — no review happened on #212._

## Changes

- **`WhitelistPolicy`** — deposit-keyed storage. Gains an `IEscrowRegistry` dependency; every write is gated by `onlyDepositor`, which validates the escrow and then reads `IEscrow(escrow).getDeposit(depositId).depositor`. Depositor only — `Deposit.delegate` cannot configure. The escrow predicate mirrors `OrchestratorV3.sol:600` exactly, so the set of escrows a maker can configure is exactly the set the orchestrator admits intents against.
- **`configureDeposit(escrow, depositId, enabled, groupIds, takers)`** — new bundled setter so a fresh deposit is locked down in one transaction after `createDeposit`. Shares internal `_addGroups`/`_addTakers` with the granular setters, so validation and event shape cannot drift.
- **`IntentLifecycleHookV1`** — no longer resolves the maker. The `IEscrow` import and `getDeposit` call leave the admission path, removing one external call and a 9-field struct decode from every signalled intent inside the bounded-gas callback.
- **Governance-settable escrow registry.** `WhitelistPolicy` is now `Ownable` and exposes `setEscrowRegistry`. This closes a hole found in review: the policy's registry was `immutable` while `OrchestratorV3.setEscrowRegistry` is owner-mutable, so once the two diverged, deposits on an escrow admitted by only one of them could be neither gated *nor revoked* while the orchestrator kept admitting intents — and the only remedy, redeploying the policy, failed **open**, because a fresh policy has `enabled == false` for every key. Rotating in place preserves all three mappings, so no deposit ever transits an ungated state.
- **`EscrowDepositorMock`** — minimal `getDeposit` stand-in for policy unit tests. Deliberately not `is IEscrow`.
- **`deploy/29`** — constructor gains the escrow registry, bound to `Parameters<WhitelistPolicy__factory["deploy"]>` (type-only import) so a missing arg is a compile error. Capability probe moves to `enabled(address,uint256)`; `escrowRegistry()` wiring assertion added.

Admission logic is unchanged in shape: pass if not `enabled`; else pass if directly whitelisted on that deposit or a member of one of its allowed groups; otherwise deny. Enabling a deposit with no groups and no addresses still fails closed.

## Testing

`yarn test` — **1508 passed, 0 failed, 0 skipped** across 94 suites (baseline before this work: 1488). Scoped TypeScript check of `deploy/29` exits 0.

New coverage worth calling out:
- Per-deposit isolation for the *same* maker, and cross-escrow isolation at the same deposit ID — the core behavior change.
- All six gated entry points rejected for a non-depositor, with non-empty arrays so the modifier is proven to fire before the `EmptyArray` guard.
- `delegate` rejected against a real `EscrowV2` deposit.
- `configureDeposit` atomicity: partial group/taker writes roll back on a later validation failure.

## Operator runbook — new, please read

The `Ownable` addition creates three obligations that are documented but **not enforced on-chain**:

1. **Always batch both registry setters in one Safe transaction.** `WhitelistPolicy.setEscrowRegistry` and `OrchestratorV3.setEscrowRegistry` must move together. Rotating one and not the other reopens the exact divergence this PR fixes, for the duration of the gap.
2. **Never call `renounceOwnership()` on this policy.** It is reachable via OZ `Ownable` (no repo contract overrides it) and would permanently brick `setEscrowRegistry`, restoring the original unrecoverable, fail-open state.
3. **On `base_staging` the policy owner is the deployer EOA, not the multisig.** `MULTI_SIG` is empty for `localhost`/`hardhat`/`base_staging`, so `governance` falls back to `deployer` and the `setNewOwner` call is a no-op there. Treat the staging rotation key as hot. The transfer line is correct and takes effect on any network with a real `MULTI_SIG`.

The policy owner should remain the same entity that owns `EscrowRegistry` and `OrchestratorV3` — otherwise the divergence this PR repairs becomes a deliberate attack surface for whoever holds only one key.

**Centralization scope:** the owner can do exactly one thing, rotate the registry. Worst case is a reversible *configuration freeze* — gated deposits keep their current allowlist, ungated ones can't be gated. The owner cannot admit or reject a taker, because `isTakerAllowed` never reads the escrow registry; `groupRegistry` is still `immutable`. No path to funds. Governance can already produce an equivalent freeze via `EscrowRegistry.removeEscrow`; what is new is that it can now do so without also halting intent creation.

## Reviewer notes

- **`configureDeposit` replaces `enabled` but appends the arrays.** Passing `false` disables enforcement on an already-gated deposit. Documented in NatSpec on `IWhitelistPolicy.configureDeposit` and pinned by a test, but worth a second opinion on whether replace-vs-append is the right split.
- **Not deployable as-is.** The staging `WhitelistPolicy` still has the old ABI; redeploy is a separate `ship-contracts` run. On redeploy, all existing staging policy state is discarded and every gated maker must re-run `configureDeposit` per deposit. `deployments/base_staging/WhitelistPolicy.json` and `deployments/outputs/baseStagingContracts.ts` still carry the old `enabled(address)` ABI and must be regenerated before the next `@zkp2p/contracts-v2` publish.
- **One-block gap.** A new deposit is unrestricted between `createDeposit` and `configureDeposit`. `CreateDepositParams` has no paused-on-create option and `EscrowV2` was out of scope. This is now a recurring exposure per deposit rather than the one-time exposure the maker-wide model had — maker-facing clients should batch both calls.
- **Orphaned policy storage.** When a deposit closes, `depositor` is zeroed, so `onlyDepositor` reverts and the config can never be cleared. Harmless: deposit IDs are monotonic and never reused.
- **`AddressGroupRegistry.sol` NatSpec still says "maker's admission policy"** and was deliberately left stale. A comment-only edit changes the solc metadata hash, which would make hardhat-deploy redeploy the registry and orphan every existing group (IDs are keyed by registry address and are never deletable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ay1Bd974WSfQ2vpELt5rjN
