### PR TITLE
ci: speed up trusted RC validation

### DIFF
--- a/.agents/skills/zkp2p-contracts-publish/SKILL.md
+++ b/.agents/skills/zkp2p-contracts-publish/SKILL.md
@@ -19,7 +19,7 @@ Read `NPM_RELEASE.md` completely before preparing or initiating a release. Do no
 - Autonomous RC environment: `npm-publish-rc`
 - Registry tag: hard-coded `rc`
 
-The workflow must be dispatched from `main`. Its `release` input must exactly match the committed `0.4.0-rc.N` package version, and the repository-controlled `contracts-v2-v<version>` tag must point to that same main commit. Every version must be new on npm.
+The workflow must be dispatched from `main`. Its `release` input must exactly match the committed `0.4.0-rc.N` package version, the repository-controlled `contracts-v2-v<version>` tag must point to that same main commit, and live `latest` must match the repository-controlled `0.3.0` baseline. Every version must be new on npm.
 
 ## Prepare the version PR
 

--- a/.agents/skills/zkp2p-contracts-publish/SKILL.md
+++ b/.agents/skills/zkp2p-contracts-publish/SKILL.md
@@ -2,9 +2,9 @@
 name: zkp2p-contracts-publish
 description: >
   Prepare and publish @zkp2p/contracts-v2 through the protected GitHub Actions
-  trusted-publishing workflow, including build, tests, ABI/address integrity,
-  npm pack, provenance, dist-tag, and post-publish verification.
-compatibility: Requires Node.js 22.14+, Yarn 4.9.1, and maintainer access to dispatch the autonomous RC workflow.
+  trusted-publishing workflow. Use for RC version selection, release validation,
+  ABI/address checks, fast CI-equivalent Foundry gating, npm OIDC publication,
+  registry verification, or safe post-publish recovery.
 ---
 
 # `@zkp2p/contracts-v2` trusted release
@@ -27,21 +27,28 @@ Set the first unused `0.4.0-rc.N` version. Stable or `latest` publishing is a se
 
 Update the package README or changelog for consumer-visible changes. Confirm `repository.url` remains exactly `https://github.com/zkp2p/zkp2p-contracts.git` for npm OIDC provenance.
 
-## Local preflight
+## Fast preflight and full test gate
 
-From a clean checkout with the tracked non-production environment defaults loaded:
+Do not rerun the full Foundry suite serially before a release when the exact commit already passed normal CI. Run the package-specific preflight locally from a clean checkout:
 
 ```bash
 yarn install --immutable
-yarn build
+yarn compile
 yarn pkg:build
 yarn pkg:test
 yarn workspace @zkp2p/contracts-v2 verify:release
-cd packages/contracts
-npm pack --dry-run
+yarn test:release-policy
+(cd packages/contracts && npm pack --dry-run)
 ```
 
-The verification derives required ABIs and addresses from the current hard-cut package and must match exact Base/Base Staging deployment artifacts.
+The verification derives required ABIs and addresses from the current hard-cut package and must match exact Base/Base Staging deployment artifacts. Normal CI and the publishing workflow remain authoritative for the complete Foundry suite.
+
+The release workflow mirrors CI's fast structure:
+
+- package compile, integrity checks, pack, and tarball smoke test run in one job;
+- the complete Foundry suite runs concurrently in another job;
+- the Foundry job restores `out` and `cache_forge` from a key derived from `foundry.toml`, Solidity sources, Foundry tests, and `forge-std`;
+- publication requires both jobs, so optimization must never remove or weaken the full-suite gate.
 
 ## Initiate and verify
 
