### PR TITLE
feat: make whitelist policy an OrchestratorV2 hook

### DIFF
--- a/contracts/hooks/WhitelistPolicy.sol
+++ b/contracts/hooks/WhitelistPolicy.sol
@@ -7,6 +7,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IAddressGroupRegistry} from "../interfaces/IAddressGroupRegistry.sol";
 import {IEscrow} from "../interfaces/IEscrow.sol";
 import {IEscrowRegistry} from "../interfaces/IEscrowRegistry.sol";
+import {IOrchestratorRegistry} from "../interfaces/IOrchestratorRegistry.sol";
 import {IWhitelistPolicy} from "../interfaces/IWhitelistPolicy.sol";
 
 /**
@@ -32,6 +33,7 @@ contract WhitelistPolicy is Ownable, IWhitelistPolicy {
 
     IAddressGroupRegistry public immutable override groupRegistry;
     IEscrowRegistry public override escrowRegistry;
+    IOrchestratorRegistry public immutable override orchestratorRegistry;
 
     mapping(address => mapping(uint256 => bool)) public override enabled;
     mapping(address => mapping(uint256 => mapping(address => bool))) public override isWhitelisted;
@@ -56,15 +58,23 @@ contract WhitelistPolicy is Ownable, IWhitelistPolicy {
     error EscrowNotWhitelisted(address escrow);
     error DepositNotFound(address escrow, uint256 depositId);
     error NotDepositor(address escrow, uint256 depositId, address caller);
+    error UnauthorizedOrchestratorCaller(address caller);
+    error TakerNotWhitelisted(address taker, address escrow, uint256 depositId);
 
     /* ============ Constructor ============ */
 
