### PR TITLE
feat: intent lifecycle hook + stake-backed chargeback policy

### DIFF
--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -45,7 +45,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
     uint256 constant MAX_PROTOCOL_FEE = 5e16;      // 5% max protocol fee
     uint256 constant MAX_MANAGER_FEE = 5e16;       // 5% max manager fee
 
-/* ============ State Variables ============ */
+    /* ============ State Variables ============ */
 
     uint256 immutable public chainId;              // chainId of the chain the orchestrator is deployed on
 
@@ -377,8 +377,8 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
             if (escrowIntent.intentHash == bytes32(0)) {
                 _pruneIntentAndNotify(intentHash);
             }
-            }
         }
+    }
 
     /* ============ Governance Functions ============ */
 
@@ -582,7 +582,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
 
     /**
      * @notice Validates hook address and authorizes the caller as depositor or delegate.
-     * @dev Shared validation for setDepositPreIntentHook and setDepositWhitelistHook.
+     * @dev Validation used by setDepositPreIntentHook.
      */
     function _validateAndAuthorizeHookSetter(address _escrow, uint256 _depositId, IPreIntentHook _hook) internal view {
         if (_escrow == address(0)) revert ZeroAddress();

--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -185,7 +185,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         intentLifecycleHooks[intentHash] = snapshottedLifecycleHook;
 
         if (address(snapshottedLifecycleHook) != address(0)) {
-            snapshottedLifecycleHook.onIntentCreated(intentHash);
+            snapshottedLifecycleHook.onIntentSignaled(intentHash);
         }
         emit IntentLifecycleHookSnapshotted(intentHash, address(snapshottedLifecycleHook));
 

--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -291,8 +291,9 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
     /**
      * @notice Allows depositor to release funds to the payer in case of a failed fulfill intent or because of some other arrangement
      * between the two parties. Upon submission we check to make sure the msg.sender is the depositor, the intent is removed, and 
-     * escrow state is updated. Manual release routes through the shared post-funds lifecycle-settlement gate, then executes the
-     * configured post-intent hook or transfers the deposit token directly to the payer when no hook is configured.
+     * escrow state is updated. Manual release routes through the shared post-funds lifecycle-settlement gate, then transfers
+     * the deposit token directly to the payer. It does not execute the taker's post-intent hook because fulfillment-time
+     * hook data is unavailable on this depositor-controlled recovery path.
      *
      * @param _intentHash        Hash of intent to resolve by releasing the funds
      */
@@ -657,10 +658,50 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
     }
 
     /**
+     * @notice Calculates and transfers fees to the protocol fee recipient and referrer.
+     */
+    function _calculateAndTransferFees(
+        IERC20 _token,
+        bytes32 _intentHash,
+        Intent memory _intent,
+        uint256 _releaseAmount,
+        address _managerFeeRecipient,
+        uint256 _managerFee
+    ) internal returns (uint256 netFees) {
+        uint256 protocolFeeAmount;
+        uint256 referralFeeAmount;
+        uint256 managerFeeAmount;
+
+        // Calculate protocol fee (taken from taker) - based on release amount
+        if (protocolFeeRecipient != address(0) && protocolFee > 0) {
+            protocolFeeAmount = (_releaseAmount * protocolFee) / PRECISE_UNIT;
+            _token.safeTransfer(protocolFeeRecipient, protocolFeeAmount);
+        }
+
+        // Calculate referral fees (taken from taker) - based on release amount
+        for (uint256 i = 0; i < _intent.referralFees.length; ++i) {
+            IReferralFee.ReferralFee memory referralFee = _intent.referralFees[i];
+            uint256 feeAmount = (_releaseAmount * referralFee.fee) / PRECISE_UNIT;
+            referralFeeAmount += feeAmount;
+            _token.safeTransfer(referralFee.recipient, feeAmount);
+            emit IntentReferralFeeDistributed(_intentHash, referralFee.recipient, feeAmount);
+        }
+
+        // Calculate manager fee (taken from taker) - based on release amount
+        if (_managerFeeRecipient != address(0) && _managerFee > 0) {
+            managerFeeAmount = (_releaseAmount * _managerFee) / PRECISE_UNIT;
+            _token.safeTransfer(_managerFeeRecipient, managerFeeAmount);
+        }
+
+        netFees = protocolFeeAmount + referralFeeAmount + managerFeeAmount;
+    }
+
+    /**
      * @notice Transfers fees, notifies the snapshotted lifecycle hook of settlement (fail-closed), then routes the
      * executable remainder through the post-intent hook or directly to the recipient.
      * @dev A reverting lifecycle hook aborts the entire settlement, including the preceding fee transfers.
-     * The lifecycle hook receives no token allowance and cannot move settlement funds.
+     * The lifecycle hook receives no token allowance and cannot move settlement funds. Manual release bypasses the
+     * post-intent hook because that recovery path has no fulfillment-time hook data.
      */
     function _collectFeesTransferFundsAndExecuteAction(
         IERC20 _token,
@@ -684,15 +725,15 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
                     intentHash: _intentHash,
                     token: address(_token),
                     recipient: _intent.to,
-                    grossAmount: _releaseAmount,
-                    executableAmount: netAmount,
+                    releaseAmount: _releaseAmount,
+                    netAmount: netAmount,
                     isManualRelease: _isManualRelease
                 })
             );
         }
 
         address fundsTransferredTo = _intent.to;
-        if (address(_intent.postIntentHook) != address(0)) {
+        if (!_isManualRelease && address(_intent.postIntentHook) != address(0)) {
             // Snapshot balance to enforce exact consumption by the hook
             uint256 preBalance = _token.balanceOf(address(this));
 
@@ -740,42 +781,6 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
             netAmount, 
             _isManualRelease
         );
-    }
-
-    function _calculateAndTransferFees(
-        IERC20 _token,
-        bytes32 _intentHash,
-        Intent memory _intent, 
-        uint256 _releaseAmount,
-        address _managerFeeRecipient,
-        uint256 _managerFee
-    ) internal returns (uint256 netFees) {
-        uint256 protocolFeeAmount;
-        uint256 referralFeeAmount;
-        uint256 managerFeeAmount;
-
-        // Calculate protocol fee (taken from taker) - based on release amount
-        if (protocolFeeRecipient != address(0) && protocolFee > 0) {
-            protocolFeeAmount = (_releaseAmount * protocolFee) / PRECISE_UNIT;
-            _token.safeTransfer(protocolFeeRecipient, protocolFeeAmount);
-        }
-        
-        // Calculate referral fees (taken from taker) - based on release amount
-        for (uint256 i = 0; i < _intent.referralFees.length; ++i) {
-            IReferralFee.ReferralFee memory referralFee = _intent.referralFees[i];
-            uint256 feeAmount = (_releaseAmount * referralFee.fee) / PRECISE_UNIT;
-            referralFeeAmount += feeAmount;
-            _token.safeTransfer(referralFee.recipient, feeAmount);
-            emit IntentReferralFeeDistributed(_intentHash, referralFee.recipient, feeAmount);
-        }
-
-        // Calculate manager fee (taken from taker) - based on release amount
-        if (_managerFeeRecipient != address(0) && _managerFee > 0) {
-            managerFeeAmount = (_releaseAmount * _managerFee) / PRECISE_UNIT;
-            _token.safeTransfer(_managerFeeRecipient, managerFeeAmount);
-        }
-
-        netFees = protocolFeeAmount + referralFeeAmount + managerFeeAmount;
     }
 
     /**

--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -16,6 +16,7 @@ import { IReferralFee } from "./interfaces/IReferralFee.sol";
 import { IEscrow } from "./interfaces/IEscrow.sol";
 import { IEscrowV2 } from "./interfaces/IEscrowV2.sol";
 import { IEscrowRegistry } from "./interfaces/IEscrowRegistry.sol";
+import { IIntentLifecycleHook } from "./interfaces/IIntentLifecycleHook.sol";
 import { IPostIntentHookV2 } from "./interfaces/IPostIntentHookV2.sol";
 import { IPreIntentHook } from "./interfaces/IPreIntentHook.sol";
 import { IPaymentVerifier } from "./interfaces/IPaymentVerifier.sol";
@@ -25,8 +26,9 @@ import { ReferralFeeLib } from "./lib/ReferralFeeLib.sol";
 
 /**
  * @title OrchestratorV3
- * @notice Orchestrator contract for the ZKP2P protocol. This contract is responsible for managing the intent (order) 
- * lifecycle and orchestrating the P2P trading of fiat currency and onchain assets.
+ * @notice Standalone V3 orchestrator for the ZKP2P protocol. Owns the complete intent (order)
+ * lifecycle — signal, cancel, fulfill, manual release, prune, orphan cleanup — and extends it
+ * with snapshotted governance-selected fail-closed lifecycle callbacks.
  */
 contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
 
@@ -43,7 +45,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
     uint256 constant MAX_PROTOCOL_FEE = 5e16;      // 5% max protocol fee
     uint256 constant MAX_MANAGER_FEE = 5e16;       // 5% max manager fee
 
-    /* ============ State Variables ============ */
+/* ============ State Variables ============ */
 
     uint256 immutable public chainId;              // chainId of the chain the orchestrator is deployed on
 
@@ -61,8 +63,9 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
     // Optional pre-intent hooks configured per escrow + depositId.
     mapping(address => mapping(uint256 => IPreIntentHook)) internal depositPreIntentHooks;
 
-    // Dedicated whitelist hooks configured per escrow + depositId.
-    mapping(address => mapping(uint256 => IPreIntentHook)) internal depositWhitelistHooks;
+    // Governance-selected lifecycle hook; snapshotted per intent at signal.
+    IIntentLifecycleHook public lifecycleHook;
+    mapping(bytes32 => IIntentLifecycleHook) internal intentLifecycleHooks;
 
     // Contract references
     IEscrowRegistry public escrowRegistry;                              // Registry of escrow contracts
@@ -105,7 +108,8 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
      * @notice Signals intent to pay the depositor defined in the _depositId the _amount * deposit conversionRate off-chain at 
      * their given _payeeId in order to unlock _amount of funds on-chain. Caller must provide a signature from the deposit's gating
      * service to prove their eligibility to take liquidity. This function captures and stores all values required for fullfilling
-     * the intent to give strong guarantees to the buyer. Locks liquidity for the corresponding deposit on the escrow contract.
+     * the intent to give strong guarantees to the buyer. Snapshots the global lifecycle hook and executes fail-closed risk
+     * admission before locking liquidity for the corresponding deposit on the escrow contract.
      *
      * @param _params                   Struct containing all the intent parameters
      */
@@ -117,7 +121,6 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         // Checks
         _validateSignalIntent(_params);
         _executeHookIfSet(depositPreIntentHooks[_params.escrow][_params.depositId], _params);
-        _executeHookIfSet(depositWhitelistHooks[_params.escrow][_params.depositId], _params);
 
         // Effects
         bytes32 intentHash = _calculateIntentHash();
@@ -132,7 +135,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         if (managerFee > MAX_MANAGER_FEE) revert FeeExceedsMaximum(managerFee, MAX_MANAGER_FEE);  // policy cap (e.g., 5%)
         intentManagerFeeRecipient[intentHash] = managerFeeRecipient;
         intentManagerFee[intentHash] = managerFee;
-        
+
         intentMinAtSignal[intentHash] = dep.intentAmountRange.min;
         Intent storage storedIntent = intents[intentHash];
         storedIntent.owner = msg.sender;
@@ -177,6 +180,15 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         // Emit manager fee snapshot last for easier indexing
         emit IntentManagerFeeSnapshotted(intentHash, managerFeeRecipient, managerFee);
 
+        // Snapshot and execute fail-closed admission for the governance-selected global hook.
+        IIntentLifecycleHook snapshottedLifecycleHook = lifecycleHook;
+        intentLifecycleHooks[intentHash] = snapshottedLifecycleHook;
+
+        if (address(snapshottedLifecycleHook) != address(0)) {
+            snapshottedLifecycleHook.onIntentCreated(intentHash);
+        }
+        emit IntentLifecycleHookSnapshotted(intentHash, address(snapshottedLifecycleHook));
+
         // Interactions
         IEscrow(_params.escrow).lockFunds(_params.depositId, intentHash, _params.amount);
     }
@@ -184,10 +196,11 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
     /**
      * @notice Only callable by the originator of the intent. Cancels an outstanding intent. Unlocks liquidity
      * for the corresponding deposit on the escrow contract.
+     * @dev Guarded because cancellation invokes an external lifecycle callback during resolution.
      *
      * @param _intentHash    Hash of intent being cancelled
      */
-    function cancelIntent(bytes32 _intentHash) external {
+    function cancelIntent(bytes32 _intentHash) external nonReentrant {
         // Checks
         Intent memory intent = intents[_intentHash];
         
@@ -195,7 +208,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         if (intent.owner != msg.sender) revert UnauthorizedCaller(msg.sender, intent.owner);
 
         // Effects
-        _pruneIntent(_intentHash);
+        _pruneIntentAndNotify(_intentHash);
 
         // Interactions
         IEscrow(intent.escrow).unlockFunds(intent.depositId, _intentHash);
@@ -218,27 +231,10 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
     }
 
     /**
-     * @notice Sets or removes the whitelist hook for a specific deposit.
-     * @dev Callable only by the deposit's depositor or delegate. The whitelist hook is a
-     * dedicated slot separate from the generic pre-intent hook, enabling private orderbook
-     * functionality without occupying the generic hook slot.
-     *
-     * @param _escrow       Escrow address.
-     * @param _depositId    Deposit id.
-     * @param _hook         Hook address (address(0) to remove).
-     */
-    function setDepositWhitelistHook(address _escrow, uint256 _depositId, IPreIntentHook _hook) external nonReentrant {
-        _validateAndAuthorizeHookSetter(_escrow, _depositId, _hook);
-
-        depositWhitelistHooks[_escrow][_depositId] = _hook;
-
-        emit DepositWhitelistHookSet(_escrow, _depositId, address(_hook), msg.sender);
-    }
-
-    /**
      * @notice Anyone can submit a fulfill intent transaction, even if caller isn't the intent owner. Upon submission the
      * offchain payment proof is verified, payment details are validated, intent is removed, and escrow state is updated.
-     * Deposit token is transferred to the intent.to address.
+     * Settlement notifies the snapshotted lifecycle hook (fail-closed), then executes the exact fee plan and
+     * transfers the deposit token to the intent.to address (or post-intent hook).
      * @dev This function adds a reentrancy guard as it's calling the post intent hook contract which itself might call 
      * malicious contracts.
      *
@@ -287,14 +283,16 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
             verificationResult.releaseAmount,
             _params.postIntentHookData,
             managerFeeRecipient,
-            managerFee
+            managerFee,
+            false
         );
     }
 
     /**
      * @notice Allows depositor to release funds to the payer in case of a failed fulfill intent or because of some other arrangement
      * between the two parties. Upon submission we check to make sure the msg.sender is the depositor, the intent is removed, and 
-     * escrow state is updated. Deposit token is transferred to the payer.
+     * escrow state is updated. Manual release routes through the shared post-funds lifecycle-settlement gate, then executes the
+     * configured post-intent hook or transfers the deposit token directly to the payer when no hook is configured.
      *
      * @param _intentHash        Hash of intent to resolve by releasing the funds
      */
@@ -316,7 +314,16 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         // Interactions
         IEscrow(intent.escrow).unlockAndTransferFunds(intent.depositId, _intentHash, intent.amount, address(this));
 
-        _collectFeesAndTransferFunds(deposit.token, _intentHash, intent, intent.amount, managerFeeRecipient, managerFee);
+        _collectFeesTransferFundsAndExecuteAction(
+            deposit.token,
+            _intentHash,
+            intent,
+            intent.amount,
+            "",
+            managerFeeRecipient,
+            managerFee,
+            true
+        );
     }
 
     /* ============ Escrow Functions ============ */
@@ -336,7 +343,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
                     intent.timestamp != 0 && // Only prune if intent exists on this contract; otherwise skip
                     intent.escrow == msg.sender // Ensure only the escrow that owns the intent can prune it; otherwise skip
                 ) {
-                    _pruneIntent(intentHash);
+                    _pruneIntentAndNotify(intentHash);
                 }
             }
         }
@@ -348,10 +355,11 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
      * @notice ANYONE: Cleans up orphaned intents that were pruned from the Escrow but not from the Orchestrator.
      * An intent is considered orphaned if it exists on the Orchestrator but no longer exists on the Escrow.
      * This can happen when Escrow._tryOrchestratorPruneIntents runs out of gas and the revert is silently caught.
+     * @dev Guarded because cleanup invokes an external lifecycle callback during resolution.
      *
      * @param _intentHashes    Array of intent hashes to check and clean up
      */
-    function cleanupOrphanedIntents(bytes32[] calldata _intentHashes) external {
+    function cleanupOrphanedIntents(bytes32[] calldata _intentHashes) external nonReentrant {
         for (uint256 i = 0; i < _intentHashes.length; i++) {
             bytes32 intentHash = _intentHashes[i];
             Intent memory intent = intents[intentHash];
@@ -367,12 +375,30 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
 
             // If intent doesn't exist on escrow, it's orphaned — prune it
             if (escrowIntent.intentHash == bytes32(0)) {
-                _pruneIntent(intentHash);
+                _pruneIntentAndNotify(intentHash);
+            }
             }
         }
-    }
 
     /* ============ Governance Functions ============ */
+
+    /**
+     * @notice GOVERNANCE ONLY: Updates the global lifecycle hook used by future intents.
+     * @dev Existing intents retain their snapshotted hook. The zero address disables callbacks
+     * for future intents.
+     *
+     * @param _hook   New global lifecycle hook
+     */
+    function setLifecycleHook(IIntentLifecycleHook _hook) external onlyOwner {
+        address hookAddress = address(_hook);
+        if (hookAddress != address(0) && hookAddress.code.length == 0) {
+            revert InvalidLifecycleHook(hookAddress);
+        }
+
+        address previousHook = address(lifecycleHook);
+        lifecycleHook = _hook;
+        emit LifecycleHookUpdated(previousHook, hookAddress);
+    }
 
     /**
      * @notice GOVERNANCE ONLY: Updates the escrow registry address.
@@ -473,15 +499,33 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         return depositPreIntentHooks[_escrow][_depositId];
     }
 
-    function getDepositWhitelistHook(address _escrow, uint256 _depositId) external view returns (IPreIntentHook) {
-        return depositWhitelistHooks[_escrow][_depositId];
-    }
-
     function getIntentMinAtSignal(bytes32 _intentHash) external view returns (uint256) {
         return intentMinAtSignal[_intentHash];
     }
 
+    /**
+     * @notice Returns the immutable hook snapshot for an active intent.
+     */
+    function getIntentLifecycleHook(bytes32 _intentHash) external view returns (IIntentLifecycleHook) {
+        return intentLifecycleHooks[_intentHash];
+    }
+
     /* ============ Internal Functions ============ */
+
+    /**
+     * @notice Prunes a cancelled (cancel / escrow prune / orphan cleanup) intent, then executes the fail-closed
+     * cancellation callback on the snapshotted lifecycle hook. A reverting hook aborts the entire cancellation,
+     * including escrow prune and withdrawal flows that prune expired intents.
+     */
+    function _pruneIntentAndNotify(bytes32 _intentHash) internal {
+        IIntentLifecycleHook snapshottedLifecycleHook = intentLifecycleHooks[_intentHash];
+        _pruneIntent(_intentHash);
+        delete intentLifecycleHooks[_intentHash];
+
+        if (address(snapshottedLifecycleHook) != address(0)) {
+            snapshottedLifecycleHook.onIntentCancelled(_intentHash);
+        }
+    }
 
     /**
      * @notice Validates an intent before it is signaled.
@@ -613,96 +657,39 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
     }
 
     /**
-     * @notice Calculates and transfers fees to the protocol fee recipient and referrer.
-     */
-    function _calculateAndTransferFees(
-        IERC20 _token,
-        bytes32 _intentHash,
-        Intent memory _intent, 
-        uint256 _releaseAmount,
-        address _managerFeeRecipient,
-        uint256 _managerFee
-    ) internal returns (uint256 netFees) {
-        uint256 protocolFeeAmount;
-        uint256 referralFeeAmount;
-        uint256 managerFeeAmount;
-
-        // Calculate protocol fee (taken from taker) - based on release amount
-        if (protocolFeeRecipient != address(0) && protocolFee > 0) {
-            protocolFeeAmount = (_releaseAmount * protocolFee) / PRECISE_UNIT;
-            _token.safeTransfer(protocolFeeRecipient, protocolFeeAmount);
-        }
-        
-        // Calculate referral fees (taken from taker) - based on release amount
-        for (uint256 i = 0; i < _intent.referralFees.length; ++i) {
-            IReferralFee.ReferralFee memory referralFee = _intent.referralFees[i];
-            uint256 feeAmount = (_releaseAmount * referralFee.fee) / PRECISE_UNIT;
-            referralFeeAmount += feeAmount;
-            _token.safeTransfer(referralFee.recipient, feeAmount);
-            emit IntentReferralFeeDistributed(_intentHash, referralFee.recipient, feeAmount);
-        }
-
-        // Calculate manager fee (taken from taker) - based on release amount
-        if (_managerFeeRecipient != address(0) && _managerFee > 0) {
-            managerFeeAmount = (_releaseAmount * _managerFee) / PRECISE_UNIT;
-            _token.safeTransfer(_managerFeeRecipient, managerFeeAmount);
-        }
-
-        netFees = protocolFeeAmount + referralFeeAmount + managerFeeAmount;
-    }
-
-    /**
-     * @notice Transfers funds to the intent recipient. Called by manual release.
-     */
-    function _collectFeesAndTransferFunds(
-        IERC20 _token, 
-        bytes32 _intentHash, 
-        Intent memory _intent,
-        uint256 _releaseAmount,
-        address _managerFeeRecipient,
-        uint256 _managerFee
-    ) internal {
-        uint256 netFees = _calculateAndTransferFees(
-            _token,
-            _intentHash,
-            _intent,
-            _releaseAmount,
-            _managerFeeRecipient,
-            _managerFee
-        );
-        uint256 netAmount = _releaseAmount - netFees;
-
-        _token.safeTransfer(_intent.to, netAmount);
-
-        emit IntentFulfilled(
-            _intentHash, 
-            _intent.to, 
-            netAmount, 
-            true
-        );
-    }
-
-    /**
-     * @notice Handles fee calculations and transfers, then executes any post-intent hooks if present. Called by fulfillIntent.
+     * @notice Transfers fees, notifies the snapshotted lifecycle hook of settlement (fail-closed), then routes the
+     * executable remainder through the post-intent hook or directly to the recipient.
+     * @dev A reverting lifecycle hook aborts the entire settlement, including the preceding fee transfers.
+     * The lifecycle hook receives no token allowance and cannot move settlement funds.
      */
     function _collectFeesTransferFundsAndExecuteAction(
-        IERC20 _token, 
-        bytes32 _intentHash, 
-        Intent memory _intent, 
+        IERC20 _token,
+        bytes32 _intentHash,
+        Intent memory _intent,
         uint256 _releaseAmount,
         bytes memory _postIntentHookData,
         address _managerFeeRecipient,
-        uint256 _managerFee
+        uint256 _managerFee,
+        bool _isManualRelease
     ) internal {
-        uint256 netFees = _calculateAndTransferFees(
-            _token,
-            _intentHash,
-            _intent,
-            _releaseAmount,
-            _managerFeeRecipient,
-            _managerFee
-        );
+        IIntentLifecycleHook snapshottedLifecycleHook = intentLifecycleHooks[_intentHash];
+        delete intentLifecycleHooks[_intentHash];
+
+        uint256 netFees = _calculateAndTransferFees(_token, _intentHash, _intent, _releaseAmount, _managerFeeRecipient, _managerFee);
         uint256 netAmount = _releaseAmount - netFees;
+
+        if (address(snapshottedLifecycleHook) != address(0)) {
+            snapshottedLifecycleHook.settleIntent(
+                IIntentLifecycleHook.SettlementContext({
+                    intentHash: _intentHash,
+                    token: address(_token),
+                    recipient: _intent.to,
+                    grossAmount: _releaseAmount,
+                    executableAmount: netAmount,
+                    isManualRelease: _isManualRelease
+                })
+            );
+        }
 
         address fundsTransferredTo = _intent.to;
         if (address(_intent.postIntentHook) != address(0)) {
@@ -751,8 +738,44 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
             _intentHash, 
             fundsTransferredTo, 
             netAmount, 
-            false
+            _isManualRelease
         );
+    }
+
+    function _calculateAndTransferFees(
+        IERC20 _token,
+        bytes32 _intentHash,
+        Intent memory _intent, 
+        uint256 _releaseAmount,
+        address _managerFeeRecipient,
+        uint256 _managerFee
+    ) internal returns (uint256 netFees) {
+        uint256 protocolFeeAmount;
+        uint256 referralFeeAmount;
+        uint256 managerFeeAmount;
+
+        // Calculate protocol fee (taken from taker) - based on release amount
+        if (protocolFeeRecipient != address(0) && protocolFee > 0) {
+            protocolFeeAmount = (_releaseAmount * protocolFee) / PRECISE_UNIT;
+            _token.safeTransfer(protocolFeeRecipient, protocolFeeAmount);
+        }
+        
+        // Calculate referral fees (taken from taker) - based on release amount
+        for (uint256 i = 0; i < _intent.referralFees.length; ++i) {
+            IReferralFee.ReferralFee memory referralFee = _intent.referralFees[i];
+            uint256 feeAmount = (_releaseAmount * referralFee.fee) / PRECISE_UNIT;
+            referralFeeAmount += feeAmount;
+            _token.safeTransfer(referralFee.recipient, feeAmount);
+            emit IntentReferralFeeDistributed(_intentHash, referralFee.recipient, feeAmount);
+        }
+
+        // Calculate manager fee (taken from taker) - based on release amount
+        if (_managerFeeRecipient != address(0) && _managerFee > 0) {
+            managerFeeAmount = (_releaseAmount * _managerFee) / PRECISE_UNIT;
+            _token.safeTransfer(_managerFeeRecipient, managerFeeAmount);
+        }
+
+        netFees = protocolFeeAmount + referralFeeAmount + managerFeeAmount;
     }
 
     /**

--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -291,9 +291,9 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
     /**
      * @notice Allows depositor to release funds to the payer in case of a failed fulfill intent or because of some other arrangement
      * between the two parties. Upon submission we check to make sure the msg.sender is the depositor, the intent is removed, and 
-     * escrow state is updated. Manual release routes through the shared post-funds lifecycle-settlement gate, then transfers
-     * the deposit token directly to the payer. It does not execute the taker's post-intent hook because fulfillment-time
-     * hook data is unavailable on this depositor-controlled recovery path.
+     * escrow state is updated. Manual release routes through the shared post-funds lifecycle-settlement gate, then executes the
+     * configured post-intent hook with empty fulfillment-time data or transfers the deposit token directly to the payer when
+     * no hook is configured.
      *
      * @param _intentHash        Hash of intent to resolve by releasing the funds
      */
@@ -700,8 +700,8 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
      * @notice Transfers fees, notifies the snapshotted lifecycle hook of settlement (fail-closed), then routes the
      * executable remainder through the post-intent hook or directly to the recipient.
      * @dev A reverting lifecycle hook aborts the entire settlement, including the preceding fee transfers.
-     * The lifecycle hook receives no token allowance and cannot move settlement funds. Manual release bypasses the
-     * post-intent hook because that recovery path has no fulfillment-time hook data.
+     * The lifecycle hook receives no token allowance and cannot move settlement funds. Manual release executes the configured
+     * post-intent hook with empty fulfillment-time data or transfers directly to the recipient when no hook is configured.
      */
     function _collectFeesTransferFundsAndExecuteAction(
         IERC20 _token,
@@ -733,7 +733,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         }
 
         address fundsTransferredTo = _intent.to;
-        if (!_isManualRelease && address(_intent.postIntentHook) != address(0)) {
+        if (address(_intent.postIntentHook) != address(0)) {
             // Snapshot balance to enforce exact consumption by the hook
             uint256 preBalance = _token.balanceOf(address(this));
 

--- a/contracts/StakeVault.sol
+++ b/contracts/StakeVault.sol
@@ -1,0 +1,632 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+
+import {IStakeVault} from "./interfaces/IStakeVault.sol";
+
+/**
+ * @title StakeVault
+ * @notice Policy-agnostic custody, delegation, lock, and immediately claimable token accounting.
+ *
+ * @dev ACCOUNTING MODEL
+ *      Stake principal belongs to a `stakeOwner` and is split into locked and free amounts:
+ *
+ *        freeStake(owner) = stakeBalance(owner) - lockedStake(owner)
+ *        totalAccounted() = totalStaked + totalClaimable
+ *
+ *      Creating, increasing, resizing, or unlocking a lock only moves principal between locked and free accounting.
+ *      Resolving a lock may move some principal from `totalStaked` into beneficiary `claimable` balances; every
+ *      unallocated unit becomes free stake of the original owner. Claims are immediately withdrawable and are never
+ *      stake. `fundLock` is the sole path that adopts tokens already transferred into the vault as new locked stake.
+ *
+ * @dev DELEGATION MODEL
+ *      A stake owner may authorize any number of takers, and each taker explicitly selects at most one authorized owner.
+ *      Authorizations are additive: one owner's authorization never overwrites another's, and a taker can always fall
+ *      back to its own stake. Delegation never transfers ownership, custody rights, or withdrawal rights. Revocation
+ *      clears an active selection for future policy reads but cannot alter locks already created for that owner.
+ *
+ * @dev LOCK AND CONTROLLER MODEL
+ *      The vault deliberately knows nothing about intents, fees, chargebacks, or lock purpose. Lock IDs and beneficiary
+ *      allocations are opaque controller inputs. A lock maturity prevents further increase or resize once reached, but
+ *      does not automatically resolve the lock; the controller remains responsible for choosing whether and how every
+ *      lock is unlocked or converted into claims. `NEVER_MATURES` represents exposure requiring an explicit controller
+ *      transition on all paths.
+ *
+ *      Controller replacement is delayed, but accepted authority is global: the new controller immediately gains the
+ *      same power over existing and future locks. The owner can cancel a pending handover during the delay and cannot
+ *      renounce ownership, preserving a governance recovery path.
+ *
+ * @dev SECURITY INVARIANTS AND RATIONALE
+ *      1. Only free stake may be withdrawn or newly locked. Existing locks remain fully backed in aggregate accounting.
+ *      2. Lock IDs are globally unique while active, preventing one owner's lock from colliding with another's.
+ *      3. Only the controller can create, resize, unlock, fund, or resolve locks. The controller must enforce all policy,
+ *         including whether a named stake owner authorized the economic action; the vault enforces accounting only.
+ *      4. Resolution conserves liabilities: claim allocations cannot exceed the lock, and unclaimed remainder stays with
+ *         the stake owner rather than being transferred to the controller.
+ *      5. Deposits require an exact token balance delta. Funded locks can adopt only balance already held above existing
+ *         liabilities, while the controller remains responsible for transfer-specific delta checks. The controller never
+ *         takes custody.
+ *      6. User withdrawals and claims apply accounting effects before token interactions and are reentrancy guarded.
+ *      7. Initializing an omitted controller is allowed only before any stake or claim liabilities exist. Later controller
+ *         replacements always use the configured handover delay.
+ */
+contract StakeVault is IStakeVault, Ownable2Step, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    /* ============ Constants ============ */
+
+    /// @notice Minimum governance delay allowed for controller replacement.
+    uint64 public constant MIN_CONTROLLER_CHANGE_DELAY = 1 days;
+
+    /// @notice Sentinel maturity for locks that must never become mature through passage of practical time.
+    uint64 public constant NEVER_MATURES = type(uint64).max;
+
+    /* ============ Immutable Configuration ============ */
+
+    /// @notice Token held and accounted by the vault.
+    IERC20 public immutable override stakeToken;
+
+    /// @notice Delay between controller proposal and acceptance eligibility.
+    uint64 public immutable override controllerChangeDelay;
+
+    /* ============ Controller State ============ */
+
+    /// @notice Address with authority over every active and future lock.
+    address public override controller;
+
+    /// @notice Proposed replacement controller, or zero when no handover is pending.
+    address public override pendingController;
+
+    /// @notice Earliest timestamp at which the pending controller may accept authority.
+    uint64 public override pendingControllerValidAt;
+
+    /* ============ Stake and Claim State ============ */
+
+    /// @notice Total principal owned by each stake owner, including both free and locked stake.
+    mapping(address => uint256) public override stakeBalance;
+
+    /// @notice Principal committed across all active locks for each stake owner.
+    mapping(address => uint256) public override lockedStake;
+
+    /// @notice Immediately withdrawable, non-stake token balance credited to each beneficiary.
+    mapping(address => uint256) public override claimable;
+
+    /// @notice Active lock accounting keyed by controller-defined globally unique identifiers.
+    mapping(bytes32 => StakeLock) public override locks;
+
+    /* ============ Delegation State ============ */
+
+    /// @notice Whether a stake owner permits a taker to select its stake for future controller policy reads.
+    mapping(address => mapping(address => bool)) public override authorizedTakers;
+
+    /// @notice Stake owner explicitly selected by each taker, subject to live authorization.
+    mapping(address => address) public override selectedStakeOwner;
+
+    /// @notice Aggregate stake principal liability across all owners.
+    uint256 public override totalStaked;
+
+    /// @notice Aggregate immediately withdrawable claim liability across all beneficiaries.
+    uint256 public override totalClaimable;
+
+    /* ============ Modifiers ============ */
+
+    /**
+     * @dev Restricts lock and claim-allocation transitions to the current global controller.
+     */
+    modifier onlyController() {
+        if (msg.sender != controller) revert UnauthorizedController(msg.sender);
+        _;
+    }
+
+    /* ============ Constructor ============ */
+
+    /**
+     * @notice Creates a token vault with an optional initial controller and delayed controller replacement.
+     * @dev `_controller` may be zero to break circular deployment dependencies; it can then be initialized exactly once
+     *      before any liabilities exist. The owner and token must be non-zero, and the handover delay must be at least
+     *      one day. Future ownership transfers use Ownable2Step.
+     * @param _owner Governance owner responsible for controller selection and recovery.
+     * @param _stakeToken Token held and accounted by the vault.
+     * @param _controller Initial global lock-policy controller, or zero for later liability-free initialization.
+     * @param _controllerChangeDelay Delay required before a proposed replacement controller may accept authority.
+     */
+    constructor(address _owner, IERC20 _stakeToken, address _controller, uint64 _controllerChangeDelay) {
+        if (_owner == address(0) || address(_stakeToken) == address(0)) revert ZeroAddress();
+        if (_controllerChangeDelay < MIN_CONTROLLER_CHANGE_DELAY) {
+            revert InvalidControllerChangeDelay(_controllerChangeDelay);
+        }
+
+        stakeToken = _stakeToken;
+        controller = _controller;
+        controllerChangeDelay = _controllerChangeDelay;
+        _transferOwnership(_owner);
+    }
+
+    /* ============ User Stake and Claim Accounting ============ */
+
+    /**
+     * @notice Deposits stake-token principal owned exclusively by the caller.
+     * @dev Pulls exactly `_amount` from the caller and verifies the vault's balance increased by that amount before
+     *      crediting stake. Fee-on-transfer and rebasing behavior that changes the observed delta is rejected. Deposited
+     *      principal begins as free stake and does not affect delegation selections or authorizations.
+     * @param _amount Amount of stake token to transfer into and credit within the vault.
+     */
+    function depositStake(uint256 _amount) external override nonReentrant {
+        if (_amount == 0) revert ZeroAmount();
+
+        uint256 balanceBefore = stakeToken.balanceOf(address(this));
+        stakeToken.safeTransferFrom(msg.sender, address(this), _amount);
+        uint256 balanceAfter = stakeToken.balanceOf(address(this));
+        uint256 received = balanceAfter > balanceBefore ? balanceAfter - balanceBefore : 0;
+        if (received != _amount) revert InvalidReceivedAmount(_amount, received);
+
+        stakeBalance[msg.sender] += _amount;
+        totalStaked += _amount;
+        emit StakeDeposited(msg.sender, _amount, stakeBalance[msg.sender]);
+    }
+
+    /**
+     * @notice Withdraws caller-owned free stake directly to the caller.
+     * @dev Reverts unless the complete amount is free; active locks are never implicitly matured, resolved, or resized.
+     *      Accounting is reduced before the token transfer and the function is reentrancy guarded.
+     * @param _amount Amount of free stake principal to withdraw.
+     */
+    function withdrawStake(uint256 _amount) external override nonReentrant {
+        if (_amount == 0) revert ZeroAmount();
+        uint256 available = freeStake(msg.sender);
+        if (available < _amount) revert InsufficientFreeStake(msg.sender, available, _amount);
+
+        stakeBalance[msg.sender] -= _amount;
+        totalStaked -= _amount;
+        emit StakeWithdrawn(msg.sender, _amount, stakeBalance[msg.sender]);
+        stakeToken.safeTransfer(msg.sender, _amount);
+    }
+
+    /**
+     * @notice Withdraws the caller's complete immediately claimable balance.
+     * @dev Claims are separate from stake principal and cannot be delegated or used for locks. The claim balance and
+     *      aggregate claim liability are cleared before the token transfer. Partial claim withdrawal is intentionally
+     *      unsupported, keeping claim settlement to one state transition per beneficiary withdrawal.
+     */
+    function claim() external override nonReentrant {
+        uint256 amount = claimable[msg.sender];
+        if (amount == 0) revert ZeroAmount();
+
+        claimable[msg.sender] = 0;
+        totalClaimable -= amount;
+        emit ClaimWithdrawn(msg.sender, amount);
+        stakeToken.safeTransfer(msg.sender, amount);
+    }
+
+    /* ============ Delegation ============ */
+
+    /**
+     * @notice Authorizes or revokes a taker's ability to select the caller's stake for future policy reads.
+     * @dev The caller remains the stake owner and retains all deposit and withdrawal rights. Revoking the authorization
+     *      automatically clears the taker's selection if it currently points to the caller. Existing locks remain owned
+     *      by and charged against the original stake owner. Self-authorization is unnecessary because every taker falls
+     *      back to its own stake when it has no valid selection.
+     * @param _taker Taker whose authorization is being changed.
+     * @param _authorized True to authorize selection of the caller's stake; false to revoke it.
+     */
+    function setTakerAuthorization(address _taker, bool _authorized) external override {
+        if (_taker == address(0) || _taker == msg.sender) revert InvalidTaker(_taker);
+
+        authorizedTakers[msg.sender][_taker] = _authorized;
+        emit TakerAuthorizationUpdated(msg.sender, _taker, _authorized);
+
+        if (!_authorized && selectedStakeOwner[_taker] == msg.sender) {
+            delete selectedStakeOwner[_taker];
+            emit StakeOwnerSelected(_taker, msg.sender, address(0));
+        }
+    }
+
+    /**
+     * @notice Selects an authorizing third-party stake owner for the caller's future policy reads.
+     * @dev Selection does not lock or transfer funds and overwrites only the caller's previous selection. The named owner
+     *      must currently authorize the caller. Selecting oneself or zero is unsupported; use `clearStakeOwner` to return
+     *      to the implicit self-staking fallback.
+     * @param _stakeOwner Authorized third party whose stake the caller wants future policy to resolve.
+     */
+    function selectStakeOwner(address _stakeOwner) external override {
+        if (_stakeOwner == address(0) || _stakeOwner == msg.sender) revert ZeroAddress();
+        if (!authorizedTakers[_stakeOwner][msg.sender]) {
+            revert UnauthorizedStakeOwner(msg.sender, _stakeOwner);
+        }
+
+        address previousStakeOwner = selectedStakeOwner[msg.sender];
+        selectedStakeOwner[msg.sender] = _stakeOwner;
+        emit StakeOwnerSelected(msg.sender, previousStakeOwner, _stakeOwner);
+    }
+
+    /**
+     * @notice Clears the caller's selected third-party stake owner and restores the self-staking fallback.
+     * @dev Does not change any owner's authorization mapping and cannot alter existing locks. Emits an event even when no
+     *      selection was active, allowing indexers to treat the call as an explicit preference reset.
+     */
+    function clearStakeOwner() external override {
+        address previousStakeOwner = selectedStakeOwner[msg.sender];
+        delete selectedStakeOwner[msg.sender];
+        emit StakeOwnerSelected(msg.sender, previousStakeOwner, address(0));
+    }
+
+    /* ============ Controller Lock Accounting ============ */
+
+    /**
+     * @notice CONTROLLER ONLY: Creates a new lock backed by an owner's existing free stake.
+     * @dev The lock ID must be non-zero and globally unused, the owner and amount must be non-zero, and maturity must be
+     *      strictly in the future. This function does not consult delegation state; authorization and lock purpose are
+     *      controller policy. Principal remains in `stakeBalance` while `lockedStake` increases by the lock amount.
+     * @param _stakeOwner Owner whose free stake backs the new lock.
+     * @param _lockId Controller-defined globally unique identifier for the active lock.
+     * @param _amount Amount of existing free stake to commit.
+     * @param _maturesAt Timestamp after which this lock can no longer be increased or resized.
+     */
+    function lockStake(address _stakeOwner, bytes32 _lockId, uint256 _amount, uint64 _maturesAt)
+        external
+        override
+        onlyController
+    {
+        _validateNewLock(_stakeOwner, _lockId, _amount, _maturesAt);
+        _requireFreeStake(_stakeOwner, _amount);
+        _storeLock(_stakeOwner, _lockId, _amount, _maturesAt);
+    }
+
+    /**
+     * @notice CONTROLLER ONLY: Adopts unaccounted vault tokens as new stake and immediately locks them.
+     * @dev Intended for atomic flows that transfer tokens directly to StakeVault before calling this function. The vault
+     *      must hold at least `_amount` above existing stake and claim liabilities. Funding increases the named owner's
+     *      stake balance and aggregate stake, then commits the complete amount under a validated new lock. Any excess
+     *      unaccounted tokens remain available for a later funding operation.
+     * @param _stakeOwner Owner credited with the newly accounted stake.
+     * @param _lockId Controller-defined globally unique identifier for the active lock.
+     * @param _amount Amount of unaccounted token balance to adopt and lock.
+     * @param _maturesAt Timestamp after which this lock can no longer be increased or resized.
+     */
+    function fundLock(address _stakeOwner, bytes32 _lockId, uint256 _amount, uint64 _maturesAt)
+        external
+        override
+        onlyController
+    {
+        _validateNewLock(_stakeOwner, _lockId, _amount, _maturesAt);
+        uint256 available = unaccountedBalance();
+        if (available < _amount) revert InsufficientUnaccountedTokens(available, _amount);
+
+        stakeBalance[_stakeOwner] += _amount;
+        totalStaked += _amount;
+        emit LockFunded(_lockId, _stakeOwner, _amount, stakeBalance[_stakeOwner]);
+        _storeLock(_stakeOwner, _lockId, _amount, _maturesAt);
+    }
+
+    /**
+     * @notice CONTROLLER ONLY: Adds owner free stake to an active lock without changing its maturity.
+     * @dev The lock must exist and remain strictly before maturity. Only the incremental amount is checked against the
+     *      owner's current free stake; principal and aggregate stake liabilities are unchanged.
+     * @param _lockId Identifier of the active lock to increase.
+     * @param _additionalAmount Non-zero amount of owner free stake to add.
+     */
+    function increaseLock(bytes32 _lockId, uint256 _additionalAmount) external override onlyController {
+        if (_additionalAmount == 0) revert ZeroAmount();
+        StakeLock storage stakeLock = locks[_lockId];
+        if (stakeLock.stakeOwner == address(0)) revert LockNotFound(_lockId);
+
+        uint64 currentTime = _currentTimestamp();
+        if (currentTime >= stakeLock.maturesAt) {
+            revert LockAlreadyMatured(_lockId, stakeLock.maturesAt, currentTime);
+        }
+
+        address stakeOwner = stakeLock.stakeOwner;
+        _requireFreeStake(stakeOwner, _additionalAmount);
+        uint256 previousAmount = stakeLock.amount;
+        stakeLock.amount = previousAmount + _additionalAmount;
+        lockedStake[stakeOwner] += _additionalAmount;
+
+        emit StakeLockIncreased(_lockId, stakeOwner, previousAmount, stakeLock.amount, lockedStake[stakeOwner]);
+    }
+
+    /**
+     * @notice CONTROLLER ONLY: Decreases an active lock and replaces its maturity.
+     * @dev The existing lock must not already be mature, the new maturity must be strictly in the future, and the new
+     *      non-zero amount cannot exceed the current amount. A same-amount call may retime the lock; increases must use
+     *      `increaseLock`. Any removed amount immediately becomes free stake of the original owner.
+     * @param _lockId Identifier of the active lock to resize.
+     * @param _newAmount New non-zero locked amount, less than or equal to the current amount.
+     * @param _newMaturesAt Replacement maturity timestamp.
+     */
+    function resizeLock(bytes32 _lockId, uint256 _newAmount, uint64 _newMaturesAt) external override onlyController {
+        if (_newAmount == 0) revert ZeroAmount();
+        StakeLock storage stakeLock = locks[_lockId];
+        if (stakeLock.stakeOwner == address(0)) revert LockNotFound(_lockId);
+
+        uint64 currentTime = _currentTimestamp();
+        if (currentTime >= stakeLock.maturesAt) {
+            revert LockAlreadyMatured(_lockId, stakeLock.maturesAt, currentTime);
+        }
+        _validateMaturity(_newMaturesAt, currentTime);
+
+        uint256 previousAmount = stakeLock.amount;
+        if (_newAmount > previousAmount) revert InvalidLockAmount(_newAmount, previousAmount);
+
+        address stakeOwner = stakeLock.stakeOwner;
+        uint64 previousMaturity = stakeLock.maturesAt;
+        lockedStake[stakeOwner] -= previousAmount - _newAmount;
+        stakeLock.amount = _newAmount;
+        stakeLock.maturesAt = _newMaturesAt;
+
+        emit StakeLockResized(
+            _lockId, stakeOwner, previousAmount, _newAmount, previousMaturity, _newMaturesAt, lockedStake[stakeOwner]
+        );
+    }
+
+    /**
+     * @notice CONTROLLER ONLY: Deletes an active lock and returns its complete amount to owner free stake.
+     * @dev Unlocking is permitted before or after maturity because business policy belongs to the controller. No stake or
+     *      aggregate liability changes; only the lock record and owner's locked subtotal are reduced.
+     * @param _lockId Identifier of the active lock to delete.
+     */
+    function unlockStake(bytes32 _lockId) external override onlyController {
+        StakeLock memory stakeLock = _removeLock(_lockId);
+        emit StakeUnlocked(_lockId, stakeLock.stakeOwner, stakeLock.amount, lockedStake[stakeLock.stakeOwner]);
+    }
+
+    /**
+     * @notice CONTROLLER ONLY: Deletes an active lock and converts selected principal into beneficiary claims.
+     * @dev Resolution is permitted before or after maturity. Every allocation requires a non-zero beneficiary and amount,
+     *      and their sum cannot exceed the lock. Allocated principal moves atomically from the owner's stake liability to
+     *      immediately withdrawable claim liabilities; duplicate beneficiaries accumulate. The unallocated remainder
+     *      becomes owner free stake. An empty claim array is equivalent in accounting effect to an unlock.
+     * @param _lockId Identifier of the active lock to resolve.
+     * @param _claims Beneficiary allocations to create from the locked principal.
+     */
+    function resolveLock(bytes32 _lockId, Claim[] calldata _claims) external override onlyController {
+        StakeLock memory stakeLock = locks[_lockId];
+        if (stakeLock.stakeOwner == address(0)) revert LockNotFound(_lockId);
+
+        uint256 claimsAmount;
+        for (uint256 claimIndex = 0; claimIndex < _claims.length; claimIndex++) {
+            Claim calldata claimAllocation = _claims[claimIndex];
+            if (claimAllocation.beneficiary == address(0) || claimAllocation.amount == 0) {
+                revert InvalidClaim(claimAllocation.beneficiary, claimAllocation.amount);
+            }
+            claimsAmount += claimAllocation.amount;
+        }
+        if (claimsAmount > stakeLock.amount) revert ClaimsExceedLock(stakeLock.amount, claimsAmount);
+
+        _removeLock(_lockId);
+        if (claimsAmount != 0) {
+            stakeBalance[stakeLock.stakeOwner] -= claimsAmount;
+            totalStaked -= claimsAmount;
+            totalClaimable += claimsAmount;
+
+            for (uint256 claimIndex = 0; claimIndex < _claims.length; claimIndex++) {
+                Claim calldata claimAllocation = _claims[claimIndex];
+                claimable[claimAllocation.beneficiary] += claimAllocation.amount;
+                emit ClaimCreated(
+                    _lockId, claimAllocation.beneficiary, claimAllocation.amount, claimable[claimAllocation.beneficiary]
+                );
+            }
+        }
+
+        emit StakeLockResolved(
+            _lockId,
+            stakeLock.stakeOwner,
+            stakeLock.amount,
+            stakeLock.amount - claimsAmount,
+            claimsAmount,
+            lockedStake[stakeLock.stakeOwner]
+        );
+    }
+
+    /* ============ Controller Governance ============ */
+
+    /**
+     * @notice GOVERNANCE ONLY: Initializes controller authority when deployment intentionally omitted a controller.
+     * @dev This path is available only while `controller` is zero and both aggregate stake and claim liabilities are zero.
+     *      The liability check prevents governance from bypassing delayed handover after user funds are accounted. Once
+     *      initialized, every subsequent replacement must use proposal and delayed acceptance.
+     * @param _controller Non-zero initial controller address.
+     */
+    function initializeController(address _controller) external override onlyOwner {
+        if (_controller == address(0)) revert ZeroAddress();
+        if (controller != address(0)) revert ControllerAlreadyInitialized(controller);
+        if (totalStaked != 0 || totalClaimable != 0) {
+            revert ControllerInitializationWithLiabilities(totalStaked, totalClaimable);
+        }
+        controller = _controller;
+        emit ControllerInitialized(_controller);
+    }
+
+    /**
+     * @notice Ownership renunciation is disabled so governance always retains a delayed controller recovery path.
+     * @dev Always reverts for the owner; non-owners revert through the inherited ownership check first.
+     */
+    function renounceOwnership() public view override onlyOwner {
+        revert OwnershipRenunciationDisabled();
+    }
+
+    /**
+     * @notice GOVERNANCE ONLY: Proposes a replacement global controller subject to the immutable handover delay.
+     * @dev A new proposal overwrites any existing proposal and restarts the full delay. The current controller remains
+     *      authoritative until the proposed controller accepts after `pendingControllerValidAt`.
+     * @param _controller Non-zero address proposed to receive global lock authority.
+     */
+    function proposeController(address _controller) external override onlyOwner {
+        if (_controller == address(0)) revert ZeroAddress();
+        uint64 currentTime = _currentTimestamp();
+        uint64 validAt = currentTime + controllerChangeDelay;
+        pendingController = _controller;
+        pendingControllerValidAt = validAt;
+        emit ControllerProposed(controller, _controller, validAt);
+    }
+
+    /**
+     * @notice GOVERNANCE ONLY: Cancels the active controller replacement proposal.
+     * @dev Leaves the current controller unchanged and clears both pending-controller fields.
+     */
+    function cancelControllerProposal() external override onlyOwner {
+        address proposedController = pendingController;
+        if (proposedController == address(0)) revert NoPendingController();
+        delete pendingController;
+        delete pendingControllerValidAt;
+        emit ControllerProposalCancelled(proposedController);
+    }
+
+    /**
+     * @notice PENDING CONTROLLER ONLY: Accepts global lock authority after the handover delay.
+     * @dev The caller must equal the pending controller and the current timestamp must be at least the proposal's valid
+     *      timestamp. Acceptance immediately grants authority over all existing and future locks, then clears proposal
+     *      state. Governance cannot accept on the proposed controller's behalf.
+     */
+    function acceptController() external override {
+        address proposedController = pendingController;
+        if (proposedController == address(0)) revert NoPendingController();
+        if (msg.sender != proposedController) {
+            revert UnauthorizedPendingController(msg.sender, proposedController);
+        }
+
+        uint64 currentTime = _currentTimestamp();
+        uint64 validAt = pendingControllerValidAt;
+        if (currentTime < validAt) revert ControllerProposalNotReady(validAt, currentTime);
+
+        address previousController = controller;
+        controller = proposedController;
+        delete pendingController;
+        delete pendingControllerValidAt;
+        emit ControllerAccepted(previousController, proposedController);
+    }
+
+    /* ============ Views ============ */
+
+    /**
+     * @notice Resolves the stake owner used for a taker's future controller policy reads.
+     * @dev Returns the selected owner only while its authorization remains live; otherwise returns the taker itself.
+     *      Existing locks are independent of this live lookup and retain the owner stored in each lock.
+     * @param _taker Taker whose effective stake owner should be resolved.
+     * @return Effective stake owner for future policy decisions.
+     */
+    function stakeOwnerOf(address _taker) external view override returns (address) {
+        address selectedOwner = selectedStakeOwner[_taker];
+        if (selectedOwner != address(0) && authorizedTakers[selectedOwner][_taker]) return selectedOwner;
+        return _taker;
+    }
+
+    /**
+     * @notice Returns principal the owner may immediately withdraw or commit to another lock.
+     * @dev Derived from aggregate owner balances; lock creation and release maintain `lockedStake <= stakeBalance`.
+     * @param _stakeOwner Owner whose free principal should be calculated.
+     * @return Stake balance not committed to any active lock.
+     */
+    function freeStake(address _stakeOwner) public view override returns (uint256) {
+        return stakeBalance[_stakeOwner] - lockedStake[_stakeOwner];
+    }
+
+    /**
+     * @notice Returns whether an existing lock has reached or passed its recorded maturity.
+     * @dev Returns false for an unknown lock. Maturity does not automatically unlock or resolve principal; it only blocks
+     *      later increase and resize operations and can be used by controller policy to authorize a terminal transition.
+     * @param _lockId Identifier of the lock to inspect.
+     * @return True when the lock exists and its maturity is not later than the current block timestamp.
+     */
+    function isLockMature(bytes32 _lockId) external view override returns (bool) {
+        StakeLock memory stakeLock = locks[_lockId];
+        return stakeLock.stakeOwner != address(0) && block.timestamp >= stakeLock.maturesAt;
+    }
+
+    /**
+     * @notice Returns aggregate token liabilities represented by stake principal and beneficiary claims.
+     * @return Sum of `totalStaked` and `totalClaimable`.
+     */
+    function totalAccounted() public view override returns (uint256) {
+        return totalStaked + totalClaimable;
+    }
+
+    /**
+     * @notice Returns vault token balance available to be adopted through `fundLock`.
+     * @dev Direct transfers and settlement transfers are unaccounted until funded. The subtraction saturates at zero, so
+     *      an external token-balance deficit is not represented as a negative value and remains an insolvency condition.
+     * @return Token balance held above aggregate stake and claim liabilities.
+     */
+    function unaccountedBalance() public view override returns (uint256) {
+        uint256 tokenBalance = stakeToken.balanceOf(address(this));
+        uint256 accounted = totalAccounted();
+        return tokenBalance > accounted ? tokenBalance - accounted : 0;
+    }
+
+    /* ============ Internal Lock Helpers ============ */
+
+    /**
+     * @dev Validates common creation requirements without changing accounting. A lock ID may be reused only after its
+     *      previous lock has been deleted by unlock or resolution.
+     * @param _stakeOwner Non-zero owner to record on the lock.
+     * @param _lockId Non-zero globally unused active lock identifier.
+     * @param _amount Non-zero amount to lock.
+     * @param _maturesAt Maturity timestamp required to be strictly in the future.
+     */
+    function _validateNewLock(address _stakeOwner, bytes32 _lockId, uint256 _amount, uint64 _maturesAt) internal view {
+        if (_stakeOwner == address(0)) revert ZeroAddress();
+        if (_lockId == bytes32(0)) revert ZeroLockId();
+        if (_amount == 0) revert ZeroAmount();
+        if (locks[_lockId].stakeOwner != address(0)) revert LockAlreadyExists(_lockId);
+        _validateMaturity(_maturesAt, _currentTimestamp());
+    }
+
+    /**
+     * @dev Enforces a strictly future maturity; equality is already mature and therefore invalid for a new lock state.
+     * @param _maturesAt Proposed lock maturity.
+     * @param _currentTime Current checked timestamp.
+     */
+    function _validateMaturity(uint64 _maturesAt, uint64 _currentTime) internal pure {
+        if (_maturesAt <= _currentTime) revert InvalidMaturity(_maturesAt, _currentTime);
+    }
+
+    /**
+     * @dev Verifies that an owner can commit the requested principal. The subsequent lock write performs the accounting
+     *      transition by increasing `lockedStake`; this helper itself is intentionally read-only.
+     * @param _stakeOwner Owner whose free stake backs the operation.
+     * @param _amount Amount of free stake required.
+     */
+    function _requireFreeStake(address _stakeOwner, uint256 _amount) internal view {
+        uint256 available = freeStake(_stakeOwner);
+        if (available < _amount) revert InsufficientFreeStake(_stakeOwner, available, _amount);
+    }
+
+    /**
+     * @dev Writes a previously validated new lock and increases the owner's aggregate locked principal.
+     * @param _stakeOwner Owner recorded on the lock.
+     * @param _lockId Globally unused active lock identifier.
+     * @param _amount Amount of owner principal being committed.
+     * @param _maturesAt Recorded maturity timestamp.
+     */
+    function _storeLock(address _stakeOwner, bytes32 _lockId, uint256 _amount, uint64 _maturesAt) internal {
+        locks[_lockId] = StakeLock({stakeOwner: _stakeOwner, amount: _amount, maturesAt: _maturesAt});
+        lockedStake[_stakeOwner] += _amount;
+        emit StakeLocked(_lockId, _stakeOwner, _amount, _maturesAt, lockedStake[_stakeOwner]);
+    }
+
+    /**
+     * @dev Loads and deletes one active lock, returning its complete principal to the owner's free subtotal. Callers may
+     *      subsequently move some of that principal into claims as part of the same transaction.
+     * @param _lockId Identifier of the active lock to remove.
+     * @return stakeLock Deleted lock snapshot used by the caller's terminal accounting.
+     */
+    function _removeLock(bytes32 _lockId) internal returns (StakeLock memory stakeLock) {
+        stakeLock = locks[_lockId];
+        if (stakeLock.stakeOwner == address(0)) revert LockNotFound(_lockId);
+        delete locks[_lockId];
+        lockedStake[stakeLock.stakeOwner] -= stakeLock.amount;
+    }
+
+    /**
+     * @dev Returns the current block timestamp after checked narrowing to the lock timestamp width.
+     * @return Current EVM timestamp represented as `uint64`.
+     */
+    function _currentTimestamp() internal view returns (uint64) {
+        if (block.timestamp > type(uint64).max) revert TimestampOverflow(block.timestamp);
+        return uint64(block.timestamp);
+    }
+}

--- a/contracts/StakeVault.sol
+++ b/contracts/StakeVault.sol
@@ -39,7 +39,15 @@ import {IStakeVault} from "./interfaces/IStakeVault.sol";
  *
  *      Controller replacement is delayed, but accepted authority is global: the new controller immediately gains the
  *      same power over existing and future locks. The owner can cancel a pending handover during the delay and cannot
- *      renounce ownership, preserving a governance recovery path.
+ *      renounce ownership, preserving a governance recovery path. Governance must drain all active locks before replacing
+ *      a policy controller unless the replacement explicitly adopts the predecessor's lock state; the delay alone does
+ *      not give a new policy contract the state needed to resolve predecessor locks.
+ *
+ * @dev TOKEN ASSUMPTION
+ *      ZKP2P deployments configure the vault only with canonical USDC. USDC administration, upgrades, pauses, and
+ *      blocklisting remain accepted external operational risks. Tokens with transfer fees, rebasing, or other balance
+ *      transformations are unsupported; the exact inbound balance-delta check is defense in depth, not generic-token
+ *      compatibility.
  *
  * @dev SECURITY INVARIANTS AND RATIONALE
  *      1. Only free stake may be withdrawn or newly locked. Existing locks remain fully backed in aggregate accounting.
@@ -131,7 +139,7 @@ contract StakeVault is IStakeVault, Ownable2Step, ReentrancyGuard {
      *      before any liabilities exist. The owner and token must be non-zero, and the handover delay must be at least
      *      one day. Future ownership transfers use Ownable2Step.
      * @param _owner Governance owner responsible for controller selection and recovery.
-     * @param _stakeToken Token held and accounted by the vault.
+     * @param _stakeToken Canonical USDC token held and accounted by the vault.
      * @param _controller Initial global lock-policy controller, or zero for later liability-free initialization.
      * @param _controllerChangeDelay Delay required before a proposed replacement controller may accept authority.
      */
@@ -452,7 +460,8 @@ contract StakeVault is IStakeVault, Ownable2Step, ReentrancyGuard {
     /**
      * @notice GOVERNANCE ONLY: Proposes a replacement global controller subject to the immutable handover delay.
      * @dev A new proposal overwrites any existing proposal and restarts the full delay. The current controller remains
-     *      authoritative until the proposed controller accepts after `pendingControllerValidAt`.
+     *      authoritative until the proposed controller accepts after `pendingControllerValidAt`. Governance must drain
+     *      active locks first unless the replacement controller can adopt and resolve the predecessor's lock state.
      * @param _controller Non-zero address proposed to receive global lock authority.
      */
     function proposeController(address _controller) external override onlyOwner {
@@ -480,7 +489,8 @@ contract StakeVault is IStakeVault, Ownable2Step, ReentrancyGuard {
      * @notice PENDING CONTROLLER ONLY: Accepts global lock authority after the handover delay.
      * @dev The caller must equal the pending controller and the current timestamp must be at least the proposal's valid
      *      timestamp. Acceptance immediately grants authority over all existing and future locks, then clears proposal
-     *      state. Governance cannot accept on the proposed controller's behalf.
+     *      state. Governance cannot accept on the proposed controller's behalf. A policy controller must not accept while
+     *      predecessor locks remain unless it has an explicit migration/adoption path for those locks.
      */
     function acceptController() external override {
         address proposedController = pendingController;
@@ -509,10 +519,32 @@ contract StakeVault is IStakeVault, Ownable2Step, ReentrancyGuard {
      * @param _taker Taker whose effective stake owner should be resolved.
      * @return Effective stake owner for future policy decisions.
      */
-    function stakeOwnerOf(address _taker) external view override returns (address) {
+    function stakeOwnerOf(address _taker) public view override returns (address) {
         address selectedOwner = selectedStakeOwner[_taker];
         if (selectedOwner != address(0) && authorizedTakers[selectedOwner][_taker]) return selectedOwner;
         return _taker;
+    }
+
+    /**
+     * @notice Returns a taker's currently selected stake owner and that owner's aggregate stake balances.
+     * @dev Delegation is resolved live. If a previous authorization was revoked, the taker falls back to its own
+     *      stake and the returned balances describe the taker's account.
+     * @param _taker Taker whose effective stake owner and balances are queried.
+     * @return stakeOwner Effective owner supplying stake for the taker.
+     * @return totalStake Total principal owned by `stakeOwner`, including free and locked stake.
+     * @return lockedStakeAmount Principal currently committed to active locks.
+     * @return freeStakeAmount Principal currently available for withdrawal or new locks.
+     */
+    function getTakerState(address _taker)
+        external
+        view
+        override
+        returns (address stakeOwner, uint256 totalStake, uint256 lockedStakeAmount, uint256 freeStakeAmount)
+    {
+        stakeOwner = stakeOwnerOf(_taker);
+        totalStake = stakeBalance[stakeOwner];
+        lockedStakeAmount = lockedStake[stakeOwner];
+        freeStakeAmount = totalStake - lockedStakeAmount;
     }
 
     /**

--- a/contracts/hooks/ChargebackPolicy.sol
+++ b/contracts/hooks/ChargebackPolicy.sol
@@ -2,34 +2,33 @@
 
 pragma solidity ^0.8.18;
 
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
 import {IChargebackPolicy} from "../interfaces/IChargebackPolicy.sol";
 import {IChargebackVerifier} from "../interfaces/IChargebackVerifier.sol";
-import {IEscrowRegistry} from "../interfaces/IEscrowRegistry.sol";
 import {IEscrowV2} from "../interfaces/IEscrowV2.sol";
+import {INullifierRegistry} from "../interfaces/INullifierRegistry.sol";
 import {IStakeVault} from "../interfaces/IStakeVault.sol";
 
 /**
  * @title ChargebackPolicy
  * @notice Deposit-scoped, stake-backed chargeback coverage for intent settlement.
- * @dev The policy owns no tokens. It controls StakeVault locks and delegates chargeback evidence verification before
- * converting valid chargebacks into depositor claims.
- * `escrowRegistry` is governance-settable and MUST be kept in sync with the orchestrator's escrow registry, because
- * divergence can leave deposits admitted by one component but unavailable for depositor chargeback configuration.
+ * @dev The policy owns no tokens. StakeVault is the source of truth for collateral locks, a dedicated
+ * `chargebackNullifierRegistry` deployment is the source of truth for consumed dispute nullifiers, and the calling
+ * Orchestrator is the source of truth for valid escrows and intents.
  *
- * TRUST: Positions are keyed by intent hash, which embeds the originating orchestrator (OrchestratorV3 hashes its own
- * address into every intent hash), so identities never collide across orchestrators. Positions are NOT
- * orchestrator-bound: lifecycle entrypoints trust that every orchestrator admitted to OrchestratorRegistry (and
- * therefore able to reach this policy through the lifecycle hook) invokes callbacks only for intents it created. A
- * registered orchestrator that reported foreign intent hashes could cancel or settle another orchestrator's
- * coverage. Registering an orchestrator is a governance action that vouches for exactly this behavior. Rotating the
- * lifecycle hook keeps predecessors authorized so intents snapshotted to them can still cancel or settle; revoke a
- * predecessor only after its intents are drained, or their terminal callbacks revert fail-closed. Deregistering an
- * orchestrator while it has unresolved intents snapshotted to a hook permanently blocks those terminal callbacks,
- * so governance must drain its intents before removing it from OrchestratorRegistry.
+ * TRUST: Chargeback intents are keyed by intent hash, which embeds the originating orchestrator
+ * (OrchestratorV3 hashes its own address into every intent hash), so identities do not collide across orchestrators.
+ * Lifecycle entrypoints trust every orchestrator admitted by OrchestratorRegistry to invoke callbacks only for
+ * intents it created and already validated against its EscrowRegistry. Registering an orchestrator is therefore a
+ * governance assertion about its callback behavior.
+ *
+ * Governance must authorize a lifecycle hook here before configuring it on an Orchestrator. Predecessor hooks must
+ * remain authorized until all intents snapshotted to them have been cancelled or settled. Likewise, an orchestrator
+ * must be drained before it is removed from OrchestratorRegistry. This policy must also drain every active chargeback
+ * intent before StakeVault controller authority moves to a replacement policy unless that replacement explicitly adopts
+ * this policy's intent and lock state.
  */
 contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
     /* ============ Constants ============ */
@@ -39,51 +38,69 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
 
     /* ============ State Variables ============ */
 
-    IStakeVault public immutable override stakeVault;
-    IChargebackVerifier public override chargebackVerifier;
-    IEscrowRegistry public override escrowRegistry;
-    address public override lifecycleHook;
-    bool public override admissionsPaused;
+    /// @notice Stake custody and lock accounting controlled by this policy.
+    IStakeVault public immutable stakeVault;
 
-    mapping(address => bool) public override authorizedLifecycleHooks;
-    mapping(address => mapping(uint256 => bool)) public override enabled;
-    mapping(bytes32 => uint64) public override riskWindows;
-    mapping(bytes32 => Position) internal positions;
-    mapping(bytes32 => bool) public override usedChargebackNullifiers;
+    /// @notice Dedicated replay registry for payment-method-scoped chargeback dispute nullifiers.
+    INullifierRegistry public immutable chargebackNullifierRegistry;
+
+    /// @notice Verifier used to validate signed chargeback evidence.
+    IChargebackVerifier public chargebackVerifier;
+
+    /// @notice Whether new chargeback-backed admissions are paused. Terminal transitions remain available.
+    bool public admissionsPaused;
+
+    /// @dev Lifecycle-hook authorization keyed by lifecycle hook address.
+    mapping(address => bool) internal isLifecycleHookAuthorizedByHook;
+
+    /// @dev Deposit opt-in keyed first by escrow address and then by deposit id.
+    mapping(address => mapping(uint256 => bool)) internal isChargebackEnabledByEscrowAndDepositId;
+
+    /// @dev Minimum collateral lock window keyed by payment method.
+    mapping(bytes32 => uint64) internal riskWindowByPaymentMethod;
+
+    /// @dev Chargeback lifecycle state keyed by globally unique intent hash.
+    mapping(bytes32 => ChargebackIntent) internal chargebackIntentByIntentHash;
 
     /* ============ Constructor ============ */
 
+    /**
+     * @notice Creates a chargeback policy over one StakeVault and one dedicated dispute-nullifier registry.
+     * @dev After deployment, authorize this policy as the StakeVault controller and as a writer on the dedicated
+     * chargeback nullifier registry before enabling deposits.
+     * @param _owner Governance owner for policy and dependency configuration.
+     * @param _stakeVault Vault holding and locking taker collateral.
+     * @param _chargebackVerifier Verifier for signed chargeback evidence.
+     * @param _chargebackNullifierRegistry Dedicated registry that rejects reused dispute nullifiers.
+     */
     constructor(
         address _owner,
         IStakeVault _stakeVault,
         IChargebackVerifier _chargebackVerifier,
-        IEscrowRegistry _escrowRegistry
+        INullifierRegistry _chargebackNullifierRegistry
     ) {
         if (_owner == address(0)) revert ZeroAddress();
         _validateDependency(address(_stakeVault));
         _validateDependency(address(_chargebackVerifier));
-        _validateDependency(address(_escrowRegistry));
+        _validateDependency(address(_chargebackNullifierRegistry));
 
         stakeVault = _stakeVault;
         chargebackVerifier = _chargebackVerifier;
-        escrowRegistry = _escrowRegistry;
+        chargebackNullifierRegistry = _chargebackNullifierRegistry;
         _transferOwnership(_owner);
     }
 
     /* ============ Modifiers ============ */
 
     modifier onlyLifecycleHook() {
-        if (!authorizedLifecycleHooks[msg.sender]) revert UnauthorizedLifecycleHook(msg.sender);
+        if (!isLifecycleHookAuthorizedByHook[msg.sender]) {
+            revert UnauthorizedLifecycleHook(msg.sender);
+        }
         _;
     }
 
     modifier onlyDepositor(address _escrow, uint256 _depositId) {
-        if (!escrowRegistry.isWhitelistedEscrow(_escrow) && !escrowRegistry.isAcceptingAllEscrows()) {
-            revert EscrowNotWhitelisted(_escrow);
-        }
-
         address depositor = IEscrowV2(_escrow).getDeposit(_depositId).depositor;
-        if (depositor == address(0)) revert DepositNotFound(_escrow, _depositId);
         if (msg.sender != depositor) revert NotDepositor(_escrow, _depositId, msg.sender);
         _;
     }
@@ -91,9 +108,7 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
     /* ============ Lifecycle Functions ============ */
 
     /**
-     * @notice Opens stake-backed coverage for a chargeback-enabled intent.
-     * @dev A zero risk window passes through before paused, enabled, or duplicate checks because a
-     * non-chargebackable method uses direct access and pass-through is not an admission.
+     * @inheritdoc IChargebackPolicy
      */
     function onIntentSignaled(
         bytes32 _intentHash,
@@ -103,89 +118,71 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
         bytes32 _paymentMethod,
         uint256 _amount
     ) external override onlyLifecycleHook nonReentrant {
-        uint64 riskWindow = riskWindows[_paymentMethod];
+        uint64 riskWindow = riskWindowByPaymentMethod[_paymentMethod];
         if (riskWindow == 0) return;
 
-        if (admissionsPaused) revert AdmissionsPaused();
-        if (positions[_intentHash].status != PositionStatus.NONE) revert PositionAlreadyExists(_intentHash);
-        if (!enabled[_escrow][_depositId]) revert ChargebackNotEnabled(_escrow, _depositId);
+        (address stakeOwner, address depositor) = _validateIntentAdmission(_intentHash, _escrow, _depositId, _taker);
 
-        IEscrowV2.Deposit memory deposit = IEscrowV2(_escrow).getDeposit(_depositId);
-        address expectedToken = address(stakeVault.stakeToken());
-        if (address(deposit.token) != expectedToken) {
-            revert IntentTokenMismatch(expectedToken, address(deposit.token));
-        }
-
-        address stakeOwner = stakeVault.stakeOwnerOf(_taker);
-        uint256 available = stakeVault.freeStake(stakeOwner);
-        if (available < _amount) revert InsufficientCollateral(stakeOwner, available, _amount);
-
-        positions[_intentHash] = Position({
+        chargebackIntentByIntentHash[_intentHash] = ChargebackIntent({
             taker: _taker,
             stakeOwner: stakeOwner,
-            depositor: deposit.depositor,
+            depositor: depositor,
             paymentMethod: _paymentMethod,
-            status: PositionStatus.PENDING,
+            status: ChargebackIntentStatus.PENDING,
             isManualRelease: false,
             riskWindow: riskWindow,
-            coverageDeadline: 0,
-            intentAmount: _amount,
-            coverageAmount: _amount,
-            grossReleasedAmount: 0
+            releaseEligibleAt: 0,
+            releaseAmount: 0
         });
 
         stakeVault.lockStake(stakeOwner, _intentHash, _amount, PENDING_COVERAGE_MATURITY);
-        emit PositionOpened(
-            _intentHash, stakeOwner, deposit.depositor, _taker, _paymentMethod, _amount, riskWindow
-        );
+        emit ChargebackIntentOpened(_intentHash, stakeOwner, depositor, _taker, _paymentMethod, _amount, riskWindow);
     }
 
     /**
      * @inheritdoc IChargebackPolicy
      */
     function onIntentCancelled(bytes32 _intentHash) external override onlyLifecycleHook nonReentrant {
-        Position storage position = positions[_intentHash];
-        if (position.status == PositionStatus.NONE) return;
-        if (position.status != PositionStatus.PENDING) {
-            revert PositionNotPending(_intentHash, position.status);
+        ChargebackIntent storage chargebackIntent = chargebackIntentByIntentHash[_intentHash];
+        if (chargebackIntent.status == ChargebackIntentStatus.NONE) return;
+        if (chargebackIntent.status != ChargebackIntentStatus.PENDING) {
+            revert ChargebackIntentNotPending(_intentHash, chargebackIntent.status);
         }
 
-        uint256 releasedCoverage = position.coverageAmount;
-        position.coverageAmount = 0;
-        position.status = PositionStatus.CANCELLED;
+        (, uint256 releasedAmount,) = stakeVault.locks(_intentHash);
+        chargebackIntent.status = ChargebackIntentStatus.CANCELLED;
         stakeVault.unlockStake(_intentHash);
-        emit PositionCancelled(_intentHash, position.stakeOwner, releasedCoverage);
+        emit ChargebackIntentCancelled(_intentHash, chargebackIntent.stakeOwner, releasedAmount);
     }
 
     /**
      * @inheritdoc IChargebackPolicy
      */
-    function onIntentSettled(bytes32 _intentHash, uint256 _grossAmount, bool _isManualRelease)
+    function onIntentSettled(bytes32 _intentHash, uint256 _releaseAmount, bool _isManualRelease)
         external
         override
         onlyLifecycleHook
         nonReentrant
     {
-        Position storage position = positions[_intentHash];
-        if (position.status == PositionStatus.NONE) return;
-        if (position.status != PositionStatus.PENDING) {
-            revert PositionNotPending(_intentHash, position.status);
+        ChargebackIntent storage chargebackIntent = chargebackIntentByIntentHash[_intentHash];
+        if (chargebackIntent.status == ChargebackIntentStatus.NONE) return;
+        if (chargebackIntent.status != ChargebackIntentStatus.PENDING) {
+            revert ChargebackIntentNotPending(_intentHash, chargebackIntent.status);
         }
 
-        uint64 coverageDeadline = _calculateCoverageDeadline(position.riskWindow);
-        position.grossReleasedAmount = _grossAmount;
-        position.isManualRelease = _isManualRelease;
-        position.coverageDeadline = coverageDeadline;
-        position.coverageAmount = _grossAmount;
-        position.status = PositionStatus.SETTLED;
+        uint64 releaseEligibleAt = _calculateReleaseEligibleAt(chargebackIntent.riskWindow);
+        chargebackIntent.releaseAmount = _releaseAmount;
+        chargebackIntent.isManualRelease = _isManualRelease;
+        chargebackIntent.releaseEligibleAt = releaseEligibleAt;
+        chargebackIntent.status = ChargebackIntentStatus.SETTLED;
 
-        stakeVault.resizeLock(_intentHash, _grossAmount, coverageDeadline);
-        emit PositionSettled(
+        stakeVault.resizeLock(_intentHash, _releaseAmount, releaseEligibleAt);
+        emit ChargebackIntentSettled(
             _intentHash,
-            position.stakeOwner,
-            position.depositor,
-            _grossAmount,
-            coverageDeadline,
+            chargebackIntent.stakeOwner,
+            chargebackIntent.depositor,
+            _releaseAmount,
+            releaseEligibleAt,
             _isManualRelease
         );
     }
@@ -193,58 +190,53 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
     /* ============ Permissionless Functions ============ */
 
     /**
-     * @inheritdoc IChargebackPolicy
+     * @notice Releases collateral for one settled intent once its minimum risk window has elapsed.
+     * @dev Chargebacks remain valid after `releaseEligibleAt` until this release transaction executes.
+     * @param _intentHash Settled chargeback intent whose collateral should be unlocked.
      */
-    function releaseMaturedPosition(bytes32 _intentHash) external override nonReentrant {
-        _releaseMaturedPosition(_intentHash);
+    function releaseMaturedChargebackIntent(bytes32 _intentHash) external nonReentrant {
+        _releaseMaturedChargebackIntent(_intentHash);
     }
 
     /**
-     * @inheritdoc IChargebackPolicy
+     * @notice Releases collateral for a batch of settled intents whose minimum risk windows have elapsed.
+     * @dev The batch is atomic: one invalid or ineligible intent reverts every release in the call.
+     * @param _intentHashes Settled chargeback intents whose collateral should be unlocked.
      */
-    function releaseMaturedPositions(bytes32[] calldata _intentHashes) external override nonReentrant {
+    function releaseMaturedChargebackIntents(bytes32[] calldata _intentHashes) external nonReentrant {
         for (uint256 intentIndex = 0; intentIndex < _intentHashes.length; intentIndex++) {
-            _releaseMaturedPosition(_intentHashes[intentIndex]);
+            _releaseMaturedChargebackIntent(_intentHashes[intentIndex]);
         }
     }
 
     /**
-     * @inheritdoc IChargebackPolicy
+     * @notice Resolves valid chargeback evidence into an immediately claimable depositor award.
+     * @dev A settled intent remains chargebackable until its collateral release executes, even after
+     * `releaseEligibleAt`. The dedicated chargeback nullifier registry atomically rejects replayed disputes.
+     * @param _attestation Signed chargeback evidence for a settled intent.
      */
-    function submitChargeback(IChargebackVerifier.ChargebackAttestation calldata _attestation)
-        external
-        override
-        nonReentrant
-    {
-        Position storage position = positions[_attestation.intentHash];
-        if (position.status != PositionStatus.SETTLED) {
-            revert PositionNotSettled(_attestation.intentHash, position.status);
-        }
-        if (block.timestamp >= position.coverageDeadline) {
-            revert ChargebackWindowClosed(position.coverageDeadline, _currentTimestamp());
+    function submitChargeback(IChargebackVerifier.ChargebackAttestation calldata _attestation) external nonReentrant {
+        ChargebackIntent storage chargebackIntent = chargebackIntentByIntentHash[_attestation.intentHash];
+        if (chargebackIntent.status != ChargebackIntentStatus.SETTLED) {
+            revert ChargebackIntentNotSettled(_attestation.intentHash, chargebackIntent.status);
         }
 
-        (bytes32 disputeId, bytes32 disputeNullifier) =
-            chargebackVerifier.verifyChargeback(_attestation, position.paymentMethod, position.isManualRelease);
-        if (usedChargebackNullifiers[disputeNullifier]) revert ChargebackEvidenceUsed(disputeNullifier);
+        (bytes32 disputeId, bytes32 disputeNullifier) = chargebackVerifier.verifyChargeback(
+            _attestation, chargebackIntent.paymentMethod, chargebackIntent.isManualRelease
+        );
+        chargebackNullifierRegistry.addNullifier(disputeNullifier);
 
-        uint256 compensatedAmount = position.grossReleasedAmount;
-        if (position.coverageAmount != compensatedAmount) {
-            revert IncompleteChargebackCoverage(position.coverageAmount, compensatedAmount);
-        }
-
-        usedChargebackNullifiers[disputeNullifier] = true;
-        position.coverageAmount = 0;
-        position.status = PositionStatus.SLASHED;
+        uint256 compensatedAmount = chargebackIntent.releaseAmount;
+        chargebackIntent.status = ChargebackIntentStatus.CHARGED_BACK;
 
         IStakeVault.Claim[] memory claims = new IStakeVault.Claim[](1);
-        claims[0] = IStakeVault.Claim({beneficiary: position.depositor, amount: compensatedAmount});
+        claims[0] = IStakeVault.Claim({beneficiary: chargebackIntent.depositor, amount: compensatedAmount});
         stakeVault.resolveLock(_attestation.intentHash, claims);
 
         emit ChargebackSettled(
             _attestation.intentHash,
-            position.stakeOwner,
-            position.depositor,
+            chargebackIntent.stakeOwner,
+            chargebackIntent.depositor,
             compensatedAmount,
             disputeId
         );
@@ -253,32 +245,41 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
     /* ============ Depositor Functions ============ */
 
     /**
-     * @inheritdoc IChargebackPolicy
+     * @notice DEPOSITOR ONLY: Enables or disables chargeback-backed admission for a deposit.
+     * @dev OrchestratorV3 validates Escrow registration before signaling an intent. This policy only verifies that
+     * the caller is the deposit's current depositor.
+     * @param _escrow Escrow containing the deposit.
+     * @param _depositId Deposit whose chargeback configuration is updated.
+     * @param _isEnabled Whether non-whitelisted takers may use stake-backed chargeback admission.
      */
-    function setEnabled(address _escrow, uint256 _depositId, bool _enabled)
+    function setChargebackEnabled(address _escrow, uint256 _depositId, bool _isEnabled)
         external
-        override
         onlyDepositor(_escrow, _depositId)
     {
-        enabled[_escrow][_depositId] = _enabled;
-        emit EnabledUpdated(_escrow, _depositId, _enabled);
+        isChargebackEnabledByEscrowAndDepositId[_escrow][_depositId] = _isEnabled;
+        emit ChargebackEnabledUpdated(_escrow, _depositId, _isEnabled);
     }
 
     /* ============ Governance Functions ============ */
 
     /**
-     * @inheritdoc IChargebackPolicy
+     * @notice GOVERNANCE ONLY: Sets the minimum collateral lock window for future intents of a payment method.
+     * @dev Zero disables chargeback state and lets the lifecycle hook pass the payment method through without a lock.
+     * Existing chargeback intents retain their snapshotted risk window.
+     * @param _paymentMethod Payment method whose future risk window is updated.
+     * @param _riskWindow Minimum seconds collateral remains locked after settlement.
      */
-    function setRiskWindow(bytes32 _paymentMethod, uint64 _riskWindow) external override onlyOwner {
+    function setRiskWindow(bytes32 _paymentMethod, uint64 _riskWindow) external onlyOwner {
         if (_riskWindow > MAX_RISK_WINDOW) revert InvalidRiskWindow(_riskWindow);
-        riskWindows[_paymentMethod] = _riskWindow;
+        riskWindowByPaymentMethod[_paymentMethod] = _riskWindow;
         emit RiskWindowUpdated(_paymentMethod, _riskWindow);
     }
 
     /**
-     * @inheritdoc IChargebackPolicy
+     * @notice GOVERNANCE ONLY: Replaces the verifier used for future chargeback submissions.
+     * @param _verifier New non-zero deployed chargeback verifier.
      */
-    function setChargebackVerifier(address _verifier) external override onlyOwner {
+    function setChargebackVerifier(address _verifier) external onlyOwner {
         _validateDependency(_verifier);
         address previousVerifier = address(chargebackVerifier);
         chargebackVerifier = IChargebackVerifier(_verifier);
@@ -286,107 +287,129 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
     }
 
     /**
-     * @inheritdoc IChargebackPolicy
+     * @notice GOVERNANCE ONLY: Authorizes or revokes one lifecycle hook.
+     * @dev Authorize a hook before configuring it on an Orchestrator. Revoke a predecessor only after every intent
+     * snapshotted to it has been cancelled or settled.
+     * @param _hook Lifecycle hook whose callback authority is updated.
+     * @param _isAuthorized Whether the hook may mutate chargeback intent state.
      */
-    function setLifecycleHook(address _hook) external override onlyOwner {
-        _validateDependency(_hook);
-        address previousHook = lifecycleHook;
-        lifecycleHook = _hook;
-        authorizedLifecycleHooks[_hook] = true;
-        emit LifecycleHookUpdated(previousHook, _hook);
-        emit LifecycleHookAuthorizationUpdated(_hook, true);
+    function setLifecycleHookAuthorization(address _hook, bool _isAuthorized) external onlyOwner {
+        if (_isAuthorized) _validateDependency(_hook);
+        isLifecycleHookAuthorizedByHook[_hook] = _isAuthorized;
+        emit LifecycleHookAuthorizationUpdated(_hook, _isAuthorized);
     }
 
     /**
-     * @inheritdoc IChargebackPolicy
+     * @notice GOVERNANCE ONLY: Pauses or resumes new chargeback-backed admissions.
+     * @dev Cancellation, settlement, release, and chargeback submission remain available while admissions are paused.
+     * @param _isPaused Whether new chargeback admissions should revert.
      */
-    function revokeLifecycleHook(address _hook) external override onlyOwner {
-        if (_hook == lifecycleHook) revert CannotRevokeCurrentLifecycleHook(_hook);
-        if (!authorizedLifecycleHooks[_hook]) revert LifecycleHookNotAuthorized(_hook);
-        authorizedLifecycleHooks[_hook] = false;
-        emit LifecycleHookAuthorizationUpdated(_hook, false);
+    function setAdmissionsPaused(bool _isPaused) external onlyOwner {
+        admissionsPaused = _isPaused;
+        emit AdmissionsPausedUpdated(_isPaused);
     }
 
     /**
-     * @inheritdoc IChargebackPolicy
+     * @notice GOVERNANCE ONLY: Accepts this policy as StakeVault's controller after its handover delay.
+     * @dev Before replacing another policy, governance must drain its active chargeback intents or execute an explicit
+     * state-and-lock migration. Accepting controller authority alone cannot import the predecessor's intent state.
      */
-    function setEscrowRegistry(IEscrowRegistry _escrowRegistry) external override onlyOwner {
-        _validateDependency(address(_escrowRegistry));
-        escrowRegistry = _escrowRegistry;
-        emit EscrowRegistryUpdated(address(_escrowRegistry));
-    }
-
-    /**
-     * @inheritdoc IChargebackPolicy
-     */
-    function setAdmissionsPaused(bool _paused) external override onlyOwner {
-        admissionsPaused = _paused;
-        emit AdmissionsPausedUpdated(_paused);
-    }
-
-    /**
-     * @inheritdoc IChargebackPolicy
-     */
-    function acceptVaultController() external override onlyOwner {
+    function acceptVaultController() external onlyOwner {
         stakeVault.acceptController();
     }
 
     /**
      * @notice Disables ownership renunciation so governed safety controls cannot become unreachable.
      */
-    function renounceOwnership() public view override(IChargebackPolicy, Ownable) onlyOwner {
+    function renounceOwnership() public view override onlyOwner {
         revert OwnershipRenunciationDisabled();
     }
 
     /* ============ View Functions ============ */
 
     /**
-     * @inheritdoc IChargebackPolicy
+     * @notice Returns the stored chargeback state for an intent.
+     * @param _intentHash Intent whose chargeback state is queried.
      */
-    function getPosition(bytes32 _intentHash) external view override returns (Position memory) {
-        return positions[_intentHash];
+    function getChargebackIntent(bytes32 _intentHash) external view returns (ChargebackIntent memory) {
+        return chargebackIntentByIntentHash[_intentHash];
     }
 
     /**
      * @inheritdoc IChargebackPolicy
      */
-    function getTakerState(address _taker)
-        external
-        view
-        override
-        returns (address stakeOwner, uint256 totalStake, uint256 lockedStake, uint256 freeStake)
-    {
-        stakeOwner = stakeVault.stakeOwnerOf(_taker);
-        totalStake = stakeVault.stakeBalance(stakeOwner);
-        lockedStake = stakeVault.lockedStake(stakeOwner);
-        freeStake = stakeVault.freeStake(stakeOwner);
+    function isChargebackEnabled(address _escrow, uint256 _depositId) external view override returns (bool) {
+        return isChargebackEnabledByEscrowAndDepositId[_escrow][_depositId];
+    }
+
+    /**
+     * @notice Returns whether a lifecycle hook may mutate chargeback intent state.
+     * @param _hook Lifecycle hook whose callback authorization is queried.
+     */
+    function isLifecycleHookAuthorized(address _hook) external view returns (bool) {
+        return isLifecycleHookAuthorizedByHook[_hook];
+    }
+
+    /**
+     * @notice Returns the risk window applied to future intents for a payment method.
+     * @param _paymentMethod Payment method whose configured risk window is queried.
+     */
+    function getRiskWindow(bytes32 _paymentMethod) external view returns (uint64) {
+        return riskWindowByPaymentMethod[_paymentMethod];
     }
 
     /* ============ Internal Functions ============ */
 
-    function _releaseMaturedPosition(bytes32 _intentHash) internal {
-        Position storage position = positions[_intentHash];
-        if (position.status != PositionStatus.SETTLED) {
-            revert PositionNotSettled(_intentHash, position.status);
+    /**
+     * @dev Validates policy-owned admission requirements and returns the collateral owner and depositor to snapshot.
+     * StakeVault remains authoritative for collateral sufficiency and reverts from `lockStake` when free stake is
+     * insufficient.
+     */
+    function _validateIntentAdmission(bytes32 _intentHash, address _escrow, uint256 _depositId, address _taker)
+        internal
+        view
+        returns (address stakeOwner, address depositor)
+    {
+        if (admissionsPaused) revert AdmissionsPaused();
+        if (chargebackIntentByIntentHash[_intentHash].status != ChargebackIntentStatus.NONE) {
+            revert ChargebackIntentAlreadyExists(_intentHash);
+        }
+        if (!isChargebackEnabledByEscrowAndDepositId[_escrow][_depositId]) {
+            revert ChargebackNotEnabled(_escrow, _depositId);
+        }
+
+        IEscrowV2.Deposit memory deposit = IEscrowV2(_escrow).getDeposit(_depositId);
+        address expectedToken = address(stakeVault.stakeToken());
+        if (address(deposit.token) != expectedToken) {
+            revert IntentTokenMismatch(expectedToken, address(deposit.token));
+        }
+
+        stakeOwner = stakeVault.stakeOwnerOf(_taker);
+        depositor = deposit.depositor;
+    }
+
+    function _releaseMaturedChargebackIntent(bytes32 _intentHash) internal {
+        ChargebackIntent storage chargebackIntent = chargebackIntentByIntentHash[_intentHash];
+        if (chargebackIntent.status != ChargebackIntentStatus.SETTLED) {
+            revert ChargebackIntentNotSettled(_intentHash, chargebackIntent.status);
         }
 
         uint64 currentTime = _currentTimestamp();
-        uint64 coverageDeadline = position.coverageDeadline;
-        if (coverageDeadline == 0 || currentTime < coverageDeadline) {
-            revert PositionNotMature(coverageDeadline, currentTime);
+        uint64 releaseEligibleAt = chargebackIntent.releaseEligibleAt;
+        if (currentTime < releaseEligibleAt) {
+            revert ChargebackIntentNotReleaseEligible(releaseEligibleAt, currentTime);
         }
 
-        uint256 releasedCoverage = position.coverageAmount;
-        position.coverageAmount = 0;
-        position.status = PositionStatus.RELEASED;
+        uint256 releasedAmount = chargebackIntent.releaseAmount;
+        chargebackIntent.status = ChargebackIntentStatus.RELEASED;
         stakeVault.unlockStake(_intentHash);
-        emit PositionReleased(_intentHash, position.stakeOwner, releasedCoverage);
+        emit ChargebackIntentReleased(_intentHash, chargebackIntent.stakeOwner, releasedAmount);
     }
 
-    function _calculateCoverageDeadline(uint64 _riskWindow) internal view returns (uint64) {
-        uint256 deadline = block.timestamp + _riskWindow;
-        if (deadline > type(uint64).max) revert TimestampOverflow(deadline);
-        return uint64(deadline);
+    function _calculateReleaseEligibleAt(uint64 _riskWindow) internal view returns (uint64) {
+        uint256 releaseEligibleAt = block.timestamp + _riskWindow;
+        if (releaseEligibleAt > type(uint64).max) revert TimestampOverflow(releaseEligibleAt);
+        return uint64(releaseEligibleAt);
     }
 
     function _currentTimestamp() internal view returns (uint64) {

--- a/contracts/hooks/ChargebackPolicy.sol
+++ b/contracts/hooks/ChargebackPolicy.sol
@@ -53,11 +53,11 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
     /// @dev Lifecycle-hook authorization keyed by lifecycle hook address.
     mapping(address => bool) internal isLifecycleHookAuthorizedByHook;
 
-    /// @dev Deposit opt-in keyed first by escrow address and then by deposit id.
-    mapping(address => mapping(uint256 => bool)) internal isChargebackEnabledByEscrowAndDepositId;
+    /// @dev Whether chargebacks are enabled for each escrow deposit.
+    mapping(address => mapping(uint256 => bool)) internal isDepositChargebackEnabled;
 
-    /// @dev Minimum collateral lock window keyed by payment method.
-    mapping(bytes32 => uint64) internal riskWindowByPaymentMethod;
+    /// @dev Minimum collateral lock window for each payment method.
+    mapping(bytes32 => uint64) internal paymentMethodRiskWindow;
 
     /// @dev Chargeback lifecycle state keyed by globally unique intent hash.
     mapping(bytes32 => ChargebackIntent) internal chargebackIntentByIntentHash;
@@ -118,7 +118,7 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
         bytes32 _paymentMethod,
         uint256 _amount
     ) external override onlyLifecycleHook nonReentrant {
-        uint64 riskWindow = riskWindowByPaymentMethod[_paymentMethod];
+        uint64 riskWindow = paymentMethodRiskWindow[_paymentMethod];
         if (riskWindow == 0) return;
 
         (address stakeOwner, address depositor) = _validateIntentAdmission(_intentHash, _escrow, _depositId, _taker);
@@ -256,7 +256,7 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
         external
         onlyDepositor(_escrow, _depositId)
     {
-        isChargebackEnabledByEscrowAndDepositId[_escrow][_depositId] = _isEnabled;
+        isDepositChargebackEnabled[_escrow][_depositId] = _isEnabled;
         emit ChargebackEnabledUpdated(_escrow, _depositId, _isEnabled);
     }
 
@@ -271,7 +271,7 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
      */
     function setRiskWindow(bytes32 _paymentMethod, uint64 _riskWindow) external onlyOwner {
         if (_riskWindow > MAX_RISK_WINDOW) revert InvalidRiskWindow(_riskWindow);
-        riskWindowByPaymentMethod[_paymentMethod] = _riskWindow;
+        paymentMethodRiskWindow[_paymentMethod] = _riskWindow;
         emit RiskWindowUpdated(_paymentMethod, _riskWindow);
     }
 
@@ -339,7 +339,7 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
      * @inheritdoc IChargebackPolicy
      */
     function isChargebackEnabled(address _escrow, uint256 _depositId) external view override returns (bool) {
-        return isChargebackEnabledByEscrowAndDepositId[_escrow][_depositId];
+        return isDepositChargebackEnabled[_escrow][_depositId];
     }
 
     /**
@@ -355,7 +355,7 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
      * @param _paymentMethod Payment method whose configured risk window is queried.
      */
     function getRiskWindow(bytes32 _paymentMethod) external view returns (uint64) {
-        return riskWindowByPaymentMethod[_paymentMethod];
+        return paymentMethodRiskWindow[_paymentMethod];
     }
 
     /* ============ Internal Functions ============ */
@@ -374,7 +374,7 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
         if (chargebackIntentByIntentHash[_intentHash].status != ChargebackIntentStatus.NONE) {
             revert ChargebackIntentAlreadyExists(_intentHash);
         }
-        if (!isChargebackEnabledByEscrowAndDepositId[_escrow][_depositId]) {
+        if (!isDepositChargebackEnabled[_escrow][_depositId]) {
             revert ChargebackNotEnabled(_escrow, _depositId);
         }
 

--- a/contracts/hooks/ChargebackPolicy.sol
+++ b/contracts/hooks/ChargebackPolicy.sol
@@ -5,19 +5,18 @@ pragma solidity ^0.8.18;
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
-import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 
-import {IAttestationVerifier} from "../interfaces/IAttestationVerifier.sol";
 import {IChargebackPolicy} from "../interfaces/IChargebackPolicy.sol";
+import {IChargebackVerifier} from "../interfaces/IChargebackVerifier.sol";
 import {IEscrowRegistry} from "../interfaces/IEscrowRegistry.sol";
 import {IEscrowV2} from "../interfaces/IEscrowV2.sol";
-import {INullifierRegistryV2} from "../interfaces/INullifierRegistryV2.sol";
 import {IStakeVault} from "../interfaces/IStakeVault.sol";
 
 /**
  * @title ChargebackPolicy
  * @notice Deposit-scoped, stake-backed chargeback coverage for intent settlement.
- * @dev The policy owns no tokens. It controls StakeVault locks and converts valid chargebacks into depositor claims.
+ * @dev The policy owns no tokens. It controls StakeVault locks and delegates chargeback evidence verification before
+ * converting valid chargebacks into depositor claims.
  * `escrowRegistry` is governance-settable and MUST be kept in sync with the orchestrator's escrow registry, because
  * divergence can leave deposits admitted by one component but unavailable for depositor chargeback configuration.
  *
@@ -32,19 +31,16 @@ import {IStakeVault} from "../interfaces/IStakeVault.sol";
  * orchestrator while it has unresolved intents snapshotted to a hook permanently blocks those terminal callbacks,
  * so governance must drain its intents before removing it from OrchestratorRegistry.
  */
-contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard, EIP712 {
+contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
     /* ============ Constants ============ */
 
     uint64 public constant MAX_RISK_WINDOW = 365 days;
     uint64 public constant PENDING_COVERAGE_MATURITY = type(uint64).max;
-    bytes32 public constant CHARGEBACK_ATTESTATION_TYPEHASH =
-        keccak256("ChargebackAttestation(bytes32 intentHash,bytes32 dataHash)");
 
     /* ============ State Variables ============ */
 
     IStakeVault public immutable override stakeVault;
-    INullifierRegistryV2 public immutable override nullifierRegistry;
-    IAttestationVerifier public override attestationVerifier;
+    IChargebackVerifier public override chargebackVerifier;
     IEscrowRegistry public override escrowRegistry;
     address public override lifecycleHook;
     bool public override admissionsPaused;
@@ -60,19 +56,16 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard, E
     constructor(
         address _owner,
         IStakeVault _stakeVault,
-        INullifierRegistryV2 _nullifierRegistry,
-        IAttestationVerifier _attestationVerifier,
+        IChargebackVerifier _chargebackVerifier,
         IEscrowRegistry _escrowRegistry
-    ) EIP712("ZKP2P ChargebackPolicy", "1") {
+    ) {
         if (_owner == address(0)) revert ZeroAddress();
         _validateDependency(address(_stakeVault));
-        _validateDependency(address(_nullifierRegistry));
-        _validateDependency(address(_attestationVerifier));
+        _validateDependency(address(_chargebackVerifier));
         _validateDependency(address(_escrowRegistry));
 
         stakeVault = _stakeVault;
-        nullifierRegistry = _nullifierRegistry;
-        attestationVerifier = _attestationVerifier;
+        chargebackVerifier = _chargebackVerifier;
         escrowRegistry = _escrowRegistry;
         _transferOwnership(_owner);
     }
@@ -218,17 +211,22 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard, E
     /**
      * @inheritdoc IChargebackPolicy
      */
-    function submitChargeback(ChargebackAttestation calldata _attestation) external override nonReentrant {
+    function submitChargeback(IChargebackVerifier.ChargebackAttestation calldata _attestation)
+        external
+        override
+        nonReentrant
+    {
         Position storage position = positions[_attestation.intentHash];
         if (position.status != PositionStatus.SETTLED) {
             revert PositionNotSettled(_attestation.intentHash, position.status);
         }
-
-        (bytes32 disputeId, bytes32 disputeNullifier) = _validateChargebackAttestation(_attestation, position);
-        bytes32 digest = _hashTypedDataV4(_chargebackAttestationStructHash(_attestation));
-        if (!attestationVerifier.verify(digest, _attestation.signatures, _attestation.data)) {
-            revert AttestationVerificationFailed();
+        if (block.timestamp >= position.coverageDeadline) {
+            revert ChargebackWindowClosed(position.coverageDeadline, _currentTimestamp());
         }
+
+        (bytes32 disputeId, bytes32 disputeNullifier) =
+            chargebackVerifier.verifyChargeback(_attestation, position.paymentMethod, position.isManualRelease);
+        if (usedChargebackNullifiers[disputeNullifier]) revert ChargebackEvidenceUsed(disputeNullifier);
 
         uint256 compensatedAmount = position.grossReleasedAmount;
         if (position.coverageAmount != compensatedAmount) {
@@ -280,11 +278,11 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard, E
     /**
      * @inheritdoc IChargebackPolicy
      */
-    function setAttestationVerifier(address _verifier) external override onlyOwner {
+    function setChargebackVerifier(address _verifier) external override onlyOwner {
         _validateDependency(_verifier);
-        address previousVerifier = address(attestationVerifier);
-        attestationVerifier = IAttestationVerifier(_verifier);
-        emit AttestationVerifierUpdated(previousVerifier, _verifier);
+        address previousVerifier = address(chargebackVerifier);
+        chargebackVerifier = IChargebackVerifier(_verifier);
+        emit ChargebackVerifierUpdated(previousVerifier, _verifier);
     }
 
     /**
@@ -352,18 +350,6 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard, E
     /**
      * @inheritdoc IChargebackPolicy
      */
-    function hashChargebackAttestation(ChargebackAttestation calldata _attestation)
-        external
-        view
-        override
-        returns (bytes32)
-    {
-        return _hashTypedDataV4(_chargebackAttestationStructHash(_attestation));
-    }
-
-    /**
-     * @inheritdoc IChargebackPolicy
-     */
     function getTakerState(address _taker)
         external
         view
@@ -395,43 +381,6 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard, E
         position.status = PositionStatus.RELEASED;
         stakeVault.unlockStake(_intentHash);
         emit PositionReleased(_intentHash, position.stakeOwner, releasedCoverage);
-    }
-
-    function _validateChargebackAttestation(
-        ChargebackAttestation calldata _attestation,
-        Position storage _position
-    ) internal view returns (bytes32 disputeId, bytes32 disputeNullifier) {
-        if (keccak256(_attestation.data) != _attestation.dataHash) {
-            revert InvalidAttestation();
-        }
-        if (block.timestamp >= _position.coverageDeadline) {
-            revert ChargebackWindowClosed(_position.coverageDeadline, _currentTimestamp());
-        }
-
-        ChargebackDetails memory details = abi.decode(_attestation.data, (ChargebackDetails));
-        if (details.paymentMethod != _position.paymentMethod) revert InvalidAttestation();
-
-        if (!_position.isManualRelease) {
-            bytes32 paymentNullifier = keccak256(abi.encodePacked(details.paymentMethod, details.originalPaymentId));
-            if (
-                nullifierRegistry.intentHashByNullifier(paymentNullifier) != _attestation.intentHash
-                    || nullifierRegistry.nullifierByIntentHash(_attestation.intentHash) != paymentNullifier
-            ) {
-                revert InvalidPaymentBinding(_attestation.intentHash, paymentNullifier);
-            }
-        }
-
-        disputeId = details.disputeId;
-        disputeNullifier = keccak256(abi.encodePacked(details.paymentMethod, details.disputeId));
-        if (usedChargebackNullifiers[disputeNullifier]) revert ChargebackEvidenceUsed(disputeNullifier);
-    }
-
-    function _chargebackAttestationStructHash(ChargebackAttestation calldata _attestation)
-        internal
-        pure
-        returns (bytes32)
-    {
-        return keccak256(abi.encode(CHARGEBACK_ATTESTATION_TYPEHASH, _attestation.intentHash, _attestation.dataHash));
     }
 
     function _calculateCoverageDeadline(uint64 _riskWindow) internal view returns (uint64) {

--- a/contracts/hooks/ChargebackPolicy.sol
+++ b/contracts/hooks/ChargebackPolicy.sol
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+
+import {IAttestationVerifier} from "../interfaces/IAttestationVerifier.sol";
+import {IChargebackPolicy} from "../interfaces/IChargebackPolicy.sol";
+import {IEscrowRegistry} from "../interfaces/IEscrowRegistry.sol";
+import {IEscrowV2} from "../interfaces/IEscrowV2.sol";
+import {INullifierRegistryV2} from "../interfaces/INullifierRegistryV2.sol";
+import {IStakeVault} from "../interfaces/IStakeVault.sol";
+
+/**
+ * @title ChargebackPolicy
+ * @notice Deposit-scoped, stake-backed chargeback coverage for intent settlement.
+ * @dev The policy owns no tokens. It controls StakeVault locks and converts valid chargebacks into depositor claims.
+ * `escrowRegistry` is governance-settable and MUST be kept in sync with the orchestrator's escrow registry, because
+ * divergence can leave deposits admitted by one component but unavailable for depositor chargeback configuration.
+ *
+ * TRUST: Positions are keyed by intent hash, which embeds the originating orchestrator (OrchestratorV3 hashes its own
+ * address into every intent hash), so identities never collide across orchestrators. Positions are NOT
+ * orchestrator-bound: lifecycle entrypoints trust that every orchestrator admitted to OrchestratorRegistry (and
+ * therefore able to reach this policy through the lifecycle hook) invokes callbacks only for intents it created. A
+ * registered orchestrator that reported foreign intent hashes could cancel or settle another orchestrator's
+ * coverage. Registering an orchestrator is a governance action that vouches for exactly this behavior.
+ */
+contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard, EIP712 {
+    /* ============ Constants ============ */
+
+    uint64 public constant MAX_RISK_WINDOW = 365 days;
+    uint64 public constant PENDING_COVERAGE_MATURITY = type(uint64).max;
+    bytes32 public constant CHARGEBACK_ATTESTATION_TYPEHASH =
+        keccak256("ChargebackAttestation(bytes32 intentHash,bytes32 dataHash)");
+
+    /* ============ State Variables ============ */
+
+    IStakeVault public immutable override stakeVault;
+    INullifierRegistryV2 public immutable override nullifierRegistry;
+    IAttestationVerifier public override attestationVerifier;
+    IEscrowRegistry public override escrowRegistry;
+    address public override lifecycleHook;
+    bool public override admissionsPaused;
+
+    mapping(address => mapping(uint256 => bool)) public override enabled;
+    mapping(bytes32 => uint64) public override riskWindows;
+    mapping(bytes32 => Position) internal positions;
+    mapping(bytes32 => bool) public override usedChargebackNullifiers;
+
+    /* ============ Constructor ============ */
+
+    constructor(
+        address _owner,
+        IStakeVault _stakeVault,
+        INullifierRegistryV2 _nullifierRegistry,
+        IAttestationVerifier _attestationVerifier,
+        IEscrowRegistry _escrowRegistry
+    ) EIP712("ZKP2P ChargebackPolicy", "1") {
+        if (_owner == address(0)) revert ZeroAddress();
+        _validateDependency(address(_stakeVault));
+        _validateDependency(address(_nullifierRegistry));
+        _validateDependency(address(_attestationVerifier));
+        _validateDependency(address(_escrowRegistry));
+
+        stakeVault = _stakeVault;
+        nullifierRegistry = _nullifierRegistry;
+        attestationVerifier = _attestationVerifier;
+        escrowRegistry = _escrowRegistry;
+        _transferOwnership(_owner);
+    }
+
+    /* ============ Modifiers ============ */
+
+    modifier onlyLifecycleHook() {
+        if (msg.sender != lifecycleHook) revert UnauthorizedLifecycleHook(msg.sender);
+        _;
+    }
+
+    modifier onlyDepositor(address _escrow, uint256 _depositId) {
+        if (!escrowRegistry.isWhitelistedEscrow(_escrow) && !escrowRegistry.isAcceptingAllEscrows()) {
+            revert EscrowNotWhitelisted(_escrow);
+        }
+
+        address depositor = IEscrowV2(_escrow).getDeposit(_depositId).depositor;
+        if (depositor == address(0)) revert DepositNotFound(_escrow, _depositId);
+        if (msg.sender != depositor) revert NotDepositor(_escrow, _depositId, msg.sender);
+        _;
+    }
+
+    /* ============ Lifecycle Functions ============ */
+
+    /**
+     * @notice Opens stake-backed coverage for a chargeback-enabled intent.
+     * @dev A zero risk window passes through before paused, enabled, or duplicate checks because a
+     * non-chargebackable method uses direct access and pass-through is not an admission.
+     */
+    function admitIntent(
+        bytes32 _intentHash,
+        address _escrow,
+        uint256 _depositId,
+        address _taker,
+        bytes32 _paymentMethod,
+        uint256 _amount
+    ) external override onlyLifecycleHook nonReentrant {
+        uint64 riskWindow = riskWindows[_paymentMethod];
+        if (riskWindow == 0) return;
+
+        if (admissionsPaused) revert AdmissionsPaused();
+        if (positions[_intentHash].status != PositionStatus.NONE) revert PositionAlreadyExists(_intentHash);
+        if (!enabled[_escrow][_depositId]) revert ChargebackNotEnabled(_escrow, _depositId);
+
+        IEscrowV2.Deposit memory deposit = IEscrowV2(_escrow).getDeposit(_depositId);
+        address expectedToken = address(stakeVault.stakeToken());
+        if (address(deposit.token) != expectedToken) {
+            revert IntentTokenMismatch(expectedToken, address(deposit.token));
+        }
+
+        address stakeOwner = stakeVault.stakeOwnerOf(_taker);
+        uint256 available = stakeVault.freeStake(stakeOwner);
+        if (available < _amount) revert InsufficientCollateral(stakeOwner, available, _amount);
+
+        positions[_intentHash] = Position({
+            taker: _taker,
+            stakeOwner: stakeOwner,
+            depositor: deposit.depositor,
+            paymentMethod: _paymentMethod,
+            status: PositionStatus.PENDING,
+            isManualRelease: false,
+            riskWindow: riskWindow,
+            coverageDeadline: 0,
+            intentAmount: _amount,
+            coverageAmount: _amount,
+            grossReleasedAmount: 0
+        });
+
+        stakeVault.lockStake(stakeOwner, _intentHash, _amount, PENDING_COVERAGE_MATURITY);
+        emit PositionOpened(
+            _intentHash, stakeOwner, deposit.depositor, _taker, _paymentMethod, _amount, riskWindow
+        );
+    }
+
+    /**
+     * @inheritdoc IChargebackPolicy
+     */
+    function onIntentCancelled(bytes32 _intentHash) external override onlyLifecycleHook nonReentrant {
+        Position storage position = positions[_intentHash];
+        if (position.status == PositionStatus.NONE) return;
+        if (position.status != PositionStatus.PENDING) {
+            revert PositionNotPending(_intentHash, position.status);
+        }
+
+        uint256 releasedCoverage = position.coverageAmount;
+        position.coverageAmount = 0;
+        position.status = PositionStatus.CANCELLED;
+        stakeVault.unlockStake(_intentHash);
+        emit PositionCancelled(_intentHash, position.stakeOwner, releasedCoverage);
+    }
+
+    /**
+     * @inheritdoc IChargebackPolicy
+     */
+    function onIntentSettled(bytes32 _intentHash, uint256 _grossAmount, bool _isManualRelease)
+        external
+        override
+        onlyLifecycleHook
+        nonReentrant
+    {
+        Position storage position = positions[_intentHash];
+        if (position.status == PositionStatus.NONE) return;
+        if (position.status != PositionStatus.PENDING) {
+            revert PositionNotPending(_intentHash, position.status);
+        }
+
+        uint64 coverageDeadline = _calculateCoverageDeadline(position.riskWindow);
+        position.grossReleasedAmount = _grossAmount;
+        position.isManualRelease = _isManualRelease;
+        position.coverageDeadline = coverageDeadline;
+        position.coverageAmount = _grossAmount;
+        position.status = PositionStatus.SETTLED;
+
+        stakeVault.resizeLock(_intentHash, _grossAmount, coverageDeadline);
+        emit PositionSettled(
+            _intentHash,
+            position.stakeOwner,
+            position.depositor,
+            _grossAmount,
+            coverageDeadline,
+            _isManualRelease
+        );
+    }
+
+    /* ============ Permissionless Functions ============ */
+
+    /**
+     * @inheritdoc IChargebackPolicy
+     */
+    function releaseMaturedPosition(bytes32 _intentHash) external override nonReentrant {
+        _releaseMaturedPosition(_intentHash);
+    }
+
+    /**
+     * @inheritdoc IChargebackPolicy
+     */
+    function releaseMaturedPositions(bytes32[] calldata _intentHashes) external override nonReentrant {
+        for (uint256 intentIndex = 0; intentIndex < _intentHashes.length; intentIndex++) {
+            _releaseMaturedPosition(_intentHashes[intentIndex]);
+        }
+    }
+
+    /**
+     * @inheritdoc IChargebackPolicy
+     */
+    function submitChargeback(ChargebackAttestation calldata _attestation) external override nonReentrant {
+        Position storage position = positions[_attestation.intentHash];
+        if (position.status != PositionStatus.SETTLED) {
+            revert PositionNotSettled(_attestation.intentHash, position.status);
+        }
+
+        (bytes32 disputeId, bytes32 disputeNullifier) = _validateChargebackAttestation(_attestation, position);
+        bytes32 digest = _hashTypedDataV4(_chargebackAttestationStructHash(_attestation));
+        if (!attestationVerifier.verify(digest, _attestation.signatures, _attestation.data)) {
+            revert AttestationVerificationFailed();
+        }
+
+        uint256 compensatedAmount = position.grossReleasedAmount;
+        if (position.coverageAmount != compensatedAmount) {
+            revert IncompleteChargebackCoverage(position.coverageAmount, compensatedAmount);
+        }
+
+        usedChargebackNullifiers[disputeNullifier] = true;
+        position.coverageAmount = 0;
+        position.status = PositionStatus.SLASHED;
+
+        IStakeVault.Claim[] memory claims = new IStakeVault.Claim[](1);
+        claims[0] = IStakeVault.Claim({beneficiary: position.depositor, amount: compensatedAmount});
+        stakeVault.resolveLock(_attestation.intentHash, claims);
+
+        emit ChargebackSettled(
+            _attestation.intentHash,
+            position.stakeOwner,
+            position.depositor,
+            compensatedAmount,
+            disputeId
+        );
+    }
+
+    /* ============ Depositor Functions ============ */
+
+    /**
+     * @inheritdoc IChargebackPolicy
+     */
+    function setEnabled(address _escrow, uint256 _depositId, bool _enabled)
+        external
+        override
+        onlyDepositor(_escrow, _depositId)
+    {
+        enabled[_escrow][_depositId] = _enabled;
+        emit EnabledUpdated(_escrow, _depositId, _enabled);
+    }
+
+    /* ============ Governance Functions ============ */
+
+    /**
+     * @inheritdoc IChargebackPolicy
+     */
+    function setRiskWindow(bytes32 _paymentMethod, uint64 _riskWindow) external override onlyOwner {
+        if (_riskWindow > MAX_RISK_WINDOW) revert InvalidRiskWindow(_riskWindow);
+        riskWindows[_paymentMethod] = _riskWindow;
+        emit RiskWindowUpdated(_paymentMethod, _riskWindow);
+    }
+
+    /**
+     * @inheritdoc IChargebackPolicy
+     */
+    function setAttestationVerifier(address _verifier) external override onlyOwner {
+        _validateDependency(_verifier);
+        address previousVerifier = address(attestationVerifier);
+        attestationVerifier = IAttestationVerifier(_verifier);
+        emit AttestationVerifierUpdated(previousVerifier, _verifier);
+    }
+
+    /**
+     * @inheritdoc IChargebackPolicy
+     */
+    function setLifecycleHook(address _hook) external override onlyOwner {
+        _validateDependency(_hook);
+        address previousHook = lifecycleHook;
+        lifecycleHook = _hook;
+        emit LifecycleHookUpdated(previousHook, _hook);
+    }
+
+    /**
+     * @inheritdoc IChargebackPolicy
+     */
+    function setEscrowRegistry(IEscrowRegistry _escrowRegistry) external override onlyOwner {
+        _validateDependency(address(_escrowRegistry));
+        escrowRegistry = _escrowRegistry;
+        emit EscrowRegistryUpdated(address(_escrowRegistry));
+    }
+
+    /**
+     * @inheritdoc IChargebackPolicy
+     */
+    function setAdmissionsPaused(bool _paused) external override onlyOwner {
+        admissionsPaused = _paused;
+        emit AdmissionsPausedUpdated(_paused);
+    }
+
+    /**
+     * @inheritdoc IChargebackPolicy
+     */
+    function acceptVaultController() external override onlyOwner {
+        stakeVault.acceptController();
+    }
+
+    /**
+     * @notice Disables ownership renunciation so governed safety controls cannot become unreachable.
+     */
+    function renounceOwnership() public view override(IChargebackPolicy, Ownable) onlyOwner {
+        revert OwnershipRenunciationDisabled();
+    }
+
+    /* ============ View Functions ============ */
+
+    /**
+     * @inheritdoc IChargebackPolicy
+     */
+    function getPosition(bytes32 _intentHash) external view override returns (Position memory) {
+        return positions[_intentHash];
+    }
+
+    /**
+     * @inheritdoc IChargebackPolicy
+     */
+    function hashChargebackAttestation(ChargebackAttestation calldata _attestation)
+        external
+        view
+        override
+        returns (bytes32)
+    {
+        return _hashTypedDataV4(_chargebackAttestationStructHash(_attestation));
+    }
+
+    /**
+     * @inheritdoc IChargebackPolicy
+     */
+    function getTakerState(address _taker)
+        external
+        view
+        override
+        returns (address stakeOwner, uint256 totalStake, uint256 lockedStake, uint256 freeStake)
+    {
+        stakeOwner = stakeVault.stakeOwnerOf(_taker);
+        totalStake = stakeVault.stakeBalance(stakeOwner);
+        lockedStake = stakeVault.lockedStake(stakeOwner);
+        freeStake = stakeVault.freeStake(stakeOwner);
+    }
+
+    /* ============ Internal Functions ============ */
+
+    function _releaseMaturedPosition(bytes32 _intentHash) internal {
+        Position storage position = positions[_intentHash];
+        if (position.status != PositionStatus.SETTLED) {
+            revert PositionNotSettled(_intentHash, position.status);
+        }
+
+        uint64 currentTime = _currentTimestamp();
+        uint64 coverageDeadline = position.coverageDeadline;
+        if (coverageDeadline == 0 || currentTime < coverageDeadline) {
+            revert PositionNotMature(coverageDeadline, currentTime);
+        }
+
+        uint256 releasedCoverage = position.coverageAmount;
+        position.coverageAmount = 0;
+        position.status = PositionStatus.RELEASED;
+        stakeVault.unlockStake(_intentHash);
+        emit PositionReleased(_intentHash, position.stakeOwner, releasedCoverage);
+    }
+
+    function _validateChargebackAttestation(
+        ChargebackAttestation calldata _attestation,
+        Position storage _position
+    ) internal view returns (bytes32 disputeId, bytes32 disputeNullifier) {
+        if (keccak256(_attestation.data) != _attestation.dataHash) {
+            revert InvalidAttestation();
+        }
+        if (block.timestamp >= _position.coverageDeadline) {
+            revert ChargebackWindowClosed(_position.coverageDeadline, _currentTimestamp());
+        }
+
+        ChargebackDetails memory details = abi.decode(_attestation.data, (ChargebackDetails));
+        if (details.paymentMethod != _position.paymentMethod) revert InvalidAttestation();
+
+        if (!_position.isManualRelease) {
+            bytes32 paymentNullifier = keccak256(abi.encodePacked(details.paymentMethod, details.originalPaymentId));
+            if (
+                nullifierRegistry.intentHashByNullifier(paymentNullifier) != _attestation.intentHash
+                    || nullifierRegistry.nullifierByIntentHash(_attestation.intentHash) != paymentNullifier
+            ) {
+                revert InvalidPaymentBinding(_attestation.intentHash, paymentNullifier);
+            }
+        }
+
+        disputeId = details.disputeId;
+        disputeNullifier = keccak256(abi.encodePacked(details.paymentMethod, details.disputeId));
+        if (usedChargebackNullifiers[disputeNullifier]) revert ChargebackEvidenceUsed(disputeNullifier);
+    }
+
+    function _chargebackAttestationStructHash(ChargebackAttestation calldata _attestation)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(CHARGEBACK_ATTESTATION_TYPEHASH, _attestation.intentHash, _attestation.dataHash));
+    }
+
+    function _calculateCoverageDeadline(uint64 _riskWindow) internal view returns (uint64) {
+        uint256 deadline = block.timestamp + _riskWindow;
+        if (deadline > type(uint64).max) revert TimestampOverflow(deadline);
+        return uint64(deadline);
+    }
+
+    function _currentTimestamp() internal view returns (uint64) {
+        if (block.timestamp > type(uint64).max) revert TimestampOverflow(block.timestamp);
+        return uint64(block.timestamp);
+    }
+
+    function _validateDependency(address _dependency) internal view {
+        if (_dependency == address(0)) revert ZeroAddress();
+        if (_dependency.code.length == 0) revert InvalidContract(_dependency);
+    }
+}

--- a/contracts/hooks/ChargebackPolicy.sol
+++ b/contracts/hooks/ChargebackPolicy.sol
@@ -26,7 +26,11 @@ import {IStakeVault} from "../interfaces/IStakeVault.sol";
  * orchestrator-bound: lifecycle entrypoints trust that every orchestrator admitted to OrchestratorRegistry (and
  * therefore able to reach this policy through the lifecycle hook) invokes callbacks only for intents it created. A
  * registered orchestrator that reported foreign intent hashes could cancel or settle another orchestrator's
- * coverage. Registering an orchestrator is a governance action that vouches for exactly this behavior.
+ * coverage. Registering an orchestrator is a governance action that vouches for exactly this behavior. Rotating the
+ * lifecycle hook keeps predecessors authorized so intents snapshotted to them can still cancel or settle; revoke a
+ * predecessor only after its intents are drained, or their terminal callbacks revert fail-closed. Deregistering an
+ * orchestrator while it has unresolved intents snapshotted to a hook permanently blocks those terminal callbacks,
+ * so governance must drain its intents before removing it from OrchestratorRegistry.
  */
 contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard, EIP712 {
     /* ============ Constants ============ */
@@ -45,6 +49,7 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard, E
     address public override lifecycleHook;
     bool public override admissionsPaused;
 
+    mapping(address => bool) public override authorizedLifecycleHooks;
     mapping(address => mapping(uint256 => bool)) public override enabled;
     mapping(bytes32 => uint64) public override riskWindows;
     mapping(bytes32 => Position) internal positions;
@@ -75,7 +80,7 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard, E
     /* ============ Modifiers ============ */
 
     modifier onlyLifecycleHook() {
-        if (msg.sender != lifecycleHook) revert UnauthorizedLifecycleHook(msg.sender);
+        if (!authorizedLifecycleHooks[msg.sender]) revert UnauthorizedLifecycleHook(msg.sender);
         _;
     }
 
@@ -289,7 +294,19 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard, E
         _validateDependency(_hook);
         address previousHook = lifecycleHook;
         lifecycleHook = _hook;
+        authorizedLifecycleHooks[_hook] = true;
         emit LifecycleHookUpdated(previousHook, _hook);
+        emit LifecycleHookAuthorizationUpdated(_hook, true);
+    }
+
+    /**
+     * @inheritdoc IChargebackPolicy
+     */
+    function revokeLifecycleHook(address _hook) external override onlyOwner {
+        if (_hook == lifecycleHook) revert CannotRevokeCurrentLifecycleHook(_hook);
+        if (!authorizedLifecycleHooks[_hook]) revert LifecycleHookNotAuthorized(_hook);
+        authorizedLifecycleHooks[_hook] = false;
+        emit LifecycleHookAuthorizationUpdated(_hook, false);
     }
 
     /**

--- a/contracts/hooks/ChargebackPolicy.sol
+++ b/contracts/hooks/ChargebackPolicy.sol
@@ -102,7 +102,7 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard, E
      * @dev A zero risk window passes through before paused, enabled, or duplicate checks because a
      * non-chargebackable method uses direct access and pass-through is not an admission.
      */
-    function admitIntent(
+    function onIntentSignaled(
         bytes32 _intentHash,
         address _escrow,
         uint256 _depositId,

--- a/contracts/hooks/IntentLifecycleHookV1.sol
+++ b/contracts/hooks/IntentLifecycleHookV1.sol
@@ -17,6 +17,8 @@ import {IWhitelistPolicy} from "../interfaces/IWhitelistPolicy.sol";
  * @dev Reads canonical intent data from the calling orchestrator and forwards cancellation and settlement accounting
  * to ChargebackPolicy. All callbacks remain fail-closed. This hook serves every registered orchestrator and forwards
  * lifecycle callbacks without provenance checks; the trust argument lives in ChargebackPolicy's header.
+ * Deregistering an orchestrator with unresolved intents snapshotted to this hook permanently blocks their terminal
+ * callbacks, so governance must drain its intents before removing it from OrchestratorRegistry.
  */
 contract IntentLifecycleHookV1 is IIntentLifecycleHook {
     /* ============ State Variables ============ */

--- a/contracts/hooks/IntentLifecycleHookV1.sol
+++ b/contracts/hooks/IntentLifecycleHookV1.sol
@@ -11,8 +11,8 @@ import {IWhitelistPolicy} from "../interfaces/IWhitelistPolicy.sol";
 /**
  * @title IntentLifecycleHookV1
  * @notice Lifecycle hook combining deposit-scoped whitelist admission with optional stake-backed chargeback coverage.
- * Whitelisted takers bypass staking; non-whitelisted takers may be admitted through an enabled chargeback policy.
- * Non-chargebackable payment methods give every taker direct access without a position or stake lock, regardless of
+ * Whitelisted takers bypass staking; non-whitelisted takers may be admitted through a chargeback-enabled deposit.
+ * Non-chargebackable payment methods give every taker direct access without a chargeback intent or stake lock, regardless of
  * whitelist state. Open deposits remain unrestricted when neither policy is enabled.
  * @dev Reads canonical intent data from the calling orchestrator and forwards cancellation and settlement accounting
  * to ChargebackPolicy. All callbacks remain fail-closed. This hook serves every registered orchestrator and forwards
@@ -60,23 +60,17 @@ contract IntentLifecycleHookV1 is IIntentLifecycleHook {
         IOrchestratorV3.Intent memory intent = IOrchestratorV3(msg.sender).getIntent(_intentHash);
         if (intent.owner == address(0)) revert IntentNotFound(_intentHash);
 
-        bool whitelistEnabled = whitelistPolicy.enabled(intent.escrow, intent.depositId);
-        if (
-            whitelistEnabled
-                && whitelistPolicy.isTakerAllowed(intent.escrow, intent.depositId, intent.owner)
-        ) {
+        bool isWhitelistEnabled = whitelistPolicy.enabled(intent.escrow, intent.depositId);
+        if (isWhitelistEnabled && whitelistPolicy.isTakerAllowed(intent.escrow, intent.depositId, intent.owner)) {
             return;
         }
-        if (chargebackPolicy.enabled(intent.escrow, intent.depositId)) {
+        // Chargeback admission is stateful, so the configuration query only selects the route.
+        // onIntentSignaled remains authoritative for token compatibility, collateral, and pause checks.
+        if (chargebackPolicy.isChargebackEnabled(intent.escrow, intent.depositId)) {
             chargebackPolicy.onIntentSignaled(
-                _intentHash,
-                intent.escrow,
-                intent.depositId,
-                intent.owner,
-                intent.paymentMethod,
-                intent.amount
+                _intentHash, intent.escrow, intent.depositId, intent.owner, intent.paymentMethod, intent.amount
             );
-        } else if (whitelistEnabled) {
+        } else if (isWhitelistEnabled) {
             revert TakerNotWhitelisted(intent.escrow, intent.depositId, intent.owner);
         }
     }
@@ -92,9 +86,7 @@ contract IntentLifecycleHookV1 is IIntentLifecycleHook {
      * @inheritdoc IIntentLifecycleHook
      */
     function settleIntent(SettlementContext calldata _context) external override onlyOrchestrator {
-        chargebackPolicy.onIntentSettled(
-            _context.intentHash, _context.grossAmount, _context.isManualRelease
-        );
+        chargebackPolicy.onIntentSettled(_context.intentHash, _context.releaseAmount, _context.isManualRelease);
     }
 
     /* ============ Modifiers ============ */

--- a/contracts/hooks/IntentLifecycleHookV1.sol
+++ b/contracts/hooks/IntentLifecycleHookV1.sol
@@ -56,7 +56,7 @@ contract IntentLifecycleHookV1 is IIntentLifecycleHook {
     /**
      * @inheritdoc IIntentLifecycleHook
      */
-    function onIntentCreated(bytes32 _intentHash) external override onlyOrchestrator {
+    function onIntentSignaled(bytes32 _intentHash) external override onlyOrchestrator {
         IOrchestratorV3.Intent memory intent = IOrchestratorV3(msg.sender).getIntent(_intentHash);
         if (intent.owner == address(0)) revert IntentNotFound(_intentHash);
 
@@ -68,7 +68,7 @@ contract IntentLifecycleHookV1 is IIntentLifecycleHook {
             return;
         }
         if (chargebackPolicy.enabled(intent.escrow, intent.depositId)) {
-            chargebackPolicy.admitIntent(
+            chargebackPolicy.onIntentSignaled(
                 _intentHash,
                 intent.escrow,
                 intent.depositId,

--- a/contracts/hooks/IntentLifecycleHookV1.sol
+++ b/contracts/hooks/IntentLifecycleHookV1.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {IIntentLifecycleHook} from "../interfaces/IIntentLifecycleHook.sol";
+import {IOrchestratorRegistry} from "../interfaces/IOrchestratorRegistry.sol";
+import {IOrchestratorV3} from "../interfaces/IOrchestratorV3.sol";
+import {IWhitelistPolicy} from "../interfaces/IWhitelistPolicy.sol";
+
+/**
+ * @title IntentLifecycleHookV1
+ * @notice Stateless lifecycle hook admitting any orchestrator registered in OrchestratorRegistry and enforcing
+ * deposit-scoped whitelist policies. A taker is admitted when enforcement is disabled for the intent's deposit
+ * or when the policy allows the taker through that deposit's direct whitelist or one of its allowed groups.
+ * Settlement and cancellation are no-ops in this version.
+ * @dev Reads the intent from the calling orchestrator and delegates admission to WhitelistPolicy.
+ */
+contract IntentLifecycleHookV1 is IIntentLifecycleHook {
+    /* ============ State Variables ============ */
+
+    IOrchestratorRegistry public immutable orchestratorRegistry;
+    IWhitelistPolicy public immutable whitelistPolicy;
+
+    /* ============ Errors ============ */
+
+    error ZeroAddress();
+    error InvalidDependency(address dependency);
+    error UnauthorizedOrchestrator(address caller);
+    error IntentNotFound(bytes32 intentHash);
+    error TakerNotWhitelisted(address escrow, uint256 depositId, address taker);
+
+    /* ============ Constructor ============ */
+
+    constructor(IOrchestratorRegistry _orchestratorRegistry, IWhitelistPolicy _whitelistPolicy) {
+        _validateDependency(address(_orchestratorRegistry));
+        _validateDependency(address(_whitelistPolicy));
+
+        orchestratorRegistry = _orchestratorRegistry;
+        whitelistPolicy = _whitelistPolicy;
+    }
+
+    /* ============ Lifecycle Callbacks ============ */
+
+    /**
+     * @inheritdoc IIntentLifecycleHook
+     */
+    function onIntentCreated(bytes32 _intentHash) external view override onlyOrchestrator {
+        IOrchestratorV3.Intent memory intent = IOrchestratorV3(msg.sender).getIntent(_intentHash);
+        if (intent.owner == address(0)) revert IntentNotFound(_intentHash);
+
+        if (!whitelistPolicy.isTakerAllowed(intent.escrow, intent.depositId, intent.owner)) {
+            revert TakerNotWhitelisted(intent.escrow, intent.depositId, intent.owner);
+        }
+    }
+
+    /**
+     * @inheritdoc IIntentLifecycleHook
+     */
+    function onIntentCancelled(bytes32) external view override onlyOrchestrator {}
+
+    /**
+     * @inheritdoc IIntentLifecycleHook
+     */
+    function settleIntent(SettlementContext calldata) external view override onlyOrchestrator {}
+
+    /* ============ Modifiers ============ */
+
+    modifier onlyOrchestrator() {
+        if (!orchestratorRegistry.isOrchestrator(msg.sender)) revert UnauthorizedOrchestrator(msg.sender);
+        _;
+    }
+
+    /* ============ Internal Functions ============ */
+
+    function _validateDependency(address _dependency) internal view {
+        if (_dependency == address(0)) revert ZeroAddress();
+        if (_dependency.code.length == 0) revert InvalidDependency(_dependency);
+    }
+}

--- a/contracts/hooks/IntentLifecycleHookV1.sol
+++ b/contracts/hooks/IntentLifecycleHookV1.sol
@@ -3,23 +3,27 @@
 pragma solidity ^0.8.18;
 
 import {IIntentLifecycleHook} from "../interfaces/IIntentLifecycleHook.sol";
+import {IChargebackPolicy} from "../interfaces/IChargebackPolicy.sol";
 import {IOrchestratorRegistry} from "../interfaces/IOrchestratorRegistry.sol";
 import {IOrchestratorV3} from "../interfaces/IOrchestratorV3.sol";
 import {IWhitelistPolicy} from "../interfaces/IWhitelistPolicy.sol";
 
 /**
  * @title IntentLifecycleHookV1
- * @notice Stateless lifecycle hook admitting any orchestrator registered in OrchestratorRegistry and enforcing
- * deposit-scoped whitelist policies. A taker is admitted when enforcement is disabled for the intent's deposit
- * or when the policy allows the taker through that deposit's direct whitelist or one of its allowed groups.
- * Settlement and cancellation are no-ops in this version.
- * @dev Reads the intent from the calling orchestrator and delegates admission to WhitelistPolicy.
+ * @notice Lifecycle hook combining deposit-scoped whitelist admission with optional stake-backed chargeback coverage.
+ * Whitelisted takers bypass staking; non-whitelisted takers may be admitted through an enabled chargeback policy.
+ * Non-chargebackable payment methods give every taker direct access without a position or stake lock, regardless of
+ * whitelist state. Open deposits remain unrestricted when neither policy is enabled.
+ * @dev Reads canonical intent data from the calling orchestrator and forwards cancellation and settlement accounting
+ * to ChargebackPolicy. All callbacks remain fail-closed. This hook serves every registered orchestrator and forwards
+ * lifecycle callbacks without provenance checks; the trust argument lives in ChargebackPolicy's header.
  */
 contract IntentLifecycleHookV1 is IIntentLifecycleHook {
     /* ============ State Variables ============ */
 
     IOrchestratorRegistry public immutable orchestratorRegistry;
     IWhitelistPolicy public immutable whitelistPolicy;
+    IChargebackPolicy public immutable chargebackPolicy;
 
     /* ============ Errors ============ */
 
@@ -31,12 +35,18 @@ contract IntentLifecycleHookV1 is IIntentLifecycleHook {
 
     /* ============ Constructor ============ */
 
-    constructor(IOrchestratorRegistry _orchestratorRegistry, IWhitelistPolicy _whitelistPolicy) {
+    constructor(
+        IOrchestratorRegistry _orchestratorRegistry,
+        IWhitelistPolicy _whitelistPolicy,
+        IChargebackPolicy _chargebackPolicy
+    ) {
         _validateDependency(address(_orchestratorRegistry));
         _validateDependency(address(_whitelistPolicy));
+        _validateDependency(address(_chargebackPolicy));
 
         orchestratorRegistry = _orchestratorRegistry;
         whitelistPolicy = _whitelistPolicy;
+        chargebackPolicy = _chargebackPolicy;
     }
 
     /* ============ Lifecycle Callbacks ============ */
@@ -44,11 +54,27 @@ contract IntentLifecycleHookV1 is IIntentLifecycleHook {
     /**
      * @inheritdoc IIntentLifecycleHook
      */
-    function onIntentCreated(bytes32 _intentHash) external view override onlyOrchestrator {
+    function onIntentCreated(bytes32 _intentHash) external override onlyOrchestrator {
         IOrchestratorV3.Intent memory intent = IOrchestratorV3(msg.sender).getIntent(_intentHash);
         if (intent.owner == address(0)) revert IntentNotFound(_intentHash);
 
-        if (!whitelistPolicy.isTakerAllowed(intent.escrow, intent.depositId, intent.owner)) {
+        bool whitelistEnabled = whitelistPolicy.enabled(intent.escrow, intent.depositId);
+        if (
+            whitelistEnabled
+                && whitelistPolicy.isTakerAllowed(intent.escrow, intent.depositId, intent.owner)
+        ) {
+            return;
+        }
+        if (chargebackPolicy.enabled(intent.escrow, intent.depositId)) {
+            chargebackPolicy.admitIntent(
+                _intentHash,
+                intent.escrow,
+                intent.depositId,
+                intent.owner,
+                intent.paymentMethod,
+                intent.amount
+            );
+        } else if (whitelistEnabled) {
             revert TakerNotWhitelisted(intent.escrow, intent.depositId, intent.owner);
         }
     }
@@ -56,12 +82,18 @@ contract IntentLifecycleHookV1 is IIntentLifecycleHook {
     /**
      * @inheritdoc IIntentLifecycleHook
      */
-    function onIntentCancelled(bytes32) external view override onlyOrchestrator {}
+    function onIntentCancelled(bytes32 _intentHash) external override onlyOrchestrator {
+        chargebackPolicy.onIntentCancelled(_intentHash);
+    }
 
     /**
      * @inheritdoc IIntentLifecycleHook
      */
-    function settleIntent(SettlementContext calldata) external view override onlyOrchestrator {}
+    function settleIntent(SettlementContext calldata _context) external override onlyOrchestrator {
+        chargebackPolicy.onIntentSettled(
+            _context.intentHash, _context.grossAmount, _context.isManualRelease
+        );
+    }
 
     /* ============ Modifiers ============ */
 

--- a/contracts/interfaces/IChargebackPolicy.sol
+++ b/contracts/interfaces/IChargebackPolicy.sol
@@ -2,40 +2,54 @@
 
 pragma solidity ^0.8.18;
 
-import {IChargebackVerifier} from "./IChargebackVerifier.sol";
-import {IEscrowRegistry} from "./IEscrowRegistry.sol";
-import {IStakeVault} from "./IStakeVault.sol";
-
 /**
  * @title IChargebackPolicy
- * @notice Deposit-scoped, stake-backed chargeback policy used by an intent lifecycle hook.
- * Payment methods without a risk window pass through with direct access and no chargeback position.
+ * @notice Lifecycle-hook integration surface for stake-backed chargeback coverage.
+ * @dev The concrete policy exposes depositor, governance, chargeback, and release functions directly.
+ *      This interface intentionally contains only the functions consumed by IntentLifecycleHookV1.
  */
 interface IChargebackPolicy {
-    enum PositionStatus {
+    /**
+     * @notice Lifecycle state of a chargeback-enabled intent.
+     * @dev `NONE` is the required zero-value sentinel for an uninitialized mapping entry; it is not a live state.
+     *      `SETTLED` means the underlying intent completed and its collateral remains chargebackable.
+     *      `RELEASED` means the collateral was returned and the intent is no longer chargebackable.
+     */
+    enum ChargebackIntentStatus {
         NONE,
         PENDING,
         CANCELLED,
         SETTLED,
         RELEASED,
-        SLASHED
+        CHARGED_BACK
     }
 
-    struct Position {
+    /**
+     * @notice Chargeback state retained after an intent is admitted by the lifecycle hook.
+     * @param taker Account that signaled the intent.
+     * @param stakeOwner Account whose StakeVault balance collateralizes the intent.
+     * @param depositor Escrow depositor compensated by a successful chargeback.
+     * @param paymentMethod Payment method used to namespace risk configuration and dispute nullifiers.
+     * @param status Current chargeback lifecycle state.
+     * @param isManualRelease Whether settlement occurred through depositor-authorized manual release.
+     * @param riskWindow Minimum time collateral must remain locked after intent settlement.
+     * @param releaseEligibleAt Earliest timestamp at which collateral may be released. Chargeback evidence remains
+     * valid after this time until release actually executes.
+     * @param releaseAmount Amount released from Escrow before fees and therefore collateralized after settlement.
+     */
+    struct ChargebackIntent {
         address taker;
         address stakeOwner;
         address depositor;
         bytes32 paymentMethod;
-        PositionStatus status;
+        ChargebackIntentStatus status;
         bool isManualRelease;
         uint64 riskWindow;
-        uint64 coverageDeadline;
-        uint256 intentAmount;
-        uint256 coverageAmount;
-        uint256 grossReleasedAmount;
+        uint64 releaseEligibleAt;
+        uint256 releaseAmount;
     }
 
-    event PositionOpened(
+    event ChargebackIntentOpened(
         bytes32 indexed intentHash,
         address indexed stakeOwner,
         address indexed depositor,
@@ -44,20 +58,16 @@ interface IChargebackPolicy {
         uint256 amount,
         uint64 riskWindow
     );
-    event PositionCancelled(
-        bytes32 indexed intentHash, address indexed stakeOwner, uint256 releasedCoverage
-    );
-    event PositionSettled(
+    event ChargebackIntentCancelled(bytes32 indexed intentHash, address indexed stakeOwner, uint256 releasedAmount);
+    event ChargebackIntentSettled(
         bytes32 indexed intentHash,
         address indexed stakeOwner,
         address indexed depositor,
-        uint256 grossAmount,
-        uint64 coverageDeadline,
+        uint256 releaseAmount,
+        uint64 releaseEligibleAt,
         bool isManualRelease
     );
-    event PositionReleased(
-        bytes32 indexed intentHash, address indexed stakeOwner, uint256 releasedCoverage
-    );
+    event ChargebackIntentReleased(bytes32 indexed intentHash, address indexed stakeOwner, uint256 releasedAmount);
     event ChargebackSettled(
         bytes32 indexed intentHash,
         address indexed stakeOwner,
@@ -65,44 +75,38 @@ interface IChargebackPolicy {
         uint256 compensatedAmount,
         bytes32 disputeId
     );
-    event EnabledUpdated(address indexed escrow, uint256 indexed depositId, bool enabled);
+    event ChargebackEnabledUpdated(address indexed escrow, uint256 indexed depositId, bool isChargebackEnabled);
     event RiskWindowUpdated(bytes32 indexed paymentMethod, uint64 riskWindow);
     event ChargebackVerifierUpdated(address indexed previousVerifier, address indexed newVerifier);
-    event LifecycleHookUpdated(address indexed previousHook, address indexed newHook);
-    /** @notice Emitted when a lifecycle hook's callback authorization changes. */
-    event LifecycleHookAuthorizationUpdated(address indexed hook, bool authorized);
-    event EscrowRegistryUpdated(address indexed escrowRegistry);
-    event AdmissionsPausedUpdated(bool paused);
+    event LifecycleHookAuthorizationUpdated(address indexed hook, bool isAuthorized);
+    event AdmissionsPausedUpdated(bool isPaused);
 
     error ZeroAddress();
     error InvalidContract(address dependency);
     error UnauthorizedLifecycleHook(address caller);
-    /** @notice Reverts when attempting to revoke the currently designated lifecycle hook. */
-    error CannotRevokeCurrentLifecycleHook(address hook);
-    /** @notice Reverts when attempting to revoke a lifecycle hook that is not authorized. */
-    error LifecycleHookNotAuthorized(address hook);
     error AdmissionsPaused();
     error ChargebackNotEnabled(address escrow, uint256 depositId);
-    error InsufficientCollateral(address stakeOwner, uint256 available, uint256 required);
-    error PositionAlreadyExists(bytes32 intentHash);
-    error PositionNotPending(bytes32 intentHash, PositionStatus status);
-    error PositionNotSettled(bytes32 intentHash, PositionStatus status);
+    error ChargebackIntentAlreadyExists(bytes32 intentHash);
+    error ChargebackIntentNotPending(bytes32 intentHash, ChargebackIntentStatus status);
+    error ChargebackIntentNotSettled(bytes32 intentHash, ChargebackIntentStatus status);
     error IntentTokenMismatch(address expectedToken, address actualToken);
-    error PositionNotMature(uint64 coverageDeadline, uint64 currentTime);
-    error ChargebackWindowClosed(uint64 coverageDeadline, uint64 currentTime);
-    error ChargebackEvidenceUsed(bytes32 nullifier);
-    error IncompleteChargebackCoverage(uint256 available, uint256 required);
+    error ChargebackIntentNotReleaseEligible(uint64 releaseEligibleAt, uint64 currentTime);
     error TimestampOverflow(uint256 timestamp);
     error InvalidRiskWindow(uint64 riskWindow);
-    error EscrowNotWhitelisted(address escrow);
-    error DepositNotFound(address escrow, uint256 depositId);
     error NotDepositor(address escrow, uint256 depositId, address caller);
     error OwnershipRenunciationDisabled();
 
     /**
-     * @notice Opens stake-backed coverage for a chargeback-enabled intent.
-     * @dev A zero risk window passes through before paused, enabled, or duplicate checks because a
-     * non-chargebackable method uses direct access and pass-through is not an admission.
+     * @notice Admits a newly signaled intent into chargeback coverage when its payment method has a risk window.
+     * @dev Called only by an authorized lifecycle hook. A zero configured risk window is an unrestricted pass-through
+     * and creates no chargeback intent. Otherwise the call validates deposit configuration and token compatibility,
+     * snapshots the risk configuration, and locks the taker's selected stake.
+     * @param _intentHash Unique intent identifier assigned by the calling orchestrator.
+     * @param _escrow Escrow that owns the intent and deposit.
+     * @param _depositId Deposit supplying the intent liquidity.
+     * @param _taker Account that signaled the intent.
+     * @param _paymentMethod Payment method selected for the off-chain payment.
+     * @param _amount Full on-chain intent amount initially locked as collateral.
      */
     function onIntentSignaled(
         bytes32 _intentHash,
@@ -112,81 +116,28 @@ interface IChargebackPolicy {
         bytes32 _paymentMethod,
         uint256 _amount
     ) external;
-    /** @notice Cancels pending coverage, or silently ignores an intent with no position. */
+
+    /**
+     * @notice Cancels a pending chargeback intent and unlocks its collateral.
+     * @dev Missing chargeback intents are ignored because payment methods with no risk window create no policy state.
+     * @param _intentHash Intent being cancelled or pruned by the orchestrator.
+     */
     function onIntentCancelled(bytes32 _intentHash) external;
 
-    /** @notice Transitions pending coverage into its post-settlement risk window. */
-    function onIntentSettled(bytes32 _intentHash, uint256 _grossAmount, bool _isManualRelease) external;
+    /**
+     * @notice Marks a pending chargeback intent as settled and resizes its collateral to the actual release amount.
+     * @dev Missing chargeback intents are ignored. The snapshotted risk window determines when collateral becomes
+     * release-eligible; it does not invalidate chargeback evidence until release actually executes.
+     * @param _intentHash Intent completed by proof-based fulfillment or manual release.
+     * @param _releaseAmount Amount released from Escrow before protocol, referral, and manager fees.
+     * @param _isManualRelease Whether the depositor used the manual-release path without an on-chain payment proof.
+     */
+    function onIntentSettled(bytes32 _intentHash, uint256 _releaseAmount, bool _isManualRelease) external;
 
-    /** @notice Releases one settled position at or after its coverage deadline. */
-    function releaseMaturedPosition(bytes32 _intentHash) external;
-
-    /** @notice Releases a batch of settled positions at or after their coverage deadlines. */
-    function releaseMaturedPositions(bytes32[] calldata _intentHashes) external;
-
-    /** @notice Resolves valid chargeback evidence into an immediately claimable depositor award. */
-    function submitChargeback(IChargebackVerifier.ChargebackAttestation calldata _attestation) external;
-
-    /** @notice Enables or disables chargeback admission for a deposit. */
-    function setEnabled(address _escrow, uint256 _depositId, bool _enabled) external;
-
-    /** @notice Sets the coverage window snapshotted by future intents for a payment method. */
-    function setRiskWindow(bytes32 _paymentMethod, uint64 _riskWindow) external;
-
-    /** @notice Replaces the chargeback verifier used for future chargeback submissions. */
-    function setChargebackVerifier(address _verifier) external;
-
-    /** @notice Designates and authorizes the current hook without deauthorizing predecessor hooks. */
-    function setLifecycleHook(address _hook) external;
-
-    /** @notice Revokes a predecessor hook after all intents snapshotted to it have been drained. */
-    function revokeLifecycleHook(address _hook) external;
-
-    /** @notice Replaces the registry used to authorize deposit configuration. */
-    function setEscrowRegistry(IEscrowRegistry _escrowRegistry) external;
-
-    /** @notice Pauses or resumes new admissions without blocking terminal transitions. */
-    function setAdmissionsPaused(bool _paused) external;
-
-    /** @notice Accepts this policy as the StakeVault controller after a delayed handover. */
-    function acceptVaultController() external;
-
-    /** @notice Always reverts so governed safety controls cannot become unreachable. */
-    function renounceOwnership() external;
-
-    /** @notice Returns the stored chargeback position for an intent. */
-    function getPosition(bytes32 _intentHash) external view returns (Position memory);
-
-    /** @notice Returns the live selected stake owner and that owner's vault balances. */
-    function getTakerState(address _taker)
-        external
-        view
-        returns (address stakeOwner, uint256 totalStake, uint256 lockedStake, uint256 freeStake);
-
-    /** @notice Returns the policy's stake custody and accounting dependency. */
-    function stakeVault() external view returns (IStakeVault);
-
-    /** @notice Returns the verifier used to validate chargeback evidence. */
-    function chargebackVerifier() external view returns (IChargebackVerifier);
-
-    /** @notice Returns the registry used to authorize escrow deposit configuration. */
-    function escrowRegistry() external view returns (IEscrowRegistry);
-
-    /** @notice Returns the currently designated lifecycle hook for new intent routing. */
-    function lifecycleHook() external view returns (address);
-
-    /** @notice Returns whether a lifecycle hook is authorized to mutate positions. */
-    function authorizedLifecycleHooks(address _hook) external view returns (bool);
-
-    /** @notice Returns whether new chargeback admissions are paused. */
-    function admissionsPaused() external view returns (bool);
-
-    /** @notice Returns whether chargeback admission is enabled for a deposit. */
-    function enabled(address _escrow, uint256 _depositId) external view returns (bool);
-
-    /** @notice Returns the future-admission risk window for a payment method. */
-    function riskWindows(bytes32 _paymentMethod) external view returns (uint64);
-
-    /** @notice Returns whether a payment-method-scoped dispute identifier has been consumed. */
-    function usedChargebackNullifiers(bytes32 _nullifier) external view returns (bool);
+    /**
+     * @notice Returns whether a deposit opted into stake-backed chargeback admission.
+     * @param _escrow Escrow containing the deposit.
+     * @param _depositId Deposit whose chargeback configuration is queried.
+     */
+    function isChargebackEnabled(address _escrow, uint256 _depositId) external view returns (bool);
 }

--- a/contracts/interfaces/IChargebackPolicy.sol
+++ b/contracts/interfaces/IChargebackPolicy.sol
@@ -123,7 +123,7 @@ interface IChargebackPolicy {
      * @dev A zero risk window passes through before paused, enabled, or duplicate checks because a
      * non-chargebackable method uses direct access and pass-through is not an admission.
      */
-    function admitIntent(
+    function onIntentSignaled(
         bytes32 _intentHash,
         address _escrow,
         uint256 _depositId,

--- a/contracts/interfaces/IChargebackPolicy.sol
+++ b/contracts/interfaces/IChargebackPolicy.sol
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {IAttestationVerifier} from "./IAttestationVerifier.sol";
+import {IEscrowRegistry} from "./IEscrowRegistry.sol";
+import {INullifierRegistryV2} from "./INullifierRegistryV2.sol";
+import {IStakeVault} from "./IStakeVault.sol";
+
+/**
+ * @title IChargebackPolicy
+ * @notice Deposit-scoped, stake-backed chargeback policy used by an intent lifecycle hook.
+ * Payment methods without a risk window pass through with direct access and no chargeback position.
+ */
+interface IChargebackPolicy {
+    enum PositionStatus {
+        NONE,
+        PENDING,
+        CANCELLED,
+        SETTLED,
+        RELEASED,
+        SLASHED
+    }
+
+    struct Position {
+        address taker;
+        address stakeOwner;
+        address depositor;
+        bytes32 paymentMethod;
+        PositionStatus status;
+        bool isManualRelease;
+        uint64 riskWindow;
+        uint64 coverageDeadline;
+        uint256 intentAmount;
+        uint256 coverageAmount;
+        uint256 grossReleasedAmount;
+    }
+
+    struct ChargebackAttestation {
+        bytes32 intentHash;
+        bytes32 dataHash;
+        bytes[] signatures;
+        bytes data;
+    }
+
+    struct ChargebackDetails {
+        bytes32 paymentMethod;
+        bytes32 originalPaymentId;
+        bytes32 disputeId;
+        uint256 paymentAmount;
+        bytes32 paymentCurrency;
+    }
+
+    event PositionOpened(
+        bytes32 indexed intentHash,
+        address indexed stakeOwner,
+        address indexed depositor,
+        address taker,
+        bytes32 paymentMethod,
+        uint256 amount,
+        uint64 riskWindow
+    );
+    event PositionCancelled(
+        bytes32 indexed intentHash, address indexed stakeOwner, uint256 releasedCoverage
+    );
+    event PositionSettled(
+        bytes32 indexed intentHash,
+        address indexed stakeOwner,
+        address indexed depositor,
+        uint256 grossAmount,
+        uint64 coverageDeadline,
+        bool isManualRelease
+    );
+    event PositionReleased(
+        bytes32 indexed intentHash, address indexed stakeOwner, uint256 releasedCoverage
+    );
+    event ChargebackSettled(
+        bytes32 indexed intentHash,
+        address indexed stakeOwner,
+        address indexed depositor,
+        uint256 compensatedAmount,
+        bytes32 disputeId
+    );
+    event EnabledUpdated(address indexed escrow, uint256 indexed depositId, bool enabled);
+    event RiskWindowUpdated(bytes32 indexed paymentMethod, uint64 riskWindow);
+    event AttestationVerifierUpdated(address indexed previousVerifier, address indexed newVerifier);
+    event LifecycleHookUpdated(address indexed previousHook, address indexed newHook);
+    event EscrowRegistryUpdated(address indexed escrowRegistry);
+    event AdmissionsPausedUpdated(bool paused);
+
+    error ZeroAddress();
+    error InvalidContract(address dependency);
+    error UnauthorizedLifecycleHook(address caller);
+    error AdmissionsPaused();
+    error ChargebackNotEnabled(address escrow, uint256 depositId);
+    error InsufficientCollateral(address stakeOwner, uint256 available, uint256 required);
+    error PositionAlreadyExists(bytes32 intentHash);
+    error PositionNotPending(bytes32 intentHash, PositionStatus status);
+    error PositionNotSettled(bytes32 intentHash, PositionStatus status);
+    error IntentTokenMismatch(address expectedToken, address actualToken);
+    error PositionNotMature(uint64 coverageDeadline, uint64 currentTime);
+    error InvalidAttestation();
+    error InvalidPaymentBinding(bytes32 intentHash, bytes32 nullifier);
+    error ChargebackWindowClosed(uint64 coverageDeadline, uint64 currentTime);
+    error ChargebackEvidenceUsed(bytes32 nullifier);
+    error IncompleteChargebackCoverage(uint256 available, uint256 required);
+    error AttestationVerificationFailed();
+    error TimestampOverflow(uint256 timestamp);
+    error InvalidRiskWindow(uint64 riskWindow);
+    error EscrowNotWhitelisted(address escrow);
+    error DepositNotFound(address escrow, uint256 depositId);
+    error NotDepositor(address escrow, uint256 depositId, address caller);
+    error OwnershipRenunciationDisabled();
+
+    /**
+     * @notice Opens stake-backed coverage for a chargeback-enabled intent.
+     * @dev A zero risk window passes through before paused, enabled, or duplicate checks because a
+     * non-chargebackable method uses direct access and pass-through is not an admission.
+     */
+    function admitIntent(
+        bytes32 _intentHash,
+        address _escrow,
+        uint256 _depositId,
+        address _taker,
+        bytes32 _paymentMethod,
+        uint256 _amount
+    ) external;
+    /** @notice Cancels pending coverage, or silently ignores an intent with no position. */
+    function onIntentCancelled(bytes32 _intentHash) external;
+
+    /** @notice Transitions pending coverage into its post-settlement risk window. */
+    function onIntentSettled(bytes32 _intentHash, uint256 _grossAmount, bool _isManualRelease) external;
+
+    /** @notice Releases one settled position at or after its coverage deadline. */
+    function releaseMaturedPosition(bytes32 _intentHash) external;
+
+    /** @notice Releases a batch of settled positions at or after their coverage deadlines. */
+    function releaseMaturedPositions(bytes32[] calldata _intentHashes) external;
+
+    /** @notice Resolves valid chargeback evidence into an immediately claimable depositor award. */
+    function submitChargeback(ChargebackAttestation calldata _attestation) external;
+
+    /** @notice Enables or disables chargeback admission for a deposit. */
+    function setEnabled(address _escrow, uint256 _depositId, bool _enabled) external;
+
+    /** @notice Sets the coverage window snapshotted by future intents for a payment method. */
+    function setRiskWindow(bytes32 _paymentMethod, uint64 _riskWindow) external;
+
+    /** @notice Replaces the verifier used for future chargeback submissions. */
+    function setAttestationVerifier(address _verifier) external;
+
+    /** @notice Sets the contract authorized to forward intent lifecycle callbacks. */
+    function setLifecycleHook(address _hook) external;
+
+    /** @notice Replaces the registry used to authorize deposit configuration. */
+    function setEscrowRegistry(IEscrowRegistry _escrowRegistry) external;
+
+    /** @notice Pauses or resumes new admissions without blocking terminal transitions. */
+    function setAdmissionsPaused(bool _paused) external;
+
+    /** @notice Accepts this policy as the StakeVault controller after a delayed handover. */
+    function acceptVaultController() external;
+
+    /** @notice Always reverts so governed safety controls cannot become unreachable. */
+    function renounceOwnership() external;
+
+    /** @notice Returns the stored chargeback position for an intent. */
+    function getPosition(bytes32 _intentHash) external view returns (Position memory);
+
+    /** @notice Returns the EIP-712 digest signed for a chargeback attestation. */
+    function hashChargebackAttestation(ChargebackAttestation calldata _attestation)
+        external
+        view
+        returns (bytes32);
+
+    /** @notice Returns the live selected stake owner and that owner's vault balances. */
+    function getTakerState(address _taker)
+        external
+        view
+        returns (address stakeOwner, uint256 totalStake, uint256 lockedStake, uint256 freeStake);
+
+    /** @notice Returns the policy's stake custody and accounting dependency. */
+    function stakeVault() external view returns (IStakeVault);
+
+    /** @notice Returns the canonical payment-nullifier binding registry. */
+    function nullifierRegistry() external view returns (INullifierRegistryV2);
+
+    /** @notice Returns the verifier used for chargeback attestations. */
+    function attestationVerifier() external view returns (IAttestationVerifier);
+
+    /** @notice Returns the registry used to authorize escrow deposit configuration. */
+    function escrowRegistry() external view returns (IEscrowRegistry);
+
+    /** @notice Returns the lifecycle hook authorized to mutate positions. */
+    function lifecycleHook() external view returns (address);
+
+    /** @notice Returns whether new chargeback admissions are paused. */
+    function admissionsPaused() external view returns (bool);
+
+    /** @notice Returns whether chargeback admission is enabled for a deposit. */
+    function enabled(address _escrow, uint256 _depositId) external view returns (bool);
+
+    /** @notice Returns the future-admission risk window for a payment method. */
+    function riskWindows(bytes32 _paymentMethod) external view returns (uint64);
+
+    /** @notice Returns whether a payment-method-scoped dispute identifier has been consumed. */
+    function usedChargebackNullifiers(bytes32 _nullifier) external view returns (bool);
+}

--- a/contracts/interfaces/IChargebackPolicy.sol
+++ b/contracts/interfaces/IChargebackPolicy.sol
@@ -85,12 +85,18 @@ interface IChargebackPolicy {
     event RiskWindowUpdated(bytes32 indexed paymentMethod, uint64 riskWindow);
     event AttestationVerifierUpdated(address indexed previousVerifier, address indexed newVerifier);
     event LifecycleHookUpdated(address indexed previousHook, address indexed newHook);
+    /** @notice Emitted when a lifecycle hook's callback authorization changes. */
+    event LifecycleHookAuthorizationUpdated(address indexed hook, bool authorized);
     event EscrowRegistryUpdated(address indexed escrowRegistry);
     event AdmissionsPausedUpdated(bool paused);
 
     error ZeroAddress();
     error InvalidContract(address dependency);
     error UnauthorizedLifecycleHook(address caller);
+    /** @notice Reverts when attempting to revoke the currently designated lifecycle hook. */
+    error CannotRevokeCurrentLifecycleHook(address hook);
+    /** @notice Reverts when attempting to revoke a lifecycle hook that is not authorized. */
+    error LifecycleHookNotAuthorized(address hook);
     error AdmissionsPaused();
     error ChargebackNotEnabled(address escrow, uint256 depositId);
     error InsufficientCollateral(address stakeOwner, uint256 available, uint256 required);
@@ -149,8 +155,11 @@ interface IChargebackPolicy {
     /** @notice Replaces the verifier used for future chargeback submissions. */
     function setAttestationVerifier(address _verifier) external;
 
-    /** @notice Sets the contract authorized to forward intent lifecycle callbacks. */
+    /** @notice Designates and authorizes the current hook without deauthorizing predecessor hooks. */
     function setLifecycleHook(address _hook) external;
+
+    /** @notice Revokes a predecessor hook after all intents snapshotted to it have been drained. */
+    function revokeLifecycleHook(address _hook) external;
 
     /** @notice Replaces the registry used to authorize deposit configuration. */
     function setEscrowRegistry(IEscrowRegistry _escrowRegistry) external;
@@ -191,8 +200,11 @@ interface IChargebackPolicy {
     /** @notice Returns the registry used to authorize escrow deposit configuration. */
     function escrowRegistry() external view returns (IEscrowRegistry);
 
-    /** @notice Returns the lifecycle hook authorized to mutate positions. */
+    /** @notice Returns the currently designated lifecycle hook for new intent routing. */
     function lifecycleHook() external view returns (address);
+
+    /** @notice Returns whether a lifecycle hook is authorized to mutate positions. */
+    function authorizedLifecycleHooks(address _hook) external view returns (bool);
 
     /** @notice Returns whether new chargeback admissions are paused. */
     function admissionsPaused() external view returns (bool);

--- a/contracts/interfaces/IChargebackPolicy.sol
+++ b/contracts/interfaces/IChargebackPolicy.sol
@@ -2,9 +2,8 @@
 
 pragma solidity ^0.8.18;
 
-import {IAttestationVerifier} from "./IAttestationVerifier.sol";
+import {IChargebackVerifier} from "./IChargebackVerifier.sol";
 import {IEscrowRegistry} from "./IEscrowRegistry.sol";
-import {INullifierRegistryV2} from "./INullifierRegistryV2.sol";
 import {IStakeVault} from "./IStakeVault.sol";
 
 /**
@@ -34,21 +33,6 @@ interface IChargebackPolicy {
         uint256 intentAmount;
         uint256 coverageAmount;
         uint256 grossReleasedAmount;
-    }
-
-    struct ChargebackAttestation {
-        bytes32 intentHash;
-        bytes32 dataHash;
-        bytes[] signatures;
-        bytes data;
-    }
-
-    struct ChargebackDetails {
-        bytes32 paymentMethod;
-        bytes32 originalPaymentId;
-        bytes32 disputeId;
-        uint256 paymentAmount;
-        bytes32 paymentCurrency;
     }
 
     event PositionOpened(
@@ -83,7 +67,7 @@ interface IChargebackPolicy {
     );
     event EnabledUpdated(address indexed escrow, uint256 indexed depositId, bool enabled);
     event RiskWindowUpdated(bytes32 indexed paymentMethod, uint64 riskWindow);
-    event AttestationVerifierUpdated(address indexed previousVerifier, address indexed newVerifier);
+    event ChargebackVerifierUpdated(address indexed previousVerifier, address indexed newVerifier);
     event LifecycleHookUpdated(address indexed previousHook, address indexed newHook);
     /** @notice Emitted when a lifecycle hook's callback authorization changes. */
     event LifecycleHookAuthorizationUpdated(address indexed hook, bool authorized);
@@ -105,12 +89,9 @@ interface IChargebackPolicy {
     error PositionNotSettled(bytes32 intentHash, PositionStatus status);
     error IntentTokenMismatch(address expectedToken, address actualToken);
     error PositionNotMature(uint64 coverageDeadline, uint64 currentTime);
-    error InvalidAttestation();
-    error InvalidPaymentBinding(bytes32 intentHash, bytes32 nullifier);
     error ChargebackWindowClosed(uint64 coverageDeadline, uint64 currentTime);
     error ChargebackEvidenceUsed(bytes32 nullifier);
     error IncompleteChargebackCoverage(uint256 available, uint256 required);
-    error AttestationVerificationFailed();
     error TimestampOverflow(uint256 timestamp);
     error InvalidRiskWindow(uint64 riskWindow);
     error EscrowNotWhitelisted(address escrow);
@@ -144,7 +125,7 @@ interface IChargebackPolicy {
     function releaseMaturedPositions(bytes32[] calldata _intentHashes) external;
 
     /** @notice Resolves valid chargeback evidence into an immediately claimable depositor award. */
-    function submitChargeback(ChargebackAttestation calldata _attestation) external;
+    function submitChargeback(IChargebackVerifier.ChargebackAttestation calldata _attestation) external;
 
     /** @notice Enables or disables chargeback admission for a deposit. */
     function setEnabled(address _escrow, uint256 _depositId, bool _enabled) external;
@@ -152,8 +133,8 @@ interface IChargebackPolicy {
     /** @notice Sets the coverage window snapshotted by future intents for a payment method. */
     function setRiskWindow(bytes32 _paymentMethod, uint64 _riskWindow) external;
 
-    /** @notice Replaces the verifier used for future chargeback submissions. */
-    function setAttestationVerifier(address _verifier) external;
+    /** @notice Replaces the chargeback verifier used for future chargeback submissions. */
+    function setChargebackVerifier(address _verifier) external;
 
     /** @notice Designates and authorizes the current hook without deauthorizing predecessor hooks. */
     function setLifecycleHook(address _hook) external;
@@ -176,12 +157,6 @@ interface IChargebackPolicy {
     /** @notice Returns the stored chargeback position for an intent. */
     function getPosition(bytes32 _intentHash) external view returns (Position memory);
 
-    /** @notice Returns the EIP-712 digest signed for a chargeback attestation. */
-    function hashChargebackAttestation(ChargebackAttestation calldata _attestation)
-        external
-        view
-        returns (bytes32);
-
     /** @notice Returns the live selected stake owner and that owner's vault balances. */
     function getTakerState(address _taker)
         external
@@ -191,11 +166,8 @@ interface IChargebackPolicy {
     /** @notice Returns the policy's stake custody and accounting dependency. */
     function stakeVault() external view returns (IStakeVault);
 
-    /** @notice Returns the canonical payment-nullifier binding registry. */
-    function nullifierRegistry() external view returns (INullifierRegistryV2);
-
-    /** @notice Returns the verifier used for chargeback attestations. */
-    function attestationVerifier() external view returns (IAttestationVerifier);
+    /** @notice Returns the verifier used to validate chargeback evidence. */
+    function chargebackVerifier() external view returns (IChargebackVerifier);
 
     /** @notice Returns the registry used to authorize escrow deposit configuration. */
     function escrowRegistry() external view returns (IEscrowRegistry);

--- a/contracts/interfaces/IChargebackVerifier.sol
+++ b/contracts/interfaces/IChargebackVerifier.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {IAttestationVerifier} from "./IAttestationVerifier.sol";
+import {INullifierRegistryV2} from "./INullifierRegistryV2.sol";
+
+/**
+ * @title IChargebackVerifier
+ * @notice Stateless verifier for chargeback attestations. Owns the EIP-712 domain for chargeback
+ * evidence, delegates signature verification to a configurable attestation verifier, and checks
+ * payment binding against the nullifier registry. Mirrors the UnifiedPaymentVerifier layering:
+ * policy -> chargeback verifier -> attestation verifier.
+ */
+interface IChargebackVerifier {
+    struct ChargebackAttestation {
+        bytes32 intentHash;
+        bytes32 dataHash;
+        bytes[] signatures;
+        bytes data;
+    }
+
+    struct ChargebackDetails {
+        bytes32 paymentMethod;
+        bytes32 originalPaymentId;
+        bytes32 disputeId;
+        uint256 paymentAmount;
+        bytes32 paymentCurrency;
+    }
+
+    event AttestationVerifierUpdated(address indexed previousVerifier, address indexed newVerifier);
+
+    error ZeroAddress();
+    error InvalidContract(address dependency);
+    error InvalidAttestation();
+    error InvalidPaymentBinding(bytes32 intentHash, bytes32 nullifier);
+    error AttestationVerificationFailed();
+    error OwnershipRenunciationDisabled();
+
+    /**
+     * @notice Validates chargeback evidence against the position context supplied by the caller.
+     * @dev View-only and stateless: the caller owns all replay bookkeeping and state transitions.
+     * Reverts when the evidence is malformed, mismatched, unsigned, or unbound to the settled payment.
+     * @param _attestation Signed chargeback evidence for an intent.
+     * @param _paymentMethod Payment method snapshotted on the caller's position.
+     * @param _isManualRelease True when the position settled without an on-chain payment proof,
+     * which skips the payment-binding check.
+     * @return disputeId Payment-platform dispute identifier decoded from the evidence.
+     * @return disputeNullifier Payment-method-scoped replay key for the dispute.
+     */
+    function verifyChargeback(
+        ChargebackAttestation calldata _attestation,
+        bytes32 _paymentMethod,
+        bool _isManualRelease
+    ) external view returns (bytes32 disputeId, bytes32 disputeNullifier);
+
+    /** @notice Returns the EIP-712 digest signed for a chargeback attestation. */
+    function hashChargebackAttestation(ChargebackAttestation calldata _attestation)
+        external
+        view
+        returns (bytes32);
+
+    /** @notice Replaces the verifier used for future chargeback signature checks. */
+    function setAttestationVerifier(address _verifier) external;
+
+    /** @notice Always reverts so the signature-verification dependency cannot become unmanaged. */
+    function renounceOwnership() external;
+
+    /** @notice Returns the verifier used to validate witness signatures. */
+    function attestationVerifier() external view returns (IAttestationVerifier);
+
+    /** @notice Returns the canonical payment-nullifier binding registry. */
+    function nullifierRegistry() external view returns (INullifierRegistryV2);
+}

--- a/contracts/interfaces/IChargebackVerifier.sol
+++ b/contracts/interfaces/IChargebackVerifier.sol
@@ -2,17 +2,19 @@
 
 pragma solidity ^0.8.18;
 
-import {IAttestationVerifier} from "./IAttestationVerifier.sol";
-import {INullifierRegistryV2} from "./INullifierRegistryV2.sol";
-
 /**
  * @title IChargebackVerifier
- * @notice Stateless verifier for chargeback attestations. Owns the EIP-712 domain for chargeback
- * evidence, delegates signature verification to a configurable attestation verifier, and checks
- * payment binding against the nullifier registry. Mirrors the UnifiedPaymentVerifier layering:
- * policy -> chargeback verifier -> attestation verifier.
+ * @notice Minimal verification surface consumed by ChargebackPolicy.
+ * @dev The concrete verifier exposes its governance and digest helper functions directly.
  */
 interface IChargebackVerifier {
+    /**
+     * @notice Signed evidence tying a chargeback payload to one intent.
+     * @param intentHash Intent whose off-chain payment was disputed.
+     * @param dataHash Hash of the ABI-encoded `ChargebackDetails`.
+     * @param signatures Witness signatures over the verifier's EIP-712 digest.
+     * @param data ABI-encoded `ChargebackDetails`.
+     */
     struct ChargebackAttestation {
         bytes32 intentHash;
         bytes32 dataHash;
@@ -20,6 +22,14 @@ interface IChargebackVerifier {
         bytes data;
     }
 
+    /**
+     * @notice Payment and dispute identifiers attested by the chargeback witnesses.
+     * @param paymentMethod Payment rail used by the original payment.
+     * @param originalPaymentId Provider identifier for the original payment.
+     * @param disputeId Provider identifier for the chargeback or reversal.
+     * @param paymentAmount Attested off-chain payment amount.
+     * @param paymentCurrency Attested off-chain payment currency.
+     */
     struct ChargebackDetails {
         bytes32 paymentMethod;
         bytes32 originalPaymentId;
@@ -38,13 +48,13 @@ interface IChargebackVerifier {
     error OwnershipRenunciationDisabled();
 
     /**
-     * @notice Validates chargeback evidence against the position context supplied by the caller.
-     * @dev View-only and stateless: the caller owns all replay bookkeeping and state transitions.
-     * Reverts when the evidence is malformed, mismatched, unsigned, or unbound to the settled payment.
+     * @notice Validates chargeback evidence against the intent context supplied by the policy.
+     * @dev View-only and stateless. Reverts when the payload is malformed, mismatched, unsigned, or—on the
+     * proof-based path—not bound to the intent's original payment nullifier.
      * @param _attestation Signed chargeback evidence for an intent.
-     * @param _paymentMethod Payment method snapshotted on the caller's position.
-     * @param _isManualRelease True when the position settled without an on-chain payment proof,
-     * which skips the payment-binding check.
+     * @param _paymentMethod Payment method snapshotted by the policy when the intent was admitted.
+     * @param _isManualRelease Whether settlement occurred without an on-chain payment proof. Manual releases skip
+     * original-payment binding because no payment nullifier was recorded during settlement.
      * @return disputeId Payment-platform dispute identifier decoded from the evidence.
      * @return disputeNullifier Payment-method-scoped replay key for the dispute.
      */
@@ -53,22 +63,4 @@ interface IChargebackVerifier {
         bytes32 _paymentMethod,
         bool _isManualRelease
     ) external view returns (bytes32 disputeId, bytes32 disputeNullifier);
-
-    /** @notice Returns the EIP-712 digest signed for a chargeback attestation. */
-    function hashChargebackAttestation(ChargebackAttestation calldata _attestation)
-        external
-        view
-        returns (bytes32);
-
-    /** @notice Replaces the verifier used for future chargeback signature checks. */
-    function setAttestationVerifier(address _verifier) external;
-
-    /** @notice Always reverts so the signature-verification dependency cannot become unmanaged. */
-    function renounceOwnership() external;
-
-    /** @notice Returns the verifier used to validate witness signatures. */
-    function attestationVerifier() external view returns (IAttestationVerifier);
-
-    /** @notice Returns the canonical payment-nullifier binding registry. */
-    function nullifierRegistry() external view returns (INullifierRegistryV2);
 }

--- a/contracts/interfaces/IIntentLifecycleHook.sol
+++ b/contracts/interfaces/IIntentLifecycleHook.sol
@@ -20,10 +20,10 @@ interface IIntentLifecycleHook {
     }
 
     /**
-     * @notice Validates and records a newly created intent.
+     * @notice Validates and records a newly signaled intent.
      * @param _intentHash Identifier of the readable intent in the calling orchestrator.
      */
-    function onIntentCreated(bytes32 _intentHash) external;
+    function onIntentSignaled(bytes32 _intentHash) external;
 
     /**
      * @notice Resolves risk accounting for a cancelled or expired intent.

--- a/contracts/interfaces/IIntentLifecycleHook.sol
+++ b/contracts/interfaces/IIntentLifecycleHook.sol
@@ -4,38 +4,53 @@ pragma solidity ^0.8.18;
 
 /**
  * @title IIntentLifecycleHook
- * @notice Lifecycle callbacks used by OrchestratorV3 for governance-selected risk policy.
- * @dev All callbacks are fail-closed: a reverting hook aborts the operation that triggered it,
- *      including cancellation.
+ * @notice Governance-selected admission and settlement callbacks used by OrchestratorV3.
+ * @dev OrchestratorV3 snapshots the configured hook when an intent is signaled, then calls that same hook for the
+ *      intent's terminal cancellation or settlement. Every callback is fail-closed: a revert aborts the complete
+ *      Orchestrator and Escrow operation that triggered it.
  */
 interface IIntentLifecycleHook {
-    /** @notice Complete token and lifecycle context for one atomic settlement decision. */
+    /**
+     * @notice Read-only settlement context supplied after fees are transferred and before recipient funds move.
+     * @param intentHash Intent being settled.
+     * @param token Escrow token released for this settlement.
+     * @param recipient Intent recipient that receives the net amount when no post-intent hook is configured.
+     * @param releaseAmount Amount released from Escrow before protocol, referral, and manager fees.
+     * @param netAmount Remainder after all fees; this is the amount transferred to the recipient or made executable
+     * by the intent's post-intent hook.
+     * @param isManualRelease Whether the depositor used the manual-release path instead of payment-proof fulfillment.
+     */
     struct SettlementContext {
         bytes32 intentHash;
         address token;
         address recipient;
-        uint256 grossAmount;
-        uint256 executableAmount;
+        uint256 releaseAmount;
+        uint256 netAmount;
         bool isManualRelease;
     }
 
     /**
-     * @notice Validates and records a newly signaled intent.
-     * @param _intentHash Identifier of the readable intent in the calling orchestrator.
+     * @notice Validates and records lifecycle-policy state for a newly signaled intent.
+     * @dev The calling orchestrator stores the complete intent before invoking this callback, allowing the hook to
+     * read canonical intent data through `getIntent`. A revert rolls back intent creation and Escrow locking.
+     * @param _intentHash Identifier of the newly stored intent in the calling orchestrator.
      */
     function onIntentSignaled(bytes32 _intentHash) external;
 
     /**
-     * @notice Resolves risk accounting for a cancelled or expired intent.
-     * @param _intentHash Identifier of the intent being cancelled.
+     * @notice Resolves lifecycle-policy state for an intent being cancelled, expired, or pruned as an orphan.
+     * @dev A revert preserves the Orchestrator intent and aborts the corresponding Escrow unlock or prune operation.
+     * @param _intentHash Identifier of the intent being removed without settlement.
      */
     function onIntentCancelled(bytes32 _intentHash) external;
 
     /**
-     * @notice Observes or vetoes a settlement after fees are transferred and before recipient proceeds move.
-     * @dev Fail-closed: a revert aborts the entire settlement, including fee transfers. The hook receives no token
-     *      allowance and the context is informational; executableAmount is the net payout.
-     * @param _context Gross release, net executable amount, token, recipient, and resolution type.
+     * @notice Resolves lifecycle-policy state for a successfully fulfilled or manually released intent.
+     * @dev Called after fee transfers and before the net amount moves to the recipient or post-intent hook. The
+     * lifecycle hook receives no token allowance and cannot consume settlement funds. A revert rolls back the entire
+     * settlement, including Escrow release and fee transfers.
+     * @param _context Intent identifier, token, recipient, pre-fee release amount, post-fee net amount, and settlement
+     * route.
      */
     function settleIntent(SettlementContext calldata _context) external;
 }

--- a/contracts/interfaces/IIntentLifecycleHook.sol
+++ b/contracts/interfaces/IIntentLifecycleHook.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+/**
+ * @title IIntentLifecycleHook
+ * @notice Lifecycle callbacks used by OrchestratorV3 for governance-selected risk policy.
+ * @dev All callbacks are fail-closed: a reverting hook aborts the operation that triggered it,
+ *      including cancellation.
+ */
+interface IIntentLifecycleHook {
+    /** @notice Complete token and lifecycle context for one atomic settlement decision. */
+    struct SettlementContext {
+        bytes32 intentHash;
+        address token;
+        address recipient;
+        uint256 grossAmount;
+        uint256 executableAmount;
+        bool isManualRelease;
+    }
+
+    /**
+     * @notice Validates and records a newly created intent.
+     * @param _intentHash Identifier of the readable intent in the calling orchestrator.
+     */
+    function onIntentCreated(bytes32 _intentHash) external;
+
+    /**
+     * @notice Resolves risk accounting for a cancelled or expired intent.
+     * @param _intentHash Identifier of the intent being cancelled.
+     */
+    function onIntentCancelled(bytes32 _intentHash) external;
+
+    /**
+     * @notice Observes or vetoes a settlement after fees are transferred and before recipient proceeds move.
+     * @dev Fail-closed: a revert aborts the entire settlement, including fee transfers. The hook receives no token
+     *      allowance and the context is informational; executableAmount is the net payout.
+     * @param _context Gross release, net executable amount, token, recipient, and resolution type.
+     */
+    function settleIntent(SettlementContext calldata _context) external;
+}

--- a/contracts/interfaces/IOrchestratorV3.sol
+++ b/contracts/interfaces/IOrchestratorV3.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.18;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IPostIntentHookV2 } from "./IPostIntentHookV2.sol";
+import { IIntentLifecycleHook } from "./IIntentLifecycleHook.sol";
 import { IPreIntentHook } from "./IPreIntentHook.sol";
 import { IReferralFee } from "./IReferralFee.sol";
 
@@ -88,8 +89,8 @@ interface IOrchestratorV3 {
     );
     event IntentManagerFeeSnapshotted(bytes32 indexed intentHash, address indexed feeRecipient, uint256 fee);
     event DepositPreIntentHookSet(address indexed escrow, uint256 indexed depositId, address indexed hook, address setter);
-    event DepositWhitelistHookSet(address indexed escrow, uint256 indexed depositId, address indexed hook, address setter);
-
+    event LifecycleHookUpdated(address indexed previousHook, address indexed newHook);
+    event IntentLifecycleHookSnapshotted(bytes32 indexed intentHash, address indexed lifecycleHook);
     event AllowMultipleIntentsUpdated(bool allowMultiple);
 
     event PaymentVerifierRegistryUpdated(address indexed paymentVerifierRegistry);
@@ -132,6 +133,7 @@ interface IOrchestratorV3 {
     error AccountHasActiveIntent(address account, bytes32 existingIntent);
     error InvalidPostIntentHook(address hook);
     error InvalidPreIntentHook(address hook);
+    error InvalidLifecycleHook(address hook);
     error InvalidSignature();
     error SignatureExpired(uint256 expiration, uint256 currentTime);
 
@@ -148,14 +150,14 @@ interface IOrchestratorV3 {
     function getIntent(bytes32 intentHash) external view returns (Intent memory);
     function getAccountIntents(address account) external view returns (bytes32[] memory);
     function getDepositPreIntentHook(address escrow, uint256 depositId) external view returns (IPreIntentHook);
-    function getDepositWhitelistHook(address escrow, uint256 depositId) external view returns (IPreIntentHook);
+    function lifecycleHook() external view returns (IIntentLifecycleHook);
+    function getIntentLifecycleHook(bytes32 intentHash) external view returns (IIntentLifecycleHook);
 
     /* ============ External Functions for Users ============ */
 
     function signalIntent(SignalIntentParams calldata params) external;
     function setDepositPreIntentHook(address escrow, uint256 depositId, IPreIntentHook hook) external;
-    function setDepositWhitelistHook(address escrow, uint256 depositId, IPreIntentHook hook) external;
-
+    function setLifecycleHook(IIntentLifecycleHook hook) external;
     function cancelIntent(bytes32 intentHash) external;
 
     function fulfillIntent(FulfillIntentParams calldata params) external;

--- a/contracts/interfaces/IStakeVault.sol
+++ b/contracts/interfaces/IStakeVault.sol
@@ -8,6 +8,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  * @title IStakeVault
  * @notice Custody, delegation, locking, and immediately claimable token accounting.
  * @dev The controller supplies all risk policy. Lock identifiers and claim allocations are opaque to the vault.
+ * ZKP2P deployments support canonical USDC only; fee-on-transfer and rebasing tokens are unsupported.
  */
 interface IStakeVault {
     struct StakeLock {
@@ -122,6 +123,15 @@ interface IStakeVault {
     function selectedStakeOwner(address _taker) external view returns (address);
     function authorizedTakers(address _stakeOwner, address _taker) external view returns (bool);
     function stakeOwnerOf(address _taker) external view returns (address);
+
+    /**
+     * @notice Returns a taker's live selected stake owner and that owner's aggregate balances.
+     * @param _taker Taker whose effective stake owner and balances are queried.
+     */
+    function getTakerState(address _taker)
+        external
+        view
+        returns (address stakeOwner, uint256 totalStake, uint256 lockedStakeAmount, uint256 freeStakeAmount);
     function freeStake(address _stakeOwner) external view returns (uint256);
     function isLockMature(bytes32 _lockId) external view returns (bool);
     function totalAccounted() external view returns (uint256);

--- a/contracts/interfaces/IStakeVault.sol
+++ b/contracts/interfaces/IStakeVault.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @title IStakeVault
+ * @notice Custody, delegation, locking, and immediately claimable token accounting.
+ * @dev The controller supplies all risk policy. Lock identifiers and claim allocations are opaque to the vault.
+ */
+interface IStakeVault {
+    struct StakeLock {
+        address stakeOwner;
+        uint256 amount;
+        uint64 maturesAt;
+    }
+
+    struct Claim {
+        address beneficiary;
+        uint256 amount;
+    }
+
+    error ZeroAddress();
+    error ZeroAmount();
+    error ZeroLockId();
+    error InvalidControllerChangeDelay(uint64 suppliedDelay);
+    error ControllerAlreadyInitialized(address controller);
+    error ControllerInitializationWithLiabilities(uint256 totalStaked, uint256 totalClaimable);
+    error UnauthorizedController(address caller);
+    error UnauthorizedPendingController(address caller, address pendingController);
+    error NoPendingController();
+    error ControllerProposalNotReady(uint64 validAt, uint64 currentTime);
+    error InvalidTaker(address taker);
+    error UnauthorizedStakeOwner(address taker, address stakeOwner);
+    error InvalidMaturity(uint64 maturity, uint64 currentTime);
+    error LockAlreadyExists(bytes32 lockId);
+    error LockNotFound(bytes32 lockId);
+    error LockAlreadyMatured(bytes32 lockId, uint64 maturesAt, uint64 currentTime);
+    error InvalidLockAmount(uint256 newAmount, uint256 currentAmount);
+    error InsufficientFreeStake(address stakeOwner, uint256 available, uint256 required);
+    error InsufficientUnaccountedTokens(uint256 available, uint256 required);
+    error InvalidReceivedAmount(uint256 expected, uint256 received);
+    error InvalidClaim(address beneficiary, uint256 amount);
+    error ClaimsExceedLock(uint256 lockAmount, uint256 claimsAmount);
+    error TimestampOverflow(uint256 timestamp);
+    error OwnershipRenunciationDisabled();
+
+    event StakeDeposited(address indexed stakeOwner, uint256 amount, uint256 newStakeBalance);
+    event StakeWithdrawn(address indexed stakeOwner, uint256 amount, uint256 newStakeBalance);
+    event TakerAuthorizationUpdated(address indexed stakeOwner, address indexed taker, bool authorized);
+    event StakeOwnerSelected(address indexed taker, address indexed previousStakeOwner, address indexed newStakeOwner);
+    event StakeLocked(
+        bytes32 indexed lockId, address indexed stakeOwner, uint256 amount, uint64 maturesAt, uint256 totalLockedStake
+    );
+    event LockFunded(bytes32 indexed lockId, address indexed stakeOwner, uint256 amount, uint256 newStakeBalance);
+    event StakeLockIncreased(
+        bytes32 indexed lockId,
+        address indexed stakeOwner,
+        uint256 previousAmount,
+        uint256 newAmount,
+        uint256 totalLockedStake
+    );
+    event StakeLockResized(
+        bytes32 indexed lockId,
+        address indexed stakeOwner,
+        uint256 previousAmount,
+        uint256 newAmount,
+        uint64 previousMaturity,
+        uint64 newMaturity,
+        uint256 totalLockedStake
+    );
+    event StakeUnlocked(bytes32 indexed lockId, address indexed stakeOwner, uint256 amount, uint256 totalLockedStake);
+    event StakeLockResolved(
+        bytes32 indexed lockId,
+        address indexed stakeOwner,
+        uint256 lockAmount,
+        uint256 unlockedAmount,
+        uint256 claimedAmount,
+        uint256 totalLockedStake
+    );
+    event ClaimCreated(
+        bytes32 indexed lockId, address indexed beneficiary, uint256 amount, uint256 newClaimableBalance
+    );
+    event ClaimWithdrawn(address indexed beneficiary, uint256 amount);
+    event ControllerInitialized(address indexed controller);
+    event ControllerProposed(address indexed currentController, address indexed pendingController, uint64 validAt);
+    event ControllerProposalCancelled(address indexed pendingController);
+    event ControllerAccepted(address indexed previousController, address indexed newController);
+
+    function depositStake(uint256 _amount) external;
+    function withdrawStake(uint256 _amount) external;
+    function claim() external;
+
+    function setTakerAuthorization(address _taker, bool _authorized) external;
+    function selectStakeOwner(address _stakeOwner) external;
+    function clearStakeOwner() external;
+
+    function lockStake(address _stakeOwner, bytes32 _lockId, uint256 _amount, uint64 _maturesAt) external;
+    function fundLock(address _stakeOwner, bytes32 _lockId, uint256 _amount, uint64 _maturesAt) external;
+    function increaseLock(bytes32 _lockId, uint256 _additionalAmount) external;
+    function resizeLock(bytes32 _lockId, uint256 _newAmount, uint64 _newMaturesAt) external;
+    function unlockStake(bytes32 _lockId) external;
+    function resolveLock(bytes32 _lockId, Claim[] calldata _claims) external;
+
+    function initializeController(address _controller) external;
+    function proposeController(address _controller) external;
+    function cancelControllerProposal() external;
+    function acceptController() external;
+
+    function stakeToken() external view returns (IERC20);
+    function controller() external view returns (address);
+    function pendingController() external view returns (address);
+    function pendingControllerValidAt() external view returns (uint64);
+    function controllerChangeDelay() external view returns (uint64);
+    function stakeBalance(address _stakeOwner) external view returns (uint256);
+    function lockedStake(address _stakeOwner) external view returns (uint256);
+    function claimable(address _beneficiary) external view returns (uint256);
+    function totalStaked() external view returns (uint256);
+    function totalClaimable() external view returns (uint256);
+    function locks(bytes32 _lockId) external view returns (address stakeOwner, uint256 amount, uint64 maturesAt);
+    function selectedStakeOwner(address _taker) external view returns (address);
+    function authorizedTakers(address _stakeOwner, address _taker) external view returns (bool);
+    function stakeOwnerOf(address _taker) external view returns (address);
+    function freeStake(address _stakeOwner) external view returns (uint256);
+    function isLockMature(bytes32 _lockId) external view returns (bool);
+    function totalAccounted() external view returns (uint256);
+    function unaccountedBalance() external view returns (uint256);
+}

--- a/contracts/mocks/IntentLifecycleHookV1Mock.sol
+++ b/contracts/mocks/IntentLifecycleHookV1Mock.sol
@@ -9,26 +9,26 @@ import { IIntentLifecycleHook } from "../interfaces/IIntentLifecycleHook.sol";
  * @notice Configurable lifecycle hook used to exercise OrchestratorV3 callback behavior.
  */
 contract IntentLifecycleHookV1Mock is IIntentLifecycleHook {
-    bool public revertOnCreate;
+    bool public revertOnSignal;
     bool public revertOnCallback;
     bytes32 public lastIntentHash;
     SettlementContext public lastSettlementContext;
-    uint256 public createdCalls;
+    uint256 public signaledCalls;
     uint256 public cancelledCalls;
     uint256 public settlementCalls;
 
     function setRevertOnCreate(bool _shouldRevert) external {
-        revertOnCreate = _shouldRevert;
+        revertOnSignal = _shouldRevert;
     }
 
     function setRevertOnCallback(bool _shouldRevert) external {
         revertOnCallback = _shouldRevert;
     }
 
-    function onIntentCreated(bytes32 _intentHash) external override {
-        if (revertOnCreate) revert("risk admission failed");
+    function onIntentSignaled(bytes32 _intentHash) external override {
+        if (revertOnSignal) revert("risk admission failed");
         lastIntentHash = _intentHash;
-        createdCalls++;
+        signaledCalls++;
     }
 
     function onIntentCancelled(bytes32 _intentHash) external override {

--- a/contracts/mocks/IntentLifecycleHookV1Mock.sol
+++ b/contracts/mocks/IntentLifecycleHookV1Mock.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { IIntentLifecycleHook } from "../interfaces/IIntentLifecycleHook.sol";
+
+/**
+ * @title IntentLifecycleHookV1Mock
+ * @notice Configurable lifecycle hook used to exercise OrchestratorV3 callback behavior.
+ */
+contract IntentLifecycleHookV1Mock is IIntentLifecycleHook {
+    bool public revertOnCreate;
+    bool public revertOnCallback;
+    bytes32 public lastIntentHash;
+    SettlementContext public lastSettlementContext;
+    uint256 public createdCalls;
+    uint256 public cancelledCalls;
+    uint256 public settlementCalls;
+
+    function setRevertOnCreate(bool _shouldRevert) external {
+        revertOnCreate = _shouldRevert;
+    }
+
+    function setRevertOnCallback(bool _shouldRevert) external {
+        revertOnCallback = _shouldRevert;
+    }
+
+    function onIntentCreated(bytes32 _intentHash) external override {
+        if (revertOnCreate) revert("risk admission failed");
+        lastIntentHash = _intentHash;
+        createdCalls++;
+    }
+
+    function onIntentCancelled(bytes32 _intentHash) external override {
+        if (revertOnCallback) revert("risk cancellation failed");
+        lastIntentHash = _intentHash;
+        cancelledCalls++;
+    }
+
+    function settleIntent(SettlementContext calldata _context) external override {
+        if (revertOnCallback) revert("risk settlement failed");
+        lastIntentHash = _context.intentHash;
+        lastSettlementContext = _context;
+        settlementCalls++;
+    }
+}

--- a/contracts/unifiedVerifier/ChargebackVerifier.sol
+++ b/contracts/unifiedVerifier/ChargebackVerifier.sol
@@ -2,7 +2,6 @@
 
 pragma solidity ^0.8.18;
 
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 
@@ -27,16 +26,14 @@ contract ChargebackVerifier is IChargebackVerifier, Ownable2Step, EIP712 {
 
     /* ============ State Variables ============ */
 
-    INullifierRegistryV2 public immutable override nullifierRegistry;
-    IAttestationVerifier public override attestationVerifier;
+    INullifierRegistryV2 public immutable nullifierRegistry;
+    IAttestationVerifier public attestationVerifier;
 
     /* ============ Constructor ============ */
 
-    constructor(
-        address _owner,
-        INullifierRegistryV2 _nullifierRegistry,
-        IAttestationVerifier _attestationVerifier
-    ) EIP712("ZKP2P ChargebackVerifier", "1") {
+    constructor(address _owner, INullifierRegistryV2 _nullifierRegistry, IAttestationVerifier _attestationVerifier)
+        EIP712("ZKP2P ChargebackVerifier", "1")
+    {
         if (_owner == address(0)) revert ZeroAddress();
         _validateDependency(address(_nullifierRegistry));
         _validateDependency(address(_attestationVerifier));
@@ -67,8 +64,7 @@ contract ChargebackVerifier is IChargebackVerifier, Ownable2Step, EIP712 {
         }
 
         if (!_isManualRelease) {
-            bytes32 paymentNullifier =
-                keccak256(abi.encodePacked(details.paymentMethod, details.originalPaymentId));
+            bytes32 paymentNullifier = keccak256(abi.encodePacked(details.paymentMethod, details.originalPaymentId));
             if (
                 nullifierRegistry.intentHashByNullifier(paymentNullifier) != _attestation.intentHash
                     || nullifierRegistry.nullifierByIntentHash(_attestation.intentHash) != paymentNullifier
@@ -84,9 +80,10 @@ contract ChargebackVerifier is IChargebackVerifier, Ownable2Step, EIP712 {
     /* ============ Governance Functions ============ */
 
     /**
-     * @inheritdoc IChargebackVerifier
+     * @notice GOVERNANCE ONLY: Replaces the verifier used for future witness-signature checks.
+     * @param _verifier New non-zero deployed attestation-verifier contract.
      */
-    function setAttestationVerifier(address _verifier) external override onlyOwner {
+    function setAttestationVerifier(address _verifier) external onlyOwner {
         _validateDependency(_verifier);
         address previousVerifier = address(attestationVerifier);
         attestationVerifier = IAttestationVerifier(_verifier);
@@ -96,21 +93,18 @@ contract ChargebackVerifier is IChargebackVerifier, Ownable2Step, EIP712 {
     /**
      * @notice Disables ownership renunciation so the signature-verification dependency stays managed.
      */
-    function renounceOwnership() public view override(IChargebackVerifier, Ownable) onlyOwner {
+    function renounceOwnership() public view override onlyOwner {
         revert OwnershipRenunciationDisabled();
     }
 
     /* ============ View Functions ============ */
 
     /**
-     * @inheritdoc IChargebackVerifier
+     * @notice Returns the EIP-712 digest that witnesses sign for a chargeback attestation.
+     * @param _attestation Chargeback evidence whose intent hash and data hash are included in the digest.
+     * @return EIP-712 digest bound to this verifier's address and the current chain.
      */
-    function hashChargebackAttestation(ChargebackAttestation calldata _attestation)
-        external
-        view
-        override
-        returns (bytes32)
-    {
+    function hashChargebackAttestation(ChargebackAttestation calldata _attestation) external view returns (bytes32) {
         return _hashTypedDataV4(_chargebackAttestationStructHash(_attestation));
     }
 
@@ -121,9 +115,7 @@ contract ChargebackVerifier is IChargebackVerifier, Ownable2Step, EIP712 {
         pure
         returns (bytes32)
     {
-        return keccak256(
-            abi.encode(CHARGEBACK_ATTESTATION_TYPEHASH, _attestation.intentHash, _attestation.dataHash)
-        );
+        return keccak256(abi.encode(CHARGEBACK_ATTESTATION_TYPEHASH, _attestation.intentHash, _attestation.dataHash));
     }
 
     function _validateDependency(address _dependency) internal view {

--- a/contracts/unifiedVerifier/ChargebackVerifier.sol
+++ b/contracts/unifiedVerifier/ChargebackVerifier.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+
+import {IAttestationVerifier} from "../interfaces/IAttestationVerifier.sol";
+import {IChargebackVerifier} from "../interfaces/IChargebackVerifier.sol";
+import {INullifierRegistryV2} from "../interfaces/INullifierRegistryV2.sol";
+
+/**
+ * @title ChargebackVerifier
+ * @notice Stateless EIP-712 verifier for chargeback evidence, mirroring the UnifiedPaymentVerifier
+ * layering: the chargeback policy calls this verifier, which itself calls the attestation verifier
+ * for witness-signature checks. Holds no position state and can be swapped on the policy at any time.
+ * @dev Swapping this verifier rotates the EIP-712 domain (it binds this contract's address), which
+ * invalidates signed-but-unsubmitted attestations. The attestation service must always sign against
+ * the policy's currently configured verifier.
+ */
+contract ChargebackVerifier is IChargebackVerifier, Ownable2Step, EIP712 {
+    /* ============ Constants ============ */
+
+    bytes32 public constant CHARGEBACK_ATTESTATION_TYPEHASH =
+        keccak256("ChargebackAttestation(bytes32 intentHash,bytes32 dataHash)");
+
+    /* ============ State Variables ============ */
+
+    INullifierRegistryV2 public immutable override nullifierRegistry;
+    IAttestationVerifier public override attestationVerifier;
+
+    /* ============ Constructor ============ */
+
+    constructor(
+        address _owner,
+        INullifierRegistryV2 _nullifierRegistry,
+        IAttestationVerifier _attestationVerifier
+    ) EIP712("ZKP2P ChargebackVerifier", "1") {
+        if (_owner == address(0)) revert ZeroAddress();
+        _validateDependency(address(_nullifierRegistry));
+        _validateDependency(address(_attestationVerifier));
+
+        nullifierRegistry = _nullifierRegistry;
+        attestationVerifier = _attestationVerifier;
+        _transferOwnership(_owner);
+    }
+
+    /* ============ External Functions ============ */
+
+    /**
+     * @inheritdoc IChargebackVerifier
+     */
+    function verifyChargeback(
+        ChargebackAttestation calldata _attestation,
+        bytes32 _paymentMethod,
+        bool _isManualRelease
+    ) external view override returns (bytes32 disputeId, bytes32 disputeNullifier) {
+        if (keccak256(_attestation.data) != _attestation.dataHash) revert InvalidAttestation();
+
+        ChargebackDetails memory details = abi.decode(_attestation.data, (ChargebackDetails));
+        if (details.paymentMethod != _paymentMethod) revert InvalidAttestation();
+
+        bytes32 digest = _hashTypedDataV4(_chargebackAttestationStructHash(_attestation));
+        if (!attestationVerifier.verify(digest, _attestation.signatures, _attestation.data)) {
+            revert AttestationVerificationFailed();
+        }
+
+        if (!_isManualRelease) {
+            bytes32 paymentNullifier =
+                keccak256(abi.encodePacked(details.paymentMethod, details.originalPaymentId));
+            if (
+                nullifierRegistry.intentHashByNullifier(paymentNullifier) != _attestation.intentHash
+                    || nullifierRegistry.nullifierByIntentHash(_attestation.intentHash) != paymentNullifier
+            ) {
+                revert InvalidPaymentBinding(_attestation.intentHash, paymentNullifier);
+            }
+        }
+
+        disputeId = details.disputeId;
+        disputeNullifier = keccak256(abi.encodePacked(details.paymentMethod, details.disputeId));
+    }
+
+    /* ============ Governance Functions ============ */
+
+    /**
+     * @inheritdoc IChargebackVerifier
+     */
+    function setAttestationVerifier(address _verifier) external override onlyOwner {
+        _validateDependency(_verifier);
+        address previousVerifier = address(attestationVerifier);
+        attestationVerifier = IAttestationVerifier(_verifier);
+        emit AttestationVerifierUpdated(previousVerifier, _verifier);
+    }
+
+    /**
+     * @notice Disables ownership renunciation so the signature-verification dependency stays managed.
+     */
+    function renounceOwnership() public view override(IChargebackVerifier, Ownable) onlyOwner {
+        revert OwnershipRenunciationDisabled();
+    }
+
+    /* ============ View Functions ============ */
+
+    /**
+     * @inheritdoc IChargebackVerifier
+     */
+    function hashChargebackAttestation(ChargebackAttestation calldata _attestation)
+        external
+        view
+        override
+        returns (bytes32)
+    {
+        return _hashTypedDataV4(_chargebackAttestationStructHash(_attestation));
+    }
+
+    /* ============ Internal Functions ============ */
+
+    function _chargebackAttestationStructHash(ChargebackAttestation calldata _attestation)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encode(CHARGEBACK_ATTESTATION_TYPEHASH, _attestation.intentHash, _attestation.dataHash)
+        );
+    }
+
+    function _validateDependency(address _dependency) internal view {
+        if (_dependency == address(0)) revert ZeroAddress();
+        if (_dependency.code.length == 0) revert InvalidContract(_dependency);
+    }
+}

--- a/scripts/run-foundry-coverage.cjs
+++ b/scripts/run-foundry-coverage.cjs
@@ -101,6 +101,11 @@ const deterministicCoverageRuns = [
         test: "test-foundry/deterministic/registries",
     },
     {
+        name: "deterministic-staking",
+        irMinimum: true,
+        test: "test-foundry/deterministic/staking",
+    },
+    {
         name: "deterministic-verifiers",
         irMinimum: true,
         test: "test-foundry/deterministic/verifiers",
@@ -158,6 +163,7 @@ const coverageLanes = new Map([
             "deterministic-oracles",
             "deterministic-periphery",
             "deterministic-registries",
+            "deterministic-staking",
         ],
     ],
 ]);

--- a/test-foundry/deterministic/helpers/OrchestratorV3Fixture.sol
+++ b/test-foundry/deterministic/helpers/OrchestratorV3Fixture.sol
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {EscrowV2} from "contracts/EscrowV2.sol";
+import {OrchestratorV3} from "contracts/OrchestratorV3.sol";
+import {OrchestratorMock} from "contracts/mocks/OrchestratorMock.sol";
+import {PartialPullPostIntentHookV2Mock} from "contracts/mocks/PartialPullPostIntentHookV2Mock.sol";
+import {PaymentVerifierMock} from "contracts/mocks/PaymentVerifierMock.sol";
+import {PostIntentHookV2Mock} from "contracts/mocks/PostIntentHookV2Mock.sol";
+import {PreIntentHookMock} from "contracts/mocks/PreIntentHookMock.sol";
+import {PushPostIntentHookV2Mock} from "contracts/mocks/PushPostIntentHookV2Mock.sol";
+import {ReentrantPostIntentHookV2} from "contracts/mocks/ReentrantPostIntentHookV2.sol";
+import {ReentrantPreIntentHookMock} from "contracts/mocks/ReentrantPreIntentHookMock.sol";
+import {ReentrantSignalIntentCallerV2Mock} from "contracts/mocks/ReentrantSignalIntentCallerV2Mock.sol";
+import {USDCMock} from "contracts/mocks/USDCMock.sol";
+import {EscrowRegistry} from "contracts/registries/EscrowRegistry.sol";
+import {OrchestratorRegistry} from "contracts/registries/OrchestratorRegistry.sol";
+import {PaymentVerifierRegistry} from "contracts/registries/PaymentVerifierRegistry.sol";
+import {RelayerRegistry} from "contracts/registries/RelayerRegistry.sol";
+import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
+import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
+import {IPostIntentHookV2} from "contracts/interfaces/IPostIntentHookV2.sol";
+import {IReferralFee} from "contracts/interfaces/IReferralFee.sol";
+
+abstract contract OrchestratorV3Fixture is Test {
+    uint256 internal constant CHAIN_ID = 1;
+    uint256 internal constant INTENT_AMOUNT = 50e6;
+    uint256 internal constant CONVERSION_RATE = 1e18;
+    uint256 internal constant CIRCOM_PRIME_FIELD =
+        21888242871839275222246405745257275088548364400416034343698204186575808495617;
+    bytes32 internal constant METHOD = keccak256("venmo");
+    bytes32 internal constant USD = keccak256("USD");
+    bytes32 internal constant PAYEE = keccak256("payee");
+
+    uint256 internal gatingServiceKey;
+    address internal depositor;
+    address internal delegate;
+    address internal taker;
+    address internal other;
+    address internal referrer;
+    address internal protocolFeeRecipient;
+    address internal gatingService;
+    USDCMock internal token;
+    EscrowV2 internal escrow;
+    OrchestratorV3 internal orchestrator;
+    EscrowRegistry internal escrowRegistry;
+    OrchestratorRegistry internal orchestratorRegistry;
+    PaymentVerifierRegistry internal paymentVerifierRegistry;
+    RelayerRegistry internal relayerRegistry;
+    PaymentVerifierMock internal verifier;
+    PreIntentHookMock internal preIntentHook;
+    PostIntentHookV2Mock internal postIntentHook;
+    PartialPullPostIntentHookV2Mock internal partialPostIntentHook;
+    PushPostIntentHookV2Mock internal pushPostIntentHook;
+    ReentrantPostIntentHookV2 internal reentrantPostIntentHook;
+    ReentrantSignalIntentCallerV2Mock internal reentrantSignalCaller;
+    ReentrantPreIntentHookMock internal reentrantPreIntentHook;
+    OrchestratorMock internal orchestratorMock;
+    uint256 internal depositId;
+
+    function setUp() public virtual {
+        depositor = makeAddr("depositor");
+        delegate = makeAddr("delegate");
+        taker = makeAddr("taker");
+        other = makeAddr("other");
+        referrer = makeAddr("referrer");
+        protocolFeeRecipient = makeAddr("protocolFeeRecipient");
+        (gatingService, gatingServiceKey) = makeAddrAndKey("gatingService");
+
+        token = new USDCMock(1_000_000_000e6, "USDC", "USDC");
+        token.transfer(depositor, 100_000e6);
+        paymentVerifierRegistry = new PaymentVerifierRegistry();
+        escrowRegistry = new EscrowRegistry();
+        orchestratorRegistry = new OrchestratorRegistry();
+        relayerRegistry = new RelayerRegistry();
+        verifier = new PaymentVerifierMock();
+        preIntentHook = new PreIntentHookMock();
+        bytes32[] memory currencies = new bytes32[](1);
+        currencies[0] = USD;
+        paymentVerifierRegistry.addPaymentMethod(METHOD, address(verifier), currencies);
+
+        escrow = new EscrowV2(
+            address(this),
+            CHAIN_ID,
+            address(orchestratorRegistry),
+            address(paymentVerifierRegistry),
+            address(this),
+            0,
+            20,
+            1 hours
+        );
+        orchestrator = new OrchestratorV3(
+            address(this),
+            CHAIN_ID,
+            address(escrowRegistry),
+            address(paymentVerifierRegistry),
+            address(relayerRegistry),
+            0,
+            protocolFeeRecipient
+        );
+        orchestrator.setAllowMultipleIntents(true);
+        postIntentHook = new PostIntentHookV2Mock(address(token), address(orchestrator));
+        partialPostIntentHook = new PartialPullPostIntentHookV2Mock(address(token), address(orchestrator));
+        pushPostIntentHook = new PushPostIntentHookV2Mock(address(token), address(orchestrator));
+        reentrantPostIntentHook = new ReentrantPostIntentHookV2(address(token), address(orchestrator));
+        reentrantSignalCaller = new ReentrantSignalIntentCallerV2Mock(address(orchestrator));
+        reentrantPreIntentHook = new ReentrantPreIntentHookMock(address(reentrantSignalCaller));
+        orchestratorMock = new OrchestratorMock(address(escrow));
+        token.transfer(address(pushPostIntentHook), 10e6);
+
+        escrowRegistry.addEscrow(address(escrow));
+        orchestratorRegistry.addOrchestrator(address(orchestrator));
+        orchestratorRegistry.addOrchestrator(address(orchestratorMock));
+        verifier.setVerificationContext(address(orchestrator), address(escrow));
+        vm.startPrank(depositor);
+        token.approve(address(escrow), 100_000e6);
+        depositId = _createDeposit(address(0), delegate);
+        vm.stopPrank();
+    }
+
+    function _emptyOracle() internal pure returns (IEscrowV2.OracleRateConfig memory) {
+        return IEscrowV2.OracleRateConfig({adapter: address(0), adapterConfig: "", spreadBps: 0, maxStaleness: 0});
+    }
+
+    function _createDeposit(address intentGatingService, address depositDelegate) internal returns (uint256 id) {
+        id = escrow.depositCounter();
+        bytes32[] memory methods = new bytes32[](1);
+        methods[0] = METHOD;
+        IEscrowV2.DepositPaymentMethodData[] memory methodData = new IEscrowV2.DepositPaymentMethodData[](1);
+        methodData[0] = IEscrowV2.DepositPaymentMethodData({
+            intentGatingService: intentGatingService, payeeDetails: PAYEE, data: ""
+        });
+        IEscrowV2.Currency[][] memory currencies = new IEscrowV2.Currency[][](1);
+        currencies[0] = new IEscrowV2.Currency[](1);
+        currencies[0][0] =
+            IEscrowV2.Currency({code: USD, minConversionRate: CONVERSION_RATE, oracleRateConfig: _emptyOracle()});
+        escrow.createDeposit(
+            IEscrowV2.CreateDepositParams({
+                token: IERC20(address(token)),
+                amount: 500e6,
+                intentAmountRange: IEscrowV2.Range({min: 10e6, max: 200e6}),
+                paymentMethods: methods,
+                paymentMethodData: methodData,
+                currencies: currencies,
+                delegate: depositDelegate,
+                intentGuardian: address(0),
+                retainOnEmpty: false
+            })
+        );
+    }
+
+    function _emptyReferralFees() internal pure returns (IReferralFee.ReferralFee[] memory) {
+        return new IReferralFee.ReferralFee[](0);
+    }
+
+    function _twoReferralFees() internal view returns (IReferralFee.ReferralFee[] memory fees) {
+        fees = new IReferralFee.ReferralFee[](2);
+        fees[0] = IReferralFee.ReferralFee({recipient: referrer, fee: 3e15});
+        fees[1] = IReferralFee.ReferralFee({recipient: other, fee: 2e15});
+    }
+
+    function _params(
+        uint256 selectedDepositId,
+        address to,
+        uint256 amount,
+        uint256 conversionRate,
+        IReferralFee.ReferralFee[] memory referralFees,
+        IPostIntentHookV2 hook,
+        bytes memory data
+    ) internal view returns (IOrchestratorV3.SignalIntentParams memory) {
+        return IOrchestratorV3.SignalIntentParams({
+            escrow: address(escrow),
+            depositId: selectedDepositId,
+            amount: amount,
+            to: to,
+            paymentMethod: METHOD,
+            fiatCurrency: USD,
+            conversionRate: conversionRate,
+            referralFees: referralFees,
+            gatingServiceSignature: "",
+            signatureExpiration: block.timestamp + 1 days,
+            postIntentHook: hook,
+            preIntentHookData: "",
+            data: data
+        });
+    }
+
+    function _defaultParams() internal view returns (IOrchestratorV3.SignalIntentParams memory) {
+        return _params(
+            depositId, taker, INTENT_AMOUNT, CONVERSION_RATE, _emptyReferralFees(), IPostIntentHookV2(address(0)), ""
+        );
+    }
+
+    function _intentHash(uint256 counter) internal view returns (bytes32) {
+        return bytes32(uint256(keccak256(abi.encodePacked(address(orchestrator), counter))) % CIRCOM_PRIME_FIELD);
+    }
+
+    function _signal(address caller, IOrchestratorV3.SignalIntentParams memory params) internal returns (bytes32 hash) {
+        hash = _intentHash(orchestrator.intentCounter());
+        _signalCall(caller, params);
+    }
+
+    function _signalCall(address caller, IOrchestratorV3.SignalIntentParams memory params) internal {
+        vm.prank(caller);
+        orchestrator.signalIntent(params);
+    }
+
+    function _signalDefault() internal returns (bytes32) {
+        return _signal(taker, _defaultParams());
+    }
+
+    function _paymentProof(bytes32 intentHash, uint256 releaseAmount, uint256 conversionRate)
+        internal
+        view
+        returns (bytes memory)
+    {
+        uint256 fiatAmount = releaseAmount * conversionRate / 1e18;
+        return abi.encode(fiatAmount, block.timestamp, PAYEE, USD, intentHash);
+    }
+
+    function _fulfill(bytes32 intentHash, uint256 releaseAmount, uint256 conversionRate) internal {
+        orchestrator.fulfillIntent(
+            IOrchestratorV3.FulfillIntentParams({
+                paymentProof: _paymentProof(intentHash, releaseAmount, conversionRate),
+                intentHash: intentHash,
+                verificationData: "",
+                postIntentHookData: ""
+            })
+        );
+    }
+
+    function _referralHash(IReferralFee.ReferralFee[] memory fees) internal pure returns (bytes32) {
+        bytes32[] memory hashes = new bytes32[](fees.length);
+        for (uint256 i; i < fees.length; ++i) {
+            hashes[i] = keccak256(abi.encode(fees[i].recipient, fees[i].fee));
+        }
+        return keccak256(abi.encode(hashes));
+    }
+
+    function _gatingSignature(
+        uint256 signerKey,
+        address signedCaller,
+        IOrchestratorV3.SignalIntentParams memory params,
+        uint256 expiration
+    ) internal view returns (bytes memory) {
+        bytes32 messageHash = keccak256(
+            abi.encodePacked(
+                address(orchestrator),
+                params.escrow,
+                params.depositId,
+                params.amount,
+                signedCaller,
+                params.to,
+                params.paymentMethod,
+                params.fiatCurrency,
+                params.conversionRate,
+                _referralHash(params.referralFees),
+                expiration,
+                CHAIN_ID
+            )
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _gatedParams(uint256 gatedDepositId, uint256 signerKey, address signedCaller, uint256 expiration)
+        internal
+        view
+        returns (IOrchestratorV3.SignalIntentParams memory params)
+    {
+        params = _params(
+            gatedDepositId,
+            taker,
+            INTENT_AMOUNT,
+            CONVERSION_RATE,
+            _emptyReferralFees(),
+            IPostIntentHookV2(address(0)),
+            ""
+        );
+        params.signatureExpiration = expiration;
+        params.gatingServiceSignature = _gatingSignature(signerKey, signedCaller, params, expiration);
+    }
+}

--- a/test-foundry/deterministic/hooks/ChargebackPolicy.t.sol
+++ b/test-foundry/deterministic/hooks/ChargebackPolicy.t.sol
@@ -57,8 +57,8 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         _stake(taker, STAKE_AMOUNT);
     }
 
-    function test_AdmitIntentLocksStakeAndSnapshotsConfiguration() public {
-        policy.admitIntent(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+    function test_onIntentSignaledLocksStakeAndSnapshotsConfiguration() public {
+        policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         policy.setRiskWindow(METHOD, 7 days);
 
         IChargebackPolicy.Position memory position = policy.getPosition(INTENT);
@@ -75,14 +75,14 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         assertEq(maturesAt, type(uint64).max);
     }
 
-    function test_AdmitIntentRejectsUnauthorizedPausedDisabledAndDuplicate() public {
+    function test_onIntentSignaledRejectsUnauthorizedPausedDisabledAndDuplicate() public {
         vm.expectRevert(abi.encodeWithSelector(IChargebackPolicy.UnauthorizedLifecycleHook.selector, other));
         vm.prank(other);
-        policy.admitIntent(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
 
         policy.setAdmissionsPaused(true);
         vm.expectRevert(IChargebackPolicy.AdmissionsPaused.selector);
-        policy.admitIntent(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         policy.setAdmissionsPaused(false);
 
         vm.prank(depositor);
@@ -90,22 +90,22 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         vm.expectRevert(
             abi.encodeWithSelector(IChargebackPolicy.ChargebackNotEnabled.selector, address(escrow), depositId)
         );
-        policy.admitIntent(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         vm.prank(depositor);
         policy.setEnabled(address(escrow), depositId, true);
 
-        policy.admitIntent(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         vm.expectRevert(abi.encodeWithSelector(IChargebackPolicy.PositionAlreadyExists.selector, INTENT));
-        policy.admitIntent(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
     }
 
-    function test_AdmitIntentPassesThroughWindowlessMethodEvenWhenAdmissionsPaused() public {
+    function test_onIntentSignaledPassesThroughWindowlessMethodEvenWhenAdmissionsPaused() public {
         bytes32 windowlessMethod = keccak256("windowless");
         uint256 lockedBefore = vault.lockedStake(taker);
         uint256 freeBefore = vault.freeStake(taker);
         policy.setAdmissionsPaused(true);
 
-        policy.admitIntent(
+        policy.onIntentSignaled(
             INTENT, address(escrow), depositId, taker, windowlessMethod, INTENT_AMOUNT
         );
 
@@ -126,7 +126,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         assertEq(vault.freeStake(taker), freeBefore);
     }
 
-    function test_AdmitIntentRejectsWrongTokenAndInsufficientCollateral() public {
+    function test_onIntentSignaledRejectsWrongTokenAndInsufficientCollateral() public {
         USDCMock otherToken = new USDCMock(1_000e6, "Other", "OTHER");
         ChargebackEscrowMock wrongTokenEscrow = new ChargebackEscrowMock(depositor, otherToken);
         escrowRegistry.addEscrow(address(wrongTokenEscrow));
@@ -137,7 +137,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
                 IChargebackPolicy.IntentTokenMismatch.selector, address(token), address(otherToken)
             )
         );
-        policy.admitIntent(
+        policy.onIntentSignaled(
             INTENT, address(wrongTokenEscrow), depositId, taker, METHOD, INTENT_AMOUNT
         );
 
@@ -150,7 +150,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
                 INTENT_AMOUNT
             )
         );
-        policy.admitIntent(secondIntent, address(escrow), depositId, other, METHOD, INTENT_AMOUNT);
+        policy.onIntentSignaled(secondIntent, address(escrow), depositId, other, METHOD, INTENT_AMOUNT);
     }
 
     function test_DelegatedStakeLocksSelectedOwnersStake() public {
@@ -161,7 +161,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         vm.prank(other);
         vault.selectStakeOwner(stakeOwner);
 
-        policy.admitIntent(INTENT, address(escrow), depositId, other, METHOD, INTENT_AMOUNT);
+        policy.onIntentSignaled(INTENT, address(escrow), depositId, other, METHOD, INTENT_AMOUNT);
 
         assertEq(policy.getPosition(INTENT).stakeOwner, stakeOwner);
         assertEq(vault.lockedStake(stakeOwner), INTENT_AMOUNT);
@@ -170,7 +170,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
 
     function test_CancellationUnlocksPendingNoneIsNoOpAndSettledReverts() public {
         policy.onIntentCancelled(keccak256("missing"));
-        policy.admitIntent(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         policy.onIntentCancelled(INTENT);
         assertEq(vault.lockedStake(taker), 0);
         assertEq(
@@ -179,7 +179,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         );
 
         bytes32 settledIntent = keccak256("settled");
-        policy.admitIntent(settledIntent, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        policy.onIntentSignaled(settledIntent, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         policy.onIntentSettled(settledIntent, INTENT_AMOUNT, false);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -193,7 +193,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
 
     function test_SettlementResizesFullAndPartialAndSnapshotsDeadlineAndManualFlag() public {
         policy.onIntentSettled(keccak256("missing"), INTENT_AMOUNT, false);
-        policy.admitIntent(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         uint256 expectedDeadline = vm.getBlockTimestamp() + RISK_WINDOW;
         policy.onIntentSettled(INTENT, 40e6, true);
 
@@ -216,7 +216,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         policy.onIntentSettled(INTENT, 40e6, true);
 
         bytes32 fullIntent = keccak256("full");
-        policy.admitIntent(fullIntent, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        policy.onIntentSignaled(fullIntent, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         policy.onIntentSettled(fullIntent, INTENT_AMOUNT, false);
         (, amount,) = vault.locks(fullIntent);
         assertEq(amount, INTENT_AMOUNT);
@@ -457,7 +457,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
     }
 
     function _admitAndSettle(bytes32 intentHash, uint256 grossAmount, bool manualRelease) internal {
-        policy.admitIntent(intentHash, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        policy.onIntentSignaled(intentHash, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         policy.onIntentSettled(intentHash, grossAmount, manualRelease);
     }
 

--- a/test-foundry/deterministic/hooks/ChargebackPolicy.t.sol
+++ b/test-foundry/deterministic/hooks/ChargebackPolicy.t.sol
@@ -7,12 +7,14 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {StakeVault} from "contracts/StakeVault.sol";
 import {ChargebackPolicy} from "contracts/hooks/ChargebackPolicy.sol";
 import {IChargebackPolicy} from "contracts/interfaces/IChargebackPolicy.sol";
+import {IChargebackVerifier} from "contracts/interfaces/IChargebackVerifier.sol";
 import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
 import {AttestationVerifierMock} from "contracts/mocks/AttestationVerifierMock.sol";
 import {USDCMock} from "contracts/mocks/USDCMock.sol";
 import {EscrowRegistry} from "contracts/registries/EscrowRegistry.sol";
 import {NullifierRegistry} from "contracts/registries/NullifierRegistry.sol";
 import {NullifierRegistryV2} from "contracts/registries/NullifierRegistryV2.sol";
+import {ChargebackVerifier} from "contracts/unifiedVerifier/ChargebackVerifier.sol";
 
 import {OrchestratorV3Fixture} from "../helpers/OrchestratorV3Fixture.sol";
 
@@ -31,6 +33,7 @@ contract ChargebackEscrowMock {
 
 contract ChargebackPolicyTest is OrchestratorV3Fixture {
     event LifecycleHookAuthorizationUpdated(address indexed hook, bool authorized);
+    event ChargebackVerifierUpdated(address indexed previousVerifier, address indexed newVerifier);
 
     uint64 internal constant RISK_WINDOW = 30 days;
     uint256 internal constant STAKE_AMOUNT = 500e6;
@@ -39,6 +42,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
     StakeVault internal vault;
     NullifierRegistryV2 internal nullifierRegistry;
     AttestationVerifierMock internal attestationVerifier;
+    ChargebackVerifier internal chargebackVerifier;
     ChargebackPolicy internal policy;
 
     function setUp() public override {
@@ -46,9 +50,8 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         vault = new StakeVault(address(this), token, address(0), 1 days);
         nullifierRegistry = new NullifierRegistryV2(new NullifierRegistry());
         attestationVerifier = new AttestationVerifierMock();
-        policy = new ChargebackPolicy(
-            address(this), vault, nullifierRegistry, attestationVerifier, escrowRegistry
-        );
+        chargebackVerifier = new ChargebackVerifier(address(this), nullifierRegistry, attestationVerifier);
+        policy = new ChargebackPolicy(address(this), vault, chargebackVerifier, escrowRegistry);
         vault.initializeController(address(policy));
         policy.setLifecycleHook(address(this));
         policy.setRiskWindow(METHOD, RISK_WINDOW);
@@ -257,13 +260,13 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
     function test_SubmitChargebackProofPathRequiresBothDirectionBindingAndCreatesClaim() public {
         _admitAndSettle(INTENT, 40e6, false);
         bytes32 paymentId = keccak256("payment");
-        IChargebackPolicy.ChargebackAttestation memory attestation =
+        IChargebackVerifier.ChargebackAttestation memory attestation =
             _attestation(INTENT, METHOD, paymentId, keccak256("dispute"));
         bytes32 paymentNullifier = keccak256(abi.encodePacked(METHOD, paymentId));
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                IChargebackPolicy.InvalidPaymentBinding.selector, INTENT, paymentNullifier
+                IChargebackVerifier.InvalidPaymentBinding.selector, INTENT, paymentNullifier
             )
         );
         policy.submitChargeback(attestation);
@@ -284,7 +287,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
     function test_SubmitChargebackManualPathSkipsPaymentBindingAndRejectsReplay() public {
         _admitAndSettle(INTENT, 40e6, true);
         bytes32 disputeId = keccak256("dispute");
-        IChargebackPolicy.ChargebackAttestation memory attestation =
+        IChargebackVerifier.ChargebackAttestation memory attestation =
             _attestation(INTENT, METHOD, keccak256("unbound-payment"), disputeId);
         policy.submitChargeback(attestation);
 
@@ -302,19 +305,19 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
 
     function test_SubmitChargebackRejectsClosedWindowTamperingVerifierFailureAndWrongMethod() public {
         _admitAndSettle(INTENT, 40e6, true);
-        IChargebackPolicy.ChargebackAttestation memory attestation =
+        IChargebackVerifier.ChargebackAttestation memory attestation =
             _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
         attestation.dataHash = keccak256("tampered");
-        vm.expectRevert(IChargebackPolicy.InvalidAttestation.selector);
+        vm.expectRevert(IChargebackVerifier.InvalidAttestation.selector);
         policy.submitChargeback(attestation);
 
         attestation = _attestation(INTENT, keccak256("wrong"), keccak256("payment"), keccak256("dispute"));
-        vm.expectRevert(IChargebackPolicy.InvalidAttestation.selector);
+        vm.expectRevert(IChargebackVerifier.InvalidAttestation.selector);
         policy.submitChargeback(attestation);
 
         attestation = _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
         attestationVerifier.setResult(false);
-        vm.expectRevert(IChargebackPolicy.AttestationVerificationFailed.selector);
+        vm.expectRevert(IChargebackVerifier.AttestationVerificationFailed.selector);
         policy.submitChargeback(attestation);
         attestationVerifier.setResult(true);
 
@@ -335,7 +338,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         vm.expectRevert(bytes("Ownable: caller is not the owner"));
         policy.setAdmissionsPaused(true);
         vm.expectRevert(bytes("Ownable: caller is not the owner"));
-        policy.setAttestationVerifier(address(attestationVerifier));
+        policy.setChargebackVerifier(address(chargebackVerifier));
         vm.expectRevert(bytes("Ownable: caller is not the owner"));
         policy.setLifecycleHook(address(this));
         vm.expectRevert(bytes("Ownable: caller is not the owner"));
@@ -347,7 +350,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         );
         policy.setRiskWindow(METHOD, uint64(365 days + 1));
         vm.expectRevert(IChargebackPolicy.ZeroAddress.selector);
-        policy.setAttestationVerifier(address(0));
+        policy.setChargebackVerifier(address(0));
         vm.expectRevert(abi.encodeWithSelector(IChargebackPolicy.InvalidContract.selector, other));
         policy.setLifecycleHook(other);
         vm.expectRevert(IChargebackPolicy.OwnershipRenunciationDisabled.selector);
@@ -366,6 +369,20 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         policy.onIntentCancelled(keccak256("old-hook-cancel"));
         vm.prank(newHook);
         policy.onIntentSettled(keccak256("new-hook-settle"), INTENT_AMOUNT, false);
+    }
+
+    function test_SetChargebackVerifierRejectsEoaThenReplacesAndEmits() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(IChargebackPolicy.InvalidContract.selector, other)
+        );
+        policy.setChargebackVerifier(other);
+
+        ChargebackVerifier replacement =
+            new ChargebackVerifier(address(this), nullifierRegistry, attestationVerifier);
+        vm.expectEmit(true, true, false, true);
+        emit ChargebackVerifierUpdated(address(chargebackVerifier), address(replacement));
+        policy.setChargebackVerifier(address(replacement));
+        assertEq(address(policy.chargebackVerifier()), address(replacement));
     }
 
     function test_RevokeLifecycleHookRevokesNonCurrentHookAndEmitsEvent() public {
@@ -438,7 +455,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
     function test_AcceptVaultControllerCompletesDelayedTwoStepHandover() public {
         StakeVault secondVault = new StakeVault(address(this), token, address(0), 1 days);
         ChargebackPolicy secondPolicy = new ChargebackPolicy(
-            address(this), secondVault, nullifierRegistry, attestationVerifier, escrowRegistry
+            address(this), secondVault, chargebackVerifier, escrowRegistry
         );
         secondVault.initializeController(address(this));
         secondVault.proposeController(address(secondPolicy));
@@ -466,8 +483,8 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         bytes32 paymentMethod,
         bytes32 paymentId,
         bytes32 disputeId
-    ) internal pure returns (IChargebackPolicy.ChargebackAttestation memory attestation) {
-        IChargebackPolicy.ChargebackDetails memory details = IChargebackPolicy.ChargebackDetails({
+    ) internal pure returns (IChargebackVerifier.ChargebackAttestation memory attestation) {
+        IChargebackVerifier.ChargebackDetails memory details = IChargebackVerifier.ChargebackDetails({
             paymentMethod: paymentMethod,
             originalPaymentId: paymentId,
             disputeId: disputeId,
@@ -475,7 +492,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
             paymentCurrency: USD
         });
         bytes memory data = abi.encode(details);
-        attestation = IChargebackPolicy.ChargebackAttestation({
+        attestation = IChargebackVerifier.ChargebackAttestation({
             intentHash: intentHash,
             dataHash: keccak256(data),
             signatures: new bytes[](0),

--- a/test-foundry/deterministic/hooks/ChargebackPolicy.t.sol
+++ b/test-foundry/deterministic/hooks/ChargebackPolicy.t.sol
@@ -63,6 +63,11 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         _stake(taker, STAKE_AMOUNT);
     }
 
+    function test_ConstructorRejectsZeroOwner() public {
+        vm.expectRevert(IChargebackPolicy.ZeroAddress.selector);
+        new ChargebackPolicy(address(0), vault, chargebackVerifier, chargebackNullifierRegistry);
+    }
+
     function test_onIntentSignaledLocksStakeAndSnapshotsConfiguration() public {
         policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         policy.setRiskWindow(METHOD, 7 days);
@@ -270,6 +275,30 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         );
     }
 
+    function test_SubmitChargebackRequiresSettledIntent() public {
+        IChargebackVerifier.ChargebackAttestation memory attestation =
+            _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.ChargebackIntentNotSettled.selector,
+                INTENT,
+                IChargebackPolicy.ChargebackIntentStatus.NONE
+            )
+        );
+        policy.submitChargeback(attestation);
+
+        policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.ChargebackIntentNotSettled.selector,
+                INTENT,
+                IChargebackPolicy.ChargebackIntentStatus.PENDING
+            )
+        );
+        policy.submitChargeback(attestation);
+    }
+
     function test_SubmitChargebackManualPathSkipsPaymentBindingAndRejectsReplay() public {
         _admitAndSettle(INTENT, 40e6, true);
         bytes32 disputeId = keccak256("dispute");
@@ -366,6 +395,26 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         emit ChargebackVerifierUpdated(address(chargebackVerifier), address(replacement));
         policy.setChargebackVerifier(address(replacement));
         assertEq(address(policy.chargebackVerifier()), address(replacement));
+    }
+
+    function test_SettlementRejectsReleaseEligibilityTimestampOverflow() public {
+        policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        uint256 overflowingTimestamp = uint256(type(uint64).max) - RISK_WINDOW + 1;
+        vm.warp(overflowingTimestamp);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IChargebackPolicy.TimestampOverflow.selector, overflowingTimestamp + RISK_WINDOW)
+        );
+        policy.onIntentSettled(INTENT, INTENT_AMOUNT, false);
+    }
+
+    function test_MaturedReleaseRejectsCurrentTimestampOverflow() public {
+        _admitAndSettle(INTENT, INTENT_AMOUNT, false);
+        uint256 overflowingTimestamp = uint256(type(uint64).max) + 1;
+        vm.warp(overflowingTimestamp);
+
+        vm.expectRevert(abi.encodeWithSelector(IChargebackPolicy.TimestampOverflow.selector, overflowingTimestamp));
+        policy.releaseMaturedChargebackIntent(INTENT);
     }
 
     function test_SetChargebackEnabledEnforcesDepositorAndHandlesMissingDeposit() public {

--- a/test-foundry/deterministic/hooks/ChargebackPolicy.t.sol
+++ b/test-foundry/deterministic/hooks/ChargebackPolicy.t.sol
@@ -30,6 +30,8 @@ contract ChargebackEscrowMock {
 }
 
 contract ChargebackPolicyTest is OrchestratorV3Fixture {
+    event LifecycleHookAuthorizationUpdated(address indexed hook, bool authorized);
+
     uint64 internal constant RISK_WINDOW = 30 days;
     uint256 internal constant STAKE_AMOUNT = 500e6;
     bytes32 internal constant INTENT = keccak256("intent");
@@ -350,6 +352,61 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         policy.setLifecycleHook(other);
         vm.expectRevert(IChargebackPolicy.OwnershipRenunciationDisabled.selector);
         policy.renounceOwnership();
+    }
+
+    function test_SetLifecycleHookKeepsPreviousHookAuthorizedAndBothCanInvokeLifecycleEntrypoints()
+        public
+    {
+        address newHook = address(attestationVerifier);
+
+        policy.setLifecycleHook(newHook);
+
+        assertTrue(policy.authorizedLifecycleHooks(address(this)));
+        assertTrue(policy.authorizedLifecycleHooks(newHook));
+        policy.onIntentCancelled(keccak256("old-hook-cancel"));
+        vm.prank(newHook);
+        policy.onIntentSettled(keccak256("new-hook-settle"), INTENT_AMOUNT, false);
+    }
+
+    function test_RevokeLifecycleHookRevokesNonCurrentHookAndEmitsEvent() public {
+        address newHook = address(attestationVerifier);
+        policy.setLifecycleHook(newHook);
+
+        vm.expectEmit(true, false, false, true);
+        emit LifecycleHookAuthorizationUpdated(address(this), false);
+        policy.revokeLifecycleHook(address(this));
+
+        assertFalse(policy.authorizedLifecycleHooks(address(this)));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.UnauthorizedLifecycleHook.selector, address(this)
+            )
+        );
+        policy.onIntentCancelled(INTENT);
+    }
+
+    function test_RevokeLifecycleHookRejectsCurrentHook() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.CannotRevokeCurrentLifecycleHook.selector, address(this)
+            )
+        );
+        policy.revokeLifecycleHook(address(this));
+    }
+
+    function test_RevokeLifecycleHookRejectsNeverAuthorizedHook() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.LifecycleHookNotAuthorized.selector, other
+            )
+        );
+        policy.revokeLifecycleHook(other);
+    }
+
+    function test_RevokeLifecycleHookEnforcesOwnership() public {
+        vm.expectRevert(bytes("Ownable: caller is not the owner"));
+        vm.prank(other);
+        policy.revokeLifecycleHook(address(this));
     }
 
     function test_SetEnabledEnforcesRegistryDepositAndDepositor() public {

--- a/test-foundry/deterministic/hooks/ChargebackPolicy.t.sol
+++ b/test-foundry/deterministic/hooks/ChargebackPolicy.t.sol
@@ -9,9 +9,9 @@ import {ChargebackPolicy} from "contracts/hooks/ChargebackPolicy.sol";
 import {IChargebackPolicy} from "contracts/interfaces/IChargebackPolicy.sol";
 import {IChargebackVerifier} from "contracts/interfaces/IChargebackVerifier.sol";
 import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
+import {IStakeVault} from "contracts/interfaces/IStakeVault.sol";
 import {AttestationVerifierMock} from "contracts/mocks/AttestationVerifierMock.sol";
 import {USDCMock} from "contracts/mocks/USDCMock.sol";
-import {EscrowRegistry} from "contracts/registries/EscrowRegistry.sol";
 import {NullifierRegistry} from "contracts/registries/NullifierRegistry.sol";
 import {NullifierRegistryV2} from "contracts/registries/NullifierRegistryV2.sol";
 import {ChargebackVerifier} from "contracts/unifiedVerifier/ChargebackVerifier.sol";
@@ -41,6 +41,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
 
     StakeVault internal vault;
     NullifierRegistryV2 internal nullifierRegistry;
+    NullifierRegistry internal chargebackNullifierRegistry;
     AttestationVerifierMock internal attestationVerifier;
     ChargebackVerifier internal chargebackVerifier;
     ChargebackPolicy internal policy;
@@ -49,29 +50,31 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         super.setUp();
         vault = new StakeVault(address(this), token, address(0), 1 days);
         nullifierRegistry = new NullifierRegistryV2(new NullifierRegistry());
+        chargebackNullifierRegistry = new NullifierRegistry();
         attestationVerifier = new AttestationVerifierMock();
         chargebackVerifier = new ChargebackVerifier(address(this), nullifierRegistry, attestationVerifier);
-        policy = new ChargebackPolicy(address(this), vault, chargebackVerifier, escrowRegistry);
+        policy = new ChargebackPolicy(address(this), vault, chargebackVerifier, chargebackNullifierRegistry);
         vault.initializeController(address(policy));
-        policy.setLifecycleHook(address(this));
+        chargebackNullifierRegistry.addWritePermission(address(policy));
+        policy.setLifecycleHookAuthorization(address(this), true);
         policy.setRiskWindow(METHOD, RISK_WINDOW);
         vm.prank(depositor);
-        policy.setEnabled(address(escrow), depositId, true);
+        policy.setChargebackEnabled(address(escrow), depositId, true);
         _stake(taker, STAKE_AMOUNT);
     }
 
     function test_onIntentSignaledLocksStakeAndSnapshotsConfiguration() public {
         policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         policy.setRiskWindow(METHOD, 7 days);
+        assertEq(policy.getRiskWindow(METHOD), 7 days);
 
-        IChargebackPolicy.Position memory position = policy.getPosition(INTENT);
-        assertEq(position.taker, taker);
-        assertEq(position.stakeOwner, taker);
-        assertEq(position.depositor, depositor);
-        assertEq(position.riskWindow, RISK_WINDOW);
-        assertEq(position.intentAmount, INTENT_AMOUNT);
-        assertEq(position.coverageAmount, INTENT_AMOUNT);
-        assertEq(uint256(position.status), uint256(IChargebackPolicy.PositionStatus.PENDING));
+        IChargebackPolicy.ChargebackIntent memory chargebackIntent = policy.getChargebackIntent(INTENT);
+        assertEq(chargebackIntent.taker, taker);
+        assertEq(chargebackIntent.stakeOwner, taker);
+        assertEq(chargebackIntent.depositor, depositor);
+        assertEq(chargebackIntent.riskWindow, RISK_WINDOW);
+        assertEq(chargebackIntent.releaseAmount, 0);
+        assertEq(uint256(chargebackIntent.status), uint256(IChargebackPolicy.ChargebackIntentStatus.PENDING));
         (address stakeOwner, uint256 amount, uint64 maturesAt) = vault.locks(INTENT);
         assertEq(stakeOwner, taker);
         assertEq(amount, INTENT_AMOUNT);
@@ -89,16 +92,16 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         policy.setAdmissionsPaused(false);
 
         vm.prank(depositor);
-        policy.setEnabled(address(escrow), depositId, false);
+        policy.setChargebackEnabled(address(escrow), depositId, false);
         vm.expectRevert(
             abi.encodeWithSelector(IChargebackPolicy.ChargebackNotEnabled.selector, address(escrow), depositId)
         );
         policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         vm.prank(depositor);
-        policy.setEnabled(address(escrow), depositId, true);
+        policy.setChargebackEnabled(address(escrow), depositId, true);
 
         policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
-        vm.expectRevert(abi.encodeWithSelector(IChargebackPolicy.PositionAlreadyExists.selector, INTENT));
+        vm.expectRevert(abi.encodeWithSelector(IChargebackPolicy.ChargebackIntentAlreadyExists.selector, INTENT));
         policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
     }
 
@@ -108,13 +111,10 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         uint256 freeBefore = vault.freeStake(taker);
         policy.setAdmissionsPaused(true);
 
-        policy.onIntentSignaled(
-            INTENT, address(escrow), depositId, taker, windowlessMethod, INTENT_AMOUNT
-        );
+        policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, windowlessMethod, INTENT_AMOUNT);
 
         assertEq(
-            uint256(policy.getPosition(INTENT).status),
-            uint256(IChargebackPolicy.PositionStatus.NONE)
+            uint256(policy.getChargebackIntent(INTENT).status), uint256(IChargebackPolicy.ChargebackIntentStatus.NONE)
         );
         assertEq(vault.lockedStake(taker), lockedBefore);
         assertEq(vault.freeStake(taker), freeBefore);
@@ -122,36 +122,25 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         policy.onIntentSettled(INTENT, INTENT_AMOUNT, false);
         policy.onIntentCancelled(INTENT);
         assertEq(
-            uint256(policy.getPosition(INTENT).status),
-            uint256(IChargebackPolicy.PositionStatus.NONE)
+            uint256(policy.getChargebackIntent(INTENT).status), uint256(IChargebackPolicy.ChargebackIntentStatus.NONE)
         );
         assertEq(vault.lockedStake(taker), lockedBefore);
         assertEq(vault.freeStake(taker), freeBefore);
     }
 
-    function test_onIntentSignaledRejectsWrongTokenAndInsufficientCollateral() public {
+    function test_onIntentSignaledRejectsWrongTokenAndLetsVaultEnforceCollateral() public {
         USDCMock otherToken = new USDCMock(1_000e6, "Other", "OTHER");
         ChargebackEscrowMock wrongTokenEscrow = new ChargebackEscrowMock(depositor, otherToken);
-        escrowRegistry.addEscrow(address(wrongTokenEscrow));
         vm.prank(depositor);
-        policy.setEnabled(address(wrongTokenEscrow), depositId, true);
+        policy.setChargebackEnabled(address(wrongTokenEscrow), depositId, true);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IChargebackPolicy.IntentTokenMismatch.selector, address(token), address(otherToken)
-            )
+            abi.encodeWithSelector(IChargebackPolicy.IntentTokenMismatch.selector, address(token), address(otherToken))
         );
-        policy.onIntentSignaled(
-            INTENT, address(wrongTokenEscrow), depositId, taker, METHOD, INTENT_AMOUNT
-        );
+        policy.onIntentSignaled(INTENT, address(wrongTokenEscrow), depositId, taker, METHOD, INTENT_AMOUNT);
 
         bytes32 secondIntent = keccak256("second-intent");
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IChargebackPolicy.InsufficientCollateral.selector,
-                other,
-                uint256(0),
-                INTENT_AMOUNT
-            )
+            abi.encodeWithSelector(IStakeVault.InsufficientFreeStake.selector, other, uint256(0), INTENT_AMOUNT)
         );
         policy.onIntentSignaled(secondIntent, address(escrow), depositId, other, METHOD, INTENT_AMOUNT);
     }
@@ -166,7 +155,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
 
         policy.onIntentSignaled(INTENT, address(escrow), depositId, other, METHOD, INTENT_AMOUNT);
 
-        assertEq(policy.getPosition(INTENT).stakeOwner, stakeOwner);
+        assertEq(policy.getChargebackIntent(INTENT).stakeOwner, stakeOwner);
         assertEq(vault.lockedStake(stakeOwner), INTENT_AMOUNT);
         assertEq(vault.lockedStake(other), 0);
     }
@@ -177,8 +166,8 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         policy.onIntentCancelled(INTENT);
         assertEq(vault.lockedStake(taker), 0);
         assertEq(
-            uint256(policy.getPosition(INTENT).status),
-            uint256(IChargebackPolicy.PositionStatus.CANCELLED)
+            uint256(policy.getChargebackIntent(INTENT).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.CANCELLED)
         );
 
         bytes32 settledIntent = keccak256("settled");
@@ -186,34 +175,33 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         policy.onIntentSettled(settledIntent, INTENT_AMOUNT, false);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IChargebackPolicy.PositionNotPending.selector,
+                IChargebackPolicy.ChargebackIntentNotPending.selector,
                 settledIntent,
-                IChargebackPolicy.PositionStatus.SETTLED
+                IChargebackPolicy.ChargebackIntentStatus.SETTLED
             )
         );
         policy.onIntentCancelled(settledIntent);
     }
 
-    function test_SettlementResizesFullAndPartialAndSnapshotsDeadlineAndManualFlag() public {
+    function test_SettlementResizesFullAndPartialAndSnapshotsReleaseEligibilityAndManualFlag() public {
         policy.onIntentSettled(keccak256("missing"), INTENT_AMOUNT, false);
         policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
-        uint256 expectedDeadline = vm.getBlockTimestamp() + RISK_WINDOW;
+        uint256 releaseEligibleAt = vm.getBlockTimestamp() + RISK_WINDOW;
         policy.onIntentSettled(INTENT, 40e6, true);
 
-        IChargebackPolicy.Position memory position = policy.getPosition(INTENT);
-        assertEq(position.coverageDeadline, expectedDeadline);
-        assertEq(position.coverageAmount, 40e6);
-        assertEq(position.grossReleasedAmount, 40e6);
-        assertTrue(position.isManualRelease);
+        IChargebackPolicy.ChargebackIntent memory chargebackIntent = policy.getChargebackIntent(INTENT);
+        assertEq(chargebackIntent.releaseEligibleAt, releaseEligibleAt);
+        assertEq(chargebackIntent.releaseAmount, 40e6);
+        assertTrue(chargebackIntent.isManualRelease);
         (, uint256 amount, uint64 maturesAt) = vault.locks(INTENT);
         assertEq(amount, 40e6);
-        assertEq(maturesAt, expectedDeadline);
+        assertEq(maturesAt, releaseEligibleAt);
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                IChargebackPolicy.PositionNotPending.selector,
+                IChargebackPolicy.ChargebackIntentNotPending.selector,
                 INTENT,
-                IChargebackPolicy.PositionStatus.SETTLED
+                IChargebackPolicy.ChargebackIntentStatus.SETTLED
             )
         );
         policy.onIntentSettled(INTENT, 40e6, true);
@@ -225,36 +213,36 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         assertEq(amount, INTENT_AMOUNT);
     }
 
-    function test_ReleaseMaturedPositionAndBatchFreeStakeAtBoundary() public {
+    function test_ReleaseMaturedChargebackIntentAndBatchFreeStakeAtBoundary() public {
         bytes32 secondIntent = keccak256("second");
         _admitAndSettle(INTENT, 20e6, false);
         _admitAndSettle(secondIntent, 30e6, false);
-        uint64 deadline = policy.getPosition(INTENT).coverageDeadline;
+        uint64 releaseEligibleAt = policy.getChargebackIntent(INTENT).releaseEligibleAt;
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                IChargebackPolicy.PositionNotMature.selector,
-                deadline,
+                IChargebackPolicy.ChargebackIntentNotReleaseEligible.selector,
+                releaseEligibleAt,
                 uint64(vm.getBlockTimestamp())
             )
         );
-        policy.releaseMaturedPosition(INTENT);
+        policy.releaseMaturedChargebackIntent(INTENT);
 
-        vm.warp(deadline);
+        vm.warp(releaseEligibleAt);
         bytes32[] memory intents = new bytes32[](2);
         intents[0] = INTENT;
         intents[1] = secondIntent;
-        policy.releaseMaturedPositions(intents);
+        policy.releaseMaturedChargebackIntents(intents);
         assertEq(vault.lockedStake(taker), 0);
         assertEq(vault.freeStake(taker), STAKE_AMOUNT);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IChargebackPolicy.PositionNotSettled.selector,
+                IChargebackPolicy.ChargebackIntentNotSettled.selector,
                 INTENT,
-                IChargebackPolicy.PositionStatus.RELEASED
+                IChargebackPolicy.ChargebackIntentStatus.RELEASED
             )
         );
-        policy.releaseMaturedPosition(INTENT);
+        policy.releaseMaturedChargebackIntent(INTENT);
     }
 
     function test_SubmitChargebackProofPathRequiresBothDirectionBindingAndCreatesClaim() public {
@@ -265,9 +253,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         bytes32 paymentNullifier = keccak256(abi.encodePacked(METHOD, paymentId));
 
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IChargebackVerifier.InvalidPaymentBinding.selector, INTENT, paymentNullifier
-            )
+            abi.encodeWithSelector(IChargebackVerifier.InvalidPaymentBinding.selector, INTENT, paymentNullifier)
         );
         policy.submitChargeback(attestation);
 
@@ -279,8 +265,8 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         assertEq(vault.lockedStake(taker), 0);
         assertEq(vault.stakeBalance(taker), STAKE_AMOUNT - 40e6);
         assertEq(
-            uint256(policy.getPosition(INTENT).status),
-            uint256(IChargebackPolicy.PositionStatus.SLASHED)
+            uint256(policy.getChargebackIntent(INTENT).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.CHARGED_BACK)
         );
     }
 
@@ -292,18 +278,16 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         policy.submitChargeback(attestation);
 
         bytes32 disputeNullifier = keccak256(abi.encodePacked(METHOD, disputeId));
-        assertTrue(policy.usedChargebackNullifiers(disputeNullifier));
+        assertTrue(chargebackNullifierRegistry.isNullified(disputeNullifier));
 
         bytes32 secondIntent = keccak256("second");
         _admitAndSettle(secondIntent, 40e6, true);
         attestation = _attestation(secondIntent, METHOD, keccak256("other-payment"), disputeId);
-        vm.expectRevert(
-            abi.encodeWithSelector(IChargebackPolicy.ChargebackEvidenceUsed.selector, disputeNullifier)
-        );
+        vm.expectRevert(bytes("Nullifier already exists"));
         policy.submitChargeback(attestation);
     }
 
-    function test_SubmitChargebackRejectsClosedWindowTamperingVerifierFailureAndWrongMethod() public {
+    function test_SubmitChargebackRejectsInvalidEvidenceButRemainsValidUntilCollateralRelease() public {
         _admitAndSettle(INTENT, 40e6, true);
         IChargebackVerifier.ChargebackAttestation memory attestation =
             _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
@@ -321,14 +305,14 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         policy.submitChargeback(attestation);
         attestationVerifier.setResult(true);
 
-        uint64 deadline = policy.getPosition(INTENT).coverageDeadline;
-        vm.warp(deadline);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IChargebackPolicy.ChargebackWindowClosed.selector, deadline, deadline
-            )
-        );
+        uint64 releaseEligibleAt = policy.getChargebackIntent(INTENT).releaseEligibleAt;
+        vm.warp(releaseEligibleAt);
         policy.submitChargeback(attestation);
+        assertEq(vault.claimable(depositor), 40e6);
+        assertEq(
+            uint256(policy.getChargebackIntent(INTENT).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.CHARGED_BACK)
+        );
     }
 
     function test_GovernanceSettersEnforceOwnershipAndValidation() public {
@@ -340,123 +324,74 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         vm.expectRevert(bytes("Ownable: caller is not the owner"));
         policy.setChargebackVerifier(address(chargebackVerifier));
         vm.expectRevert(bytes("Ownable: caller is not the owner"));
-        policy.setLifecycleHook(address(this));
-        vm.expectRevert(bytes("Ownable: caller is not the owner"));
-        policy.setEscrowRegistry(escrowRegistry);
+        policy.setLifecycleHookAuthorization(address(this), true);
         vm.stopPrank();
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IChargebackPolicy.InvalidRiskWindow.selector, uint64(365 days + 1))
-        );
+        vm.expectRevert(abi.encodeWithSelector(IChargebackPolicy.InvalidRiskWindow.selector, uint64(365 days + 1)));
         policy.setRiskWindow(METHOD, uint64(365 days + 1));
         vm.expectRevert(IChargebackPolicy.ZeroAddress.selector);
         policy.setChargebackVerifier(address(0));
         vm.expectRevert(abi.encodeWithSelector(IChargebackPolicy.InvalidContract.selector, other));
-        policy.setLifecycleHook(other);
+        policy.setLifecycleHookAuthorization(other, true);
         vm.expectRevert(IChargebackPolicy.OwnershipRenunciationDisabled.selector);
         policy.renounceOwnership();
     }
 
-    function test_SetLifecycleHookKeepsPreviousHookAuthorizedAndBothCanInvokeLifecycleEntrypoints()
-        public
-    {
+    function test_SetLifecycleHookAuthorizationAllowsMultipleHooksAndExplicitRevocation() public {
         address newHook = address(attestationVerifier);
 
-        policy.setLifecycleHook(newHook);
+        policy.setLifecycleHookAuthorization(newHook, true);
 
-        assertTrue(policy.authorizedLifecycleHooks(address(this)));
-        assertTrue(policy.authorizedLifecycleHooks(newHook));
+        assertTrue(policy.isLifecycleHookAuthorized(address(this)));
+        assertTrue(policy.isLifecycleHookAuthorized(newHook));
         policy.onIntentCancelled(keccak256("old-hook-cancel"));
         vm.prank(newHook);
         policy.onIntentSettled(keccak256("new-hook-settle"), INTENT_AMOUNT, false);
+
+        vm.expectEmit(true, false, false, true);
+        emit LifecycleHookAuthorizationUpdated(address(this), false);
+        policy.setLifecycleHookAuthorization(address(this), false);
+
+        assertFalse(policy.isLifecycleHookAuthorized(address(this)));
+        vm.expectRevert(abi.encodeWithSelector(IChargebackPolicy.UnauthorizedLifecycleHook.selector, address(this)));
+        policy.onIntentCancelled(INTENT);
     }
 
     function test_SetChargebackVerifierRejectsEoaThenReplacesAndEmits() public {
-        vm.expectRevert(
-            abi.encodeWithSelector(IChargebackPolicy.InvalidContract.selector, other)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IChargebackPolicy.InvalidContract.selector, other));
         policy.setChargebackVerifier(other);
 
-        ChargebackVerifier replacement =
-            new ChargebackVerifier(address(this), nullifierRegistry, attestationVerifier);
+        ChargebackVerifier replacement = new ChargebackVerifier(address(this), nullifierRegistry, attestationVerifier);
         vm.expectEmit(true, true, false, true);
         emit ChargebackVerifierUpdated(address(chargebackVerifier), address(replacement));
         policy.setChargebackVerifier(address(replacement));
         assertEq(address(policy.chargebackVerifier()), address(replacement));
     }
 
-    function test_RevokeLifecycleHookRevokesNonCurrentHookAndEmitsEvent() public {
-        address newHook = address(attestationVerifier);
-        policy.setLifecycleHook(newHook);
-
-        vm.expectEmit(true, false, false, true);
-        emit LifecycleHookAuthorizationUpdated(address(this), false);
-        policy.revokeLifecycleHook(address(this));
-
-        assertFalse(policy.authorizedLifecycleHooks(address(this)));
+    function test_SetChargebackEnabledEnforcesDepositorAndHandlesMissingDeposit() public {
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IChargebackPolicy.UnauthorizedLifecycleHook.selector, address(this)
-            )
-        );
-        policy.onIntentCancelled(INTENT);
-    }
-
-    function test_RevokeLifecycleHookRejectsCurrentHook() public {
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IChargebackPolicy.CannotRevokeCurrentLifecycleHook.selector, address(this)
-            )
-        );
-        policy.revokeLifecycleHook(address(this));
-    }
-
-    function test_RevokeLifecycleHookRejectsNeverAuthorizedHook() public {
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IChargebackPolicy.LifecycleHookNotAuthorized.selector, other
-            )
-        );
-        policy.revokeLifecycleHook(other);
-    }
-
-    function test_RevokeLifecycleHookEnforcesOwnership() public {
-        vm.expectRevert(bytes("Ownable: caller is not the owner"));
-        vm.prank(other);
-        policy.revokeLifecycleHook(address(this));
-    }
-
-    function test_SetEnabledEnforcesRegistryDepositAndDepositor() public {
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IChargebackPolicy.NotDepositor.selector, address(escrow), depositId, other
-            )
+            abi.encodeWithSelector(IChargebackPolicy.NotDepositor.selector, address(escrow), depositId, other)
         );
         vm.prank(other);
-        policy.setEnabled(address(escrow), depositId, true);
+        policy.setChargebackEnabled(address(escrow), depositId, true);
 
         uint256 missingDeposit = type(uint256).max;
         vm.expectRevert(
             abi.encodeWithSelector(
-                IChargebackPolicy.DepositNotFound.selector, address(escrow), missingDeposit
+                IChargebackPolicy.NotDepositor.selector, address(escrow), missingDeposit, address(this)
             )
         );
-        policy.setEnabled(address(escrow), missingDeposit, true);
+        policy.setChargebackEnabled(address(escrow), missingDeposit, true);
 
-        EscrowRegistry emptyRegistry = new EscrowRegistry();
-        policy.setEscrowRegistry(emptyRegistry);
-        vm.expectRevert(
-            abi.encodeWithSelector(IChargebackPolicy.EscrowNotWhitelisted.selector, address(escrow))
-        );
         vm.prank(depositor);
-        policy.setEnabled(address(escrow), depositId, true);
+        policy.setChargebackEnabled(address(escrow), depositId, false);
+        assertFalse(policy.isChargebackEnabled(address(escrow), depositId));
     }
 
     function test_AcceptVaultControllerCompletesDelayedTwoStepHandover() public {
         StakeVault secondVault = new StakeVault(address(this), token, address(0), 1 days);
-        ChargebackPolicy secondPolicy = new ChargebackPolicy(
-            address(this), secondVault, chargebackVerifier, escrowRegistry
-        );
+        ChargebackPolicy secondPolicy =
+            new ChargebackPolicy(address(this), secondVault, chargebackVerifier, chargebackNullifierRegistry);
         secondVault.initializeController(address(this));
         secondVault.proposeController(address(secondPolicy));
         uint256 acceptanceTime = vm.getBlockTimestamp() + secondVault.controllerChangeDelay();
@@ -473,17 +408,16 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         vm.stopPrank();
     }
 
-    function _admitAndSettle(bytes32 intentHash, uint256 grossAmount, bool manualRelease) internal {
+    function _admitAndSettle(bytes32 intentHash, uint256 releaseAmount, bool manualRelease) internal {
         policy.onIntentSignaled(intentHash, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
-        policy.onIntentSettled(intentHash, grossAmount, manualRelease);
+        policy.onIntentSettled(intentHash, releaseAmount, manualRelease);
     }
 
-    function _attestation(
-        bytes32 intentHash,
-        bytes32 paymentMethod,
-        bytes32 paymentId,
-        bytes32 disputeId
-    ) internal pure returns (IChargebackVerifier.ChargebackAttestation memory attestation) {
+    function _attestation(bytes32 intentHash, bytes32 paymentMethod, bytes32 paymentId, bytes32 disputeId)
+        internal
+        pure
+        returns (IChargebackVerifier.ChargebackAttestation memory attestation)
+    {
         IChargebackVerifier.ChargebackDetails memory details = IChargebackVerifier.ChargebackDetails({
             paymentMethod: paymentMethod,
             originalPaymentId: paymentId,
@@ -493,10 +427,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         });
         bytes memory data = abi.encode(details);
         attestation = IChargebackVerifier.ChargebackAttestation({
-            intentHash: intentHash,
-            dataHash: keccak256(data),
-            signatures: new bytes[](0),
-            data: data
+            intentHash: intentHash, dataHash: keccak256(data), signatures: new bytes[](0), data: data
         });
     }
 }

--- a/test-foundry/deterministic/hooks/ChargebackPolicy.t.sol
+++ b/test-foundry/deterministic/hooks/ChargebackPolicy.t.sol
@@ -1,0 +1,428 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {StakeVault} from "contracts/StakeVault.sol";
+import {ChargebackPolicy} from "contracts/hooks/ChargebackPolicy.sol";
+import {IChargebackPolicy} from "contracts/interfaces/IChargebackPolicy.sol";
+import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
+import {AttestationVerifierMock} from "contracts/mocks/AttestationVerifierMock.sol";
+import {USDCMock} from "contracts/mocks/USDCMock.sol";
+import {EscrowRegistry} from "contracts/registries/EscrowRegistry.sol";
+import {NullifierRegistry} from "contracts/registries/NullifierRegistry.sol";
+import {NullifierRegistryV2} from "contracts/registries/NullifierRegistryV2.sol";
+
+import {OrchestratorV3Fixture} from "../helpers/OrchestratorV3Fixture.sol";
+
+contract ChargebackEscrowMock {
+    IEscrowV2.Deposit internal deposit;
+
+    constructor(address depositor, IERC20 token) {
+        deposit.depositor = depositor;
+        deposit.token = token;
+    }
+
+    function getDeposit(uint256) external view returns (IEscrowV2.Deposit memory) {
+        return deposit;
+    }
+}
+
+contract ChargebackPolicyTest is OrchestratorV3Fixture {
+    uint64 internal constant RISK_WINDOW = 30 days;
+    uint256 internal constant STAKE_AMOUNT = 500e6;
+    bytes32 internal constant INTENT = keccak256("intent");
+
+    StakeVault internal vault;
+    NullifierRegistryV2 internal nullifierRegistry;
+    AttestationVerifierMock internal attestationVerifier;
+    ChargebackPolicy internal policy;
+
+    function setUp() public override {
+        super.setUp();
+        vault = new StakeVault(address(this), token, address(0), 1 days);
+        nullifierRegistry = new NullifierRegistryV2(new NullifierRegistry());
+        attestationVerifier = new AttestationVerifierMock();
+        policy = new ChargebackPolicy(
+            address(this), vault, nullifierRegistry, attestationVerifier, escrowRegistry
+        );
+        vault.initializeController(address(policy));
+        policy.setLifecycleHook(address(this));
+        policy.setRiskWindow(METHOD, RISK_WINDOW);
+        vm.prank(depositor);
+        policy.setEnabled(address(escrow), depositId, true);
+        _stake(taker, STAKE_AMOUNT);
+    }
+
+    function test_AdmitIntentLocksStakeAndSnapshotsConfiguration() public {
+        policy.admitIntent(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        policy.setRiskWindow(METHOD, 7 days);
+
+        IChargebackPolicy.Position memory position = policy.getPosition(INTENT);
+        assertEq(position.taker, taker);
+        assertEq(position.stakeOwner, taker);
+        assertEq(position.depositor, depositor);
+        assertEq(position.riskWindow, RISK_WINDOW);
+        assertEq(position.intentAmount, INTENT_AMOUNT);
+        assertEq(position.coverageAmount, INTENT_AMOUNT);
+        assertEq(uint256(position.status), uint256(IChargebackPolicy.PositionStatus.PENDING));
+        (address stakeOwner, uint256 amount, uint64 maturesAt) = vault.locks(INTENT);
+        assertEq(stakeOwner, taker);
+        assertEq(amount, INTENT_AMOUNT);
+        assertEq(maturesAt, type(uint64).max);
+    }
+
+    function test_AdmitIntentRejectsUnauthorizedPausedDisabledAndDuplicate() public {
+        vm.expectRevert(abi.encodeWithSelector(IChargebackPolicy.UnauthorizedLifecycleHook.selector, other));
+        vm.prank(other);
+        policy.admitIntent(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+
+        policy.setAdmissionsPaused(true);
+        vm.expectRevert(IChargebackPolicy.AdmissionsPaused.selector);
+        policy.admitIntent(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        policy.setAdmissionsPaused(false);
+
+        vm.prank(depositor);
+        policy.setEnabled(address(escrow), depositId, false);
+        vm.expectRevert(
+            abi.encodeWithSelector(IChargebackPolicy.ChargebackNotEnabled.selector, address(escrow), depositId)
+        );
+        policy.admitIntent(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        vm.prank(depositor);
+        policy.setEnabled(address(escrow), depositId, true);
+
+        policy.admitIntent(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        vm.expectRevert(abi.encodeWithSelector(IChargebackPolicy.PositionAlreadyExists.selector, INTENT));
+        policy.admitIntent(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+    }
+
+    function test_AdmitIntentPassesThroughWindowlessMethodEvenWhenAdmissionsPaused() public {
+        bytes32 windowlessMethod = keccak256("windowless");
+        uint256 lockedBefore = vault.lockedStake(taker);
+        uint256 freeBefore = vault.freeStake(taker);
+        policy.setAdmissionsPaused(true);
+
+        policy.admitIntent(
+            INTENT, address(escrow), depositId, taker, windowlessMethod, INTENT_AMOUNT
+        );
+
+        assertEq(
+            uint256(policy.getPosition(INTENT).status),
+            uint256(IChargebackPolicy.PositionStatus.NONE)
+        );
+        assertEq(vault.lockedStake(taker), lockedBefore);
+        assertEq(vault.freeStake(taker), freeBefore);
+
+        policy.onIntentSettled(INTENT, INTENT_AMOUNT, false);
+        policy.onIntentCancelled(INTENT);
+        assertEq(
+            uint256(policy.getPosition(INTENT).status),
+            uint256(IChargebackPolicy.PositionStatus.NONE)
+        );
+        assertEq(vault.lockedStake(taker), lockedBefore);
+        assertEq(vault.freeStake(taker), freeBefore);
+    }
+
+    function test_AdmitIntentRejectsWrongTokenAndInsufficientCollateral() public {
+        USDCMock otherToken = new USDCMock(1_000e6, "Other", "OTHER");
+        ChargebackEscrowMock wrongTokenEscrow = new ChargebackEscrowMock(depositor, otherToken);
+        escrowRegistry.addEscrow(address(wrongTokenEscrow));
+        vm.prank(depositor);
+        policy.setEnabled(address(wrongTokenEscrow), depositId, true);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.IntentTokenMismatch.selector, address(token), address(otherToken)
+            )
+        );
+        policy.admitIntent(
+            INTENT, address(wrongTokenEscrow), depositId, taker, METHOD, INTENT_AMOUNT
+        );
+
+        bytes32 secondIntent = keccak256("second-intent");
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.InsufficientCollateral.selector,
+                other,
+                uint256(0),
+                INTENT_AMOUNT
+            )
+        );
+        policy.admitIntent(secondIntent, address(escrow), depositId, other, METHOD, INTENT_AMOUNT);
+    }
+
+    function test_DelegatedStakeLocksSelectedOwnersStake() public {
+        address stakeOwner = makeAddr("stakeOwner");
+        _stake(stakeOwner, STAKE_AMOUNT);
+        vm.prank(stakeOwner);
+        vault.setTakerAuthorization(other, true);
+        vm.prank(other);
+        vault.selectStakeOwner(stakeOwner);
+
+        policy.admitIntent(INTENT, address(escrow), depositId, other, METHOD, INTENT_AMOUNT);
+
+        assertEq(policy.getPosition(INTENT).stakeOwner, stakeOwner);
+        assertEq(vault.lockedStake(stakeOwner), INTENT_AMOUNT);
+        assertEq(vault.lockedStake(other), 0);
+    }
+
+    function test_CancellationUnlocksPendingNoneIsNoOpAndSettledReverts() public {
+        policy.onIntentCancelled(keccak256("missing"));
+        policy.admitIntent(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        policy.onIntentCancelled(INTENT);
+        assertEq(vault.lockedStake(taker), 0);
+        assertEq(
+            uint256(policy.getPosition(INTENT).status),
+            uint256(IChargebackPolicy.PositionStatus.CANCELLED)
+        );
+
+        bytes32 settledIntent = keccak256("settled");
+        policy.admitIntent(settledIntent, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        policy.onIntentSettled(settledIntent, INTENT_AMOUNT, false);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.PositionNotPending.selector,
+                settledIntent,
+                IChargebackPolicy.PositionStatus.SETTLED
+            )
+        );
+        policy.onIntentCancelled(settledIntent);
+    }
+
+    function test_SettlementResizesFullAndPartialAndSnapshotsDeadlineAndManualFlag() public {
+        policy.onIntentSettled(keccak256("missing"), INTENT_AMOUNT, false);
+        policy.admitIntent(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        uint256 expectedDeadline = vm.getBlockTimestamp() + RISK_WINDOW;
+        policy.onIntentSettled(INTENT, 40e6, true);
+
+        IChargebackPolicy.Position memory position = policy.getPosition(INTENT);
+        assertEq(position.coverageDeadline, expectedDeadline);
+        assertEq(position.coverageAmount, 40e6);
+        assertEq(position.grossReleasedAmount, 40e6);
+        assertTrue(position.isManualRelease);
+        (, uint256 amount, uint64 maturesAt) = vault.locks(INTENT);
+        assertEq(amount, 40e6);
+        assertEq(maturesAt, expectedDeadline);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.PositionNotPending.selector,
+                INTENT,
+                IChargebackPolicy.PositionStatus.SETTLED
+            )
+        );
+        policy.onIntentSettled(INTENT, 40e6, true);
+
+        bytes32 fullIntent = keccak256("full");
+        policy.admitIntent(fullIntent, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        policy.onIntentSettled(fullIntent, INTENT_AMOUNT, false);
+        (, amount,) = vault.locks(fullIntent);
+        assertEq(amount, INTENT_AMOUNT);
+    }
+
+    function test_ReleaseMaturedPositionAndBatchFreeStakeAtBoundary() public {
+        bytes32 secondIntent = keccak256("second");
+        _admitAndSettle(INTENT, 20e6, false);
+        _admitAndSettle(secondIntent, 30e6, false);
+        uint64 deadline = policy.getPosition(INTENT).coverageDeadline;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.PositionNotMature.selector,
+                deadline,
+                uint64(vm.getBlockTimestamp())
+            )
+        );
+        policy.releaseMaturedPosition(INTENT);
+
+        vm.warp(deadline);
+        bytes32[] memory intents = new bytes32[](2);
+        intents[0] = INTENT;
+        intents[1] = secondIntent;
+        policy.releaseMaturedPositions(intents);
+        assertEq(vault.lockedStake(taker), 0);
+        assertEq(vault.freeStake(taker), STAKE_AMOUNT);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.PositionNotSettled.selector,
+                INTENT,
+                IChargebackPolicy.PositionStatus.RELEASED
+            )
+        );
+        policy.releaseMaturedPosition(INTENT);
+    }
+
+    function test_SubmitChargebackProofPathRequiresBothDirectionBindingAndCreatesClaim() public {
+        _admitAndSettle(INTENT, 40e6, false);
+        bytes32 paymentId = keccak256("payment");
+        IChargebackPolicy.ChargebackAttestation memory attestation =
+            _attestation(INTENT, METHOD, paymentId, keccak256("dispute"));
+        bytes32 paymentNullifier = keccak256(abi.encodePacked(METHOD, paymentId));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.InvalidPaymentBinding.selector, INTENT, paymentNullifier
+            )
+        );
+        policy.submitChargeback(attestation);
+
+        nullifierRegistry.addWritePermission(address(this));
+        nullifierRegistry.addNullifier(paymentNullifier, INTENT);
+        policy.submitChargeback(attestation);
+
+        assertEq(vault.claimable(depositor), 40e6);
+        assertEq(vault.lockedStake(taker), 0);
+        assertEq(vault.stakeBalance(taker), STAKE_AMOUNT - 40e6);
+        assertEq(
+            uint256(policy.getPosition(INTENT).status),
+            uint256(IChargebackPolicy.PositionStatus.SLASHED)
+        );
+    }
+
+    function test_SubmitChargebackManualPathSkipsPaymentBindingAndRejectsReplay() public {
+        _admitAndSettle(INTENT, 40e6, true);
+        bytes32 disputeId = keccak256("dispute");
+        IChargebackPolicy.ChargebackAttestation memory attestation =
+            _attestation(INTENT, METHOD, keccak256("unbound-payment"), disputeId);
+        policy.submitChargeback(attestation);
+
+        bytes32 disputeNullifier = keccak256(abi.encodePacked(METHOD, disputeId));
+        assertTrue(policy.usedChargebackNullifiers(disputeNullifier));
+
+        bytes32 secondIntent = keccak256("second");
+        _admitAndSettle(secondIntent, 40e6, true);
+        attestation = _attestation(secondIntent, METHOD, keccak256("other-payment"), disputeId);
+        vm.expectRevert(
+            abi.encodeWithSelector(IChargebackPolicy.ChargebackEvidenceUsed.selector, disputeNullifier)
+        );
+        policy.submitChargeback(attestation);
+    }
+
+    function test_SubmitChargebackRejectsClosedWindowTamperingVerifierFailureAndWrongMethod() public {
+        _admitAndSettle(INTENT, 40e6, true);
+        IChargebackPolicy.ChargebackAttestation memory attestation =
+            _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
+        attestation.dataHash = keccak256("tampered");
+        vm.expectRevert(IChargebackPolicy.InvalidAttestation.selector);
+        policy.submitChargeback(attestation);
+
+        attestation = _attestation(INTENT, keccak256("wrong"), keccak256("payment"), keccak256("dispute"));
+        vm.expectRevert(IChargebackPolicy.InvalidAttestation.selector);
+        policy.submitChargeback(attestation);
+
+        attestation = _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
+        attestationVerifier.setResult(false);
+        vm.expectRevert(IChargebackPolicy.AttestationVerificationFailed.selector);
+        policy.submitChargeback(attestation);
+        attestationVerifier.setResult(true);
+
+        uint64 deadline = policy.getPosition(INTENT).coverageDeadline;
+        vm.warp(deadline);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.ChargebackWindowClosed.selector, deadline, deadline
+            )
+        );
+        policy.submitChargeback(attestation);
+    }
+
+    function test_GovernanceSettersEnforceOwnershipAndValidation() public {
+        vm.startPrank(other);
+        vm.expectRevert(bytes("Ownable: caller is not the owner"));
+        policy.setRiskWindow(METHOD, 1 days);
+        vm.expectRevert(bytes("Ownable: caller is not the owner"));
+        policy.setAdmissionsPaused(true);
+        vm.expectRevert(bytes("Ownable: caller is not the owner"));
+        policy.setAttestationVerifier(address(attestationVerifier));
+        vm.expectRevert(bytes("Ownable: caller is not the owner"));
+        policy.setLifecycleHook(address(this));
+        vm.expectRevert(bytes("Ownable: caller is not the owner"));
+        policy.setEscrowRegistry(escrowRegistry);
+        vm.stopPrank();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IChargebackPolicy.InvalidRiskWindow.selector, uint64(365 days + 1))
+        );
+        policy.setRiskWindow(METHOD, uint64(365 days + 1));
+        vm.expectRevert(IChargebackPolicy.ZeroAddress.selector);
+        policy.setAttestationVerifier(address(0));
+        vm.expectRevert(abi.encodeWithSelector(IChargebackPolicy.InvalidContract.selector, other));
+        policy.setLifecycleHook(other);
+        vm.expectRevert(IChargebackPolicy.OwnershipRenunciationDisabled.selector);
+        policy.renounceOwnership();
+    }
+
+    function test_SetEnabledEnforcesRegistryDepositAndDepositor() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.NotDepositor.selector, address(escrow), depositId, other
+            )
+        );
+        vm.prank(other);
+        policy.setEnabled(address(escrow), depositId, true);
+
+        uint256 missingDeposit = type(uint256).max;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.DepositNotFound.selector, address(escrow), missingDeposit
+            )
+        );
+        policy.setEnabled(address(escrow), missingDeposit, true);
+
+        EscrowRegistry emptyRegistry = new EscrowRegistry();
+        policy.setEscrowRegistry(emptyRegistry);
+        vm.expectRevert(
+            abi.encodeWithSelector(IChargebackPolicy.EscrowNotWhitelisted.selector, address(escrow))
+        );
+        vm.prank(depositor);
+        policy.setEnabled(address(escrow), depositId, true);
+    }
+
+    function test_AcceptVaultControllerCompletesDelayedTwoStepHandover() public {
+        StakeVault secondVault = new StakeVault(address(this), token, address(0), 1 days);
+        ChargebackPolicy secondPolicy = new ChargebackPolicy(
+            address(this), secondVault, nullifierRegistry, attestationVerifier, escrowRegistry
+        );
+        secondVault.initializeController(address(this));
+        secondVault.proposeController(address(secondPolicy));
+        uint256 acceptanceTime = vm.getBlockTimestamp() + secondVault.controllerChangeDelay();
+        vm.warp(acceptanceTime);
+        secondPolicy.acceptVaultController();
+        assertEq(secondVault.controller(), address(secondPolicy));
+    }
+
+    function _stake(address stakeOwner, uint256 amount) internal {
+        token.transfer(stakeOwner, amount);
+        vm.startPrank(stakeOwner);
+        token.approve(address(vault), amount);
+        vault.depositStake(amount);
+        vm.stopPrank();
+    }
+
+    function _admitAndSettle(bytes32 intentHash, uint256 grossAmount, bool manualRelease) internal {
+        policy.admitIntent(intentHash, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        policy.onIntentSettled(intentHash, grossAmount, manualRelease);
+    }
+
+    function _attestation(
+        bytes32 intentHash,
+        bytes32 paymentMethod,
+        bytes32 paymentId,
+        bytes32 disputeId
+    ) internal pure returns (IChargebackPolicy.ChargebackAttestation memory attestation) {
+        IChargebackPolicy.ChargebackDetails memory details = IChargebackPolicy.ChargebackDetails({
+            paymentMethod: paymentMethod,
+            originalPaymentId: paymentId,
+            disputeId: disputeId,
+            paymentAmount: 100,
+            paymentCurrency: USD
+        });
+        bytes memory data = abi.encode(details);
+        attestation = IChargebackPolicy.ChargebackAttestation({
+            intentHash: intentHash,
+            dataHash: keccak256(data),
+            signatures: new bytes[](0),
+            data: data
+        });
+    }
+}

--- a/test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol
@@ -10,6 +10,7 @@ import {IChargebackPolicy} from "contracts/interfaces/IChargebackPolicy.sol";
 import {IChargebackVerifier} from "contracts/interfaces/IChargebackVerifier.sol";
 import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
 import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
+import {IStakeVault} from "contracts/interfaces/IStakeVault.sol";
 import {AttestationVerifierMock} from "contracts/mocks/AttestationVerifierMock.sol";
 import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
 import {NullifierRegistry} from "contracts/registries/NullifierRegistry.sol";
@@ -27,6 +28,7 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
     WhitelistPolicy internal whitelistPolicy;
     StakeVault internal vault;
     NullifierRegistryV2 internal nullifierRegistry;
+    NullifierRegistry internal chargebackNullifierRegistry;
     ChargebackPolicy internal chargebackPolicy;
     IntentLifecycleHookV1 internal lifecycleHook;
 
@@ -36,16 +38,17 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         whitelistPolicy = new WhitelistPolicy(groupRegistry, escrowRegistry, orchestratorRegistry);
         vault = new StakeVault(address(this), token, address(0), 1 days);
         nullifierRegistry = new NullifierRegistryV2(new NullifierRegistry());
+        chargebackNullifierRegistry = new NullifierRegistry();
         chargebackPolicy = new ChargebackPolicy(
             address(this),
             vault,
             new ChargebackVerifier(address(this), nullifierRegistry, new AttestationVerifierMock()),
-            escrowRegistry
+            chargebackNullifierRegistry
         );
         vault.initializeController(address(chargebackPolicy));
-        lifecycleHook =
-            new IntentLifecycleHookV1(orchestratorRegistry, whitelistPolicy, chargebackPolicy);
-        chargebackPolicy.setLifecycleHook(address(lifecycleHook));
+        chargebackNullifierRegistry.addWritePermission(address(chargebackPolicy));
+        lifecycleHook = new IntentLifecycleHookV1(orchestratorRegistry, whitelistPolicy, chargebackPolicy);
+        chargebackPolicy.setLifecycleHookAuthorization(address(lifecycleHook), true);
         chargebackPolicy.setRiskWindow(METHOD, RISK_WINDOW);
         orchestrator.setLifecycleHook(lifecycleHook);
         _stake(taker, STAKE_AMOUNT);
@@ -58,8 +61,8 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         bytes32 intentHash = _signalDefault();
 
         assertEq(
-            uint256(chargebackPolicy.getPosition(intentHash).status),
-            uint256(IChargebackPolicy.PositionStatus.NONE)
+            uint256(chargebackPolicy.getChargebackIntent(intentHash).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.NONE)
         );
         assertEq(vault.lockedStake(taker), 0);
         assertEq(escrow.getDepositIntent(depositId, intentHash).intentHash, intentHash);
@@ -71,20 +74,15 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         bytes32 intentHash = _signalDefault();
         assertEq(vault.lockedStake(taker), INTENT_AMOUNT);
         assertEq(
-            uint256(chargebackPolicy.getPosition(intentHash).status),
-            uint256(IChargebackPolicy.PositionStatus.PENDING)
+            uint256(chargebackPolicy.getChargebackIntent(intentHash).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.PENDING)
         );
 
         uint256 counterBefore = orchestrator.intentCounter();
         bytes32 rejectedIntent = _intentHash(counterBefore);
         uint256 remainingBefore = escrow.getDeposit(depositId).remainingDeposits;
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IChargebackPolicy.InsufficientCollateral.selector,
-                other,
-                uint256(0),
-                INTENT_AMOUNT
-            )
+            abi.encodeWithSelector(IStakeVault.InsufficientFreeStake.selector, other, uint256(0), INTENT_AMOUNT)
         );
         _signalCall(other, _paramsFor(other));
         assertEq(orchestrator.intentCounter(), counterBefore);
@@ -102,8 +100,8 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         bytes32 intentHash = _signal(other, params);
 
         assertEq(
-            uint256(chargebackPolicy.getPosition(intentHash).status),
-            uint256(IChargebackPolicy.PositionStatus.NONE)
+            uint256(chargebackPolicy.getChargebackIntent(intentHash).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.NONE)
         );
         assertEq(vault.lockedStake(other), 0);
         assertEq(escrow.getDepositIntent(depositId, intentHash).intentHash, intentHash);
@@ -111,8 +109,8 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         verifier.setShouldVerifyPayment(true);
         _fulfill(intentHash, INTENT_AMOUNT, CONVERSION_RATE);
         assertEq(
-            uint256(chargebackPolicy.getPosition(intentHash).status),
-            uint256(IChargebackPolicy.PositionStatus.NONE)
+            uint256(chargebackPolicy.getChargebackIntent(intentHash).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.NONE)
         );
     }
 
@@ -120,10 +118,7 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         _setWhitelist(true, false);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IntentLifecycleHookV1.TakerNotWhitelisted.selector,
-                address(escrow),
-                depositId,
-                taker
+                IntentLifecycleHookV1.TakerNotWhitelisted.selector, address(escrow), depositId, taker
             )
         );
         _signalCall(taker, _defaultParams());
@@ -133,12 +128,7 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         _setChargeback(true);
         assertNotEq(_signalDefault(), bytes32(0));
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IChargebackPolicy.InsufficientCollateral.selector,
-                other,
-                uint256(0),
-                INTENT_AMOUNT
-            )
+            abi.encodeWithSelector(IStakeVault.InsufficientFreeStake.selector, other, uint256(0), INTENT_AMOUNT)
         );
         _signalCall(other, _paramsFor(other));
     }
@@ -152,27 +142,22 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         bytes32 intentHash = _signal(other, params);
 
         assertEq(
-            uint256(chargebackPolicy.getPosition(intentHash).status),
-            uint256(IChargebackPolicy.PositionStatus.NONE)
+            uint256(chargebackPolicy.getChargebackIntent(intentHash).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.NONE)
         );
         assertEq(vault.lockedStake(other), 0);
 
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IChargebackPolicy.InsufficientCollateral.selector,
-                other,
-                uint256(0),
-                INTENT_AMOUNT
-            )
+            abi.encodeWithSelector(IStakeVault.InsufficientFreeStake.selector, other, uint256(0), INTENT_AMOUNT)
         );
         _signalCall(other, _paramsFor(other));
     }
 
-    function test_WhitelistOffChargebackOffIsOpenAndCreatesNoPosition() public {
+    function test_WhitelistOffChargebackOffIsOpenAndCreatesNoChargebackIntent() public {
         bytes32 intentHash = _signal(other, _paramsFor(other));
         assertEq(
-            uint256(chargebackPolicy.getPosition(intentHash).status),
-            uint256(IChargebackPolicy.PositionStatus.NONE)
+            uint256(chargebackPolicy.getChargebackIntent(intentHash).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.NONE)
         );
         assertEq(vault.lockedStake(other), 0);
     }
@@ -184,8 +169,8 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         orchestrator.cancelIntent(cancelledIntent);
         assertEq(vault.lockedStake(taker), 0);
         assertEq(
-            uint256(chargebackPolicy.getPosition(cancelledIntent).status),
-            uint256(IChargebackPolicy.PositionStatus.CANCELLED)
+            uint256(chargebackPolicy.getChargebackIntent(cancelledIntent).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.CANCELLED)
         );
 
         bytes32 expiredIntent = _signalDefault();
@@ -194,8 +179,8 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         escrow.pruneExpiredIntents(depositId);
         assertEq(vault.lockedStake(taker), 0);
         assertEq(
-            uint256(chargebackPolicy.getPosition(expiredIntent).status),
-            uint256(IChargebackPolicy.PositionStatus.CANCELLED)
+            uint256(chargebackPolicy.getChargebackIntent(expiredIntent).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.CANCELLED)
         );
     }
 
@@ -203,21 +188,20 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         _setChargeback(true);
         bytes32 intentHash = _signalDefault();
         uint256 releaseAmount = 40e6;
-        uint256 expectedDeadline = vm.getBlockTimestamp() + RISK_WINDOW;
+        uint256 releaseEligibleAt = vm.getBlockTimestamp() + RISK_WINDOW;
         verifier.setShouldVerifyPayment(true);
         _fulfill(intentHash, releaseAmount, CONVERSION_RATE);
 
-        IChargebackPolicy.Position memory position = chargebackPolicy.getPosition(intentHash);
-        assertEq(position.coverageAmount, releaseAmount);
-        assertEq(position.grossReleasedAmount, releaseAmount);
-        assertEq(position.coverageDeadline, expectedDeadline);
-        assertFalse(position.isManualRelease);
+        IChargebackPolicy.ChargebackIntent memory chargebackIntent = chargebackPolicy.getChargebackIntent(intentHash);
+        assertEq(chargebackIntent.releaseAmount, releaseAmount);
+        assertEq(chargebackIntent.releaseEligibleAt, releaseEligibleAt);
+        assertFalse(chargebackIntent.isManualRelease);
         (, uint256 lockedAmount, uint64 maturesAt) = vault.locks(intentHash);
         assertEq(lockedAmount, releaseAmount);
-        assertEq(maturesAt, expectedDeadline);
+        assertEq(maturesAt, releaseEligibleAt);
 
-        vm.warp(expectedDeadline);
-        chargebackPolicy.releaseMaturedPosition(intentHash);
+        vm.warp(releaseEligibleAt);
+        chargebackPolicy.releaseMaturedChargebackIntent(intentHash);
         assertEq(vault.lockedStake(taker), 0);
         assertEq(vault.freeStake(taker), STAKE_AMOUNT);
     }
@@ -225,14 +209,14 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
     function test_ManualReleaseSettlesCoverageAndMarksManual() public {
         _setChargeback(true);
         bytes32 intentHash = _signalDefault();
-        uint256 expectedDeadline = vm.getBlockTimestamp() + RISK_WINDOW;
+        uint256 releaseEligibleAt = vm.getBlockTimestamp() + RISK_WINDOW;
         vm.prank(depositor);
         orchestrator.releaseFundsToPayer(intentHash);
 
-        IChargebackPolicy.Position memory position = chargebackPolicy.getPosition(intentHash);
-        assertTrue(position.isManualRelease);
-        assertEq(position.coverageAmount, INTENT_AMOUNT);
-        assertEq(position.coverageDeadline, expectedDeadline);
+        IChargebackPolicy.ChargebackIntent memory chargebackIntent = chargebackPolicy.getChargebackIntent(intentHash);
+        assertTrue(chargebackIntent.isManualRelease);
+        assertEq(chargebackIntent.releaseAmount, INTENT_AMOUNT);
+        assertEq(chargebackIntent.releaseEligibleAt, releaseEligibleAt);
         assertEq(vault.lockedStake(taker), INTENT_AMOUNT);
     }
 
@@ -246,15 +230,13 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         bytes32 paymentNullifier = keccak256(abi.encodePacked(METHOD, paymentId));
         nullifierRegistry.addWritePermission(address(this));
         nullifierRegistry.addNullifier(paymentNullifier, intentHash);
-        chargebackPolicy.submitChargeback(
-            _attestation(intentHash, paymentId, keccak256("dispute"))
-        );
+        chargebackPolicy.submitChargeback(_attestation(intentHash, paymentId, keccak256("dispute")));
 
         assertEq(vault.claimable(depositor), INTENT_AMOUNT);
         assertEq(vault.lockedStake(taker), 0);
         assertEq(
-            uint256(chargebackPolicy.getPosition(intentHash).status),
-            uint256(IChargebackPolicy.PositionStatus.SLASHED)
+            uint256(chargebackPolicy.getChargebackIntent(intentHash).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.CHARGED_BACK)
         );
     }
 
@@ -274,7 +256,7 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         assertEq(escrow.getDeposit(depositId).remainingDeposits, remainingBefore);
     }
 
-    function test_CancellationWithoutPositionLeavesVaultUntouched() public {
+    function test_CancellationWithoutChargebackIntentLeavesVaultUntouched() public {
         bytes32 intentHash = _signalDefault();
         uint256 totalBefore = vault.totalStaked();
         vm.prank(taker);
@@ -282,48 +264,55 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         assertEq(vault.totalStaked(), totalBefore);
         assertEq(vault.lockedStake(taker), 0);
         assertEq(
-            uint256(chargebackPolicy.getPosition(intentHash).status),
-            uint256(IChargebackPolicy.PositionStatus.NONE)
+            uint256(chargebackPolicy.getChargebackIntent(intentHash).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.NONE)
         );
     }
 
-    function test_LifecycleHookRotationPreservesOldIntentsAndRoutesNewIntentsToNewHook()
-        public
-    {
+    function test_LifecycleHookRotationPreservesOldIntentsAndRoutesNewIntentsToNewHook() public {
         _setChargeback(true);
         bytes32 oldCancelledIntent = _signalDefault();
         bytes32 oldSettledIntent = _signalDefault();
         IntentLifecycleHookV1 newLifecycleHook =
             new IntentLifecycleHookV1(orchestratorRegistry, whitelistPolicy, chargebackPolicy);
 
-        chargebackPolicy.setLifecycleHook(address(newLifecycleHook));
+        chargebackPolicy.setLifecycleHookAuthorization(address(newLifecycleHook), true);
         orchestrator.setLifecycleHook(newLifecycleHook);
 
+        chargebackPolicy.setLifecycleHookAuthorization(address(lifecycleHook), false);
+        vm.expectRevert(
+            abi.encodeWithSelector(IChargebackPolicy.UnauthorizedLifecycleHook.selector, address(lifecycleHook))
+        );
         vm.prank(taker);
         orchestrator.cancelIntent(oldCancelledIntent);
         assertEq(
-            uint256(chargebackPolicy.getPosition(oldCancelledIntent).status),
-            uint256(IChargebackPolicy.PositionStatus.CANCELLED)
+            uint256(chargebackPolicy.getChargebackIntent(oldCancelledIntent).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.PENDING)
+        );
+
+        chargebackPolicy.setLifecycleHookAuthorization(address(lifecycleHook), true);
+        vm.prank(taker);
+        orchestrator.cancelIntent(oldCancelledIntent);
+        assertEq(
+            uint256(chargebackPolicy.getChargebackIntent(oldCancelledIntent).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.CANCELLED)
         );
 
         uint256 releaseAmount = 40e6;
         verifier.setShouldVerifyPayment(true);
         _fulfill(oldSettledIntent, releaseAmount, CONVERSION_RATE);
-        IChargebackPolicy.Position memory oldSettledPosition =
-            chargebackPolicy.getPosition(oldSettledIntent);
-        assertEq(
-            uint256(oldSettledPosition.status),
-            uint256(IChargebackPolicy.PositionStatus.SETTLED)
-        );
-        assertEq(oldSettledPosition.coverageAmount, releaseAmount);
+        IChargebackPolicy.ChargebackIntent memory oldSettledIntentState =
+            chargebackPolicy.getChargebackIntent(oldSettledIntent);
+        assertEq(uint256(oldSettledIntentState.status), uint256(IChargebackPolicy.ChargebackIntentStatus.SETTLED));
+        assertEq(oldSettledIntentState.releaseAmount, releaseAmount);
 
         bytes32 newIntent = _signalDefault();
         assertEq(address(orchestrator.getIntentLifecycleHook(newIntent)), address(newLifecycleHook));
         vm.prank(taker);
         orchestrator.cancelIntent(newIntent);
         assertEq(
-            uint256(chargebackPolicy.getPosition(newIntent).status),
-            uint256(IChargebackPolicy.PositionStatus.CANCELLED)
+            uint256(chargebackPolicy.getChargebackIntent(newIntent).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.CANCELLED)
         );
         assertEq(vault.lockedStake(taker), releaseAmount);
     }
@@ -332,39 +321,28 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         address[] memory takers = new address[](includeTaker ? 1 : 0);
         if (includeTaker) takers[0] = taker;
         vm.prank(depositor);
-        whitelistPolicy.configureDeposit(
-            address(escrow), depositId, enabled, new bytes32[](0), takers
-        );
+        whitelistPolicy.configureDeposit(address(escrow), depositId, enabled, new bytes32[](0), takers);
     }
 
     function _setChargeback(bool enabled) internal {
         vm.prank(depositor);
-        chargebackPolicy.setEnabled(address(escrow), depositId, enabled);
+        chargebackPolicy.setChargebackEnabled(address(escrow), depositId, enabled);
     }
 
     function _addPaymentMethod(bytes32 _paymentMethod) internal {
         bytes32[] memory supportedCurrencies = new bytes32[](1);
         supportedCurrencies[0] = USD;
-        paymentVerifierRegistry.addPaymentMethod(
-            _paymentMethod, address(verifier), supportedCurrencies
-        );
+        paymentVerifierRegistry.addPaymentMethod(_paymentMethod, address(verifier), supportedCurrencies);
 
         bytes32[] memory paymentMethods = new bytes32[](1);
         paymentMethods[0] = _paymentMethod;
-        IEscrowV2.DepositPaymentMethodData[] memory paymentMethodData =
-            new IEscrowV2.DepositPaymentMethodData[](1);
-        paymentMethodData[0] = IEscrowV2.DepositPaymentMethodData({
-            intentGatingService: address(0),
-            payeeDetails: PAYEE,
-            data: ""
-        });
+        IEscrowV2.DepositPaymentMethodData[] memory paymentMethodData = new IEscrowV2.DepositPaymentMethodData[](1);
+        paymentMethodData[0] =
+            IEscrowV2.DepositPaymentMethodData({intentGatingService: address(0), payeeDetails: PAYEE, data: ""});
         IEscrowV2.Currency[][] memory currencies = new IEscrowV2.Currency[][](1);
         currencies[0] = new IEscrowV2.Currency[](1);
-        currencies[0][0] = IEscrowV2.Currency({
-            code: USD,
-            minConversionRate: CONVERSION_RATE,
-            oracleRateConfig: _emptyOracle()
-        });
+        currencies[0][0] =
+            IEscrowV2.Currency({code: USD, minConversionRate: CONVERSION_RATE, oracleRateConfig: _emptyOracle()});
 
         vm.prank(depositor);
         escrow.addPaymentMethods(depositId, paymentMethods, paymentMethodData, currencies);
@@ -378,11 +356,7 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         vm.stopPrank();
     }
 
-    function _paramsFor(address recipient)
-        internal
-        view
-        returns (IOrchestratorV3.SignalIntentParams memory params)
-    {
+    function _paramsFor(address recipient) internal view returns (IOrchestratorV3.SignalIntentParams memory params) {
         params = _defaultParams();
         params.to = recipient;
     }
@@ -401,10 +375,7 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         });
         bytes memory data = abi.encode(details);
         attestation = IChargebackVerifier.ChargebackAttestation({
-            intentHash: intentHash,
-            dataHash: keccak256(data),
-            signatures: new bytes[](0),
-            data: data
+            intentHash: intentHash, dataHash: keccak256(data), signatures: new bytes[](0), data: data
         });
     }
 }

--- a/test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol
@@ -7,12 +7,14 @@ import {ChargebackPolicy} from "contracts/hooks/ChargebackPolicy.sol";
 import {IntentLifecycleHookV1} from "contracts/hooks/IntentLifecycleHookV1.sol";
 import {WhitelistPolicy} from "contracts/hooks/WhitelistPolicy.sol";
 import {IChargebackPolicy} from "contracts/interfaces/IChargebackPolicy.sol";
+import {IChargebackVerifier} from "contracts/interfaces/IChargebackVerifier.sol";
 import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
 import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
 import {AttestationVerifierMock} from "contracts/mocks/AttestationVerifierMock.sol";
 import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
 import {NullifierRegistry} from "contracts/registries/NullifierRegistry.sol";
 import {NullifierRegistryV2} from "contracts/registries/NullifierRegistryV2.sol";
+import {ChargebackVerifier} from "contracts/unifiedVerifier/ChargebackVerifier.sol";
 
 import {OrchestratorV3Fixture} from "../helpers/OrchestratorV3Fixture.sol";
 
@@ -37,8 +39,7 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         chargebackPolicy = new ChargebackPolicy(
             address(this),
             vault,
-            nullifierRegistry,
-            new AttestationVerifierMock(),
+            new ChargebackVerifier(address(this), nullifierRegistry, new AttestationVerifierMock()),
             escrowRegistry
         );
         vault.initializeController(address(chargebackPolicy));
@@ -389,9 +390,9 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
     function _attestation(bytes32 intentHash, bytes32 paymentId, bytes32 disputeId)
         internal
         pure
-        returns (IChargebackPolicy.ChargebackAttestation memory attestation)
+        returns (IChargebackVerifier.ChargebackAttestation memory attestation)
     {
-        IChargebackPolicy.ChargebackDetails memory details = IChargebackPolicy.ChargebackDetails({
+        IChargebackVerifier.ChargebackDetails memory details = IChargebackVerifier.ChargebackDetails({
             paymentMethod: METHOD,
             originalPaymentId: paymentId,
             disputeId: disputeId,
@@ -399,7 +400,7 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
             paymentCurrency: USD
         });
         bytes memory data = abi.encode(details);
-        attestation = IChargebackPolicy.ChargebackAttestation({
+        attestation = IChargebackVerifier.ChargebackAttestation({
             intentHash: intentHash,
             dataHash: keccak256(data),
             signatures: new bytes[](0),

--- a/test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol
@@ -286,6 +286,47 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         );
     }
 
+    function test_LifecycleHookRotationPreservesOldIntentsAndRoutesNewIntentsToNewHook()
+        public
+    {
+        _setChargeback(true);
+        bytes32 oldCancelledIntent = _signalDefault();
+        bytes32 oldSettledIntent = _signalDefault();
+        IntentLifecycleHookV1 newLifecycleHook =
+            new IntentLifecycleHookV1(orchestratorRegistry, whitelistPolicy, chargebackPolicy);
+
+        chargebackPolicy.setLifecycleHook(address(newLifecycleHook));
+        orchestrator.setLifecycleHook(newLifecycleHook);
+
+        vm.prank(taker);
+        orchestrator.cancelIntent(oldCancelledIntent);
+        assertEq(
+            uint256(chargebackPolicy.getPosition(oldCancelledIntent).status),
+            uint256(IChargebackPolicy.PositionStatus.CANCELLED)
+        );
+
+        uint256 releaseAmount = 40e6;
+        verifier.setShouldVerifyPayment(true);
+        _fulfill(oldSettledIntent, releaseAmount, CONVERSION_RATE);
+        IChargebackPolicy.Position memory oldSettledPosition =
+            chargebackPolicy.getPosition(oldSettledIntent);
+        assertEq(
+            uint256(oldSettledPosition.status),
+            uint256(IChargebackPolicy.PositionStatus.SETTLED)
+        );
+        assertEq(oldSettledPosition.coverageAmount, releaseAmount);
+
+        bytes32 newIntent = _signalDefault();
+        assertEq(address(orchestrator.getIntentLifecycleHook(newIntent)), address(newLifecycleHook));
+        vm.prank(taker);
+        orchestrator.cancelIntent(newIntent);
+        assertEq(
+            uint256(chargebackPolicy.getPosition(newIntent).status),
+            uint256(IChargebackPolicy.PositionStatus.CANCELLED)
+        );
+        assertEq(vault.lockedStake(taker), releaseAmount);
+    }
+
     function _setWhitelist(bool enabled, bool includeTaker) internal {
         address[] memory takers = new address[](includeTaker ? 1 : 0);
         if (includeTaker) takers[0] = taker;

--- a/test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {StakeVault} from "contracts/StakeVault.sol";
+import {ChargebackPolicy} from "contracts/hooks/ChargebackPolicy.sol";
+import {IntentLifecycleHookV1} from "contracts/hooks/IntentLifecycleHookV1.sol";
+import {WhitelistPolicy} from "contracts/hooks/WhitelistPolicy.sol";
+import {IChargebackPolicy} from "contracts/interfaces/IChargebackPolicy.sol";
+import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
+import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
+import {AttestationVerifierMock} from "contracts/mocks/AttestationVerifierMock.sol";
+import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
+import {NullifierRegistry} from "contracts/registries/NullifierRegistry.sol";
+import {NullifierRegistryV2} from "contracts/registries/NullifierRegistryV2.sol";
+
+import {OrchestratorV3Fixture} from "../helpers/OrchestratorV3Fixture.sol";
+
+contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
+    uint64 internal constant RISK_WINDOW = 30 days;
+    uint256 internal constant STAKE_AMOUNT = 500e6;
+    bytes32 internal constant WINDOWLESS_METHOD = keccak256("windowless");
+
+    AddressGroupRegistry internal groupRegistry;
+    WhitelistPolicy internal whitelistPolicy;
+    StakeVault internal vault;
+    NullifierRegistryV2 internal nullifierRegistry;
+    ChargebackPolicy internal chargebackPolicy;
+    IntentLifecycleHookV1 internal lifecycleHook;
+
+    function setUp() public override {
+        super.setUp();
+        groupRegistry = new AddressGroupRegistry();
+        whitelistPolicy = new WhitelistPolicy(groupRegistry, escrowRegistry, orchestratorRegistry);
+        vault = new StakeVault(address(this), token, address(0), 1 days);
+        nullifierRegistry = new NullifierRegistryV2(new NullifierRegistry());
+        chargebackPolicy = new ChargebackPolicy(
+            address(this),
+            vault,
+            nullifierRegistry,
+            new AttestationVerifierMock(),
+            escrowRegistry
+        );
+        vault.initializeController(address(chargebackPolicy));
+        lifecycleHook =
+            new IntentLifecycleHookV1(orchestratorRegistry, whitelistPolicy, chargebackPolicy);
+        chargebackPolicy.setLifecycleHook(address(lifecycleHook));
+        chargebackPolicy.setRiskWindow(METHOD, RISK_WINDOW);
+        orchestrator.setLifecycleHook(lifecycleHook);
+        _stake(taker, STAKE_AMOUNT);
+    }
+
+    function test_WhitelistOnWhitelistedWithChargebackOnSkipsStake() public {
+        _setWhitelist(true, true);
+        _setChargeback(true);
+
+        bytes32 intentHash = _signalDefault();
+
+        assertEq(
+            uint256(chargebackPolicy.getPosition(intentHash).status),
+            uint256(IChargebackPolicy.PositionStatus.NONE)
+        );
+        assertEq(vault.lockedStake(taker), 0);
+        assertEq(escrow.getDepositIntent(depositId, intentHash).intentHash, intentHash);
+    }
+
+    function test_WhitelistOnNonMemberWithChargebackOnRequiresStakeBeforeEscrowLock() public {
+        _setWhitelist(true, false);
+        _setChargeback(true);
+        bytes32 intentHash = _signalDefault();
+        assertEq(vault.lockedStake(taker), INTENT_AMOUNT);
+        assertEq(
+            uint256(chargebackPolicy.getPosition(intentHash).status),
+            uint256(IChargebackPolicy.PositionStatus.PENDING)
+        );
+
+        uint256 counterBefore = orchestrator.intentCounter();
+        bytes32 rejectedIntent = _intentHash(counterBefore);
+        uint256 remainingBefore = escrow.getDeposit(depositId).remainingDeposits;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.InsufficientCollateral.selector,
+                other,
+                uint256(0),
+                INTENT_AMOUNT
+            )
+        );
+        _signalCall(other, _paramsFor(other));
+        assertEq(orchestrator.intentCounter(), counterBefore);
+        assertEq(escrow.getDepositIntent(depositId, rejectedIntent).intentHash, bytes32(0));
+        assertEq(escrow.getDeposit(depositId).remainingDeposits, remainingBefore);
+    }
+
+    function test_WhitelistOnNonMemberNonChargebackableMethodGetsDirectAccess() public {
+        _addPaymentMethod(WINDOWLESS_METHOD);
+        _setWhitelist(true, false);
+        _setChargeback(true);
+        IOrchestratorV3.SignalIntentParams memory params = _paramsFor(other);
+        params.paymentMethod = WINDOWLESS_METHOD;
+
+        bytes32 intentHash = _signal(other, params);
+
+        assertEq(
+            uint256(chargebackPolicy.getPosition(intentHash).status),
+            uint256(IChargebackPolicy.PositionStatus.NONE)
+        );
+        assertEq(vault.lockedStake(other), 0);
+        assertEq(escrow.getDepositIntent(depositId, intentHash).intentHash, intentHash);
+
+        verifier.setShouldVerifyPayment(true);
+        _fulfill(intentHash, INTENT_AMOUNT, CONVERSION_RATE);
+        assertEq(
+            uint256(chargebackPolicy.getPosition(intentHash).status),
+            uint256(IChargebackPolicy.PositionStatus.NONE)
+        );
+    }
+
+    function test_WhitelistOnNonMemberWithChargebackOffRejects() public {
+        _setWhitelist(true, false);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IntentLifecycleHookV1.TakerNotWhitelisted.selector,
+                address(escrow),
+                depositId,
+                taker
+            )
+        );
+        _signalCall(taker, _defaultParams());
+    }
+
+    function test_WhitelistOffChargebackOnRequiresStakeForEveryTaker() public {
+        _setChargeback(true);
+        assertNotEq(_signalDefault(), bytes32(0));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.InsufficientCollateral.selector,
+                other,
+                uint256(0),
+                INTENT_AMOUNT
+            )
+        );
+        _signalCall(other, _paramsFor(other));
+    }
+
+    function test_WhitelistOffChargebackOnNonChargebackableMethodIsOpen() public {
+        _addPaymentMethod(WINDOWLESS_METHOD);
+        _setChargeback(true);
+        IOrchestratorV3.SignalIntentParams memory params = _paramsFor(other);
+        params.paymentMethod = WINDOWLESS_METHOD;
+
+        bytes32 intentHash = _signal(other, params);
+
+        assertEq(
+            uint256(chargebackPolicy.getPosition(intentHash).status),
+            uint256(IChargebackPolicy.PositionStatus.NONE)
+        );
+        assertEq(vault.lockedStake(other), 0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.InsufficientCollateral.selector,
+                other,
+                uint256(0),
+                INTENT_AMOUNT
+            )
+        );
+        _signalCall(other, _paramsFor(other));
+    }
+
+    function test_WhitelistOffChargebackOffIsOpenAndCreatesNoPosition() public {
+        bytes32 intentHash = _signal(other, _paramsFor(other));
+        assertEq(
+            uint256(chargebackPolicy.getPosition(intentHash).status),
+            uint256(IChargebackPolicy.PositionStatus.NONE)
+        );
+        assertEq(vault.lockedStake(other), 0);
+    }
+
+    function test_CancelIntentAndExpiryPruneUnlockStake() public {
+        _setChargeback(true);
+        bytes32 cancelledIntent = _signalDefault();
+        vm.prank(taker);
+        orchestrator.cancelIntent(cancelledIntent);
+        assertEq(vault.lockedStake(taker), 0);
+        assertEq(
+            uint256(chargebackPolicy.getPosition(cancelledIntent).status),
+            uint256(IChargebackPolicy.PositionStatus.CANCELLED)
+        );
+
+        bytes32 expiredIntent = _signalDefault();
+        IEscrowV2.Intent memory intent = escrow.getDepositIntent(depositId, expiredIntent);
+        vm.warp(intent.expiryTime + 1);
+        escrow.pruneExpiredIntents(depositId);
+        assertEq(vault.lockedStake(taker), 0);
+        assertEq(
+            uint256(chargebackPolicy.getPosition(expiredIntent).status),
+            uint256(IChargebackPolicy.PositionStatus.CANCELLED)
+        );
+    }
+
+    function test_FulfillResizesCoverageThenMaturityReleasesStake() public {
+        _setChargeback(true);
+        bytes32 intentHash = _signalDefault();
+        uint256 releaseAmount = 40e6;
+        uint256 expectedDeadline = vm.getBlockTimestamp() + RISK_WINDOW;
+        verifier.setShouldVerifyPayment(true);
+        _fulfill(intentHash, releaseAmount, CONVERSION_RATE);
+
+        IChargebackPolicy.Position memory position = chargebackPolicy.getPosition(intentHash);
+        assertEq(position.coverageAmount, releaseAmount);
+        assertEq(position.grossReleasedAmount, releaseAmount);
+        assertEq(position.coverageDeadline, expectedDeadline);
+        assertFalse(position.isManualRelease);
+        (, uint256 lockedAmount, uint64 maturesAt) = vault.locks(intentHash);
+        assertEq(lockedAmount, releaseAmount);
+        assertEq(maturesAt, expectedDeadline);
+
+        vm.warp(expectedDeadline);
+        chargebackPolicy.releaseMaturedPosition(intentHash);
+        assertEq(vault.lockedStake(taker), 0);
+        assertEq(vault.freeStake(taker), STAKE_AMOUNT);
+    }
+
+    function test_ManualReleaseSettlesCoverageAndMarksManual() public {
+        _setChargeback(true);
+        bytes32 intentHash = _signalDefault();
+        uint256 expectedDeadline = vm.getBlockTimestamp() + RISK_WINDOW;
+        vm.prank(depositor);
+        orchestrator.releaseFundsToPayer(intentHash);
+
+        IChargebackPolicy.Position memory position = chargebackPolicy.getPosition(intentHash);
+        assertTrue(position.isManualRelease);
+        assertEq(position.coverageAmount, INTENT_AMOUNT);
+        assertEq(position.coverageDeadline, expectedDeadline);
+        assertEq(vault.lockedStake(taker), INTENT_AMOUNT);
+    }
+
+    function test_ChargebackAfterFulfillPaysDepositorClaim() public {
+        _setChargeback(true);
+        bytes32 intentHash = _signalDefault();
+        verifier.setShouldVerifyPayment(true);
+        _fulfill(intentHash, INTENT_AMOUNT, CONVERSION_RATE);
+
+        bytes32 paymentId = keccak256("payment");
+        bytes32 paymentNullifier = keccak256(abi.encodePacked(METHOD, paymentId));
+        nullifierRegistry.addWritePermission(address(this));
+        nullifierRegistry.addNullifier(paymentNullifier, intentHash);
+        chargebackPolicy.submitChargeback(
+            _attestation(intentHash, paymentId, keccak256("dispute"))
+        );
+
+        assertEq(vault.claimable(depositor), INTENT_AMOUNT);
+        assertEq(vault.lockedStake(taker), 0);
+        assertEq(
+            uint256(chargebackPolicy.getPosition(intentHash).status),
+            uint256(IChargebackPolicy.PositionStatus.SLASHED)
+        );
+    }
+
+    function test_PolicyAdmissionRevertBubblesRawAndRollsBackSignal() public {
+        _setChargeback(true);
+        chargebackPolicy.setAdmissionsPaused(true);
+        uint256 counterBefore = orchestrator.intentCounter();
+        bytes32 rejectedIntent = _intentHash(counterBefore);
+        uint256 remainingBefore = escrow.getDeposit(depositId).remainingDeposits;
+
+        vm.expectRevert(IChargebackPolicy.AdmissionsPaused.selector);
+        _signalCall(taker, _defaultParams());
+
+        assertEq(orchestrator.intentCounter(), counterBefore);
+        assertEq(orchestrator.getIntent(rejectedIntent).owner, address(0));
+        assertEq(escrow.getDepositIntent(depositId, rejectedIntent).intentHash, bytes32(0));
+        assertEq(escrow.getDeposit(depositId).remainingDeposits, remainingBefore);
+    }
+
+    function test_CancellationWithoutPositionLeavesVaultUntouched() public {
+        bytes32 intentHash = _signalDefault();
+        uint256 totalBefore = vault.totalStaked();
+        vm.prank(taker);
+        orchestrator.cancelIntent(intentHash);
+        assertEq(vault.totalStaked(), totalBefore);
+        assertEq(vault.lockedStake(taker), 0);
+        assertEq(
+            uint256(chargebackPolicy.getPosition(intentHash).status),
+            uint256(IChargebackPolicy.PositionStatus.NONE)
+        );
+    }
+
+    function _setWhitelist(bool enabled, bool includeTaker) internal {
+        address[] memory takers = new address[](includeTaker ? 1 : 0);
+        if (includeTaker) takers[0] = taker;
+        vm.prank(depositor);
+        whitelistPolicy.configureDeposit(
+            address(escrow), depositId, enabled, new bytes32[](0), takers
+        );
+    }
+
+    function _setChargeback(bool enabled) internal {
+        vm.prank(depositor);
+        chargebackPolicy.setEnabled(address(escrow), depositId, enabled);
+    }
+
+    function _addPaymentMethod(bytes32 _paymentMethod) internal {
+        bytes32[] memory supportedCurrencies = new bytes32[](1);
+        supportedCurrencies[0] = USD;
+        paymentVerifierRegistry.addPaymentMethod(
+            _paymentMethod, address(verifier), supportedCurrencies
+        );
+
+        bytes32[] memory paymentMethods = new bytes32[](1);
+        paymentMethods[0] = _paymentMethod;
+        IEscrowV2.DepositPaymentMethodData[] memory paymentMethodData =
+            new IEscrowV2.DepositPaymentMethodData[](1);
+        paymentMethodData[0] = IEscrowV2.DepositPaymentMethodData({
+            intentGatingService: address(0),
+            payeeDetails: PAYEE,
+            data: ""
+        });
+        IEscrowV2.Currency[][] memory currencies = new IEscrowV2.Currency[][](1);
+        currencies[0] = new IEscrowV2.Currency[](1);
+        currencies[0][0] = IEscrowV2.Currency({
+            code: USD,
+            minConversionRate: CONVERSION_RATE,
+            oracleRateConfig: _emptyOracle()
+        });
+
+        vm.prank(depositor);
+        escrow.addPaymentMethods(depositId, paymentMethods, paymentMethodData, currencies);
+    }
+
+    function _stake(address stakeOwner, uint256 amount) internal {
+        token.transfer(stakeOwner, amount);
+        vm.startPrank(stakeOwner);
+        token.approve(address(vault), amount);
+        vault.depositStake(amount);
+        vm.stopPrank();
+    }
+
+    function _paramsFor(address recipient)
+        internal
+        view
+        returns (IOrchestratorV3.SignalIntentParams memory params)
+    {
+        params = _defaultParams();
+        params.to = recipient;
+    }
+
+    function _attestation(bytes32 intentHash, bytes32 paymentId, bytes32 disputeId)
+        internal
+        pure
+        returns (IChargebackPolicy.ChargebackAttestation memory attestation)
+    {
+        IChargebackPolicy.ChargebackDetails memory details = IChargebackPolicy.ChargebackDetails({
+            paymentMethod: METHOD,
+            originalPaymentId: paymentId,
+            disputeId: disputeId,
+            paymentAmount: 100,
+            paymentCurrency: USD
+        });
+        bytes memory data = abi.encode(details);
+        attestation = IChargebackPolicy.ChargebackAttestation({
+            intentHash: intentHash,
+            dataHash: keccak256(data),
+            signatures: new bytes[](0),
+            data: data
+        });
+    }
+}

--- a/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
@@ -204,7 +204,7 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
 
         bytes32 fresh = _signalDefault();
         assertEq(address(riskOrchestrator.getIntentLifecycleHook(fresh)), address(replacementHook));
-        assertEq(replacementHook.createdCalls(), 1);
+        assertEq(replacementHook.signaledCalls(), 1);
     }
 
     function test_MaximumPolicySizeAdmitsMemberOfLastGroup() public {
@@ -225,7 +225,7 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
         bytes32 intentHash = keccak256("intent");
         vm.expectRevert(abi.encodeWithSelector(IntentLifecycleHookV1.UnauthorizedOrchestrator.selector, other));
         vm.prank(other);
-        lifecycleHook.onIntentCreated(intentHash);
+        lifecycleHook.onIntentSignaled(intentHash);
 
         vm.expectRevert(abi.encodeWithSelector(IntentLifecycleHookV1.UnauthorizedOrchestrator.selector, other));
         vm.prank(other);
@@ -248,7 +248,7 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
         bytes32 unknownIntent = keccak256("unknown-intent");
         vm.expectRevert(abi.encodeWithSelector(IntentLifecycleHookV1.IntentNotFound.selector, unknownIntent));
         vm.prank(address(orchestrator));
-        lifecycleHook.onIntentCreated(unknownIntent);
+        lifecycleHook.onIntentSignaled(unknownIntent);
     }
 
     function _enablePeerPolicyAndAddTaker() internal {

--- a/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.18;
 
 import {IIntentLifecycleHook} from "contracts/interfaces/IIntentLifecycleHook.sol";
 import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
+import {IOrchestratorRegistry} from "contracts/interfaces/IOrchestratorRegistry.sol";
 import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
 import {StakeVault} from "contracts/StakeVault.sol";
 import {ChargebackPolicy} from "contracts/hooks/ChargebackPolicy.sol";
@@ -54,6 +55,14 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
         lifecycleHook = new IntentLifecycleHookV1(orchestratorRegistry, policy, chargebackPolicy);
         chargebackPolicy.setLifecycleHookAuthorization(address(lifecycleHook), true);
         IOrchestratorV3(address(orchestrator)).setLifecycleHook(lifecycleHook);
+    }
+
+    function test_ConstructorRejectsZeroAndNonContractDependencies() public {
+        vm.expectRevert(IntentLifecycleHookV1.ZeroAddress.selector);
+        new IntentLifecycleHookV1(IOrchestratorRegistry(address(0)), policy, chargebackPolicy);
+
+        vm.expectRevert(abi.encodeWithSelector(IntentLifecycleHookV1.InvalidDependency.selector, other));
+        new IntentLifecycleHookV1(IOrchestratorRegistry(other), policy, chargebackPolicy);
     }
 
     function test_DisabledPolicyPassesThroughAndSnapshotsGlobalHook() public {

--- a/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {IIntentLifecycleHook} from "contracts/interfaces/IIntentLifecycleHook.sol";
+import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
+import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
+import {IntentLifecycleHookV1} from "contracts/hooks/IntentLifecycleHookV1.sol";
+import {WhitelistPolicy} from "contracts/hooks/WhitelistPolicy.sol";
+import {IntentLifecycleHookV1Mock} from "contracts/mocks/IntentLifecycleHookV1Mock.sol";
+import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
+
+import {OrchestratorV3Fixture} from "../helpers/OrchestratorV3Fixture.sol";
+
+contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
+    bytes32 internal constant OTHER_METHOD = keccak256("zelle");
+
+    bytes32 internal PEERS;
+    bytes32 internal PEER_PLUSES;
+    bytes32 internal PEER_MERCHANTS;
+
+    AddressGroupRegistry internal groupRegistry;
+    WhitelistPolicy internal policy;
+    IntentLifecycleHookV1 internal lifecycleHook;
+
+    function setUp() public override {
+        super.setUp();
+        groupRegistry = new AddressGroupRegistry();
+        PEERS = groupRegistry.createGroup("Peers");
+        PEER_PLUSES = groupRegistry.createGroup("Peer Pluses");
+        PEER_MERCHANTS = groupRegistry.createGroup("Peer Merchants");
+
+        policy = new WhitelistPolicy(groupRegistry, escrowRegistry, orchestratorRegistry);
+        lifecycleHook = new IntentLifecycleHookV1(orchestratorRegistry, policy);
+        IOrchestratorV3(address(orchestrator)).setLifecycleHook(lifecycleHook);
+    }
+
+    function test_DisabledPolicyPassesThroughAndSnapshotsGlobalHook() public {
+        bytes32 intentHash = _signalDefault();
+
+        assertEq(
+            address(IOrchestratorV3(address(orchestrator)).getIntentLifecycleHook(intentHash)), address(lifecycleHook)
+        );
+        assertEq(escrow.getDepositIntent(depositId, intentHash).intentHash, intentHash);
+    }
+
+    function test_EnabledEmptyPolicyFailsClosedBeforeEscrowLock() public {
+        vm.prank(depositor);
+        policy.setEnabled(address(escrow), depositId, true);
+
+        uint256 counterBefore = orchestrator.intentCounter();
+        bytes32 rejectedIntent = _intentHash(counterBefore);
+        uint256 availableBefore = escrow.getDeposit(depositId).remainingDeposits;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IntentLifecycleHookV1.TakerNotWhitelisted.selector, address(escrow), depositId, taker
+            )
+        );
+        _signalCall(taker, _defaultParams());
+
+        assertEq(orchestrator.intentCounter(), counterBefore);
+        assertEq(IOrchestratorV3(address(orchestrator)).getIntent(rejectedIntent).owner, address(0));
+        assertEq(escrow.getDepositIntent(depositId, rejectedIntent).intentHash, bytes32(0));
+        assertEq(escrow.getDeposit(depositId).remainingDeposits, availableBefore);
+    }
+
+    function test_NonMemberRejectedAndMemberAccepted() public {
+        vm.prank(depositor);
+        policy.configureDeposit(address(escrow), depositId, true, _groupIds(PEERS), new address[](0));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IntentLifecycleHookV1.TakerNotWhitelisted.selector, address(escrow), depositId, taker
+            )
+        );
+        _signalCall(taker, _defaultParams());
+
+        _addMembers(PEERS, taker);
+        bytes32 admittedIntent = _signalDefault();
+        assertEq(escrow.getDepositIntent(depositId, admittedIntent).intentHash, admittedIntent);
+    }
+
+    function test_DirectAddressWhitelistAllowsTaker() public {
+        vm.prank(depositor);
+        policy.configureDeposit(address(escrow), depositId, true, new bytes32[](0), _addresses(taker));
+
+        assertNotEq(_signalDefault(), bytes32(0));
+    }
+
+    function test_DelegateIsNotAuthorizedToConfigureDeposit() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(WhitelistPolicy.NotDepositor.selector, address(escrow), depositId, delegate)
+        );
+        vm.prank(delegate);
+        policy.configureDeposit(address(escrow), depositId, true, new bytes32[](0), new address[](0));
+
+        vm.prank(depositor);
+        policy.configureDeposit(address(escrow), depositId, true, new bytes32[](0), new address[](0));
+        assertTrue(policy.enabled(address(escrow), depositId));
+    }
+
+    function test_DepositPolicyAppliesAcrossAllPaymentMethodsOfTheDeposit() public {
+        _addPaymentMethod(OTHER_METHOD);
+
+        vm.prank(depositor);
+        policy.configureDeposit(address(escrow), depositId, true, _groupIds(PEERS), new address[](0));
+
+        IOrchestratorV3.SignalIntentParams memory otherMethodParams = _defaultParams();
+        otherMethodParams.paymentMethod = OTHER_METHOD;
+        vm.expectPartialRevert(IntentLifecycleHookV1.TakerNotWhitelisted.selector);
+        _signalCall(taker, otherMethodParams);
+
+        _addMembers(PEERS, taker);
+        assertNotEq(_signal(taker, otherMethodParams), bytes32(0));
+        assertNotEq(_signalDefault(), bytes32(0));
+    }
+
+    function test_MultipleGroupsUseOrSemantics() public {
+        vm.prank(depositor);
+        policy.configureDeposit(
+            address(escrow), depositId, true, _groupIds(PEERS, PEER_PLUSES, PEER_MERCHANTS), new address[](0)
+        );
+
+        _addMembers(PEER_PLUSES, taker);
+        assertNotEq(_signalDefault(), bytes32(0));
+    }
+
+    function test_PolicyIsScopedToDepositNotMaker() public {
+        vm.startPrank(depositor);
+        policy.configureDeposit(address(escrow), depositId, true, _groupIds(PEERS), new address[](0));
+        uint256 secondDepositId = _createDeposit(address(0), delegate);
+        vm.stopPrank();
+
+        vm.expectPartialRevert(IntentLifecycleHookV1.TakerNotWhitelisted.selector);
+        _signalCall(taker, _defaultParams());
+
+        IOrchestratorV3.SignalIntentParams memory secondDepositParams = _defaultParams();
+        secondDepositParams.depositId = secondDepositId;
+        assertNotEq(_signal(taker, secondDepositParams), bytes32(0));
+
+        vm.prank(depositor);
+        policy.configureDeposit(address(escrow), secondDepositId, true, _groupIds(PEERS), new address[](0));
+        vm.expectPartialRevert(IntentLifecycleHookV1.TakerNotWhitelisted.selector);
+        _signalCall(taker, secondDepositParams);
+    }
+
+    function test_MembershipRemovalOnlyAffectsFutureAdmissionAndCancellationRemainsLive() public {
+        _enablePeerPolicyAndAddTaker();
+        bytes32 activeIntent = _signalDefault();
+
+        groupRegistry.removeMembers(PEERS, _addresses(taker));
+        vm.prank(taker);
+        orchestrator.cancelIntent(activeIntent);
+
+        assertEq(escrow.getDepositIntent(depositId, activeIntent).intentHash, bytes32(0));
+
+        vm.expectPartialRevert(IntentLifecycleHookV1.TakerNotWhitelisted.selector);
+        _signalCall(taker, _defaultParams());
+    }
+
+    function test_SettlementIsNoOpAndDoesNotRecheckPointInTimeMembership() public {
+        _enablePeerPolicyAndAddTaker();
+        bytes32 intentHash = _signalDefault();
+        groupRegistry.removeMembers(PEERS, _addresses(taker));
+
+        uint256 takerBalanceBefore = token.balanceOf(taker);
+        vm.prank(depositor);
+        orchestrator.releaseFundsToPayer(intentHash);
+
+        assertEq(token.balanceOf(taker) - takerBalanceBefore, INTENT_AMOUNT);
+        assertEq(address(IOrchestratorV3(address(orchestrator)).getIntentLifecycleHook(intentHash)), address(0));
+    }
+
+    function test_GlobalHookReplacementDoesNotMutateActiveIntentSnapshot() public {
+        _enablePeerPolicyAndAddTaker();
+        IOrchestratorV3 riskOrchestrator = IOrchestratorV3(address(orchestrator));
+        bytes32 inFlight = _signalDefault();
+        assertEq(address(riskOrchestrator.getIntentLifecycleHook(inFlight)), address(lifecycleHook));
+
+        IntentLifecycleHookV1Mock replacementHook = new IntentLifecycleHookV1Mock();
+        riskOrchestrator.setLifecycleHook(replacementHook);
+
+        vm.prank(taker);
+        orchestrator.cancelIntent(inFlight);
+        assertEq(replacementHook.cancelledCalls(), 0);
+
+        bytes32 fresh = _signalDefault();
+        assertEq(address(riskOrchestrator.getIntentLifecycleHook(fresh)), address(replacementHook));
+        assertEq(replacementHook.createdCalls(), 1);
+    }
+
+    function test_MaximumPolicySizeAdmitsMemberOfLastGroup() public {
+        bytes32[] memory groups = new bytes32[](10);
+        groups[0] = PEERS;
+        for (uint256 i = 1; i < groups.length; i++) {
+            groups[i] = groupRegistry.createGroup("Bounded Group");
+        }
+
+        vm.prank(depositor);
+        policy.configureDeposit(address(escrow), depositId, true, groups, new address[](0));
+        _addMembers(groups[groups.length - 1], taker);
+
+        assertNotEq(_signalDefault(), bytes32(0));
+    }
+
+    function test_OnlyConfiguredOrchestratorMayCallLifecycleCallbacks() public {
+        bytes32 intentHash = keccak256("intent");
+        vm.expectRevert(abi.encodeWithSelector(IntentLifecycleHookV1.UnauthorizedOrchestrator.selector, other));
+        vm.prank(other);
+        lifecycleHook.onIntentCreated(intentHash);
+
+        vm.expectRevert(abi.encodeWithSelector(IntentLifecycleHookV1.UnauthorizedOrchestrator.selector, other));
+        vm.prank(other);
+        lifecycleHook.onIntentCancelled(intentHash);
+
+        IIntentLifecycleHook.SettlementContext memory context = IIntentLifecycleHook.SettlementContext({
+            intentHash: intentHash,
+            token: address(token),
+            recipient: taker,
+            grossAmount: 0,
+            executableAmount: 0,
+            isManualRelease: false
+        });
+        vm.expectRevert(abi.encodeWithSelector(IntentLifecycleHookV1.UnauthorizedOrchestrator.selector, other));
+        vm.prank(other);
+        lifecycleHook.settleIntent(context);
+    }
+
+    function test_RegisteredOrchestratorWithUnknownIntentFailsClosed() public {
+        bytes32 unknownIntent = keccak256("unknown-intent");
+        vm.expectRevert(abi.encodeWithSelector(IntentLifecycleHookV1.IntentNotFound.selector, unknownIntent));
+        vm.prank(address(orchestrator));
+        lifecycleHook.onIntentCreated(unknownIntent);
+    }
+
+    function _enablePeerPolicyAndAddTaker() internal {
+        vm.prank(depositor);
+        policy.configureDeposit(address(escrow), depositId, true, _groupIds(PEERS), new address[](0));
+        _addMembers(PEERS, taker);
+    }
+
+    function _addPaymentMethod(bytes32 _paymentMethod) internal {
+        bytes32[] memory supportedCurrencies = new bytes32[](1);
+        supportedCurrencies[0] = USD;
+        paymentVerifierRegistry.addPaymentMethod(_paymentMethod, address(verifier), supportedCurrencies);
+
+        bytes32[] memory paymentMethods = new bytes32[](1);
+        paymentMethods[0] = _paymentMethod;
+        IEscrowV2.DepositPaymentMethodData[] memory paymentMethodData = new IEscrowV2.DepositPaymentMethodData[](1);
+        paymentMethodData[0] =
+            IEscrowV2.DepositPaymentMethodData({intentGatingService: address(0), payeeDetails: PAYEE, data: ""});
+        IEscrowV2.Currency[][] memory currencies = new IEscrowV2.Currency[][](1);
+        currencies[0] = new IEscrowV2.Currency[](1);
+        currencies[0][0] =
+            IEscrowV2.Currency({code: USD, minConversionRate: CONVERSION_RATE, oracleRateConfig: _emptyOracle()});
+
+        vm.prank(depositor);
+        escrow.addPaymentMethods(depositId, paymentMethods, paymentMethodData, currencies);
+    }
+
+    function _addMembers(bytes32 _groupId, address _member) internal {
+        groupRegistry.addMembers(_groupId, _addresses(_member));
+    }
+
+    function _groupIds(bytes32 _first) internal pure returns (bytes32[] memory groupIds) {
+        groupIds = new bytes32[](1);
+        groupIds[0] = _first;
+    }
+
+    function _groupIds(bytes32 _first, bytes32 _second, bytes32 _third)
+        internal
+        pure
+        returns (bytes32[] memory groupIds)
+    {
+        groupIds = new bytes32[](3);
+        groupIds[0] = _first;
+        groupIds[1] = _second;
+        groupIds[2] = _third;
+    }
+
+    function _addresses(address _member) internal pure returns (address[] memory members) {
+        members = new address[](1);
+        members[0] = _member;
+    }
+}

--- a/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
@@ -40,19 +40,19 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
 
         policy = new WhitelistPolicy(groupRegistry, escrowRegistry, orchestratorRegistry);
         stakeVault = new StakeVault(address(this), token, address(0), 1 days);
+        NullifierRegistry chargebackNullifierRegistry = new NullifierRegistry();
         chargebackPolicy = new ChargebackPolicy(
             address(this),
             stakeVault,
             new ChargebackVerifier(
-                address(this),
-                new NullifierRegistryV2(new NullifierRegistry()),
-                new AttestationVerifierMock()
+                address(this), new NullifierRegistryV2(new NullifierRegistry()), new AttestationVerifierMock()
             ),
-            escrowRegistry
+            chargebackNullifierRegistry
         );
         stakeVault.initializeController(address(chargebackPolicy));
+        chargebackNullifierRegistry.addWritePermission(address(chargebackPolicy));
         lifecycleHook = new IntentLifecycleHookV1(orchestratorRegistry, policy, chargebackPolicy);
-        chargebackPolicy.setLifecycleHook(address(lifecycleHook));
+        chargebackPolicy.setLifecycleHookAuthorization(address(lifecycleHook), true);
         IOrchestratorV3(address(orchestrator)).setLifecycleHook(lifecycleHook);
     }
 
@@ -239,8 +239,8 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
             intentHash: intentHash,
             token: address(token),
             recipient: taker,
-            grossAmount: 0,
-            executableAmount: 0,
+            releaseAmount: 0,
+            netAmount: 0,
             isManualRelease: false
         });
         vm.expectRevert(abi.encodeWithSelector(IntentLifecycleHookV1.UnauthorizedOrchestrator.selector, other));

--- a/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
@@ -5,10 +5,15 @@ pragma solidity ^0.8.18;
 import {IIntentLifecycleHook} from "contracts/interfaces/IIntentLifecycleHook.sol";
 import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
 import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
+import {StakeVault} from "contracts/StakeVault.sol";
+import {ChargebackPolicy} from "contracts/hooks/ChargebackPolicy.sol";
 import {IntentLifecycleHookV1} from "contracts/hooks/IntentLifecycleHookV1.sol";
 import {WhitelistPolicy} from "contracts/hooks/WhitelistPolicy.sol";
+import {AttestationVerifierMock} from "contracts/mocks/AttestationVerifierMock.sol";
 import {IntentLifecycleHookV1Mock} from "contracts/mocks/IntentLifecycleHookV1Mock.sol";
 import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
+import {NullifierRegistry} from "contracts/registries/NullifierRegistry.sol";
+import {NullifierRegistryV2} from "contracts/registries/NullifierRegistryV2.sol";
 
 import {OrchestratorV3Fixture} from "../helpers/OrchestratorV3Fixture.sol";
 
@@ -21,6 +26,8 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
 
     AddressGroupRegistry internal groupRegistry;
     WhitelistPolicy internal policy;
+    StakeVault internal stakeVault;
+    ChargebackPolicy internal chargebackPolicy;
     IntentLifecycleHookV1 internal lifecycleHook;
 
     function setUp() public override {
@@ -31,7 +38,17 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
         PEER_MERCHANTS = groupRegistry.createGroup("Peer Merchants");
 
         policy = new WhitelistPolicy(groupRegistry, escrowRegistry, orchestratorRegistry);
-        lifecycleHook = new IntentLifecycleHookV1(orchestratorRegistry, policy);
+        stakeVault = new StakeVault(address(this), token, address(0), 1 days);
+        chargebackPolicy = new ChargebackPolicy(
+            address(this),
+            stakeVault,
+            new NullifierRegistryV2(new NullifierRegistry()),
+            new AttestationVerifierMock(),
+            escrowRegistry
+        );
+        stakeVault.initializeController(address(chargebackPolicy));
+        lifecycleHook = new IntentLifecycleHookV1(orchestratorRegistry, policy, chargebackPolicy);
+        chargebackPolicy.setLifecycleHook(address(lifecycleHook));
         IOrchestratorV3(address(orchestrator)).setLifecycleHook(lifecycleHook);
     }
 

--- a/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
@@ -14,6 +14,7 @@ import {IntentLifecycleHookV1Mock} from "contracts/mocks/IntentLifecycleHookV1Mo
 import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
 import {NullifierRegistry} from "contracts/registries/NullifierRegistry.sol";
 import {NullifierRegistryV2} from "contracts/registries/NullifierRegistryV2.sol";
+import {ChargebackVerifier} from "contracts/unifiedVerifier/ChargebackVerifier.sol";
 
 import {OrchestratorV3Fixture} from "../helpers/OrchestratorV3Fixture.sol";
 
@@ -42,8 +43,11 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
         chargebackPolicy = new ChargebackPolicy(
             address(this),
             stakeVault,
-            new NullifierRegistryV2(new NullifierRegistry()),
-            new AttestationVerifierMock(),
+            new ChargebackVerifier(
+                address(this),
+                new NullifierRegistryV2(new NullifierRegistry()),
+                new AttestationVerifierMock()
+            ),
             escrowRegistry
         );
         stakeVault.initializeController(address(chargebackPolicy));

--- a/test-foundry/deterministic/orchestrator/OrchestratorV3Lifecycle.t.sol
+++ b/test-foundry/deterministic/orchestrator/OrchestratorV3Lifecycle.t.sol
@@ -129,19 +129,26 @@ contract OrchestratorV3LifecycleTest is OrchestratorV3Fixture {
         _fulfill(intentHash, INTENT_AMOUNT, CONVERSION_RATE);
     }
 
-    function test_ManualReleaseNotifiesLifecycleAndBypassesPostIntentHook() public {
+    function test_ManualReleaseRoutesThroughLifecycleAndPostIntentHook() public {
         orchestrator.setLifecycleHook(lifecycleHookMock);
         IOrchestratorV3.SignalIntentParams memory params = _defaultParams();
+        params.referralFees = _twoReferralFees();
         params.postIntentHook = postIntentHook;
+        params.data = abi.encode(delegate);
         bytes32 intentHash = _signal(taker, params);
         uint256 recipientBefore = token.balanceOf(taker);
+        uint256 hookRecipientBefore = token.balanceOf(delegate);
+        uint256 netAmount = INTENT_AMOUNT - 250_000;
+        vm.expectEmit(true, true, true, true);
+        emit IntentFulfilled(intentHash, address(postIntentHook), netAmount, true);
         vm.prank(depositor);
         orchestrator.releaseFundsToPayer(intentHash);
         assertEq(lifecycleHookMock.settlementCalls(), 1);
         (,,,,, bool isManualRelease) = lifecycleHookMock.lastSettlementContext();
         assertTrue(isManualRelease);
-        assertEq(token.balanceOf(taker) - recipientBefore, INTENT_AMOUNT);
-        assertEq(token.balanceOf(other), 0);
+        assertEq(token.balanceOf(taker), recipientBefore);
+        assertEq(token.balanceOf(delegate) - hookRecipientBefore, netAmount);
+        assertEq(postIntentHook.lastPostIntentHookData(), "");
     }
 
     function test_GovernanceLifecycleHookSetterValidatesOwnerAndCode() public {

--- a/test-foundry/deterministic/orchestrator/OrchestratorV3Lifecycle.t.sol
+++ b/test-foundry/deterministic/orchestrator/OrchestratorV3Lifecycle.t.sol
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {IIntentLifecycleHook} from "contracts/interfaces/IIntentLifecycleHook.sol";
+import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
+import {IntentLifecycleHookV1Mock} from "contracts/mocks/IntentLifecycleHookV1Mock.sol";
+import {OrchestratorV3Fixture} from "../helpers/OrchestratorV3Fixture.sol";
+
+contract OrchestratorV3LifecycleTest is OrchestratorV3Fixture {
+    event IntentFulfilled(bytes32 indexed intentHash, address indexed fundsTransferredTo, uint256 amount, bool manual);
+
+    IntentLifecycleHookV1Mock internal lifecycleHookMock;
+
+    function setUp() public override {
+        super.setUp();
+        lifecycleHookMock = new IntentLifecycleHookV1Mock();
+    }
+
+    function test_SignalWithoutLifecycleHookSnapshotsZeroAddress() public {
+        bytes32 intentHash = _signalDefault();
+        assertEq(address(orchestrator.getIntentLifecycleHook(intentHash)), address(0));
+    }
+
+    function test_SignalWithLifecycleHookExecutesAdmissionAndSnapshotsHook() public {
+        orchestrator.setLifecycleHook(IIntentLifecycleHook(address(lifecycleHookMock)));
+
+        bytes32 intentHash = _signalDefault();
+
+        assertEq(lifecycleHookMock.createdCalls(), 1);
+        assertEq(address(orchestrator.getIntentLifecycleHook(intentHash)), address(lifecycleHookMock));
+    }
+
+    function test_RevertingAdmissionFailsClosedBeforeEscrowLock() public {
+        orchestrator.setLifecycleHook(lifecycleHookMock);
+        lifecycleHookMock.setRevertOnCreate(true);
+        uint256 counterBefore = orchestrator.intentCounter();
+        uint256 availableBefore = escrow.getDeposit(depositId).remainingDeposits;
+        vm.expectRevert(bytes("risk admission failed"));
+        _signalCall(taker, _defaultParams());
+        assertEq(orchestrator.intentCounter(), counterBefore);
+        assertEq(escrow.getDeposit(depositId).remainingDeposits, availableBefore);
+    }
+
+    function test_CancelHealthyHookUnlocksAndCallsCallback() public {
+        orchestrator.setLifecycleHook(lifecycleHookMock);
+        bytes32 intentHash = _signalDefault();
+        vm.prank(taker);
+        orchestrator.cancelIntent(intentHash);
+        assertEq(lifecycleHookMock.cancelledCalls(), 1);
+        assertEq(escrow.getDeposit(depositId).remainingDeposits, 500e6);
+    }
+
+    function test_CancelRevertingHookBlocksCancellation() public {
+        orchestrator.setLifecycleHook(lifecycleHookMock);
+        bytes32 intentHash = _signalDefault();
+        lifecycleHookMock.setRevertOnCallback(true);
+        vm.expectRevert(bytes("risk cancellation failed"));
+        vm.prank(taker);
+        orchestrator.cancelIntent(intentHash);
+        assertNotEq(orchestrator.getIntent(intentHash).owner, address(0));
+        assertEq(escrow.getDeposit(depositId).remainingDeposits, 500e6 - INTENT_AMOUNT);
+
+        lifecycleHookMock.setRevertOnCallback(false);
+        vm.prank(taker);
+        orchestrator.cancelIntent(intentHash);
+        assertEq(orchestrator.getIntent(intentHash).owner, address(0));
+        assertEq(escrow.getDeposit(depositId).remainingDeposits, 500e6);
+    }
+
+    function test_EscrowPruneRevertingHookBlocksPrune() public {
+        orchestrator.setLifecycleHook(lifecycleHookMock);
+        bytes32 intentHash = _signalDefault();
+        lifecycleHookMock.setRevertOnCallback(true);
+        vm.warp(block.timestamp + 3601);
+        vm.expectRevert(bytes("risk cancellation failed"));
+        escrow.pruneExpiredIntents(depositId);
+        assertNotEq(orchestrator.getIntent(intentHash).owner, address(0));
+    }
+
+    function test_OrphanCleanupRevertingHookBlocksCleanup() public {
+        orchestrator.setLifecycleHook(lifecycleHookMock);
+        bytes32 intentHash = _signalDefault();
+        bytes32 depositIntentsSlot = keccak256(abi.encode(depositId, uint256(14)));
+        bytes32 storageSlot = keccak256(abi.encode(intentHash, depositIntentsSlot));
+        vm.store(address(escrow), storageSlot, bytes32(0));
+        lifecycleHookMock.setRevertOnCallback(true);
+        bytes32[] memory hashes = new bytes32[](1);
+        hashes[0] = intentHash;
+        vm.expectRevert(bytes("risk cancellation failed"));
+        orchestrator.cleanupOrphanedIntents(hashes);
+        assertNotEq(orchestrator.getIntent(intentHash).owner, address(0));
+    }
+
+    function test_SettlementNotifiesHookAndFundsFlowNormally() public {
+        orchestrator.setLifecycleHook(lifecycleHookMock);
+        IOrchestratorV3.SignalIntentParams memory params = _defaultParams();
+        params.referralFees = _twoReferralFees();
+        bytes32 intentHash = _signal(taker, params);
+        uint256 recipientBefore = token.balanceOf(taker);
+        uint256 referrerBefore = token.balanceOf(referrer);
+        uint256 otherBefore = token.balanceOf(other);
+        _fulfill(intentHash, INTENT_AMOUNT, CONVERSION_RATE);
+
+        assertEq(lifecycleHookMock.settlementCalls(), 1);
+        (
+            bytes32 settledIntentHash,
+            address settlementToken,
+            address recipient,
+            uint256 grossAmount,
+            uint256 executableAmount,
+            bool isManualRelease
+        ) = lifecycleHookMock.lastSettlementContext();
+        assertEq(settledIntentHash, intentHash);
+        assertEq(settlementToken, address(token));
+        assertEq(recipient, taker);
+        assertEq(grossAmount, INTENT_AMOUNT);
+        assertEq(executableAmount, INTENT_AMOUNT - 250_000);
+        assertFalse(isManualRelease);
+        assertEq(token.balanceOf(referrer) - referrerBefore, 150_000);
+        assertEq(token.balanceOf(other) - otherBefore, 100_000);
+        assertEq(token.balanceOf(taker) - recipientBefore, INTENT_AMOUNT - 250_000);
+    }
+
+    function test_SettlementRevertFailsClosed() public {
+        orchestrator.setLifecycleHook(lifecycleHookMock);
+        lifecycleHookMock.setRevertOnCallback(true);
+        bytes32 intentHash = _signalDefault();
+        vm.expectRevert(bytes("risk settlement failed"));
+        _fulfill(intentHash, INTENT_AMOUNT, CONVERSION_RATE);
+    }
+
+    function test_ManualReleaseRoutesThroughLifecycleAndPostIntentHook() public {
+        orchestrator.setLifecycleHook(lifecycleHookMock);
+        IOrchestratorV3.SignalIntentParams memory params = _defaultParams();
+        params.postIntentHook = postIntentHook;
+        params.data = abi.encode(other);
+        bytes32 intentHash = _signal(taker, params);
+        vm.prank(depositor);
+        orchestrator.releaseFundsToPayer(intentHash);
+        assertEq(lifecycleHookMock.settlementCalls(), 1);
+        (,,,,, bool isManualRelease) = lifecycleHookMock.lastSettlementContext();
+        assertTrue(isManualRelease);
+        assertEq(token.balanceOf(other), INTENT_AMOUNT);
+    }
+
+    function test_GovernanceLifecycleHookSetterValidatesOwnerAndCode() public {
+        orchestrator.setLifecycleHook(lifecycleHookMock);
+        assertEq(address(orchestrator.lifecycleHook()), address(lifecycleHookMock));
+        orchestrator.setLifecycleHook(IIntentLifecycleHook(address(0)));
+        vm.expectRevert(abi.encodeWithSelector(IOrchestratorV3.InvalidLifecycleHook.selector, other));
+        orchestrator.setLifecycleHook(IIntentLifecycleHook(other));
+    }
+
+    function test_DepositWhitelistSelectorsNoLongerExist() public view {
+        (bool setter,) = address(orchestrator)
+            .staticcall(
+                abi.encodeWithSignature(
+                    "setDepositWhitelistHook(address,uint256,address)", address(escrow), depositId, address(0)
+                )
+            );
+        (bool getter,) = address(orchestrator)
+            .staticcall(abi.encodeWithSignature("getDepositWhitelistHook(address,uint256)", address(escrow), depositId));
+        assertFalse(setter);
+        assertFalse(getter);
+    }
+}

--- a/test-foundry/deterministic/orchestrator/OrchestratorV3Lifecycle.t.sol
+++ b/test-foundry/deterministic/orchestrator/OrchestratorV3Lifecycle.t.sol
@@ -106,15 +106,15 @@ contract OrchestratorV3LifecycleTest is OrchestratorV3Fixture {
             bytes32 settledIntentHash,
             address settlementToken,
             address recipient,
-            uint256 grossAmount,
-            uint256 executableAmount,
+            uint256 releaseAmount,
+            uint256 netAmount,
             bool isManualRelease
         ) = lifecycleHookMock.lastSettlementContext();
         assertEq(settledIntentHash, intentHash);
         assertEq(settlementToken, address(token));
         assertEq(recipient, taker);
-        assertEq(grossAmount, INTENT_AMOUNT);
-        assertEq(executableAmount, INTENT_AMOUNT - 250_000);
+        assertEq(releaseAmount, INTENT_AMOUNT);
+        assertEq(netAmount, INTENT_AMOUNT - 250_000);
         assertFalse(isManualRelease);
         assertEq(token.balanceOf(referrer) - referrerBefore, 150_000);
         assertEq(token.balanceOf(other) - otherBefore, 100_000);
@@ -129,18 +129,19 @@ contract OrchestratorV3LifecycleTest is OrchestratorV3Fixture {
         _fulfill(intentHash, INTENT_AMOUNT, CONVERSION_RATE);
     }
 
-    function test_ManualReleaseRoutesThroughLifecycleAndPostIntentHook() public {
+    function test_ManualReleaseNotifiesLifecycleAndBypassesPostIntentHook() public {
         orchestrator.setLifecycleHook(lifecycleHookMock);
         IOrchestratorV3.SignalIntentParams memory params = _defaultParams();
         params.postIntentHook = postIntentHook;
-        params.data = abi.encode(other);
         bytes32 intentHash = _signal(taker, params);
+        uint256 recipientBefore = token.balanceOf(taker);
         vm.prank(depositor);
         orchestrator.releaseFundsToPayer(intentHash);
         assertEq(lifecycleHookMock.settlementCalls(), 1);
         (,,,,, bool isManualRelease) = lifecycleHookMock.lastSettlementContext();
         assertTrue(isManualRelease);
-        assertEq(token.balanceOf(other), INTENT_AMOUNT);
+        assertEq(token.balanceOf(taker) - recipientBefore, INTENT_AMOUNT);
+        assertEq(token.balanceOf(other), 0);
     }
 
     function test_GovernanceLifecycleHookSetterValidatesOwnerAndCode() public {

--- a/test-foundry/deterministic/orchestrator/OrchestratorV3Lifecycle.t.sol
+++ b/test-foundry/deterministic/orchestrator/OrchestratorV3Lifecycle.t.sol
@@ -26,7 +26,7 @@ contract OrchestratorV3LifecycleTest is OrchestratorV3Fixture {
 
         bytes32 intentHash = _signalDefault();
 
-        assertEq(lifecycleHookMock.createdCalls(), 1);
+        assertEq(lifecycleHookMock.signaledCalls(), 1);
         assertEq(address(orchestrator.getIntentLifecycleHook(intentHash)), address(lifecycleHookMock));
     }
 

--- a/test-foundry/deterministic/staking/StakeVault.t.sol
+++ b/test-foundry/deterministic/staking/StakeVault.t.sol
@@ -246,6 +246,31 @@ contract StakeVaultTest is Test {
         assertTrue(vault.authorizedTakers(safeB, taker));
     }
 
+    function test_GetTakerStateReturnsSelectedOwnerBalancesAndFallsBackAfterRevocation() public {
+        _deposit(safeA, 500e6);
+        vm.prank(safeA);
+        vault.setTakerAuthorization(taker, true);
+        vm.prank(taker);
+        vault.selectStakeOwner(safeA);
+        vm.prank(controller);
+        vault.lockStake(safeA, keccak256("selected-owner-lock"), 125e6, NEVER_MATURES);
+
+        (address stakeOwner, uint256 totalStake, uint256 lockedStakeAmount, uint256 freeStakeAmount) =
+            vault.getTakerState(taker);
+        assertEq(stakeOwner, safeA);
+        assertEq(totalStake, 500e6);
+        assertEq(lockedStakeAmount, 125e6);
+        assertEq(freeStakeAmount, 375e6);
+
+        vm.prank(safeA);
+        vault.setTakerAuthorization(taker, false);
+        (stakeOwner, totalStake, lockedStakeAmount, freeStakeAmount) = vault.getTakerState(taker);
+        assertEq(stakeOwner, taker);
+        assertEq(totalStake, 0);
+        assertEq(lockedStakeAmount, 0);
+        assertEq(freeStakeAmount, 0);
+    }
+
     function test_AttackerAuthorizationCannotSquatOrReplaceSelection() public {
         vm.prank(safeA);
         vault.setTakerAuthorization(taker, true);

--- a/test-foundry/deterministic/staking/StakeVault.t.sol
+++ b/test-foundry/deterministic/staking/StakeVault.t.sol
@@ -1,0 +1,710 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {StakeVault} from "contracts/StakeVault.sol";
+import {IStakeVault} from "contracts/interfaces/IStakeVault.sol";
+import {USDCMock} from "contracts/mocks/USDCMock.sol";
+
+contract FeeOnTransferToken is ERC20 {
+    constructor(address _holder) ERC20("Fee Token", "FEE") {
+        _mint(_holder, 1_000_000e6);
+    }
+
+    function _transfer(address _from, address _to, uint256 _amount) internal override {
+        uint256 fee = _amount / 100;
+        super._transfer(_from, _to, _amount - fee);
+        _burn(_from, fee);
+    }
+}
+
+contract ReentrantToken is ERC20 {
+    StakeVault internal vault;
+    bool public reentrySucceeded;
+
+    constructor(address _holder) ERC20("Reentrant Token", "REENTRANT") {
+        _mint(_holder, 1_000_000e6);
+    }
+
+    function setVault(StakeVault _vault) external {
+        vault = _vault;
+    }
+
+    function _transfer(address _from, address _to, uint256 _amount) internal override {
+        super._transfer(_from, _to, _amount);
+        if (_to == address(vault)) {
+            (reentrySucceeded,) = address(vault).call(abi.encodeCall(StakeVault.depositStake, (1)));
+        }
+    }
+}
+
+contract StakeVaultTest is Test {
+    event LockFunded(bytes32 indexed lockId, address indexed stakeOwner, uint256 amount, uint256 newStakeBalance);
+
+    uint64 internal constant CONTROLLER_DELAY = 1 days;
+    uint64 internal constant NEVER_MATURES = type(uint64).max;
+
+    address internal controller;
+    address internal nextController;
+    address internal safeA;
+    address internal safeB;
+    address internal taker;
+    address internal attacker;
+    address internal lp;
+    address internal feeRecipient;
+
+    USDCMock internal token;
+    StakeVault internal vault;
+
+    function setUp() public {
+        controller = makeAddr("controller");
+        nextController = makeAddr("nextController");
+        safeA = makeAddr("safeA");
+        safeB = makeAddr("safeB");
+        taker = makeAddr("taker");
+        attacker = makeAddr("attacker");
+        lp = makeAddr("lp");
+        feeRecipient = makeAddr("feeRecipient");
+
+        token = new USDCMock(1_000_000e6, "USD Coin", "USDC");
+        vault = new StakeVault(address(this), token, controller, CONTROLLER_DELAY);
+
+        token.transfer(safeA, 10_000e6);
+        token.transfer(safeB, 10_000e6);
+        vm.prank(safeA);
+        token.approve(address(vault), type(uint256).max);
+        vm.prank(safeB);
+        token.approve(address(vault), type(uint256).max);
+    }
+
+    function test_ConstructorRejectsInvalidConfiguration() public {
+        vm.expectRevert(IStakeVault.ZeroAddress.selector);
+        new StakeVault(address(0), token, controller, CONTROLLER_DELAY);
+
+        vm.expectRevert(IStakeVault.ZeroAddress.selector);
+        new StakeVault(address(this), IERC20(address(0)), controller, CONTROLLER_DELAY);
+
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.InvalidControllerChangeDelay.selector, CONTROLLER_DELAY - 1));
+        new StakeVault(address(this), token, controller, CONTROLLER_DELAY - 1);
+    }
+
+    function test_InitialControllerCanBeInitializedOnce() public {
+        StakeVault uninitializedVault = new StakeVault(address(this), token, address(0), CONTROLLER_DELAY);
+
+        uninitializedVault.initializeController(controller);
+        assertEq(uninitializedVault.controller(), controller);
+
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.ControllerAlreadyInitialized.selector, controller));
+        uninitializedVault.initializeController(nextController);
+    }
+
+    function test_InitialControllerCannotBeInstalledAfterStakeIsDeposited() public {
+        StakeVault uninitializedVault = new StakeVault(address(this), token, address(0), CONTROLLER_DELAY);
+        vm.prank(safeA);
+        token.approve(address(uninitializedVault), type(uint256).max);
+        vm.prank(safeA);
+        uninitializedVault.depositStake(100e6);
+
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.ControllerInitializationWithLiabilities.selector, 100e6, 0));
+        uninitializedVault.initializeController(controller);
+
+        vm.prank(safeA);
+        uninitializedVault.withdrawStake(100e6);
+        uninitializedVault.initializeController(controller);
+        assertEq(uninitializedVault.controller(), controller);
+    }
+
+    function test_OwnershipTransferIsTwoStepAndOwnershipCannotBeRenounced() public {
+        vault.transferOwnership(safeA);
+        assertEq(vault.owner(), address(this));
+        assertEq(vault.pendingOwner(), safeA);
+
+        vm.prank(safeA);
+        vault.acceptOwnership();
+        assertEq(vault.owner(), safeA);
+        assertEq(vault.pendingOwner(), address(0));
+
+        vm.expectRevert(IStakeVault.OwnershipRenunciationDisabled.selector);
+        vm.prank(safeA);
+        vault.renounceOwnership();
+    }
+
+    function test_DepositAndImmediateFreeWithdrawalMaintainAccounting() public {
+        _deposit(safeA, 500e6);
+        assertEq(vault.stakeBalance(safeA), 500e6);
+        assertEq(vault.freeStake(safeA), 500e6);
+        assertEq(vault.totalStaked(), 500e6);
+        assertEq(vault.totalAccounted(), 500e6);
+        assertEq(token.balanceOf(address(vault)), 500e6);
+
+        uint256 balanceBefore = token.balanceOf(safeA);
+        vm.prank(safeA);
+        vault.withdrawStake(175e6);
+
+        assertEq(token.balanceOf(safeA) - balanceBefore, 175e6);
+        assertEq(vault.stakeBalance(safeA), 325e6);
+        assertEq(vault.totalStaked(), 325e6);
+        assertEq(token.balanceOf(address(vault)), vault.totalAccounted());
+    }
+
+    function test_DepositRejectsFeeOnTransferToken() public {
+        FeeOnTransferToken feeToken = new FeeOnTransferToken(address(this));
+        StakeVault feeVault = new StakeVault(address(this), feeToken, controller, CONTROLLER_DELAY);
+        feeToken.approve(address(feeVault), type(uint256).max);
+
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.InvalidReceivedAmount.selector, 100e6, 99e6));
+        feeVault.depositStake(100e6);
+        assertEq(feeToken.balanceOf(address(feeVault)), 0);
+    }
+
+    function test_DepositBlocksTokenCallbackReentrancy() public {
+        ReentrantToken reentrantToken = new ReentrantToken(address(this));
+        StakeVault reentrantVault = new StakeVault(address(this), reentrantToken, controller, CONTROLLER_DELAY);
+        reentrantToken.setVault(reentrantVault);
+        reentrantToken.approve(address(reentrantVault), type(uint256).max);
+
+        reentrantVault.depositStake(100e6);
+
+        assertFalse(reentrantToken.reentrySucceeded());
+        assertEq(reentrantVault.stakeBalance(address(this)), 100e6);
+        assertEq(reentrantVault.totalAccounted(), 100e6);
+    }
+
+    function test_ZeroValueUserActionsRevert() public {
+        vm.expectRevert(IStakeVault.ZeroAmount.selector);
+        vm.prank(safeA);
+        vault.depositStake(0);
+
+        vm.expectRevert(IStakeVault.ZeroAmount.selector);
+        vm.prank(safeA);
+        vault.withdrawStake(0);
+
+        vm.expectRevert(IStakeVault.ZeroAmount.selector);
+        vm.prank(safeA);
+        vault.claim();
+    }
+
+    function test_DelegationLockAndGovernanceBoundaryInputsRevert() public {
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.InvalidTaker.selector, address(0)));
+        vm.prank(safeA);
+        vault.setTakerAuthorization(address(0), true);
+
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.InvalidTaker.selector, safeA));
+        vm.prank(safeA);
+        vault.setTakerAuthorization(safeA, true);
+
+        vm.expectRevert(IStakeVault.ZeroAddress.selector);
+        vm.prank(taker);
+        vault.selectStakeOwner(address(0));
+
+        vm.expectRevert(IStakeVault.ZeroAddress.selector);
+        vm.prank(taker);
+        vault.selectStakeOwner(taker);
+
+        vm.expectRevert(IStakeVault.ZeroAmount.selector);
+        vm.prank(controller);
+        vault.increaseLock(keccak256("missing-increase"), 0);
+
+        vm.expectRevert(IStakeVault.ZeroAmount.selector);
+        vm.prank(controller);
+        vault.resizeLock(keccak256("missing-resize"), 0, NEVER_MATURES);
+
+        vm.expectRevert(IStakeVault.ZeroAddress.selector);
+        vault.initializeController(address(0));
+
+        vm.expectRevert(IStakeVault.ZeroAddress.selector);
+        vault.proposeController(address(0));
+    }
+
+    function test_ControllerProposalRejectsTimestampOverflow() public {
+        vm.warp(uint256(type(uint64).max) + 1);
+
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.TimestampOverflow.selector, block.timestamp));
+        vault.proposeController(nextController);
+    }
+
+    function test_DelegationRequiresOwnerAuthorizationAndTakerSelection() public {
+        vm.prank(safeA);
+        vault.setTakerAuthorization(taker, true);
+        vm.prank(safeB);
+        vault.setTakerAuthorization(taker, true);
+
+        assertEq(vault.stakeOwnerOf(taker), taker);
+
+        vm.prank(taker);
+        vault.selectStakeOwner(safeA);
+        assertEq(vault.stakeOwnerOf(taker), safeA);
+
+        vm.prank(taker);
+        vault.selectStakeOwner(safeB);
+        assertEq(vault.stakeOwnerOf(taker), safeB);
+        assertTrue(vault.authorizedTakers(safeA, taker));
+        assertTrue(vault.authorizedTakers(safeB, taker));
+    }
+
+    function test_AttackerAuthorizationCannotSquatOrReplaceSelection() public {
+        vm.prank(safeA);
+        vault.setTakerAuthorization(taker, true);
+        vm.prank(taker);
+        vault.selectStakeOwner(safeA);
+
+        vm.prank(attacker);
+        vault.setTakerAuthorization(taker, true);
+
+        assertEq(vault.selectedStakeOwner(taker), safeA);
+        assertEq(vault.stakeOwnerOf(taker), safeA);
+        assertTrue(vault.authorizedTakers(attacker, taker));
+    }
+
+    function test_RevocationClearsSelectionAndReauthorizationDoesNotRestoreIt() public {
+        vm.prank(safeA);
+        vault.setTakerAuthorization(taker, true);
+        vm.prank(taker);
+        vault.selectStakeOwner(safeA);
+
+        vm.prank(safeA);
+        vault.setTakerAuthorization(taker, false);
+        assertEq(vault.selectedStakeOwner(taker), address(0));
+        assertEq(vault.stakeOwnerOf(taker), taker);
+
+        vm.prank(safeA);
+        vault.setTakerAuthorization(taker, true);
+        assertEq(vault.stakeOwnerOf(taker), taker);
+    }
+
+    function test_TakerCannotSelectUnauthorizedStakeOwner() public {
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.UnauthorizedStakeOwner.selector, taker, safeA));
+        vm.prank(taker);
+        vault.selectStakeOwner(safeA);
+    }
+
+    function test_TakerCanExplicitlyClearSelectedStakeOwner() public {
+        vm.prank(safeA);
+        vault.setTakerAuthorization(taker, true);
+        vm.prank(taker);
+        vault.selectStakeOwner(safeA);
+
+        vm.prank(taker);
+        vault.clearStakeOwner();
+
+        assertEq(vault.selectedStakeOwner(taker), address(0));
+        assertEq(vault.stakeOwnerOf(taker), taker);
+        assertTrue(vault.authorizedTakers(safeA, taker));
+    }
+
+    function test_LockConsumesOnlyFreeStake() public {
+        _deposit(safeA, 500e6);
+        bytes32 lockId = keccak256("chargeback");
+
+        vm.prank(controller);
+        vault.lockStake(safeA, lockId, 300e6, NEVER_MATURES);
+
+        assertEq(vault.lockedStake(safeA), 300e6);
+        assertEq(vault.freeStake(safeA), 200e6);
+        (address lockOwner, uint256 amount, uint64 maturesAt) = vault.locks(lockId);
+        assertEq(lockOwner, safeA);
+        assertEq(amount, 300e6);
+        assertEq(maturesAt, NEVER_MATURES);
+
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.InsufficientFreeStake.selector, safeA, 200e6, 201e6));
+        vm.prank(controller);
+        vault.lockStake(safeA, keccak256("second-lock"), 201e6, NEVER_MATURES);
+    }
+
+    function test_LockRejectsInvalidIdentityAmountMaturityAndDuplicate() public {
+        bytes32 lockId = keccak256("lock");
+        _deposit(safeA, 100e6);
+
+        vm.expectRevert(IStakeVault.ZeroAddress.selector);
+        vm.prank(controller);
+        vault.lockStake(address(0), lockId, 1, NEVER_MATURES);
+
+        vm.expectRevert(IStakeVault.ZeroLockId.selector);
+        vm.prank(controller);
+        vault.lockStake(safeA, bytes32(0), 1, NEVER_MATURES);
+
+        vm.expectRevert(IStakeVault.ZeroAmount.selector);
+        vm.prank(controller);
+        vault.lockStake(safeA, lockId, 0, NEVER_MATURES);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IStakeVault.InvalidMaturity.selector, uint64(block.timestamp), uint64(block.timestamp)
+            )
+        );
+        vm.prank(controller);
+        vault.lockStake(safeA, lockId, 1, uint64(block.timestamp));
+
+        vm.prank(controller);
+        vault.lockStake(safeA, lockId, 1, NEVER_MATURES);
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.LockAlreadyExists.selector, lockId));
+        vm.prank(controller);
+        vault.lockStake(safeA, lockId, 1, NEVER_MATURES);
+    }
+
+    function test_OnlyControllerCanMutateLocks() public {
+        _deposit(safeA, 100e6);
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.UnauthorizedController.selector, safeA));
+        vm.prank(safeA);
+        vault.lockStake(safeA, keccak256("unauthorized"), 1e6, NEVER_MATURES);
+    }
+
+    function test_MissingLockRevertsEveryMutation() public {
+        bytes32 missingLockId = keccak256("missing");
+
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.LockNotFound.selector, missingLockId));
+        vm.prank(controller);
+        vault.increaseLock(missingLockId, 1);
+
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.LockNotFound.selector, missingLockId));
+        vm.prank(controller);
+        vault.resizeLock(missingLockId, 1, NEVER_MATURES);
+
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.LockNotFound.selector, missingLockId));
+        vm.prank(controller);
+        vault.unlockStake(missingLockId);
+
+        IStakeVault.Claim[] memory claims = new IStakeVault.Claim[](0);
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.LockNotFound.selector, missingLockId));
+        vm.prank(controller);
+        vault.resolveLock(missingLockId, claims);
+    }
+
+    function test_IncreaseLockIsAdditiveAndRejectsMaturedLocks() public {
+        _deposit(safeA, 500e6);
+        bytes32 extensionLockId = keccak256("extension");
+        vm.prank(controller);
+        vault.lockStake(safeA, extensionLockId, 100e6, NEVER_MATURES);
+
+        vm.prank(controller);
+        vault.increaseLock(extensionLockId, 125e6);
+        (, uint256 amount,) = vault.locks(extensionLockId);
+        assertEq(amount, 225e6);
+        assertEq(vault.lockedStake(safeA), 225e6);
+        assertEq(vault.freeStake(safeA), 275e6);
+
+        bytes32 finiteLockId = keccak256("finite");
+        uint64 maturesAt = uint64(block.timestamp + 1 days);
+        vm.prank(controller);
+        vault.lockStake(safeA, finiteLockId, 10e6, maturesAt);
+        vm.warp(maturesAt);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IStakeVault.LockAlreadyMatured.selector, finiteLockId, maturesAt, maturesAt)
+        );
+        vm.prank(controller);
+        vault.increaseLock(finiteLockId, 1e6);
+    }
+
+    function test_ResizeLockOnlyDecreasesAndSetsFiniteMaturity() public {
+        _deposit(safeA, 500e6);
+        bytes32 lockId = keccak256("chargeback-resize");
+        vm.prank(controller);
+        vault.lockStake(safeA, lockId, 400e6, NEVER_MATURES);
+
+        uint64 coverageDeadline = uint64(block.timestamp + 30 days);
+        vm.prank(controller);
+        vault.resizeLock(lockId, 250e6, coverageDeadline);
+
+        (, uint256 amount, uint64 maturesAt) = vault.locks(lockId);
+        assertEq(amount, 250e6);
+        assertEq(maturesAt, coverageDeadline);
+        assertEq(vault.lockedStake(safeA), 250e6);
+        assertEq(vault.freeStake(safeA), 250e6);
+
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.InvalidLockAmount.selector, 251e6, 250e6));
+        vm.prank(controller);
+        vault.resizeLock(lockId, 251e6, coverageDeadline);
+    }
+
+    function test_ResizeRejectsPastNewMaturityAndMaturedLock() public {
+        _deposit(safeA, 100e6);
+        bytes32 lockId = keccak256("mature-resize");
+        uint64 maturesAt = uint64(block.timestamp + 1 days);
+        vm.prank(controller);
+        vault.lockStake(safeA, lockId, 100e6, maturesAt);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IStakeVault.InvalidMaturity.selector, uint64(block.timestamp), uint64(block.timestamp)
+            )
+        );
+        vm.prank(controller);
+        vault.resizeLock(lockId, 50e6, uint64(block.timestamp));
+
+        vm.warp(maturesAt);
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.LockAlreadyMatured.selector, lockId, maturesAt, maturesAt));
+        vm.prank(controller);
+        vault.resizeLock(lockId, 50e6, uint64(block.timestamp + 1 days));
+    }
+
+    function test_UnlockDeletesLockAndMakesAllStakeFreeImmediately() public {
+        _deposit(safeA, 500e6);
+        bytes32 lockId = keccak256("cancelled");
+        vm.prank(controller);
+        vault.lockStake(safeA, lockId, 400e6, NEVER_MATURES);
+
+        vm.prank(controller);
+        vault.unlockStake(lockId);
+
+        (address lockOwner, uint256 amount,) = vault.locks(lockId);
+        assertEq(lockOwner, address(0));
+        assertEq(amount, 0);
+        assertEq(vault.lockedStake(safeA), 0);
+        assertEq(vault.freeStake(safeA), 500e6);
+    }
+
+    function test_ResolveCreatesImmediateAggregatedClaimsAndFreesRemainder() public {
+        _deposit(safeA, 100e6);
+        bytes32 lockId = keccak256("deferred-clean-maturity");
+        vm.prank(controller);
+        vault.lockStake(safeA, lockId, 80e6, NEVER_MATURES);
+
+        IStakeVault.Claim[] memory claims = new IStakeVault.Claim[](3);
+        claims[0] = IStakeVault.Claim({beneficiary: lp, amount: 30e6});
+        claims[1] = IStakeVault.Claim({beneficiary: feeRecipient, amount: 10e6});
+        claims[2] = IStakeVault.Claim({beneficiary: feeRecipient, amount: 5e6});
+
+        vm.prank(controller);
+        vault.resolveLock(lockId, claims);
+
+        assertEq(vault.stakeBalance(safeA), 55e6);
+        assertEq(vault.lockedStake(safeA), 0);
+        assertEq(vault.freeStake(safeA), 55e6);
+        assertEq(vault.claimable(lp), 30e6);
+        assertEq(vault.claimable(feeRecipient), 15e6);
+        assertEq(vault.totalStaked(), 55e6);
+        assertEq(vault.totalClaimable(), 45e6);
+        assertEq(vault.totalAccounted(), 100e6);
+        assertEq(token.balanceOf(address(vault)), 100e6);
+    }
+
+    function test_ResolveRejectsInvalidOrExcessClaimsAtomically() public {
+        _deposit(safeA, 100e6);
+        bytes32 lockId = keccak256("invalid-claims");
+        vm.prank(controller);
+        vault.lockStake(safeA, lockId, 80e6, NEVER_MATURES);
+
+        IStakeVault.Claim[] memory claims = new IStakeVault.Claim[](2);
+        claims[0] = IStakeVault.Claim({beneficiary: lp, amount: 50e6});
+        claims[1] = IStakeVault.Claim({beneficiary: feeRecipient, amount: 31e6});
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.ClaimsExceedLock.selector, 80e6, 81e6));
+        vm.prank(controller);
+        vault.resolveLock(lockId, claims);
+
+        (, uint256 amount,) = vault.locks(lockId);
+        assertEq(amount, 80e6);
+        assertEq(vault.lockedStake(safeA), 80e6);
+        assertEq(vault.claimable(lp), 0);
+    }
+
+    function test_ResolveRejectsZeroBeneficiaryAndZeroClaimAmount() public {
+        _deposit(safeA, 100e6);
+        bytes32 lockId = keccak256("malformed-claim");
+        vm.prank(controller);
+        vault.lockStake(safeA, lockId, 100e6, NEVER_MATURES);
+
+        IStakeVault.Claim[] memory claims = new IStakeVault.Claim[](1);
+        claims[0] = IStakeVault.Claim({beneficiary: address(0), amount: 1});
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.InvalidClaim.selector, address(0), 1));
+        vm.prank(controller);
+        vault.resolveLock(lockId, claims);
+
+        claims[0] = IStakeVault.Claim({beneficiary: lp, amount: 0});
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.InvalidClaim.selector, lp, 0));
+        vm.prank(controller);
+        vault.resolveLock(lockId, claims);
+
+        (, uint256 amount,) = vault.locks(lockId);
+        assertEq(amount, 100e6);
+    }
+
+    function test_ClaimWithdrawsAllImmediately() public {
+        _deposit(safeA, 100e6);
+        bytes32 lockId = keccak256("claim");
+        vm.prank(controller);
+        vault.lockStake(safeA, lockId, 80e6, NEVER_MATURES);
+
+        IStakeVault.Claim[] memory claims = new IStakeVault.Claim[](1);
+        claims[0] = IStakeVault.Claim({beneficiary: lp, amount: 80e6});
+        vm.prank(controller);
+        vault.resolveLock(lockId, claims);
+
+        uint256 balanceBefore = token.balanceOf(lp);
+        vm.prank(lp);
+        vault.claim();
+
+        assertEq(token.balanceOf(lp) - balanceBefore, 80e6);
+        assertEq(vault.claimable(lp), 0);
+        assertEq(vault.totalClaimable(), 0);
+        assertEq(vault.totalAccounted(), 20e6);
+        assertEq(token.balanceOf(address(vault)), 20e6);
+    }
+
+    function test_FundLockCreditsOnlyActuallyUnaccountedTokens() public {
+        bytes32 lockId = keccak256("funded-deferred");
+        uint64 maturesAt = uint64(block.timestamp + 30 days);
+
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.InsufficientUnaccountedTokens.selector, 0, 100e6));
+        vm.prank(controller);
+        vault.fundLock(taker, lockId, 100e6, maturesAt);
+
+        token.transfer(address(vault), 120e6);
+        vm.expectEmit(true, true, false, true, address(vault));
+        emit LockFunded(lockId, taker, 100e6, 100e6);
+        vm.prank(controller);
+        vault.fundLock(taker, lockId, 100e6, maturesAt);
+
+        assertEq(vault.stakeBalance(taker), 100e6);
+        assertEq(vault.lockedStake(taker), 100e6);
+        assertEq(vault.totalStaked(), 100e6);
+        assertEq(vault.unaccountedBalance(), 20e6);
+    }
+
+    function test_FundLockRejectsInvalidInputsAndDuplicateId() public {
+        bytes32 lockId = keccak256("fund-validation");
+        token.transfer(address(vault), 100e6);
+
+        vm.expectRevert(IStakeVault.ZeroAddress.selector);
+        vm.prank(controller);
+        vault.fundLock(address(0), lockId, 1, NEVER_MATURES);
+
+        vm.expectRevert(IStakeVault.ZeroLockId.selector);
+        vm.prank(controller);
+        vault.fundLock(taker, bytes32(0), 1, NEVER_MATURES);
+
+        vm.expectRevert(IStakeVault.ZeroAmount.selector);
+        vm.prank(controller);
+        vault.fundLock(taker, lockId, 0, NEVER_MATURES);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IStakeVault.InvalidMaturity.selector, uint64(block.timestamp), uint64(block.timestamp)
+            )
+        );
+        vm.prank(controller);
+        vault.fundLock(taker, lockId, 1, uint64(block.timestamp));
+
+        vm.prank(controller);
+        vault.fundLock(taker, lockId, 100e6, NEVER_MATURES);
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.LockAlreadyExists.selector, lockId));
+        vm.prank(controller);
+        vault.fundLock(taker, lockId, 1, NEVER_MATURES);
+    }
+
+    function test_MaturityIsRecordedButResolutionRemainsControllerDriven() public {
+        _deposit(safeA, 100e6);
+        bytes32 lockId = keccak256("maturity");
+        uint64 maturesAt = uint64(block.timestamp + 30 days);
+        vm.prank(controller);
+        vault.lockStake(safeA, lockId, 100e6, maturesAt);
+
+        assertFalse(vault.isLockMature(lockId));
+        vm.warp(maturesAt);
+        assertTrue(vault.isLockMature(lockId));
+
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.UnauthorizedController.selector, safeA));
+        vm.prank(safeA);
+        vault.unlockStake(lockId);
+
+        vm.prank(controller);
+        vault.unlockStake(lockId);
+        assertEq(vault.freeStake(safeA), 100e6);
+    }
+
+    function test_ControllerHandoverImmediatelyTransfersAuthorityOverExistingLocks() public {
+        _deposit(safeA, 100e6);
+        bytes32 lockId = keccak256("handover");
+        vm.prank(controller);
+        vault.lockStake(safeA, lockId, 100e6, NEVER_MATURES);
+
+        vault.proposeController(nextController);
+        uint64 validAt = vault.pendingControllerValidAt();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IStakeVault.ControllerProposalNotReady.selector, validAt, uint64(block.timestamp))
+        );
+        vm.prank(nextController);
+        vault.acceptController();
+
+        vm.warp(validAt);
+        vm.prank(nextController);
+        vault.acceptController();
+        assertEq(vault.controller(), nextController);
+
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.UnauthorizedController.selector, controller));
+        vm.prank(controller);
+        vault.unlockStake(lockId);
+
+        vm.prank(nextController);
+        vault.unlockStake(lockId);
+        assertEq(vault.freeStake(safeA), 100e6);
+    }
+
+    function test_ControllerProposalCanBeCancelled() public {
+        vault.proposeController(nextController);
+        vault.cancelControllerProposal();
+
+        assertEq(vault.pendingController(), address(0));
+        assertEq(vault.pendingControllerValidAt(), 0);
+        vm.expectRevert(IStakeVault.NoPendingController.selector);
+        vm.prank(nextController);
+        vault.acceptController();
+    }
+
+    function test_ControllerGovernanceRejectsUnauthorizedAndMissingActions() public {
+        vm.expectRevert("Ownable: caller is not the owner");
+        vm.prank(attacker);
+        vault.proposeController(nextController);
+
+        vm.expectRevert(IStakeVault.NoPendingController.selector);
+        vault.cancelControllerProposal();
+
+        vault.proposeController(nextController);
+        vm.expectRevert(
+            abi.encodeWithSelector(IStakeVault.UnauthorizedPendingController.selector, attacker, nextController)
+        );
+        vm.prank(attacker);
+        vault.acceptController();
+    }
+
+    function test_ReproposalReplacesPendingControllerAndRestartsDelay() public {
+        vault.proposeController(nextController);
+        uint64 firstValidAt = vault.pendingControllerValidAt();
+        vm.warp(block.timestamp + 1 hours);
+
+        vault.proposeController(attacker);
+        uint64 replacementValidAt = vault.pendingControllerValidAt();
+        assertEq(vault.pendingController(), attacker);
+        assertGt(replacementValidAt, firstValidAt);
+
+        vm.warp(replacementValidAt);
+        vm.prank(attacker);
+        vault.acceptController();
+        assertEq(vault.controller(), attacker);
+    }
+
+    function test_WithdrawCannotConsumeLockedStake() public {
+        _deposit(safeA, 100e6);
+        vm.prank(controller);
+        vault.lockStake(safeA, keccak256("locked-withdrawal"), 80e6, NEVER_MATURES);
+
+        vm.expectRevert(abi.encodeWithSelector(IStakeVault.InsufficientFreeStake.selector, safeA, 20e6, 21e6));
+        vm.prank(safeA);
+        vault.withdrawStake(21e6);
+
+        vm.prank(safeA);
+        vault.withdrawStake(20e6);
+        assertEq(vault.stakeBalance(safeA), 80e6);
+        assertEq(vault.lockedStake(safeA), 80e6);
+    }
+
+    function _deposit(address _stakeOwner, uint256 _amount) internal {
+        vm.prank(_stakeOwner);
+        vault.depositStake(_amount);
+    }
+}

--- a/test-foundry/deterministic/verifiers/ChargebackVerifier.t.sol
+++ b/test-foundry/deterministic/verifiers/ChargebackVerifier.t.sol
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+
+import {ChargebackVerifier} from "contracts/unifiedVerifier/ChargebackVerifier.sol";
+import {IAttestationVerifier} from "contracts/interfaces/IAttestationVerifier.sol";
+import {IChargebackVerifier} from "contracts/interfaces/IChargebackVerifier.sol";
+import {INullifierRegistryV2} from "contracts/interfaces/INullifierRegistryV2.sol";
+import {AttestationVerifierMock} from "contracts/mocks/AttestationVerifierMock.sol";
+import {NullifierRegistry} from "contracts/registries/NullifierRegistry.sol";
+import {NullifierRegistryV2} from "contracts/registries/NullifierRegistryV2.sol";
+
+contract ChargebackVerifierTest is Test {
+    event AttestationVerifierUpdated(address indexed previousVerifier, address indexed newVerifier);
+
+    bytes32 internal constant METHOD = keccak256("method");
+    bytes32 internal constant INTENT = keccak256("intent");
+    bytes32 internal constant USD = keccak256("USD");
+
+    NullifierRegistryV2 internal nullifierRegistry;
+    AttestationVerifierMock internal attestationVerifier;
+    ChargebackVerifier internal verifier;
+    address internal other = address(0xBEEF);
+
+    function setUp() public {
+        nullifierRegistry = new NullifierRegistryV2(new NullifierRegistry());
+        attestationVerifier = new AttestationVerifierMock();
+        verifier = new ChargebackVerifier(address(this), nullifierRegistry, attestationVerifier);
+    }
+
+    function test_VerifyChargebackManualPathReturnsDisputeData() public {
+        IChargebackVerifier.ChargebackAttestation memory attestation =
+            _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
+
+        (bytes32 disputeId, bytes32 disputeNullifier) =
+            verifier.verifyChargeback(attestation, METHOD, true);
+
+        assertEq(disputeId, keccak256("dispute"));
+        assertEq(disputeNullifier, keccak256(abi.encodePacked(METHOD, keccak256("dispute"))));
+    }
+
+    function test_VerifyChargebackRejectsTamperedDataHash() public {
+        IChargebackVerifier.ChargebackAttestation memory attestation =
+            _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
+        attestation.dataHash = keccak256("tampered");
+
+        vm.expectRevert(IChargebackVerifier.InvalidAttestation.selector);
+        verifier.verifyChargeback(attestation, METHOD, true);
+    }
+
+    function test_VerifyChargebackRejectsMethodMismatch() public {
+        IChargebackVerifier.ChargebackAttestation memory attestation =
+            _attestation(INTENT, keccak256("wrong"), keccak256("payment"), keccak256("dispute"));
+
+        vm.expectRevert(IChargebackVerifier.InvalidAttestation.selector);
+        verifier.verifyChargeback(attestation, METHOD, true);
+    }
+
+    function test_VerifyChargebackRejectsSignatureFailure() public {
+        IChargebackVerifier.ChargebackAttestation memory attestation =
+            _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
+        attestationVerifier.setResult(false);
+
+        vm.expectRevert(IChargebackVerifier.AttestationVerificationFailed.selector);
+        verifier.verifyChargeback(attestation, METHOD, true);
+    }
+
+    function test_VerifyChargebackProofPathRequiresBothDirectionBinding() public {
+        bytes32 paymentId = keccak256("payment");
+        IChargebackVerifier.ChargebackAttestation memory attestation =
+            _attestation(INTENT, METHOD, paymentId, keccak256("dispute"));
+        bytes32 paymentNullifier = keccak256(abi.encodePacked(METHOD, paymentId));
+        bytes memory bindingRevert = abi.encodeWithSelector(
+            IChargebackVerifier.InvalidPaymentBinding.selector, INTENT, paymentNullifier
+        );
+
+        vm.expectRevert(bindingRevert);
+        verifier.verifyChargeback(attestation, METHOD, false);
+
+        // Forward direction only: nullifier -> intent resolves, intent -> nullifier does not.
+        vm.mockCall(
+            address(nullifierRegistry),
+            abi.encodeCall(INullifierRegistryV2.intentHashByNullifier, (paymentNullifier)),
+            abi.encode(INTENT)
+        );
+        vm.expectRevert(bindingRevert);
+        verifier.verifyChargeback(attestation, METHOD, false);
+        vm.clearMockedCalls();
+
+        // Reverse direction only: intent -> nullifier resolves, nullifier -> intent does not.
+        vm.mockCall(
+            address(nullifierRegistry),
+            abi.encodeCall(INullifierRegistryV2.nullifierByIntentHash, (INTENT)),
+            abi.encode(paymentNullifier)
+        );
+        vm.expectRevert(bindingRevert);
+        verifier.verifyChargeback(attestation, METHOD, false);
+        vm.clearMockedCalls();
+
+        nullifierRegistry.addWritePermission(address(this));
+        nullifierRegistry.addNullifier(paymentNullifier, INTENT);
+
+        (bytes32 disputeId,) = verifier.verifyChargeback(attestation, METHOD, false);
+        assertEq(disputeId, keccak256("dispute"));
+    }
+
+    function test_VerifyChargebackForwardsDigestSignaturesAndDataToAttestationVerifier() public {
+        IChargebackVerifier.ChargebackAttestation memory attestation =
+            _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
+        bytes32 expectedDigest = verifier.hashChargebackAttestation(attestation);
+
+        vm.expectCall(
+            address(attestationVerifier),
+            abi.encodeCall(
+                IAttestationVerifier.verify,
+                (expectedDigest, attestation.signatures, attestation.data)
+            )
+        );
+        verifier.verifyChargeback(attestation, METHOD, true);
+    }
+
+    function test_HashChargebackAttestationMatchesEip712Digest() public {
+        IChargebackVerifier.ChargebackAttestation memory attestation =
+            _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
+
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                keccak256(
+                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                ),
+                keccak256(bytes("ZKP2P ChargebackVerifier")),
+                keccak256(bytes("1")),
+                block.chainid,
+                address(verifier)
+            )
+        );
+        bytes32 structHash = keccak256(
+            abi.encode(
+                keccak256("ChargebackAttestation(bytes32 intentHash,bytes32 dataHash)"),
+                attestation.intentHash,
+                attestation.dataHash
+            )
+        );
+        bytes32 expected = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+
+        assertEq(verifier.hashChargebackAttestation(attestation), expected);
+    }
+
+    function test_SetAttestationVerifierEnforcesOwnershipValidationAndEmits() public {
+        vm.prank(other);
+        vm.expectRevert(bytes("Ownable: caller is not the owner"));
+        verifier.setAttestationVerifier(address(attestationVerifier));
+
+        vm.expectRevert(IChargebackVerifier.ZeroAddress.selector);
+        verifier.setAttestationVerifier(address(0));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IChargebackVerifier.InvalidContract.selector, other)
+        );
+        verifier.setAttestationVerifier(other);
+
+        AttestationVerifierMock replacement = new AttestationVerifierMock();
+        vm.expectEmit(true, true, false, true);
+        emit AttestationVerifierUpdated(address(attestationVerifier), address(replacement));
+        verifier.setAttestationVerifier(address(replacement));
+        assertEq(address(verifier.attestationVerifier()), address(replacement));
+    }
+
+    function test_ConstructorValidatesDependencies() public {
+        vm.expectRevert(IChargebackVerifier.ZeroAddress.selector);
+        new ChargebackVerifier(address(0), nullifierRegistry, attestationVerifier);
+
+        vm.expectRevert(IChargebackVerifier.ZeroAddress.selector);
+        new ChargebackVerifier(
+            address(this), NullifierRegistryV2(address(0)), attestationVerifier
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IChargebackVerifier.InvalidContract.selector, other)
+        );
+        new ChargebackVerifier(address(this), NullifierRegistryV2(other), attestationVerifier);
+
+        vm.expectRevert(IChargebackVerifier.ZeroAddress.selector);
+        new ChargebackVerifier(address(this), nullifierRegistry, IAttestationVerifier(address(0)));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IChargebackVerifier.InvalidContract.selector, other)
+        );
+        new ChargebackVerifier(address(this), nullifierRegistry, AttestationVerifierMock(other));
+    }
+
+    function test_RenounceOwnershipDisabled() public {
+        vm.expectRevert(IChargebackVerifier.OwnershipRenunciationDisabled.selector);
+        verifier.renounceOwnership();
+    }
+
+    function _attestation(
+        bytes32 intentHash,
+        bytes32 paymentMethod,
+        bytes32 paymentId,
+        bytes32 disputeId
+    ) internal pure returns (IChargebackVerifier.ChargebackAttestation memory attestation) {
+        IChargebackVerifier.ChargebackDetails memory details = IChargebackVerifier.ChargebackDetails({
+            paymentMethod: paymentMethod,
+            originalPaymentId: paymentId,
+            disputeId: disputeId,
+            paymentAmount: 100,
+            paymentCurrency: USD
+        });
+        bytes memory data = abi.encode(details);
+        attestation = IChargebackVerifier.ChargebackAttestation({
+            intentHash: intentHash,
+            dataHash: keccak256(data),
+            signatures: new bytes[](0),
+            data: data
+        });
+    }
+}

--- a/test-foundry/fuzz/StakeVaultFuzz.t.sol
+++ b/test-foundry/fuzz/StakeVaultFuzz.t.sol
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+
+import {StakeVault} from "contracts/StakeVault.sol";
+import {IStakeVault} from "contracts/interfaces/IStakeVault.sol";
+import {USDCMock} from "contracts/mocks/USDCMock.sol";
+
+contract StakeVaultFuzzTest is Test {
+    uint256 internal constant MAX_AMOUNT = 1_000_000e6;
+    uint64 internal constant NEVER_MATURES = type(uint64).max;
+
+    address internal controller;
+    address internal stakeOwner;
+    address internal beneficiary;
+    address internal taker;
+    address internal alternateOwner;
+
+    USDCMock internal token;
+    StakeVault internal vault;
+
+    function setUp() public {
+        controller = makeAddr("controller");
+        stakeOwner = makeAddr("stakeOwner");
+        beneficiary = makeAddr("beneficiary");
+        taker = makeAddr("taker");
+        alternateOwner = makeAddr("alternateOwner");
+
+        token = new USDCMock(MAX_AMOUNT * 4, "USD Coin", "USDC");
+        vault = new StakeVault(address(this), token, controller, 1 days);
+        token.transfer(stakeOwner, MAX_AMOUNT);
+        token.transfer(alternateOwner, MAX_AMOUNT);
+        vm.prank(stakeOwner);
+        token.approve(address(vault), type(uint256).max);
+        vm.prank(alternateOwner);
+        token.approve(address(vault), type(uint256).max);
+    }
+
+    function testFuzz_ResolveConservesStakeClaimsAndTokens(uint96 rawDeposit, uint96 rawLock, uint96 rawClaim) public {
+        uint256 depositAmount = bound(uint256(rawDeposit), 1, MAX_AMOUNT);
+        uint256 lockAmount = bound(uint256(rawLock), 1, depositAmount);
+        uint256 claimAmount = bound(uint256(rawClaim), 0, lockAmount);
+        bytes32 lockId = keccak256(abi.encode(depositAmount, lockAmount, claimAmount));
+
+        vm.prank(stakeOwner);
+        vault.depositStake(depositAmount);
+        vm.prank(controller);
+        vault.lockStake(stakeOwner, lockId, lockAmount, NEVER_MATURES);
+
+        IStakeVault.Claim[] memory claims;
+        if (claimAmount == 0) {
+            claims = new IStakeVault.Claim[](0);
+        } else {
+            claims = new IStakeVault.Claim[](1);
+            claims[0] = IStakeVault.Claim({beneficiary: beneficiary, amount: claimAmount});
+        }
+        vm.prank(controller);
+        vault.resolveLock(lockId, claims);
+
+        assertEq(vault.stakeBalance(stakeOwner), depositAmount - claimAmount);
+        assertEq(vault.freeStake(stakeOwner), depositAmount - claimAmount);
+        assertEq(vault.lockedStake(stakeOwner), 0);
+        assertEq(vault.claimable(beneficiary), claimAmount);
+        assertEq(vault.totalAccounted(), depositAmount);
+        assertEq(token.balanceOf(address(vault)), depositAmount);
+    }
+
+    function testFuzz_IndependentLocksCannotConsumeEachOther(uint96 rawFirst, uint96 rawSecond, uint96 rawFirstClaim)
+        public
+    {
+        uint256 firstAmount = bound(uint256(rawFirst), 1, MAX_AMOUNT / 2);
+        uint256 secondAmount = bound(uint256(rawSecond), 1, MAX_AMOUNT / 2);
+        uint256 claimAmount = bound(uint256(rawFirstClaim), 0, firstAmount);
+        uint256 depositAmount = firstAmount + secondAmount;
+        bytes32 firstLockId = keccak256(abi.encode("first", firstAmount, secondAmount));
+        bytes32 secondLockId = keccak256(abi.encode("second", firstAmount, secondAmount));
+
+        vm.prank(stakeOwner);
+        vault.depositStake(depositAmount);
+        vm.startPrank(controller);
+        vault.lockStake(stakeOwner, firstLockId, firstAmount, NEVER_MATURES);
+        vault.lockStake(stakeOwner, secondLockId, secondAmount, NEVER_MATURES);
+
+        IStakeVault.Claim[] memory claims;
+        if (claimAmount == 0) {
+            claims = new IStakeVault.Claim[](0);
+        } else {
+            claims = new IStakeVault.Claim[](1);
+            claims[0] = IStakeVault.Claim({beneficiary: beneficiary, amount: claimAmount});
+        }
+        vault.resolveLock(firstLockId, claims);
+        vm.stopPrank();
+
+        (, uint256 remainingLockAmount,) = vault.locks(secondLockId);
+        assertEq(remainingLockAmount, secondAmount);
+        assertEq(vault.lockedStake(stakeOwner), secondAmount);
+        assertEq(vault.freeStake(stakeOwner), firstAmount - claimAmount);
+        assertEq(vault.totalAccounted(), depositAmount);
+    }
+
+    function testFuzz_FundedLockResolutionConservesGross(uint96 rawGross, uint96 rawClaim) public {
+        uint256 grossAmount = bound(uint256(rawGross), 1, MAX_AMOUNT);
+        uint256 claimAmount = bound(uint256(rawClaim), 0, grossAmount);
+        bytes32 lockId = keccak256(abi.encode("funded", grossAmount, claimAmount));
+
+        token.transfer(address(vault), grossAmount);
+        vm.prank(controller);
+        vault.fundLock(stakeOwner, lockId, grossAmount, uint64(block.timestamp + 30 days));
+
+        IStakeVault.Claim[] memory claims;
+        if (claimAmount == 0) {
+            claims = new IStakeVault.Claim[](0);
+        } else {
+            claims = new IStakeVault.Claim[](1);
+            claims[0] = IStakeVault.Claim({beneficiary: beneficiary, amount: claimAmount});
+        }
+        vm.prank(controller);
+        vault.resolveLock(lockId, claims);
+
+        assertEq(vault.stakeBalance(stakeOwner), grossAmount - claimAmount);
+        assertEq(vault.claimable(beneficiary), claimAmount);
+        assertEq(vault.totalAccounted(), grossAmount);
+        assertEq(token.balanceOf(address(vault)), grossAmount);
+        assertEq(vault.unaccountedBalance(), 0);
+    }
+
+    function testFuzz_ArbitrarySponsorAuthorizationCannotChangeTakerSelection(address sponsor) public {
+        vm.assume(sponsor != address(0) && sponsor != taker && sponsor != stakeOwner && sponsor != alternateOwner);
+
+        vm.prank(stakeOwner);
+        vault.setTakerAuthorization(taker, true);
+        vm.prank(alternateOwner);
+        vault.setTakerAuthorization(taker, true);
+        vm.prank(taker);
+        vault.selectStakeOwner(stakeOwner);
+
+        vm.prank(sponsor);
+        vault.setTakerAuthorization(taker, true);
+
+        assertEq(vault.stakeOwnerOf(taker), stakeOwner);
+        assertEq(vault.selectedStakeOwner(taker), stakeOwner);
+    }
+
+    function testFuzz_MultipleStakeOwnersRemainAccountingIsolated(
+        uint96 rawFirstAmount,
+        uint96 rawSecondAmount,
+        uint96 rawClaimAmount
+    ) public {
+        uint256 firstAmount = bound(uint256(rawFirstAmount), 1, MAX_AMOUNT);
+        uint256 secondAmount = bound(uint256(rawSecondAmount), 1, MAX_AMOUNT);
+        uint256 claimAmount = bound(uint256(rawClaimAmount), 0, firstAmount);
+        bytes32 firstLockId = keccak256(abi.encode("owner-one", firstAmount));
+        bytes32 secondLockId = keccak256(abi.encode("owner-two", secondAmount));
+
+        vm.prank(stakeOwner);
+        vault.depositStake(firstAmount);
+        vm.prank(alternateOwner);
+        vault.depositStake(secondAmount);
+        vm.startPrank(controller);
+        vault.lockStake(stakeOwner, firstLockId, firstAmount, NEVER_MATURES);
+        vault.lockStake(alternateOwner, secondLockId, secondAmount, NEVER_MATURES);
+
+        IStakeVault.Claim[] memory claims;
+        if (claimAmount == 0) {
+            claims = new IStakeVault.Claim[](0);
+        } else {
+            claims = new IStakeVault.Claim[](1);
+            claims[0] = IStakeVault.Claim({beneficiary: beneficiary, amount: claimAmount});
+        }
+        vault.resolveLock(firstLockId, claims);
+        vm.stopPrank();
+
+        assertEq(vault.stakeBalance(stakeOwner), firstAmount - claimAmount);
+        assertEq(vault.lockedStake(stakeOwner), 0);
+        assertEq(vault.stakeBalance(alternateOwner), secondAmount);
+        assertEq(vault.lockedStake(alternateOwner), secondAmount);
+        assertEq(vault.totalAccounted(), firstAmount + secondAmount);
+    }
+
+    function testFuzz_MaturityBoundaryPreventsFurtherLockMutation(uint96 rawAmount, uint32 rawDuration) public {
+        uint256 amount = bound(uint256(rawAmount), 1, MAX_AMOUNT);
+        uint64 duration = uint64(bound(uint256(rawDuration), 1, 365 days));
+        uint64 maturesAt = uint64(block.timestamp) + duration;
+        bytes32 lockId = keccak256(abi.encode("maturity", amount, duration));
+
+        vm.prank(stakeOwner);
+        vault.depositStake(amount);
+        vm.prank(controller);
+        vault.lockStake(stakeOwner, lockId, amount, maturesAt);
+        vm.warp(maturesAt);
+
+        assertTrue(vault.isLockMature(lockId));
+        vm.expectPartialRevert(IStakeVault.LockAlreadyMatured.selector);
+        vm.prank(controller);
+        vault.increaseLock(lockId, 1);
+
+        vm.expectPartialRevert(IStakeVault.LockAlreadyMatured.selector);
+        vm.prank(controller);
+        vault.resizeLock(lockId, amount, NEVER_MATURES);
+
+        vm.prank(controller);
+        vault.unlockStake(lockId);
+        assertEq(vault.freeStake(stakeOwner), amount);
+    }
+
+    function testFuzz_IncreaseResizeResolveSequenceConservesAccounting(
+        uint96 rawDeposit,
+        uint96 rawInitialLock,
+        uint96 rawIncrease,
+        uint96 rawResizedAmount,
+        uint96 rawClaim
+    ) public {
+        uint256 depositAmount = bound(uint256(rawDeposit), 2, MAX_AMOUNT);
+        uint256 initialAmount = bound(uint256(rawInitialLock), 1, depositAmount - 1);
+        uint256 additionalAmount = bound(uint256(rawIncrease), 1, depositAmount - initialAmount);
+        uint256 increasedAmount = initialAmount + additionalAmount;
+        uint256 resizedAmount = bound(uint256(rawResizedAmount), 1, increasedAmount);
+        uint256 claimAmount = bound(uint256(rawClaim), 0, resizedAmount);
+        bytes32 lockId = keccak256(abi.encode("sequence", depositAmount, initialAmount, additionalAmount));
+
+        vm.prank(stakeOwner);
+        vault.depositStake(depositAmount);
+        vm.startPrank(controller);
+        vault.lockStake(stakeOwner, lockId, initialAmount, NEVER_MATURES);
+        vault.increaseLock(lockId, additionalAmount);
+        vault.resizeLock(lockId, resizedAmount, NEVER_MATURES);
+
+        IStakeVault.Claim[] memory claims;
+        if (claimAmount == 0) {
+            claims = new IStakeVault.Claim[](0);
+        } else {
+            claims = new IStakeVault.Claim[](1);
+            claims[0] = IStakeVault.Claim({beneficiary: beneficiary, amount: claimAmount});
+        }
+        vault.resolveLock(lockId, claims);
+        vm.stopPrank();
+
+        assertEq(vault.stakeBalance(stakeOwner), depositAmount - claimAmount);
+        assertEq(vault.lockedStake(stakeOwner), 0);
+        assertEq(vault.claimable(beneficiary), claimAmount);
+        assertEq(vault.totalAccounted(), depositAmount);
+        assertEq(token.balanceOf(address(vault)), depositAmount);
+    }
+}

--- a/test-foundry/invariant/StakeVaultInvariant.t.sol
+++ b/test-foundry/invariant/StakeVaultInvariant.t.sol
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {StdInvariant} from "forge-std/StdInvariant.sol";
+import {Test} from "forge-std/Test.sol";
+
+import {StakeVault} from "contracts/StakeVault.sol";
+import {IStakeVault} from "contracts/interfaces/IStakeVault.sol";
+import {USDCMock} from "contracts/mocks/USDCMock.sol";
+
+contract StakeVaultInvariantHandler is Test {
+    uint256 internal constant LOCK_SLOTS = 8;
+    uint64 internal constant NEVER_MATURES = type(uint64).max;
+
+    StakeVault public immutable vault;
+    USDCMock public immutable token;
+
+    constructor(StakeVault _vault, USDCMock _token) {
+        vault = _vault;
+        token = _token;
+        _token.approve(address(_vault), type(uint256).max);
+    }
+
+    function deposit(uint256 _rawAmount) external {
+        uint256 available = token.balanceOf(address(this));
+        if (available == 0) return;
+        vault.depositStake(bound(_rawAmount, 1, available));
+    }
+
+    function lock(uint256 _rawSlot, uint256 _rawAmount) external {
+        bytes32 lockId = lockIdAt(_rawSlot % LOCK_SLOTS);
+        (address stakeOwner,,) = vault.locks(lockId);
+        uint256 available = vault.freeStake(address(this));
+        if (stakeOwner != address(0) || available == 0) return;
+        vault.lockStake(address(this), lockId, bound(_rawAmount, 1, available), NEVER_MATURES);
+    }
+
+    function fundLock(uint256 _rawSlot, uint256 _rawAmount) external {
+        bytes32 lockId = lockIdAt(_rawSlot % LOCK_SLOTS);
+        (address stakeOwner,,) = vault.locks(lockId);
+        uint256 available = token.balanceOf(address(this));
+        if (stakeOwner != address(0) || available == 0) return;
+
+        uint256 amount = bound(_rawAmount, 1, available);
+        token.transfer(address(vault), amount);
+        vault.fundLock(address(this), lockId, amount, NEVER_MATURES);
+    }
+
+    function donate(uint256 _rawAmount) external {
+        uint256 available = token.balanceOf(address(this));
+        if (available == 0) return;
+        token.transfer(address(vault), bound(_rawAmount, 1, available));
+    }
+
+    function increase(uint256 _rawSlot, uint256 _rawAmount) external {
+        bytes32 lockId = lockIdAt(_rawSlot % LOCK_SLOTS);
+        (address stakeOwner,,) = vault.locks(lockId);
+        uint256 available = vault.freeStake(address(this));
+        if (stakeOwner == address(0) || available == 0) return;
+        vault.increaseLock(lockId, bound(_rawAmount, 1, available));
+    }
+
+    function resize(uint256 _rawSlot, uint256 _rawAmount) external {
+        bytes32 lockId = lockIdAt(_rawSlot % LOCK_SLOTS);
+        (address stakeOwner, uint256 amount,) = vault.locks(lockId);
+        if (stakeOwner == address(0) || amount <= 1) return;
+        vault.resizeLock(lockId, bound(_rawAmount, 1, amount), NEVER_MATURES);
+    }
+
+    function unlock(uint256 _rawSlot) external {
+        bytes32 lockId = lockIdAt(_rawSlot % LOCK_SLOTS);
+        (address stakeOwner,,) = vault.locks(lockId);
+        if (stakeOwner == address(0)) return;
+        vault.unlockStake(lockId);
+    }
+
+    function resolve(uint256 _rawSlot, uint256 _rawClaimAmount) external {
+        bytes32 lockId = lockIdAt(_rawSlot % LOCK_SLOTS);
+        (address stakeOwner, uint256 amount,) = vault.locks(lockId);
+        if (stakeOwner == address(0)) return;
+
+        uint256 claimAmount = bound(_rawClaimAmount, 0, amount);
+        IStakeVault.Claim[] memory claims;
+        if (claimAmount == 0) {
+            claims = new IStakeVault.Claim[](0);
+        } else {
+            claims = new IStakeVault.Claim[](1);
+            claims[0] = IStakeVault.Claim({beneficiary: address(this), amount: claimAmount});
+        }
+        vault.resolveLock(lockId, claims);
+    }
+
+    function withdraw(uint256 _rawAmount) external {
+        uint256 available = vault.freeStake(address(this));
+        if (available == 0) return;
+        vault.withdrawStake(bound(_rawAmount, 1, available));
+    }
+
+    function withdrawClaim() external {
+        if (vault.claimable(address(this)) == 0) return;
+        vault.claim();
+    }
+
+    function lockIdAt(uint256 _slot) public pure returns (bytes32) {
+        return keccak256(abi.encode("STAKE_VAULT_INVARIANT_LOCK", _slot));
+    }
+
+    function lockSlots() external pure returns (uint256) {
+        return LOCK_SLOTS;
+    }
+}
+
+contract StakeVaultInvariantTest is StdInvariant, Test {
+    StakeVault internal vault;
+    USDCMock internal token;
+    StakeVaultInvariantHandler internal handler;
+
+    function setUp() public {
+        token = new USDCMock(10_000_000e6, "USD Coin", "USDC");
+        vault = new StakeVault(address(this), token, address(0), 1 days);
+        handler = new StakeVaultInvariantHandler(vault, token);
+        vault.initializeController(address(handler));
+        token.transfer(address(handler), 5_000_000e6);
+        targetContract(address(handler));
+    }
+
+    function invariant_TokenBalanceCoversEveryRecordedLiability() public view {
+        uint256 tokenBalance = token.balanceOf(address(vault));
+        uint256 accounted = vault.totalAccounted();
+        assertGe(tokenBalance, accounted);
+        assertEq(vault.unaccountedBalance(), tokenBalance - accounted);
+    }
+
+    function invariant_StakeOwnerBalanceAlwaysCoversItsLocks() public view {
+        assertLe(vault.lockedStake(address(handler)), vault.stakeBalance(address(handler)));
+        assertEq(
+            vault.freeStake(address(handler)),
+            vault.stakeBalance(address(handler)) - vault.lockedStake(address(handler))
+        );
+    }
+
+    function invariant_GlobalTotalsEqualPerAccountBalances() public view {
+        assertEq(vault.totalStaked(), vault.stakeBalance(address(handler)));
+        assertEq(vault.totalClaimable(), vault.claimable(address(handler)));
+    }
+
+    function invariant_EveryLockIsIncludedInAggregateLockedStake() public view {
+        uint256 aggregateLockAmount;
+        for (uint256 slot = 0; slot < handler.lockSlots(); slot++) {
+            (, uint256 amount,) = vault.locks(handler.lockIdAt(slot));
+            aggregateLockAmount += amount;
+        }
+        assertEq(aggregateLockAmount, vault.lockedStake(address(handler)));
+    }
+}


### PR DESCRIPTION
## Summary
- Revives the intent lifecycle hook from `32a1d7d` and wires it into OrchestratorV3: a governance-set, per-intent-snapshotted `IIntentLifecycleHook` invoked at signal (admission), cancel/prune/orphan-cleanup, and fulfill/manual release. All callbacks are fail-closed with raw revert bubbling — no bounded-call, gas-cap, or fail-open recovery machinery (hooks are governance-deployed and trusted).
- Adds `ChargebackPolicy`: a lightweight stake-backed-only fold of the `32a1d7d` RiskManager + ChargebackManager. It does accounting and stake lock/unlock/resolve against StakeVault only — it never holds tokens. Intent extensions (owned by the paid IntentGuardian) and deferred-payout mode are deliberately dropped.
- Adds `ChargebackVerifier` (review feedback): a stateless verifier that owns chargeback evidence verification, mirroring the UnifiedPaymentVerifier layering — `policy → chargeback verifier → attestation verifier`. The policy keeps only position state and stake resolution.
- Ports `StakeVault` + `IStakeVault` byte-identical to `32a1d7d`, including their unit/fuzz/invariant test suites verbatim.
- Removes the per-deposit whitelist hook slot from OrchestratorV3 (`setDepositWhitelistHook` et al.) — whitelist gating now flows through the lifecycle hook + `WhitelistPolicy`.

## Changes

**OrchestratorV3 / IOrchestratorV3**
- Per-intent lifecycle hook snapshot at signal; `setLifecycleHook` governance setter; fail-closed callbacks at signal (before `lockFunds`), cancel/prune/cleanup (`_pruneIntentAndNotify`), and settlement
- Settlement is notification-only: the hook receives full `SettlementContext` but no token allowance; fee math is unchanged from OrchestratorV2 (`_calculateAndTransferFees` restored verbatim)
- Manual release (`releaseFundsToPayer`) now routes through the shared settlement tail, including the intent's post-intent hook
- Whitelist hook slot, mapping, events, and getters removed
- Signal-stage callbacks named `onIntentSignaled` end-to-end (review feedback: matches `signalIntent` / `IntentSignaled`; formerly `onIntentCreated` / `admitIntent`)

**IntentLifecycleHookV1** — admission decision table (user-confirmed):

| WL | whitelisted | CB | method chargebackable | outcome |
|---|---|---|---|---|
| on | yes | any | any | allow, no stake |
| on | no | on | yes | stake-backed or revert |
| on | no | on | no | allow, no stake (pass-through) |
| on | no | off | — | revert |
| off | — | on | yes | everyone stakes |
| off | — | on | no | open (pass-through) |
| off | — | off | — | open |

**ChargebackPolicy**
- Hybrid config: depositors set `enabled(escrow, depositId)`; governance sets `riskWindows[paymentMethod]` (0 = not chargebackable → direct-access pass-through, deliberately ordered before pause/enable checks)
- Admission locks the intent amount from the taker's vault-selected stake owner; settlement resizes the lock to the gross release and opens the chargeback window; matured positions release permissionlessly
- `submitChargeback` is a pure state machine: it checks position status and the coverage window, delegates all evidence verification to the governance-swappable `ChargebackVerifier` (`setChargebackVerifier`, emits `ChargebackVerifierUpdated`), then enforces dispute-replay protection and the full-coverage requirement before slashing the entire gross to the depositor as a vault claim
- Positions are not orchestrator-bound; the OrchestratorRegistry trust assumption is documented in the contract header

**ChargebackVerifier / IChargebackVerifier**
- Stateless and view-only: dataHash integrity, `ChargebackDetails` decode, payment-method match, EIP-712 signature verification via a swappable `IAttestationVerifier` (same `setAttestationVerifier` pattern as `BaseUnifiedPaymentVerifier`), and dual-direction NullifierRegistryV2 payment binding (skipped for manual releases)
- Owns the `ChargebackAttestation`/`ChargebackDetails` structs, the verification errors, and `hashChargebackAttestation`
- EIP-712 domain is `("ZKP2P ChargebackVerifier", "1", chainId, verifierAddress)` — the attestation service signs against the verifier, not the policy; swapping the verifier rotates the signing domain
- The policy no longer references the nullifier registry at all (4-arg constructor: owner, stakeVault, chargebackVerifier, escrowRegistry)

## Spec Alignment
No spec in `docs/specs/` (docs/ is untracked in this repo). Design decisions were made interactively and are recorded in the commit messages.

## Test Plan
- [x] `forge test`: 1428 passed, 0 failed (87 suites; +122 tests vs main)
- [x] `yarn coverage`: 0 failing tests under `--ir-minimum`; only the pre-existing global-floor gate failure remains (coverage improved: lines 90.15% → 97.35%)
- [x] StakeVault + IStakeVault + their 3 test files diff-verified byte-identical to `32a1d7d`
- [x] All 7 admission truth-table rows covered end-to-end through the real OrchestratorV3 + EscrowV2 + policies stack
- [x] Lifecycle flows: stake unlock via cancel and expiry-prune, coverage resize on fulfill (full + partial), manual-release marking, matured release, chargeback slash paying the depositor claim
- [x] ChargebackVerifier unit-tested in isolation: one-sided payment-binding states (via `vm.mockCall`), exact digest/signature/data forwarding to the attestation verifier (via `vm.expectCall`), EIP-712 digest pinned against a manual domain computation
- [x] Fail-closed rollbacks: policy admission revert aborts `signalIntent` before the escrow lock
- [x] Bytecode: OrchestratorV3 20,782 / ChargebackPolicy 9,316 / ChargebackVerifier 3,831 / StakeVault 8,616 — all under the EIP-170 limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpcKH6RzmFBRxHKPuCVTyC
https://claude.ai/code/session_01D5S39N2nT8VgEM6KLz7xL3