@@ -50,3 +57,5 @@ After the version PR and normal CI merge to `main`, create `contracts-v2-v<versi
 The publish job uses OIDC with `id-token: write`, publishes the validated tarball using `npm publish --tag rc --provenance`, and checks registry integrity, provenance, unchanged `latest`, exact-version and `@rc` clean installs, required exports, ABIs, and addresses.
 
 If npm accepted the version but post-publish verification failed, do not rerun the publish. Inspect the immutable version and repair only a wrong dist-tag through an interactive maintainer action protected by 2FA.
+
+For registry propagation failures only, follow the recovery procedure in `NPM_RELEASE.md`. Recovery must run from canonical `main`, accept only the original release tag as an ancestor plus the allowlisted release-only files, rebuild the exact package, rerun all release gates, and verify the registry without OIDC or publication.

--- a/.github/workflows/publish-contracts-v2.yml
+++ b/.github/workflows/publish-contracts-v2.yml
@@ -30,6 +30,7 @@ env:
   RELEASE_LINE: 0.4.0
   RELEASE_TAG: contracts-v2-v${{ inputs.release }}
   DIST_TAG: rc
+  LATEST_BASELINE: 0.3.0
   NPM_CONFIG_PROVENANCE: "true"
   REQUIRE_PROVENANCE: "true"
   RECOVERY_MODE: ${{ inputs.recovery }}
@@ -74,7 +75,7 @@ jobs:
             node scripts/npm-release.mjs guard "$PACKAGE_JSON" "$RELEASE_VERSION" "$DIST_TAG"
           fi
           latest=$(npm view @zkp2p/contracts-v2 dist-tags.latest)
-          test -n "$latest"
+          test "$latest" = "$LATEST_BASELINE"
           echo "latest=$latest" >> "$GITHUB_OUTPUT"
 
       - name: Require autonomous RC environment

--- a/.github/workflows/publish-contracts-v2.yml
+++ b/.github/workflows/publish-contracts-v2.yml
@@ -9,6 +9,11 @@ on:
         description: Exact 0.4.0-rc.N version committed on canonical main
         required: true
         type: string
+      recovery:
+        description: Verify an already-published immutable version after a post-publish propagation failure
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -27,10 +32,11 @@ env:
   DIST_TAG: rc
   NPM_CONFIG_PROVENANCE: "true"
   REQUIRE_PROVENANCE: "true"
+  RECOVERY_MODE: ${{ inputs.recovery }}
 
 jobs:
   validate:
-    name: Build, test, and pack
+    name: Build, validate, and pack
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     outputs:
@@ -50,7 +56,7 @@ jobs:
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22.14.0
-          package-manager-cache: false
+          cache: yarn
           registry-url: https://registry.npmjs.org
 
       - name: Pin release tooling
@@ -59,15 +65,14 @@ jobs:
           corepack enable
           test "$(npm --version)" = "11.9.0"
 
-      - name: Install pinned Foundry
-        uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
-        with:
-          version: ${{ env.FOUNDRY_VERSION }}
-
       - name: Guard canonical RC source and unpublished version
         id: release-guard
         run: |
-          node scripts/npm-release.mjs guard "$PACKAGE_JSON" "$RELEASE_VERSION" "$DIST_TAG"
+          if [ "$RECOVERY_MODE" = "true" ]; then
+            node scripts/npm-release.mjs recover "$PACKAGE_JSON" "$RELEASE_VERSION" "$DIST_TAG"
+          else
+            node scripts/npm-release.mjs guard "$PACKAGE_JSON" "$RELEASE_VERSION" "$DIST_TAG"
+          fi
           latest=$(npm view @zkp2p/contracts-v2 dist-tags.latest)
           test -n "$latest"
           echo "latest=$latest" >> "$GITHUB_OUTPUT"
@@ -88,16 +93,14 @@ jobs:
           set -a
           . ./.env.default
           set +a
-          yarn build
-
-      - name: Run complete Foundry suite
-        run: yarn test
+          yarn compile
 
       - name: Build and test package
         run: |
           yarn pkg:build
           yarn pkg:test
           yarn workspace @zkp2p/contracts-v2 verify:release
+          yarn test:release-policy
 
       - name: Pack exact publish candidate
         run: |
@@ -126,9 +129,69 @@ jobs:
           retention-days: 1
           compression-level: 0
 
+  foundry-tests:
+    name: Complete Foundry suite
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout canonical release commit
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Install pinned Foundry
+        uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+        with:
+          version: ${{ env.FOUNDRY_VERSION }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22.14.0
+          cache: yarn
+          registry-url: https://registry.npmjs.org
+
+      - name: Pin release tooling
+        run: |
+          npm install --global npm@11.9.0 corepack@0.34.0
+          corepack enable
+          test "$(npm --version)" = "11.9.0"
+
+      - name: Guard canonical release source
+        run: |
+          if [ "$RECOVERY_MODE" = "true" ]; then
+            node scripts/npm-release.mjs recover "$PACKAGE_JSON" "$RELEASE_VERSION" "$DIST_TAG"
+          else
+            node scripts/npm-release.mjs guard "$PACKAGE_JSON" "$RELEASE_VERSION" "$DIST_TAG"
+          fi
+
+      - name: Install immutable dependencies
+        run: yarn install --immutable
+
+      - name: Prepare local environment
+        run: cp .env.default .env
+
+      - name: Restore exact-source Foundry cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v5
+        with:
+          path: |
+            out
+            cache_forge
+          key: ${{ runner.os }}-foundry-${{ env.FOUNDRY_VERSION }}-${{ hashFiles('foundry.toml', 'contracts/**/*.sol', 'test-foundry/**/*.sol', 'lib/forge-std/src/**/*.sol') }}
+          restore-keys: |
+            ${{ runner.os }}-foundry-${{ env.FOUNDRY_VERSION }}-
+
+      - name: Run complete Foundry suite
+        run: yarn test
+
   publish:
     name: Publish with npm OIDC
-    needs: validate
+    needs: [validate, foundry-tests]
+    if: inputs.recovery == false
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     environment:
@@ -172,6 +235,73 @@ jobs:
         run: |
           tarball=$(node -e "const fs=require('fs'),p=require('path');const r=JSON.parse(fs.readFileSync(process.argv[1]))[0];process.stdout.write(p.join(process.argv[2],r.filename))" "$RUNNER_TEMP/npm-pack/pack.json" "$RUNNER_TEMP/npm-pack")
           npm publish "$tarball" --access public --tag rc --provenance
+
+      - name: Verify registry version, dist-tag, integrity, and contents
+        env:
+          EXPECTED_LATEST: ${{ needs.validate.outputs.latest-before }}
+        run: |
+          node scripts/npm-release.mjs verify "$PACKAGE_JSON" "$RELEASE_VERSION" "$DIST_TAG" "$RUNNER_TEMP/npm-pack/pack.json"
+          mkdir -p "$RUNNER_TEMP/registry-pack"
+          for attempt in {1..12}; do
+            if npm pack "@zkp2p/contracts-v2@$RELEASE_VERSION" --ignore-scripts --json --pack-destination "$RUNNER_TEMP/registry-pack" > "$RUNNER_TEMP/registry-pack.json"; then
+              break
+            fi
+            test "$attempt" -lt 12
+            sleep 5
+          done
+          node packages/contracts/scripts/verify-release.mjs --pack-json "$RUNNER_TEMP/registry-pack.json" --pack-dir "$RUNNER_TEMP/registry-pack"
+          for spec in "@zkp2p/contracts-v2@$RELEASE_VERSION" "@zkp2p/contracts-v2@rc"; do
+            smoke_dir=$(mktemp -d "$RUNNER_TEMP/npm-registry-smoke.XXXXXX")
+            cd "$smoke_dir"
+            npm init --yes
+            for attempt in {1..12}; do
+              if npm install "$spec" --ignore-scripts --no-audit --no-fund; then
+                break
+              fi
+              test "$attempt" -lt 12
+              sleep 5
+            done
+            node "$GITHUB_WORKSPACE/packages/contracts/scripts/smoke-installed.mjs" "$RELEASE_VERSION"
+          done
+
+  recover:
+    name: Verify published RC recovery
+    needs: [validate, foundry-tests]
+    if: inputs.recovery == true
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout release verification code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js and npm registry
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24.14.0
+          package-manager-cache: false
+          registry-url: https://registry.npmjs.org
+
+      - name: Pin release tooling
+        run: |
+          npm install --global npm@11.9.0
+          test "$(npm --version)" = "11.9.0"
+
+      - name: Re-check canonical recovery source
+        run: node scripts/npm-release.mjs recover "$PACKAGE_JSON" "$RELEASE_VERSION" "$DIST_TAG"
+
+      - name: Download validated tarball
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          name: ${{ env.PACK_ARTIFACT }}
+          path: ${{ runner.temp }}/npm-pack
+
+      - name: Verify downloaded tarball
+        run: node packages/contracts/scripts/verify-release.mjs --pack-json "$RUNNER_TEMP/npm-pack/pack.json" --pack-dir "$RUNNER_TEMP/npm-pack"
 
       - name: Verify registry version, dist-tag, integrity, and contents
         env:

--- a/NPM_RELEASE.md
+++ b/NPM_RELEASE.md
@@ -33,14 +33,16 @@ The validation job reads the environment and deployment-branch policy through Gi
 3. Merge only after all required checks pass.
 4. Create `contracts-v2-v<version>` at the exact canonical-main merge commit.
 5. Recheck the registry guard, tag SHA, workflow SHA, and tarball digest.
-6. Dispatch **Publish contracts-v2** from `main` with only the exact version input.
+6. Dispatch **Publish contracts-v2** from `main` with the exact version and leave `recovery` disabled.
 
 The workflow has no tag input. It accepts only `0.4.0-rc.N`, requires `workflow_dispatch`, canonical `main`, and the exact repository-controlled tag, then runs `npm publish --tag rc --provenance`. It has no PR-triggered publishing path and cannot publish a stable version or move `latest`.
 
 ## Release gates
 
-The workflow performs an immutable Yarn install, clean compilation, repository and package tests, exact Base/Base Staging deployment-output/address/ABI agreement, canonical source ABI verification, `npm pack` digest inspection, and clean installation/import from the exact tarball. It preserves those exact bytes for the OIDC publish job.
+The package-validation job performs an immutable Yarn install, compiles the contracts once, builds and tests the package, verifies exact Base/Base Staging deployment-output/address/ABI agreement and canonical source ABIs, inspects the `npm pack` digest, and clean-installs/imports the exact tarball. In parallel, the complete Foundry suite runs in a separate job with the same exact-source `out`/`cache_forge` cache used by normal CI. Publication and recovery require both jobs, so the full suite remains a release gate without serializing package construction behind it.
 
 After publication it verifies the immutable registry integrity and provenance, confirms `rc` points to the new version and `latest` is unchanged, downloads and inspects the registry tarball, and clean-installs both the exact version and `@rc`.
 
-If npm accepts the version but a later verification fails, do not rerun publication. npm versions are immutable; repair through a new RC forward-fix unless evidence proves only the `rc` tag needs an interactive, 2FA-protected correction.
+If npm accepts the version but a later verification fails because registry metadata or tarball propagation lagged, do not rerun publication. First verify the exact version, `rc` tag, unchanged `latest`, integrity, and package contents. A focused recovery commit may then change only this runbook, the publishing workflow, release script, or publishing skill, after which the workflow can be dispatched with `recovery` enabled. Recovery requires the original release tag to be an ancestor of canonical `main`, rebuilds and revalidates the package, runs the full Foundry gate, and performs registry checks without `id-token: write` or `npm publish`.
+
+For a content, integrity, or dist-tag mismatch, do not use recovery. npm versions are immutable; publish a new RC forward-fix unless an interactive, 2FA-protected `rc` correction is separately approved.

--- a/NPM_RELEASE.md
+++ b/NPM_RELEASE.md
@@ -35,7 +35,7 @@ The validation job reads the environment and deployment-branch policy through Gi
 5. Recheck the registry guard, tag SHA, workflow SHA, and tarball digest.
 6. Dispatch **Publish contracts-v2** from `main` with the exact version and leave `recovery` disabled.
 
-The workflow has no tag input. It accepts only `0.4.0-rc.N`, requires `workflow_dispatch`, canonical `main`, and the exact repository-controlled tag, then runs `npm publish --tag rc --provenance`. It has no PR-triggered publishing path and cannot publish a stable version or move `latest`.
+The workflow has no tag input. It accepts only `0.4.0-rc.N`, requires `workflow_dispatch`, canonical `main`, the exact repository-controlled tag, and the repository-controlled pre-release `latest` baseline (`0.3.0` for this RC line), then runs `npm publish --tag rc --provenance`. It has no PR-triggered publishing path and cannot publish a stable version or move `latest`.
 
 ## Release gates
 

--- a/scripts/npm-release.mjs
+++ b/scripts/npm-release.mjs
@@ -13,8 +13,8 @@ function fail(message) {
   process.exit(1);
 }
 
-if (!['guard', 'verify'].includes(command) || !packageJsonArg || !release || !tag) {
-  fail('usage: npm-release.mjs <guard|verify> <package.json> <version> rc [pack.json]');
+if (!['guard', 'recover', 'verify'].includes(command) || !packageJsonArg || !release || !tag) {
+  fail('usage: npm-release.mjs <guard|recover|verify> <package.json> <version> rc [pack.json]');
 }
 
 const packageJsonPath = path.resolve(packageJsonArg);
@@ -49,7 +49,7 @@ async function readJson(url, allowedStatuses = [200]) {
   return response.status === 404 ? null : response.json();
 }
 
-if (command === 'guard') {
+if (command === 'guard' || command === 'recover') {
   if (process.env.GITHUB_ACTIONS === 'true') {
     if (process.env.GITHUB_EVENT_NAME !== 'workflow_dispatch') {
       fail(`publishing requires workflow_dispatch, received ${process.env.GITHUB_EVENT_NAME}`);
@@ -73,12 +73,38 @@ if (command === 'guard') {
       fail(`canonical main is ${currentMain}, not workflow SHA ${process.env.GITHUB_SHA}`);
     }
     if (taggedCommit !== process.env.GITHUB_SHA) {
-      fail(`release tag ${expectedTag} points to ${taggedCommit}, not workflow SHA ${process.env.GITHUB_SHA}`);
+      if (command !== 'recover') {
+        fail(`release tag ${expectedTag} points to ${taggedCommit}, not workflow SHA ${process.env.GITHUB_SHA}`);
+      }
+      try {
+        execFileSync('git', ['merge-base', '--is-ancestor', taggedCommit, checkedOutCommit]);
+      } catch {
+        fail(`recovery requires release tag ${expectedTag} to be an ancestor of canonical main`);
+      }
+      const changedFiles = execFileSync(
+        'git',
+        ['diff', '--name-only', `${taggedCommit}..${checkedOutCommit}`],
+        { encoding: 'utf8' },
+      )
+        .trim()
+        .split('\n')
+        .filter(Boolean);
+      const allowedRecoveryChanges = new Set([
+        '.agents/skills/zkp2p-contracts-publish/SKILL.md',
+        '.github/workflows/publish-contracts-v2.yml',
+        'NPM_RELEASE.md',
+        'scripts/npm-release.mjs',
+      ]);
+      const unexpectedChanges = changedFiles.filter((file) => !allowedRecoveryChanges.has(file));
+      if (unexpectedChanges.length > 0) {
+        fail(`recovery main differs from the release tag outside recovery code: ${unexpectedChanges.join(', ')}`);
+      }
     }
   }
   const existing = await readJson(versionUrl, [200, 404]);
-  if (existing) fail(`${packageJson.name}@${release} is already published`);
-  console.log(`Release guard passed for ${packageJson.name}@${release} with dist-tag ${tag}.`);
+  if (command === 'guard' && existing) fail(`${packageJson.name}@${release} is already published`);
+  if (command === 'recover' && !existing) fail(`${packageJson.name}@${release} is not published`);
+  console.log(`${command === 'guard' ? 'Release' : 'Recovery'} guard passed for ${packageJson.name}@${release} with dist-tag ${tag}.`);
   process.exit(0);
 }
 


### PR DESCRIPTION
Summary:
- run package validation and the complete Foundry suite concurrently
- restore the same exact-source Foundry cache used by normal CI
- add a fail-closed verification-only recovery path for registry propagation failures
- update the repository publishing skill and runbook

Validation:
- package compile, build, Jest, release integrity, and release-policy tests passed locally
- full Foundry suite is intentionally delegated to the authoritative PR CI gate