-    constructor(IAddressGroupRegistry _groupRegistry, IEscrowRegistry _escrowRegistry) Ownable() {
+    constructor(
+        IAddressGroupRegistry _groupRegistry,
+        IEscrowRegistry _escrowRegistry,
+        IOrchestratorRegistry _orchestratorRegistry
+    ) Ownable() {
         _validateDependency(address(_groupRegistry));
         _validateDependency(address(_escrowRegistry));
+        _validateDependency(address(_orchestratorRegistry));
 
         groupRegistry = _groupRegistry;
         escrowRegistry = _escrowRegistry;
+        orchestratorRegistry = _orchestratorRegistry;
     }
 
     /* ============ Modifiers ============ */
@@ -103,11 +113,7 @@ contract WhitelistPolicy is Ownable, IWhitelistPolicy {
         bool _enabled,
         bytes32[] calldata _groupIds,
         address[] calldata _takers
-    )
-        external
-        override
-        onlyDepositor(_escrow, _depositId)
-    {
+    ) external override onlyDepositor(_escrow, _depositId) {
         _setEnabled(_escrow, _depositId, _enabled);
         _addGroups(_escrow, _depositId, _groupIds);
         _addTakers(_escrow, _depositId, _takers);
@@ -213,12 +219,24 @@ contract WhitelistPolicy is Ownable, IWhitelistPolicy {
     /**
      * @inheritdoc IWhitelistPolicy
      */
-    function isTakerAllowed(address _escrow, uint256 _depositId, address _taker)
-        external
-        view
-        override
-        returns (bool)
-    {
+    function isTakerAllowed(address _escrow, uint256 _depositId, address _taker) external view override returns (bool) {
+        return _isTakerAllowed(_escrow, _depositId, _taker);
+    }
+
+    /**
+     * @notice Enforces this deposit's whitelist policy during intent signaling.
+     * @dev Only registered orchestrators may invoke the hook.
+     */
+    function validateSignalIntent(PreIntentContext calldata _ctx) external view override {
+        if (!orchestratorRegistry.isOrchestrator(msg.sender)) revert UnauthorizedOrchestratorCaller(msg.sender);
+        if (!_isTakerAllowed(_ctx.escrow, _ctx.depositId, _ctx.taker)) {
+            revert TakerNotWhitelisted(_ctx.taker, _ctx.escrow, _ctx.depositId);
+        }
+    }
+
+    /* ============ Internal Functions ============ */
+
+    function _isTakerAllowed(address _escrow, uint256 _depositId, address _taker) internal view returns (bool) {
         if (!enabled[_escrow][_depositId]) return true;
         if (isWhitelisted[_escrow][_depositId][_taker]) return true;
 
@@ -228,8 +246,6 @@ contract WhitelistPolicy is Ownable, IWhitelistPolicy {
         }
         return false;
     }
-
-    /* ============ Internal Functions ============ */
 
     function _setEnabled(address _escrow, uint256 _depositId, bool _enabled) internal {
         enabled[_escrow][_depositId] = _enabled;

--- a/contracts/interfaces/IWhitelistPolicy.sol
+++ b/contracts/interfaces/IWhitelistPolicy.sol
@@ -4,10 +4,13 @@ pragma solidity ^0.8.18;
 
 import {IAddressGroupRegistry} from "./IAddressGroupRegistry.sol";
 import {IEscrowRegistry} from "./IEscrowRegistry.sol";
+import {IOrchestratorRegistry} from "./IOrchestratorRegistry.sol";
+import {IPreIntentHook} from "./IPreIntentHook.sol";
 
-interface IWhitelistPolicy {
+interface IWhitelistPolicy is IPreIntentHook {
     function groupRegistry() external view returns (IAddressGroupRegistry);
     function escrowRegistry() external view returns (IEscrowRegistry);
+    function orchestratorRegistry() external view returns (IOrchestratorRegistry);
     function enabled(address escrow, uint256 depositId) external view returns (bool);
     function isWhitelisted(address escrow, uint256 depositId, address taker) external view returns (bool);
     function getAllowedGroups(address escrow, uint256 depositId) external view returns (bytes32[] memory);

--- a/deploy/29_deploy_maker_group_risk_system.ts
+++ b/deploy/29_deploy_maker_group_risk_system.ts
@@ -63,6 +63,7 @@ async function systemFullyWired(network: string): Promise<boolean> {
 
   if ((await policy.groupRegistry()).toLowerCase() !== registryAddress.toLowerCase()) return false;
   if ((await policy.escrowRegistry()).toLowerCase() !== escrowRegistryAddress.toLowerCase()) return false;
+  if ((await policy.orchestratorRegistry()).toLowerCase() !== orchestratorRegistryAddress.toLowerCase()) return false;
   if ((await hook.whitelistPolicy()).toLowerCase() !== policyAddress.toLowerCase()) return false;
   if ((await hook.orchestratorRegistry()).toLowerCase() !== orchestratorRegistryAddress.toLowerCase()) return false;
   if ((await orchestrator.lifecycleHook()).toLowerCase() !== hookAddress.toLowerCase()) return false;
@@ -148,6 +149,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const whitelistPolicyArgs: Parameters<WhitelistPolicy__factory["deploy"]> = [
     addressGroupRegistry.address,
     escrowRegistryAddress,
+    orchestratorRegistryAddress,
   ];
 
   const whitelistPolicy = await deploy("WhitelistPolicy", {

--- a/test-foundry/deterministic/hooks/WhitelistPolicy.t.sol
+++ b/test-foundry/deterministic/hooks/WhitelistPolicy.t.sol
@@ -6,8 +6,11 @@ import {Test} from "forge-std/Test.sol";
 
 import {EscrowDepositorMock} from "contracts/mocks/EscrowDepositorMock.sol";
 import {WhitelistPolicy} from "contracts/hooks/WhitelistPolicy.sol";
+import {IPreIntentHook} from "contracts/interfaces/IPreIntentHook.sol";
+import {IReferralFee} from "contracts/interfaces/IReferralFee.sol";
 import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
 import {EscrowRegistry} from "contracts/registries/EscrowRegistry.sol";
+import {OrchestratorRegistry} from "contracts/registries/OrchestratorRegistry.sol";
 
 contract WhitelistPolicyTest is Test {
     uint256 internal constant DEPOSIT_ONE = 1;
@@ -25,6 +28,7 @@ contract WhitelistPolicyTest is Test {
 
     AddressGroupRegistry internal registry;
     EscrowRegistry internal escrowRegistry;
+    OrchestratorRegistry internal orchestratorRegistry;
     EscrowDepositorMock internal escrow;
     EscrowDepositorMock internal otherEscrow;
     EscrowDepositorMock internal unregisteredEscrow;
@@ -49,6 +53,7 @@ contract WhitelistPolicyTest is Test {
         PEER_MERCHANTS = registry.createGroup("Peer Merchants");
 
         escrowRegistry = new EscrowRegistry();
+        orchestratorRegistry = new OrchestratorRegistry();
         escrow = new EscrowDepositorMock();
         otherEscrow = new EscrowDepositorMock();
         unregisteredEscrow = new EscrowDepositorMock();
@@ -60,29 +65,39 @@ contract WhitelistPolicyTest is Test {
         otherEscrow.setDepositor(DEPOSIT_ONE, otherMaker);
         unregisteredEscrow.setDepositor(DEPOSIT_ONE, maker);
 
-        policy = new WhitelistPolicy(registry, escrowRegistry);
+        policy = new WhitelistPolicy(registry, escrowRegistry, orchestratorRegistry);
     }
 
     /* ============ Constructor ============ */
 
     function test_ConstructorRejectsZeroAndCodelessDependencies() public {
         vm.expectRevert(WhitelistPolicy.ZeroAddress.selector);
-        new WhitelistPolicy(AddressGroupRegistry(address(0)), escrowRegistry);
+        new WhitelistPolicy(AddressGroupRegistry(address(0)), escrowRegistry, orchestratorRegistry);
 
         vm.expectRevert(WhitelistPolicy.ZeroAddress.selector);
-        new WhitelistPolicy(registry, EscrowRegistry(address(0)));
+        new WhitelistPolicy(registry, EscrowRegistry(address(0)), orchestratorRegistry);
+
+        vm.expectRevert(WhitelistPolicy.ZeroAddress.selector);
+        new WhitelistPolicy(registry, escrowRegistry, OrchestratorRegistry(address(0)));
 
         vm.expectRevert(abi.encodeWithSelector(WhitelistPolicy.InvalidDependency.selector, maker));
-        new WhitelistPolicy(AddressGroupRegistry(maker), escrowRegistry);
+        new WhitelistPolicy(AddressGroupRegistry(maker), escrowRegistry, orchestratorRegistry);
 
         vm.expectRevert(abi.encodeWithSelector(WhitelistPolicy.InvalidDependency.selector, maker));
-        new WhitelistPolicy(registry, EscrowRegistry(maker));
+        new WhitelistPolicy(registry, EscrowRegistry(maker), orchestratorRegistry);
+
+        vm.expectRevert(abi.encodeWithSelector(WhitelistPolicy.InvalidDependency.selector, maker));
+        new WhitelistPolicy(registry, escrowRegistry, OrchestratorRegistry(maker));
     }
 
     /* ============ Governance ============ */
 
     function test_ConstructorSetsDeployerAsOwner() public {
         assertEq(policy.owner(), address(this));
+    }
+
+    function test_ConstructorStoresOrchestratorRegistry() public view {
+        assertEq(address(policy.orchestratorRegistry()), address(orchestratorRegistry));
     }
 
     function test_SetEscrowRegistryUpdatesRegistryAndEmits() public {
@@ -124,9 +139,7 @@ contract WhitelistPolicyTest is Test {
 
         escrowRegistry.removeEscrow(address(escrow));
 
-        vm.expectRevert(
-            abi.encodeWithSelector(WhitelistPolicy.EscrowNotWhitelisted.selector, address(escrow))
-        );
+        vm.expectRevert(abi.encodeWithSelector(WhitelistPolicy.EscrowNotWhitelisted.selector, address(escrow)));
         vm.prank(maker);
         policy.removeWhitelistedAddresses(address(escrow), DEPOSIT_ONE, _addresses(taker));
 
@@ -154,9 +167,8 @@ contract WhitelistPolicyTest is Test {
     }
 
     function test_AllSixGatedEntryPointsRevertForNonDepositor() public {
-        bytes memory expectedRevert = abi.encodeWithSelector(
-            WhitelistPolicy.NotDepositor.selector, address(escrow), DEPOSIT_ONE, otherMaker
-        );
+        bytes memory expectedRevert =
+            abi.encodeWithSelector(WhitelistPolicy.NotDepositor.selector, address(escrow), DEPOSIT_ONE, otherMaker);
 
         vm.expectRevert(expectedRevert);
         vm.prank(otherMaker);
@@ -380,9 +392,7 @@ contract WhitelistPolicyTest is Test {
 
     function test_ConfigureDepositSetsEnabledGroupsAndTakersInOneCall() public {
         vm.prank(maker);
-        policy.configureDeposit(
-            address(escrow), DEPOSIT_ONE, true, _groupIds(PEERS, PEER_PLUSES), _addresses(taker)
-        );
+        policy.configureDeposit(address(escrow), DEPOSIT_ONE, true, _groupIds(PEERS, PEER_PLUSES), _addresses(taker));
 
         assertTrue(policy.enabled(address(escrow), DEPOSIT_ONE));
         assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE).length, 2);
@@ -402,9 +412,7 @@ contract WhitelistPolicyTest is Test {
     function test_ConfigureDepositIsAdditive() public {
         vm.startPrank(maker);
         policy.configureDeposit(address(escrow), DEPOSIT_ONE, true, _groupIds(PEERS), _addresses(taker));
-        policy.configureDeposit(
-            address(escrow), DEPOSIT_ONE, true, _groupIds(PEER_PLUSES), _addresses(otherTaker)
-        );
+        policy.configureDeposit(address(escrow), DEPOSIT_ONE, true, _groupIds(PEER_PLUSES), _addresses(otherTaker));
         vm.stopPrank();
 
         assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE).length, 2);
@@ -430,9 +438,7 @@ contract WhitelistPolicyTest is Test {
         bytes32 unknownGroup = bytes32(uint256(999));
         vm.expectRevert(abi.encodeWithSelector(WhitelistPolicy.GroupDoesNotExist.selector, unknownGroup));
         vm.prank(maker);
-        policy.configureDeposit(
-            address(escrow), DEPOSIT_ONE, true, _groupIds(PEERS, unknownGroup), _addresses(taker)
-        );
+        policy.configureDeposit(address(escrow), DEPOSIT_ONE, true, _groupIds(PEERS, unknownGroup), _addresses(taker));
 
         assertFalse(policy.enabled(address(escrow), DEPOSIT_ONE));
         assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE).length, 0);
@@ -440,9 +446,7 @@ contract WhitelistPolicyTest is Test {
 
         vm.expectRevert(WhitelistPolicy.ZeroAddress.selector);
         vm.prank(maker);
-        policy.configureDeposit(
-            address(escrow), DEPOSIT_ONE, true, _groupIds(PEERS), _addresses(taker, address(0))
-        );
+        policy.configureDeposit(address(escrow), DEPOSIT_ONE, true, _groupIds(PEERS), _addresses(taker, address(0)));
 
         assertFalse(policy.enabled(address(escrow), DEPOSIT_ONE));
         assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE).length, 0);
@@ -557,6 +561,46 @@ contract WhitelistPolicyTest is Test {
         assertFalse(policy.isTakerAllowed(address(otherEscrow), DEPOSIT_ONE, taker));
     }
 
+    /* ============ Pre-intent hook ============ */
+
+    function test_ValidateSignalIntentAllowsDisabledPolicy() public {
+        orchestratorRegistry.addOrchestrator(address(this));
+        policy.validateSignalIntent(_preIntentContext(taker));
+    }
+
+    function test_ValidateSignalIntentAllowsDirectlyWhitelistedTaker() public {
+        vm.prank(maker);
+        policy.configureDeposit(address(escrow), DEPOSIT_ONE, true, new bytes32[](0), _addresses(taker));
+        orchestratorRegistry.addOrchestrator(address(this));
+
+        policy.validateSignalIntent(_preIntentContext(taker));
+    }
+
+    function test_ValidateSignalIntentAllowsGroupMember() public {
+        vm.prank(maker);
+        policy.configureDeposit(address(escrow), DEPOSIT_ONE, true, _groupIds(PEERS), new address[](0));
+        registry.addMembers(PEERS, _addresses(taker));
+        orchestratorRegistry.addOrchestrator(address(this));
+
+        policy.validateSignalIntent(_preIntentContext(taker));
+    }
+
+    function test_ValidateSignalIntentRejectsNonWhitelistedTaker() public {
+        vm.prank(maker);
+        policy.setEnabled(address(escrow), DEPOSIT_ONE, true);
+        orchestratorRegistry.addOrchestrator(address(this));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(WhitelistPolicy.TakerNotWhitelisted.selector, taker, address(escrow), DEPOSIT_ONE)
+        );
+        policy.validateSignalIntent(_preIntentContext(taker));
+    }
+
+    function test_ValidateSignalIntentRejectsUnregisteredCaller() public {
+        vm.expectRevert(abi.encodeWithSelector(WhitelistPolicy.UnauthorizedOrchestratorCaller.selector, address(this)));
+        policy.validateSignalIntent(_preIntentContext(taker));
+    }
+
     /* ============ Helpers ============ */
 
     function _groupIds(bytes32 _first) internal pure returns (bytes32[] memory groupIds) {
@@ -590,5 +634,20 @@ contract WhitelistPolicyTest is Test {
         addresses = new address[](2);
         addresses[0] = _first;
         addresses[1] = _second;
+    }
+
+    function _preIntentContext(address _taker) internal view returns (IPreIntentHook.PreIntentContext memory context) {
+        context = IPreIntentHook.PreIntentContext({
+            taker: _taker,
+            escrow: address(escrow),
+            depositId: DEPOSIT_ONE,
+            amount: 1,
+            to: _taker,
+            paymentMethod: bytes32(0),
+            fiatCurrency: bytes32(0),
+            conversionRate: 0,
+            referralFees: new IReferralFee.ReferralFee[](0),
+            preIntentHookData: ""
+        });
     }
 }

--- a/test-foundry/deterministic/hooks/WhitelistPreIntentHook.t.sol
+++ b/test-foundry/deterministic/hooks/WhitelistPreIntentHook.t.sol
@@ -6,10 +6,12 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {EscrowV2} from "contracts/EscrowV2.sol";
 import {OrchestratorV2} from "contracts/OrchestratorV2.sol";
+import {WhitelistPolicy} from "contracts/hooks/WhitelistPolicy.sol";
 import {WhitelistPreIntentHook} from "contracts/hooks/WhitelistPreIntentHook.sol";
 import {PaymentVerifierMock} from "contracts/mocks/PaymentVerifierMock.sol";
 import {PreIntentHookMock} from "contracts/mocks/PreIntentHookMock.sol";
 import {USDCMock} from "contracts/mocks/USDCMock.sol";
+import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
 import {EscrowRegistry} from "contracts/registries/EscrowRegistry.sol";
 import {OrchestratorRegistry} from "contracts/registries/OrchestratorRegistry.sol";
 import {PaymentVerifierRegistry} from "contracts/registries/PaymentVerifierRegistry.sol";
@@ -56,7 +58,10 @@ contract WhitelistPreIntentHookTest is Test {
     USDCMock internal token;
     EscrowV2 internal escrow;
     OrchestratorV2 internal orchestrator;
+    AddressGroupRegistry internal groupRegistry;
+    EscrowRegistry internal escrowRegistry;
     OrchestratorRegistry internal orchestratorRegistry;
+    WhitelistPolicy internal policy;
     WhitelistPreIntentHook internal whitelistHook;
     PreIntentHookMock internal genericHook;
 
@@ -69,7 +74,7 @@ contract WhitelistPreIntentHookTest is Test {
         token = new USDCMock(1_000_000_000e6, "USDC", "USDC");
         token.transfer(depositor, 10_000e6);
 
-        EscrowRegistry escrowRegistry = new EscrowRegistry();
+        escrowRegistry = new EscrowRegistry();
         PaymentVerifierRegistry paymentVerifierRegistry = new PaymentVerifierRegistry();
         orchestratorRegistry = new OrchestratorRegistry();
         PaymentVerifierMock verifier = new PaymentVerifierMock();
@@ -100,6 +105,8 @@ contract WhitelistPreIntentHookTest is Test {
         orchestrator.setAllowMultipleIntents(true);
         orchestratorRegistry.addOrchestrator(address(orchestrator));
         verifier.setVerificationContext(address(orchestrator), address(escrow));
+        groupRegistry = new AddressGroupRegistry();
+        policy = new WhitelistPolicy(groupRegistry, escrowRegistry, orchestratorRegistry);
         whitelistHook = new WhitelistPreIntentHook(address(orchestratorRegistry));
         genericHook = new PreIntentHookMock();
 
@@ -366,6 +373,24 @@ contract WhitelistPreIntentHookTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(WhitelistPreIntentHook.TakerNotWhitelisted.selector, taker, address(escrow), 0)
         );
+        _signalCall();
+        assertEq(orchestrator.getAccountIntents(taker).length, 0);
+    }
+
+    function test_WhitelistPolicyCanBeUsedAsV2WhitelistHook() public {
+        vm.prank(depositor);
+        policy.configureDeposit(address(escrow), 0, true, new bytes32[](0), _address(taker));
+        _setWhitelistHook(depositor, address(escrow), policy);
+
+        assertNotEq(_signal(), bytes32(0));
+    }
+
+    function test_WhitelistPolicyRejectsNonWhitelistedV2Taker() public {
+        vm.prank(depositor);
+        policy.setEnabled(address(escrow), 0, true);
+        _setWhitelistHook(depositor, address(escrow), policy);
+
+        vm.expectRevert(abi.encodeWithSelector(WhitelistPolicy.TakerNotWhitelisted.selector, taker, address(escrow), 0));
         _signalCall();
         assertEq(orchestrator.getAccountIntents(taker).length, 0);
     }

--- a/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
@@ -34,7 +34,7 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV2LegacyFixture 
         PEER_PLUSES = groupRegistry.createGroup("Peer Pluses");
         PEER_MERCHANTS = groupRegistry.createGroup("Peer Merchants");
 
-        policy = new WhitelistPolicy(groupRegistry, escrowRegistry);
+        policy = new WhitelistPolicy(groupRegistry, escrowRegistry, orchestratorRegistry);
         lifecycleHook = new IntentLifecycleHookV1(orchestratorRegistry, policy);
         IOrchestratorV3(address(orchestrator)).setLifecycleHook(lifecycleHook);
     }


### PR DESCRIPTION
## Summary

- extend `IWhitelistPolicy` with the existing `IPreIntentHook` interface
- add `validateSignalIntent` to `WhitelistPolicy`, reusing its direct-address and group admission logic
- authorize hook callbacks through `OrchestratorRegistry`
- wire the registry into deployment construction and capability checks
- cover direct calls and the real `OrchestratorV2.setDepositWhitelistHook` signal path

## Why

`WhitelistPolicy` already owns the deposit-scoped admission rules, but it could only be consumed through the OrchestratorV3 lifecycle hook. Implementing the existing pre-intent hook callback lets current OrchestratorV2 deployments enforce the same policy without changing or redeploying OrchestratorV2.

Contract, getter, and event names remain unchanged. A new `WhitelistPolicy` deployment will be required because its constructor and bytecode change; no deployment is included in this PR.

## Validation

- `forge test --match-path test-foundry/deterministic/hooks/WhitelistPolicy.t.sol` — 41 passed
- `forge test --match-path test-foundry/deterministic/hooks/WhitelistPreIntentHook.t.sol` — 31 passed
- `forge test --match-path test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol` — 14 passed
- `yarn compile`
- `yarn transpile`
- `forge fmt --check` on changed Solidity files
- `git diff --check`