### PR TITLE
docs: tighten audit and release skills

### DIFF
--- a/.agents/skills/zkp2p-contracts-publish/SKILL.md
+++ b/.agents/skills/zkp2p-contracts-publish/SKILL.md
@@ -34,6 +34,22 @@ Do not carry a version from an older release or this skill.
 Query the live npm registry and select the first unused candidate permitted by
 the current policy. Every npm version is immutable.
 
+## Canonical release source
+
+Do not trust a checkout's `origin`, a contributor fork, or a legacy redirect.
+Resolve the release source through the canonical repository explicitly:
+
+```bash
+canonical_main_ref=refs/remotes/zkp2p-canonical/main
+git fetch --no-tags https://github.com/zkp2p/zkp2p-contracts.git \
+  "+main:${canonical_main_ref}"
+git rev-parse "$canonical_main_ref"
+git rev-parse HEAD
+```
+
+Tags, workflow dispatch, package version, and CI evidence must all resolve to
+the same canonical-main commit.
+
 ## Modes and approvals
 
 - Audit: read registry, workflow, package, tags, and CI only.

--- a/.agents/skills/zkp2p-contracts-publish/SKILL.md
+++ b/.agents/skills/zkp2p-contracts-publish/SKILL.md
@@ -1,35 +1,65 @@
 ---
 name: zkp2p-contracts-publish
 description: >
-  Prepare and publish @zkp2p/contracts-v2 through the protected GitHub Actions
-  trusted-publishing workflow. Use for RC version selection, release validation,
-  ABI/address checks, fast CI-equivalent Foundry gating, npm OIDC publication,
-  registry verification, or safe post-publish recovery.
+  Prepare, initiate, and verify @zkp2p/contracts-v2 releases through the
+  repository's protected GitHub Actions trusted publisher. Use for release-line
+  discovery, RC selection, package and address validation, pinned Foundry
+  gating, npm OIDC publication, registry verification, or post-publish
+  recovery. Never hard-code a release line or publish locally.
 ---
 
-# `@zkp2p/contracts-v2` trusted release
+# Trusted contracts package release
 
-Read `NPM_RELEASE.md` completely before preparing or initiating a release. Do not use local `npm publish`, `npm dist-tag`, an OTP, or an `NPM_TOKEN` as the normal release path.
+Read `NPM_RELEASE.md`, the active publishing workflow, package manifest, and
+release-policy scripts completely before preparing a release. The repository
+policy and workflow are authoritative.
 
-## Package and workflow
+Do not use local `npm publish`, `npm dist-tag`, an OTP, `NPM_TOKEN`, or another
+developer credential as the normal release path.
 
-- Package: `packages/contracts/`
-- Version source: `packages/contracts/package.json`
-- Workflow: `.github/workflows/publish-contracts-v2.yml`
-- Autonomous RC environment: `npm-publish-rc`
-- Registry tag: hard-coded `rc`
+## Determine the current policy
 
-The workflow must be dispatched from `main`. Its `release` input must exactly match the committed `0.4.0-rc.N` package version, the repository-controlled `contracts-v2-v<version>` tag must point to that same main commit, and live `latest` must match the repository-controlled `0.3.0` baseline. Every version must be new on npm.
+Read, do not assume:
+
+- package name and candidate from `packages/contracts/package.json`;
+- release line, dist-tag, latest baseline, environment, and allowed input shape
+  from `.github/workflows/publish-contracts-v2.yml`;
+- canonical tag format and recovery allowlist from `NPM_RELEASE.md`;
+- pinned Foundry version from the active CI and publish workflows.
+
+Derive the release line by removing the allowed prerelease suffix from the
+package candidate and require it to equal the workflow's release-line policy.
+Do not carry a version from an older release or this skill.
+
+Query the live npm registry and select the first unused candidate permitted by
+the current policy. Every npm version is immutable.
+
+## Modes and approvals
+
+- Audit: read registry, workflow, package, tags, and CI only.
+- Prepare: change version and consumer-facing metadata in a focused PR.
+- RC publish: requires explicit approval for the exact version, commit, tag,
+  dist-tag, and workflow dispatch.
+- Stable publish: requires separate explicit approval and a repository workflow
+  that implements stable publication.
+
+If stable publication is not implemented by current policy, stop. Do not adapt
+the RC workflow or publish locally.
 
 ## Prepare the version PR
 
-Set the first unused `0.4.0-rc.N` version. Stable or `latest` publishing is a separate future workflow and is not implemented here. Do not reuse or overwrite an npm version.
+Keep package version, release-policy files, and consumer-visible documentation
+consistent. Confirm package repository metadata points to
+`https://github.com/zkp2p/zkp2p-contracts.git`.
 
-Update the package README or changelog for consumer-visible changes. Confirm `repository.url` remains exactly `https://github.com/zkp2p/zkp2p-contracts.git` for npm OIDC provenance.
+Do not create or move a release tag before the version PR merges to canonical
+`main`. Do not reuse an existing registry version.
 
-## Fast preflight and full test gate
+## Local preflight
 
-Do not rerun the full Foundry suite serially before a release when the exact commit already passed normal CI. Run the package-specific preflight locally from a clean checkout:
+Use a clean checkout and the repository-pinned Node/Yarn/Foundry setup. Confirm
+local `forge --version` matches the active workflow pin; otherwise rely on CI
+for Foundry evidence rather than claiming parity.
 
 ```bash
 yarn install --immutable
@@ -38,24 +68,64 @@ yarn pkg:build
 yarn pkg:test
 yarn workspace @zkp2p/contracts-v2 verify:release
 yarn test:release-policy
-(cd packages/contracts && npm pack --dry-run)
+(cd packages/contracts && npm pack --dry-run --ignore-scripts --json)
 ```
 
-The verification derives required ABIs and addresses from the current hard-cut package and must match exact Base/Base Staging deployment artifacts. Normal CI and the publishing workflow remain authoritative for the complete Foundry suite.
+The release verifier must prove current hard-cut package exports, canonical
+source ABIs, and exact Base/Base Staging deployment addresses.
 
-The release workflow mirrors CI's fast structure:
+Do not rerun the complete Foundry suite locally when the exact commit is already
+green in current CI. The publish workflow's pinned full-suite job remains an
+authoritative gate and must not be weakened or skipped.
 
-- package compile, integrity checks, pack, and tarball smoke test run in one job;
-- the complete Foundry suite runs concurrently in another job;
-- the Foundry job restores `out` and `cache_forge` from a key derived from `foundry.toml`, Solidity sources, Foundry tests, and `forge-std`;
-- publication requires both jobs, so optimization must never remove or weaken the full-suite gate.
+## Initiate
 
-## Initiate and verify
+After merge and current CI:
 
-After the version PR and normal CI merge to `main`, create `contracts-v2-v<version>` at the exact merge commit and dispatch **Publish contracts-v2** from `main` with the exact version. The `npm-publish-rc` environment has no reviewer or secret and permits only `main`, so RC publication is autonomous.
+1. Resolve canonical `main` and its exact commit.
+2. Confirm the candidate is still unused in npm.
+3. Obtain explicit approval to create the exact release tag and dispatch the
+   trusted workflow for the named version, commit, release line, and dist-tag.
+4. Create the repository-controlled package tag required by current policy at
+   that exact commit.
+5. Recheck tag SHA, workflow SHA, package version, release line, dist-tag, and
+   latest baseline.
+6. Dispatch the trusted publishing workflow from canonical `main`. If any
+   checked value changed after approval, stop and obtain new approval.
 
-The publish job uses OIDC with `id-token: write`, publishes the validated tarball using `npm publish --tag rc --provenance`, and checks registry integrity, provenance, unchanged `latest`, exact-version and `@rc` clean installs, required exports, ABIs, and addresses.
+The publish job must use GitHub OIDC provenance and the protected environment
+defined by current policy.
 
-If npm accepted the version but post-publish verification failed, do not rerun the publish. Inspect the immutable version and repair only a wrong dist-tag through an interactive maintainer action protected by 2FA.
+## Verify
 
-For registry propagation failures only, follow the recovery procedure in `NPM_RELEASE.md`. Recovery must run from canonical `main` with `release_run_id` set to the original non-recovery publish run whose validated tarball npm accepted, accept only the original release tag as an ancestor plus the allowlisted release-only files, rebuild the package, rerun all release gates, compare registry integrity to that original validated tarball, and verify the registry without OIDC or publication.
+Require:
+
+- workflow validation and pinned Foundry jobs passed for the published commit;
+- npm exact version and intended dist-tag match;
+- stable/latest remains unchanged for an RC;
+- registry integrity and provenance match the validated tarball;
+- clean installs of the exact version and intended tag expose required ABIs,
+  addresses, and module formats.
+
+## Recovery
+
+If npm accepted an immutable version but registry propagation caused only a
+post-publish verification failure, follow `NPM_RELEASE.md` recovery exactly.
+Recovery verifies; it must not obtain OIDC publication authority or republish.
+
+Recovery must run from canonical `main` with `release_run_id` set to the
+original non-recovery publish run whose validated tarball npm accepted. Require
+the original release tag to be an ancestor, permit only the runbook's
+allowlisted release-only files after that tag, rebuild the package, rerun every
+release gate, compare registry integrity to the original validated tarball, and
+verify the registry without OIDC publication authority.
+
+For content, integrity, version, provenance, or dist-tag disagreement, stop and
+prepare a new forward-fix version unless current policy explicitly authorizes a
+protected maintainer correction. Never rerun publication blindly.
+
+## Report
+
+Report current release policy, derived release line, exact candidate, source and
+tag SHAs, approvals, local preflight, pinned CI/Foundry evidence, workflow URL,
+registry/provenance verification, and any stable boundary left unimplemented.

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: audit
 description: >
-  Review zkp2p-contracts for branch-introduced security and correctness issues.
-  Use for full audits, current-branch differential reviews, pull-request
-  reviews, focused invariant checks, or V2-to-V3 scaffold parity checks. Resolve
-  a fresh canonical main baseline, stay read-only unless the user explicitly
-  requests an artifact, and separate blocking findings from inherited,
-  theoretical, unavailable, or baseline issues.
+  Review zkp2p-contracts for security and correctness issues. Use for full
+  audits, current-branch differential reviews, pull-request reviews, focused
+  invariant checks, or V2-to-V3 invariant parity checks. Resolve a fresh
+  canonical main baseline, stay read-only unless the user explicitly requests
+  an artifact, and apply branch-introduction gates only to differential work.
 ---
 
 # Audit zkp2p-contracts
@@ -20,25 +19,28 @@ commit, push, or open a PR unless the user explicitly asks for that mutation.
 - `diff`: review the current branch against canonical `main`.
 - `pr <number>`: review the current head of the named PR.
 - `check <area>`: inspect one invariant, contract, or failure class.
-- `v3-parity`: verify that the retained OrchestratorV3 scaffold has not diverged
-  from OrchestratorV2 beyond its explicitly allowed identity changes.
+- `v3-parity`: verify shared V2/V3 invariants while preserving the current
+  intentional V3 lifecycle, hook, settlement, and deployment differences.
 
 If the request is explanatory or read-only, do not compile or test unless the
 answer depends on execution.
 
 ## Establish current evidence
 
-The canonical repository is `zkp2p/zkp2p-contracts`. Follow a legacy remote
-redirect to that owner; never substitute a similarly named repository.
+The canonical repository is `zkp2p/zkp2p-contracts`. Do not trust a checkout's
+remote name, contributor fork, or legacy redirect as proof of that baseline.
 
 For a branch review:
 
 ```bash
-git fetch origin main
-git rev-parse origin/main
+git remote get-url origin
+canonical_main_ref=refs/remotes/zkp2p-canonical/main
+git fetch --no-tags https://github.com/zkp2p/zkp2p-contracts.git \
+  "+main:${canonical_main_ref}"
+git rev-parse "$canonical_main_ref"
 git rev-parse HEAD
-git diff --stat origin/main...HEAD
-git diff --name-status origin/main...HEAD
+git diff --stat "$canonical_main_ref...HEAD"
+git diff --name-status "$canonical_main_ref...HEAD"
 ```
 
 For a PR, resolve its current head and diff through connected GitHub or `gh`,
@@ -64,16 +66,21 @@ and deployment consumers. Do not expand into unrelated cleanup.
 
 ## Finding standard
 
-A blocking finding must be:
+For `diff` and `pr` modes, a blocking finding must be:
 
-1. introduced by the reviewed branch or PR;
+1. introduced or materially worsened by the reviewed branch or PR;
 2. material to correctness, security, deployment, or a named invariant;
 3. reproducible or supported by current code evidence;
 4. actionable within the branch's ownership boundary.
 
-Report inherited bugs, baseline failures, theoretical risks, unavailable
-checks, and pending CI separately. Do not block a branch on them unless the
-branch materially worsens the condition.
+For `full`, `check`, and `v3-parity`, classify every material finding supported
+by the selected revision, regardless of when it entered the repository. Label
+inherited or baseline findings accurately; branch ownership limits the proposed
+remediation, not whether the audit may report the issue.
+
+In differential work, report inherited bugs, baseline failures, theoretical
+risks, unavailable checks, and pending CI separately. Do not block that branch
+on them unless it materially worsens the condition.
 
 For every finding include severity, tight file/line scope, concrete failure
 path, impact, and smallest corrective action. Do not inflate style preferences
@@ -93,24 +100,37 @@ Check the invariants relevant to the scope:
 - package ABIs and addresses match canonical source and deployment artifacts;
 - historical artifacts remain historical and cannot reactivate old semantics.
 
-## OrchestratorV3 scaffold parity
+## OrchestratorV3 invariant parity
 
-`OrchestratorV3` and `IOrchestratorV3` are future scaffolds, not an active
-deployment lane. When either V2 or V3 source changes:
+`OrchestratorV3` is a dedicated current implementation with a mounted
+Base-staging lifecycle lane, not a textual V2 scaffold. Current source retains
+the relayer-gated multi-intent admission and core escrow, fee, registry, and
+payment-verification boundaries. It intentionally replaces the V2
+deposit-whitelist-hook path with a governance-selected lifecycle hook
+snapshotted per intent and fail-closed callbacks across signal, cancellation,
+fulfillment, and manual release.
 
-1. Diff `OrchestratorV2.sol` against `OrchestratorV3.sol`.
-2. Diff `IOrchestratorV2.sol` against `IOrchestratorV3.sol`.
-3. Normalize only the contract/interface import, identifier, title, and
-   version-specific documentation.
-4. Require the remaining source diff to be empty unless the task explicitly
-   authorizes V3 behavior.
-5. Confirm V3 is absent from active deploy scripts, deployment outputs, package
-   addresses, and production cutover instructions.
+When either V2 or V3 source changes:
 
-If an exact parity claim matters, run the smallest compile needed and compare
-ABI, storage layout, selectors, and normalized runtime bytecode with compiler
-metadata and version identifiers handled explicitly. Do not call the scaffold
-byte-identical based only on a visual source diff.
+1. Diff both implementations and interfaces against canonical current main.
+2. Derive the intended V3 deltas from current interfaces, lifecycle tests,
+   deployment tests, and `deploy/30_deploy_v3_lifecycle_stack.ts`; do not copy an
+   allowlist from an older review.
+3. Verify shared admission, fee, escrow, registry, payment-verifier, nullifier,
+   replay, authorization, and settlement invariants semantically.
+4. Verify the V3 lifecycle-hook snapshot, callback ordering, fail-closed
+   behavior, reentrancy protection, cancellation/pruning, and chargeback/stake
+   ownership boundaries with the closest deterministic, fuzz, invariant, and
+   integration tests.
+5. Inspect `scripts/deployActive.ts`, lane `30` network guards and `skip`
+   behavior, Base-staging artifacts, package addresses, and live state
+   separately. A mounted script or checked-in artifact is not production or
+   live-state evidence.
+
+Do not require the remaining V2/V3 source diff to be empty and do not normalize
+away a lifecycle, storage, governance, or settlement delta. If bytecode,
+storage, ABI, or selector parity is claimed for a shared component, prove that
+specific claim with the pinned compiler and explicit metadata handling.
 
 ## Validation
 
@@ -128,7 +148,7 @@ and local results separately.
 
 ## Output
 
-Lead with findings in severity order. If none meet the blocker standard, say so
-and list residual risks or unavailable evidence. Include base/head SHAs, scope,
-checks run, baseline failures, branch failures, pending CI, and whether V3
-parity was applicable.
+Lead with findings in severity order. If none meet the applicable mode's
+finding standard, say so and list residual risks or unavailable evidence.
+Include base/head SHAs, scope, checks run, baseline failures, branch failures,
+pending CI, and whether V3 invariant parity was applicable.

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,161 +1,134 @@
 ---
 name: audit
-description: Run security audits on ZKP2P V2 contracts using Trail of Bits security skills. Supports full audits, differential PR reviews, and individual security checks.
+description: >
+  Review zkp2p-contracts for branch-introduced security and correctness issues.
+  Use for full audits, current-branch differential reviews, pull-request
+  reviews, focused invariant checks, or V2-to-V3 scaffold parity checks. Resolve
+  a fresh canonical main baseline, stay read-only unless the user explicitly
+  requests an artifact, and separate blocking findings from inherited,
+  theoretical, unavailable, or baseline issues.
 ---
 
-# /audit — Security Audit Skill
+# Audit zkp2p-contracts
 
-Run structured security audits on ZKP2P V2 contracts.
+Default to a read-only review. Do not edit code, write an audit report, stage,
+commit, push, or open a PR unless the user explicitly asks for that mutation.
 
 ## Modes
 
-Parse the argument to determine mode:
+- `full`: inspect the requested contracts and their security boundaries.
+- `diff`: review the current branch against canonical `main`.
+- `pr <number>`: review the current head of the named PR.
+- `check <area>`: inspect one invariant, contract, or failure class.
+- `v3-parity`: verify that the retained OrchestratorV3 scaffold has not diverged
+  from OrchestratorV2 beyond its explicitly allowed identity changes.
 
-| Invocation | Mode | Description |
-|-----------|------|-------------|
-| `/audit` or `/audit full` | Full | 10-step comprehensive audit |
-| `/audit diff` | Differential | Review current branch vs main |
-| `/audit pr <number>` | Differential | Review a specific PR |
-| `/audit check <skill>` | Single | Run one security skill |
-| `/audit maturity` | Single | Quick code maturity assessment |
-| `/audit entries` | Single | Entry point mapping only |
+If the request is explanatory or read-only, do not compile or test unless the
+answer depends on execution.
 
-## Mode: Full Audit
+## Establish current evidence
 
-Run the 10-step workflow. This is thorough and takes time.
+The canonical repository is `zkp2p/zkp2p-contracts`. Follow a legacy remote
+redirect to that owner; never substitute a similarly named repository.
 
-### Step 1: Scope
-Confirm scope. Default is all V2 contracts:
-```
-contracts/EscrowV2.sol
-contracts/OrchestratorV2.sol
-contracts/RateManagerV1.sol
-contracts/ProtocolViewerV2.sol
-contracts/unifiedVerifier/
-contracts/registries/
-contracts/hooks/
-contracts/oracles/
-contracts/lib/
-```
-Excluded: `contracts/mocks/`, `contracts/external/`, `contracts/archive/`, V1 contracts (`Escrow.sol`, `Orchestrator.sol`, `ProtocolViewer.sol`).
+For a branch review:
 
-### Step 2: Entry Point Mapping
-```
-Run skill: entry-point-analyzer:entry-point-analyzer
-Scope: contracts/ (V2 only)
-```
-Save raw output to `audits/_scratch/entry-points.md`.
-
-### Step 3: Code Maturity Assessment
-```
-Run skill: building-secure-contracts:code-maturity-assessor
-Scope: contracts/ (V2 only)
-```
-Save raw output to `audits/_scratch/code-maturity.md`.
-
-### Step 4: Guidelines Check
-```
-Run skill: building-secure-contracts:guidelines-advisor
-Scope: contracts/ (V2 only)
-```
-Save raw output to `audits/_scratch/guidelines.md`.
-
-### Step 5: Static Analysis
-```
-Run skill: static-analysis:semgrep
-Scope: contracts/ (exclude mocks, archive, external)
-```
-Save raw output to `audits/_scratch/semgrep.md`.
-
-### Step 6: Token Integration
-```
-Run skill: building-secure-contracts:token-integration-analyzer
-Focus: USDC (ERC20) integration in EscrowV2, OrchestratorV2
-```
-Save raw output to `audits/_scratch/token-integration.md`.
-
-### Step 7: Sharp Edges
-```
-Run skill: sharp-edges:sharp-edges
-Scope: contracts/ (V2 only)
-```
-Save raw output to `audits/_scratch/sharp-edges.md`.
-
-### Step 8: Deep Context
-Based on findings from steps 2-7, identify the 3-5 highest-risk functions. Then:
-```
-Run skill: audit-context-building:audit-context-building
-Focus: identified high-risk functions
-```
-Save raw output to `audits/_scratch/deep-context.md`.
-
-### Step 9: Property Testing Recommendations
-```
-Run skill: property-based-testing:property-based-testing
-Focus: key invariants (liquidity conservation, fee bounds, nullifier uniqueness, expiry, oracle floors, access control)
-```
-Save raw output to `audits/_scratch/property-testing.md`.
-
-### Step 10: Synthesize Report
-1. Read all `audits/_scratch/*.md` outputs
-2. Read `audits/templates/full-audit-template.md`
-3. Deduplicate findings across tools
-4. Assign severity: CRITICAL / HIGH / MEDIUM / LOW / INFORMATIONAL
-5. Write final report to `audits/full/YYYY-MM-DD-full-audit.md`
-6. Get current commit SHA: `git rev-parse --short HEAD`
-7. Stage and commit:
-   ```bash
-   git add audits/full/YYYY-MM-DD-full-audit.md
-   git commit -m "audit: full security audit at <sha>"
-   ```
-
-## Mode: Differential Review
-
-### Step 1: Determine Diff Range
-- If `/audit diff`: compare current branch to `main`
-- If `/audit pr <number>`: fetch PR diff with `gh pr diff <number>`
-- List changed files, filter to `contracts/` only
-- If no contract changes, report "No contracts changed" and exit
-
-### Step 2: Run Differential Review
-```
-Run skill: differential-review:differential-review
-Input: the diff from step 1
+```bash
+git fetch origin main
+git rev-parse origin/main
+git rev-parse HEAD
+git diff --stat origin/main...HEAD
+git diff --name-status origin/main...HEAD
 ```
 
-### Step 3: Deep Dive (conditional)
-If any HIGH or CRITICAL findings from step 2:
-```
-Run skill: audit-context-building:audit-context-building
-Focus: functions containing critical findings
-```
+For a PR, resolve its current head and diff through connected GitHub or `gh`,
+then record both base and head SHAs. Review the current head again before merge.
+Do not ask the user to paste a diff when repository access is available.
 
-### Step 4: Write Report
-1. Read `audits/templates/differential-template.md`
-2. Fill in findings, blast radius, test coverage assessment
-3. Write to `audits/differential/YYYY-MM-DD-pr-<number>.md` or `audits/differential/YYYY-MM-DD-<branch>.md`
-4. Stage and commit:
-   ```bash
-   git add audits/differential/YYYY-MM-DD-*.md
-   git commit -m "audit: differential review of PR #<number> at <sha>"
-   ```
+If fresh remote evidence is unavailable, state that limitation and do not
+present a stale local ref as current.
 
-## Mode: Single Check
+## Scope
 
-Run one specific skill and print results inline. Do NOT commit unless user asks.
+Map the exact changed or requested surface:
 
-| Shortcut | Skill |
-|----------|-------|
-| `semgrep` | `static-analysis:semgrep` |
-| `codeql` | `static-analysis:codeql` |
-| `maturity` | `building-secure-contracts:code-maturity-assessor` |
-| `guidelines` | `building-secure-contracts:guidelines-advisor` |
-| `entries` | `entry-point-analyzer:entry-point-analyzer` |
-| `token` | `building-secure-contracts:token-integration-analyzer` |
-| `sharp` | `sharp-edges:sharp-edges` |
-| `context <function>` | `audit-context-building:audit-context-building` |
-| `variants <pattern>` | `variant-analysis:variant-analysis` |
-| `property` | `property-based-testing:property-based-testing` |
-| `prep` | `building-secure-contracts:audit-prep-assistant` |
-| `workflow` | `building-secure-contracts:secure-workflow-guide` |
-| `rules` | `semgrep-rule-creator:semgrep-rule-creator` |
+- production contracts, interfaces, libraries, and inherited code;
+- storage layout, authorization, accounting, settlement, replay, and
+  reentrancy boundaries;
+- deploy scripts, governance batches, registries, permissions, and skip logic;
+- deployment artifacts, package extraction, ABIs, addresses, and consumers;
+- closest deterministic, fuzz, invariant, integration, and deployment tests.
+
+Use direct searches for imports, calls, selectors, events, errors, fixtures,
+and deployment consumers. Do not expand into unrelated cleanup.
+
+## Finding standard
+
+A blocking finding must be:
+
+1. introduced by the reviewed branch or PR;
+2. material to correctness, security, deployment, or a named invariant;
+3. reproducible or supported by current code evidence;
+4. actionable within the branch's ownership boundary.
+
+Report inherited bugs, baseline failures, theoretical risks, unavailable
+checks, and pending CI separately. Do not block a branch on them unless the
+branch materially worsens the condition.
+
+For every finding include severity, tight file/line scope, concrete failure
+path, impact, and smallest corrective action. Do not inflate style preferences
+into security findings.
+
+## Review invariants
+
+Check the invariants relevant to the scope:
+
+- authorization and ownership transitions fail closed;
+- locked and unlocked value, fees, refunds, and transfers conserve value;
+- nullifiers and payment identifiers cannot be replayed;
+- signatures bind the intended chain, deployment, contract, actor, amount, and
+  expiration;
+- registry and verifier cutovers remove retired active paths;
+- deploy scripts are idempotent only for the exact intended state;
+- package ABIs and addresses match canonical source and deployment artifacts;
+- historical artifacts remain historical and cannot reactivate old semantics.
+
+## OrchestratorV3 scaffold parity
+
+`OrchestratorV3` and `IOrchestratorV3` are future scaffolds, not an active
+deployment lane. When either V2 or V3 source changes:
+
+1. Diff `OrchestratorV2.sol` against `OrchestratorV3.sol`.
+2. Diff `IOrchestratorV2.sol` against `IOrchestratorV3.sol`.
+3. Normalize only the contract/interface import, identifier, title, and
+   version-specific documentation.
+4. Require the remaining source diff to be empty unless the task explicitly
+   authorizes V3 behavior.
+5. Confirm V3 is absent from active deploy scripts, deployment outputs, package
+   addresses, and production cutover instructions.
+
+If an exact parity claim matters, run the smallest compile needed and compare
+ABI, storage layout, selectors, and normalized runtime bytecode with compiler
+metadata and version identifiers handled explicitly. Do not call the scaffold
+byte-identical based only on a visual source diff.
+
+## Validation
+
+Follow `AGENTS.md`:
+
+- markdown or explanation only: `git diff --check` when there is a diff;
+- one behavior: closest deterministic Foundry target;
+- shared accounting, authorization, settlement, storage, or reentrancy:
+  affected deterministic plus relevant fuzz/invariant, then one full suite only
+  at the finalized state when justified;
+- package or public ABI: package release checks after focused contract tests.
+
+Use the repository-pinned Foundry toolchain for executed evidence. Report CI
+and local results separately.
+
+## Output
+
+Lead with findings in severity order. If none meet the blocker standard, say so
+and list residual risks or unavailable evidence. Include base/head SHAs, scope,
+checks run, baseline failures, branch failures, pending CI, and whether V3
+parity was applicable.

--- a/.claude/skills/ship-contracts/SKILL.md
+++ b/.claude/skills/ship-contracts/SKILL.md
@@ -1,366 +1,129 @@
 ---
 name: ship-contracts
-description: >-
-  Full deployment pipeline for ZKP2P V2 contracts scoped to this repo. Phases:
-  write deploy script + tests, run on localhost, deploy to staging (test, verify,
-  commit, publish RC), deploy to prod (test, verify, commit, publish stable).
-  Use when the user says "ship contracts", "deploy contracts", "deploy staging",
-  "deploy prod", "redeploy escrow", "full deploy pipeline", or "ship it" in the
-  contracts repo context.
+description: >
+  Prepare and coordinate zkp2p-contracts deployment changes across source,
+  staging activation, production activation, package export, RC publication,
+  and stable publication. Use when asked to ship or deploy contracts. Keep
+  these as separately reviewed and approved boundaries, use hard cutovers, and
+  delegate every package release to zkp2p-contracts-publish.
 ---
 
-# Ship Contracts
+# Ship contracts
 
-End-to-end deployment pipeline for ZKP2P V2 contracts. Follows a staged gate model: each phase must pass before moving to the next.
+Shipping is not one automatic pipeline. Treat each boundary as an independent
+deliverable with its own evidence and explicit authorization:
 
-```
-Phase 0: Script    Write deploy script + deploy tests
-Phase 1: Local     Deploy to localhost, run full test suite + deploy tests
-Phase 2: Staging   Deploy, test, verify etherscan, commit artifacts, publish RC package
-Phase 3: Prod      Deploy, test, verify etherscan, commit artifacts, publish stable package
-```
+1. source and deployment scaffold;
+2. staging activation;
+3. production activation;
+4. package export;
+5. RC publication;
+6. stable publication.
 
-The user may enter at any phase (e.g., skip to Phase 2 if the script already exists and local testing is done). Ask which phase to start from if unclear.
+Approval for one boundary does not authorize the next. Never infer production,
+RC, or stable approval from "deploy staging" or "ship the code."
 
----
+## Establish current state
 
-## Phase 0: Write Deploy Script + Tests
+Use canonical `zkp2p/zkp2p-contracts`, fetch `origin/main`, and record the source
+SHA, deployment artifacts, active runner, package version, and live target
+network before preparing a plan.
 
-**Goal:** Create the deploy script and its corresponding deploy test.
+Read:
 
-### 0a. Determine the next script number
+- `AGENTS.md`;
+- the affected contracts and interfaces;
+- `scripts/deployActive.ts`;
+- the closest current deploy scripts and Foundry deployment tests;
+- `deployments/parameters.ts`, target artifacts, and package extraction;
+- `.agents/skills/zkp2p-contracts-publish/SKILL.md` for any release.
 
-```bash
-ls deploy/*.ts | sort | tail -5
-```
+Do not route through the legacy repository name or an archived deployment lane.
 
-Pick the next available `NN_` prefix (e.g., if last is `23_`, use `24_`).
+## Boundary 1: source and deployment scaffold
 
-### 0b. Write the deploy script
+Create the smallest source, interface, deployment, and test changes that encode
+the approved target state.
 
-Create `deploy/NN_description.ts` following the pattern in existing redeploy scripts (e.g., `deploy/19_redeploy_escrowv2_orchestratorv2_staging.ts`).
+- Keep source scaffolding distinct from deployment activation.
+- Do not add a deploy script merely because source exists.
+- Do not activate future `OrchestratorV3` scaffolding without a separately
+  approved V3 deployment design.
+- Remove retired active routes, permissions, exports, and aliases in the same
+  hard cutover.
+- Do not add rollback compatibility to a one-way verifier or nullifier
+  migration.
 
-Key elements:
-- Import parameters from `deployments/parameters.ts`
-- Import helpers from `deployments/helpers.ts`
-- Define `OLD_*` address maps for contracts being replaced (keyed by network name)
-- Deploy new contracts, wire registries (add new, remove old), transfer ownership
-- Skip logic: skip if old addresses no longer match current deployments
-- Dependencies: `["16_configure_v2_payment_methods"]`
-- Use `waitForDeploymentDelay(hre)` between transactions
+Numbered deploy metadata is immutable identity only when current tooling
+requires it. Before retaining an inactive numbered script, prove from
+`scripts/deployActive.ts`, its `skip` logic, network guards, deployment tests,
+and package export that it cannot execute or surface as active state. If the
+active runner loads it and the proof is absent, remove or disable the active
+lane rather than documenting intent.
 
-### 0c. Write the deploy test
+Validate with the smallest Foundry and deployment checks required by
+`AGENTS.md`. Source preparation must not mutate a live network.
 
-Create `test/deploy/NN_description.spec.ts` following the pattern in `test/deploy/14_v2System.spec.ts`.
+## Boundary 2: staging activation
 
-Key elements:
-- Attach to deployed contracts using `getDeployedContractAddress(network, name)`
-- Validate ownership, parameters, registry wiring, permissions
-- Test against `deployments/parameters.ts` expected values
+Require explicit approval naming Base staging and the exact source SHA.
 
-### 0d. Update deploy/CLAUDE.md
+Before activation:
 
-Add the new script to the script inventory table.
+- verify deployer, chain ID, RPC, parameters, expected old state, and expected
+  new state;
+- simulate or run the closest local deployment test;
+- show every deploy, registry, permission, ownership, and governance action;
+- define post-deploy reads that prove the hard cut.
 
-**Gate:** Deploy script and test file exist and compile (`yarn compile`).
+After activation, verify on-chain state and record addresses, transaction hashes,
+ownership, permissions, and artifacts. Do not publish an RC automatically.
 
----
+## Boundary 3: production activation
 
-## Phase 1: Local Chain
+Require a separate explicit approval naming Base production, exact source SHA,
+and governance/deployer path. Re-run state and simulation checks against
+production immediately before submission.
 
-**Goal:** Validate the deploy script runs correctly on a fresh local chain.
+Fail closed on chain, address, signer, ownership, permission, or expected-state
+mismatch. Do not reuse staging approval. Do not publish a package automatically.
 
-### 1a. Deploy to localhost
+## Boundary 4: package export
 
-```bash
-yarn deploy:localhost
-```
+Package extraction is a source artifact boundary, not publication. Confirm:
 
-Verify output shows:
-- New contract addresses deployed
-- Registry wiring completed
-- Ownership transferred (to deployer on localhost)
+- exported ABIs match canonical source;
+- Base and Base Staging addresses match deployment artifacts;
+- inactive/future contracts are absent from active address and runtime exports;
+- source ABI exports required by current package/release policy may include an
+  undeployed contract, but must never imply an active address or deployment;
+- consumer-visible changes are documented and tested.
 
-### 1b. Run full test suite
+Run package build, tests, release verification, and dry-run packing without
+publishing.
 
-```bash
-yarn test
-```
+## Boundaries 5 and 6: publication
 
-All tests must pass. This catches any contract changes that break existing functionality.
+Delegate both RC and stable requests to
+`.agents/skills/zkp2p-contracts-publish/SKILL.md`.
 
-### 1c. Run deploy tests against localhost
-
-```bash
-npx hardhat test test/deploy/*.ts --network localhost
-```
-
-All deploy tests must pass, including the new one from Phase 0.
-
-### 1d. Run foundry tests
-
-```bash
-yarn test:forge
-```
-
-**Gate:** All tests green on localhost.
-
----
-
-## Phase 2: Staging
-
-**Goal:** Deploy to Base staging, validate, verify, commit, publish RC.
-
-### 2a. Deploy to staging
-
-```bash
-yarn deploy:base_staging
-```
-
-Extract and save new contract addresses from deploy output.
-
-### 2b. Export deployment outputs
-
-```bash
-npx hardhat export --export-all deployments/outputs/baseStagingContracts.ts --network base_staging
-```
-
-### 2c. Run deploy tests against staging
-
-```bash
-npx hardhat test test/deploy/*.ts --network base_staging
-```
-
-All tests must pass. If any fail, investigate before proceeding.
-
-### 2d. Verify on Etherscan
-
-```bash
-yarn etherscan:base_staging
-```
-
-Only newly deployed contracts need to verify successfully. Old contracts may fail (bytecode mismatch from earlier deployments) -- that's expected.
-
-### 2e. Commit staging artifacts
-
-1. Stage deployment artifacts:
-   ```bash
-   git add deployments/base_staging/*.json deployments/outputs/ deploy/ test/deploy/
-   ```
-   Exclude: `deployments/base_staging/solcInputs/` (large, not needed)
-
-2. Commit with conventional format:
-   ```
-   feat(base-staging): redeploy <ContractNames> with <reason>
-   ```
-
-### 2f. Build and verify package (staging)
-
-```bash
-yarn pkg:build
-```
-
-Verify staging addresses in the built package match what was deployed:
-
-```bash
-cat packages/contracts/addresses/baseStaging.json | grep -i <contract_name>
-```
-
-The addresses must match Step 2a output.
-
-### 2g. Bump and publish RC
-
-1. Bump RC version:
-   ```bash
-   cd packages/contracts && npm version prerelease --preid rc --no-git-tag-version && cd ../..
-   ```
-
-2. Run package tests:
-   ```bash
-   yarn pkg:test
-   ```
-
-3. Verify addresses match deployment artifacts:
-   ```bash
-   node -e "
-   const fs=require('fs'),p=require('path');
-   let m=0;
-   for(const[n,pf,dd]of[['base','packages/contracts/addresses/base.json','deployments/base'],['staging','packages/contracts/addresses/baseStaging.json','deployments/base_staging']]){
-     const pkg=JSON.parse(fs.readFileSync(pf));
-     for(const[c,a]of Object.entries(pkg.contracts)){
-       const ap=p.join(dd,c+'.json');
-       if(!fs.existsSync(ap))continue;
-       const d=JSON.parse(fs.readFileSync(ap));
-       if(a.toLowerCase()!==d.address.toLowerCase()){console.log('MISMATCH',n,c,a,d.address);m++;}
-     }
-   }
-   if(m){console.log(m+' mismatch(es)');process.exit(1);}
-   console.log('All addresses OK');
-   "
-   ```
-
-4. Publish:
-   ```bash
-   cd packages/contracts && npm publish --access public --tag dev --no-provenance && cd ../..
-   ```
-
-5. Commit version bump:
-   ```bash
-   git add packages/contracts/package.json
-   git commit -m "chore(contracts): bump @zkp2p/contracts-v2 to $(node -p "require('./packages/contracts/package.json').version")"
-   ```
-
-6. Verify publication:
-   ```bash
-   npm view @zkp2p/contracts-v2 dist-tags
-   ```
-
-**Gate:** RC published, all staging artifacts committed, addresses verified.
-
----
-
-## Phase 3: Production
-
-**Goal:** Deploy to Base mainnet, validate, verify, commit, publish stable.
-
-### 3a. Deploy to production
-
-```bash
-yarn deploy:base
-```
-
-Extra caution:
-- Ownership transfers to multisig (`0x0bC26FF515411396DD588Abd6Ef6846E04470227`)
-- Double-check registry wiring in output
-- Extract and save new contract addresses
-
-### 3b. Export deployment outputs
-
-```bash
-npx hardhat export --export-all deployments/outputs/baseContracts.ts --network base
-```
-
-### 3c. Run deploy tests against production
-
-```bash
-npx hardhat test test/deploy/*.ts --network base
-```
-
-### 3d. Verify on Etherscan
-
-```bash
-yarn etherscan:base
-```
-
-### 3e. Commit production artifacts
-
-1. Stage:
-   ```bash
-   git add deployments/base/*.json deployments/outputs/
-   ```
-   Exclude: `deployments/base/solcInputs/`
-
-2. Commit:
-   ```
-   feat(base): redeploy <ContractNames> with <reason>
-   ```
-
-### 3f. Build and verify package (prod + staging)
-
-```bash
-yarn pkg:build
-```
-
-Verify BOTH staging and prod addresses are correct in the built package:
-
-```bash
-cat packages/contracts/addresses/base.json | grep -i <contract_name>
-cat packages/contracts/addresses/baseStaging.json | grep -i <contract_name>
-```
-
-Both must match their respective deployed addresses.
-
-### 3g. Bump and publish stable
-
-1. Bump stable version:
-   ```bash
-   cd packages/contracts && npm version patch --no-git-tag-version && cd ../..
-   ```
-   Use `minor` for significant changes.
-
-2. Run package tests:
-   ```bash
-   yarn pkg:test
-   ```
-
-3. Verify addresses (same script as 2g).
-
-4. Publish stable:
-   ```bash
-   cd packages/contracts && npm publish --access public --no-provenance --otp <CODE> && cd ../..
-   ```
-   Ask user for OTP. Automation token in `~/.npmrc` may bypass this for RC but stable may require it.
-
-5. Commit version bump:
-   ```bash
-   git add packages/contracts/package.json
-   git commit -m "chore(contracts): release @zkp2p/contracts-v2@$(node -p "require('./packages/contracts/package.json').version")"
-   ```
-
-6. Verify:
-   ```bash
-   npm view @zkp2p/contracts-v2 dist-tags
-   ```
-
-**Gate:** Stable published, all prod artifacts committed, addresses verified for both networks.
-
----
-
-## Phase Summary
-
-After completing all phases, push and open a PR:
-
-```bash
-git push -u origin <branch>
-```
-
-PR description should include:
-- New contract addresses (staging + prod)
-- What changed and why
-- Deploy script link
-- NPM package versions published
-
----
-
-## Network Reference
-
-| Network | Deploy Command | Etherscan Command | Ownership | Intent Expiry |
-|---------|---------------|-------------------|-----------|---------------|
-| localhost | `yarn deploy:localhost` | N/A | deployer | 24 hours |
-| base_staging | `yarn deploy:base_staging` | `yarn etherscan:base_staging` | deployer | 1 hour |
-| base | `yarn deploy:base` | `yarn etherscan:base` | multisig | 6 hours |
-
-## Common Issues
-
-| Issue | Fix |
-|-------|-----|
-| Deploy script runs but deploys nothing | Check skip logic -- old addresses may already be replaced |
-| Deploy tests fail on staging/prod | Check RPC connectivity, verify contract state matches expectations |
-| Etherscan verification fails for old contracts | Expected -- bytecode mismatch from previous deployments |
-| Package address mismatch | Re-run `yarn pkg:extract` then `yarn pkg:build` |
-| `EOTP` on npm publish | Automation token in `~/.npmrc` should bypass for RC. Stable may need OTP |
-| Localhost tests pass but staging fails | Check `deployments/parameters.ts` has correct values for the target network |
-
-## File Reference
-
-| File | Purpose |
-|------|---------|
-| `deploy/*.ts` | Hardhat deploy scripts |
-| `test/deploy/*.ts` | Deployment validation tests |
-| `deployments/parameters.ts` | Network-specific config values |
-| `deployments/helpers.ts` | Registry wiring, ownership transfer helpers |
-| `deployments/base_staging/*.json` | Staging deployment artifacts |
-| `deployments/base/*.json` | Production deployment artifacts |
-| `deployments/outputs/` | Auto-exported address files |
-| `packages/contracts/package.json` | NPM package version |
-| `packages/contracts/addresses/` | Built package address JSONs |
+- Require separate approval for RC publication.
+- Require another separate approval for stable publication.
+- Derive the release line and candidate from current package and repository
+  release policy.
+- Never run local `npm publish`, request an OTP, use a developer token, or move
+  a dist-tag as this skill.
+- If the trusted workflow does not implement the requested stable path, stop
+  and request a focused release-policy/workflow PR. Do not improvise a local
+  stable release.
+
+## Handoff
+
+For each boundary, report:
+
+- exact source commit and network/package target;
+- actions prepared versus actions executed;
+- approval obtained for that boundary;
+- focused validation and current CI;
+- addresses, transactions, artifacts, package candidate, or release URL;
+- the next boundary, explicitly marked unapproved until the user authorizes it.

--- a/.claude/skills/ship-contracts/SKILL.md
+++ b/.claude/skills/ship-contracts/SKILL.md
@@ -13,7 +13,7 @@ description: >
 Shipping is not one automatic pipeline. Treat each boundary as an independent
 deliverable with its own evidence and explicit authorization:
 
-1. source and deployment scaffold;
+1. source and network-scoped deployment lane;
 2. staging activation;
 3. production activation;
 4. package export;
@@ -25,9 +25,19 @@ RC, or stable approval from "deploy staging" or "ship the code."
 
 ## Establish current state
 
-Use canonical `zkp2p/zkp2p-contracts`, fetch `origin/main`, and record the source
-SHA, deployment artifacts, active runner, package version, and live target
-network before preparing a plan.
+Resolve canonical main explicitly; do not trust a checkout's `origin`, a
+contributor fork, or a legacy redirect:
+
+```bash
+canonical_main_ref=refs/remotes/zkp2p-canonical/main
+git fetch --no-tags https://github.com/zkp2p/zkp2p-contracts.git \
+  "+main:${canonical_main_ref}"
+git rev-parse "$canonical_main_ref"
+git rev-parse HEAD
+```
+
+Record the source SHA, deployment artifacts, active runner, package version,
+and live target network before preparing a plan.
 
 Read:
 
@@ -40,15 +50,20 @@ Read:
 
 Do not route through the legacy repository name or an archived deployment lane.
 
-## Boundary 1: source and deployment scaffold
+## Boundary 1: source and network-scoped deployment lane
 
 Create the smallest source, interface, deployment, and test changes that encode
 the approved target state.
 
-- Keep source scaffolding distinct from deployment activation.
+- Keep source, a mounted deploy lane, checked-in artifacts, and verified live
+  activation as distinct states.
 - Do not add a deploy script merely because source exists.
-- Do not activate future `OrchestratorV3` scaffolding without a separately
-  approved V3 deployment design.
+- Treat `OrchestratorV3` as a dedicated implementation. Its current lifecycle
+  design intentionally differs from V2 and its mounted lane `30` supports only
+  `localhost`, `hardhat`, and Base staging.
+- Do not add Base production to lane `30`, relax its network guard, or infer a
+  production path from Base-staging artifacts without a separately reviewed and
+  approved production design.
 - Remove retired active routes, permissions, exports, and aliases in the same
   hard cutover.
 - Do not add rollback compatibility to a one-way verifier or nullifier
@@ -72,6 +87,10 @@ Before activation:
 
 - verify deployer, chain ID, RPC, parameters, expected old state, and expected
   new state;
+- for lane `30`, resolve the expected `OrchestratorV3`,
+  `UnifiedPaymentVerifierV3`, lifecycle hook, stake vault, chargeback policy,
+  verifier/nullifier, registries, ownership, and prior-orchestrator state from
+  current source and artifacts;
 - simulate or run the closest local deployment test;
 - show every deploy, registry, permission, ownership, and governance action;
 - define post-deploy reads that prove the hard cut.
@@ -85,6 +104,10 @@ Require a separate explicit approval naming Base production, exact source SHA,
 and governance/deployer path. Re-run state and simulation checks against
 production immediately before submission.
 
+The current V3 lifecycle lane skips Base production. Production activation
+requires a focused network-scoped implementation and review; do not remove the
+guard or reuse staging artifacts as a shortcut.
+
 Fail closed on chain, address, signer, ownership, permission, or expected-state
 mismatch. Do not reuse staging approval. Do not publish a package automatically.
 
@@ -93,10 +116,11 @@ mismatch. Do not reuse staging approval. Do not publish a package automatically.
 Package extraction is a source artifact boundary, not publication. Confirm:
 
 - exported ABIs match canonical source;
-- Base and Base Staging addresses match deployment artifacts;
-- inactive/future contracts are absent from active address and runtime exports;
-- source ABI exports required by current package/release policy may include an
-  undeployed contract, but must never imply an active address or deployment;
+- each network's addresses match that network's deployment artifacts;
+- Base-staging V3 lifecycle addresses remain distinct from Base production
+  exports and claims;
+- source ABI exports required by current package/release policy may exist
+  without an address on another network, but must never imply activation there;
 - consumer-visible changes are documented and tested.
 
 Run package build, tests, release verification, and dry-run packing without

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,12 +11,15 @@
 
 ## Staging Deployment Status
 
-- `OrchestratorV3` and `IOrchestratorV3` are retained as future implementations. They are not part of the current
-  V2 guardian/whitelist rollout and will receive fresh deployment scripts when that lane is ready.
-- The prior staging-only `RiskManager`/`OrchestratorV3` deployment lane is not active deployment history.
-- `IntentGuardian` and `WhitelistPolicy` extend the existing `EscrowV2`/`OrchestratorV2` stack. Deploy them through
-  their separate V2 intent-guardian and whitelist-policy scripts as a hard cut on both Base staging and production;
-  do not redeploy the V2 core as part of that workflow.
+- `deploy/30_deploy_v3_lifecycle_stack.ts` is the mounted V3 lifecycle lane for `localhost`, `hardhat`, and Base
+  staging. It reuses `EscrowV2` and `WhitelistPolicy` and wires `OrchestratorV3`, `UnifiedPaymentVerifierV3`,
+  `NullifierRegistryV2`, `IntentLifecycleHookV1`, `StakeVault`, `ChargebackPolicy`, and their verifier/nullifier
+  dependencies. The checked-in Base-staging artifacts record this lane, but live reads remain required before
+  claiming the currently active addresses or wiring.
+- Lane `30` skips Base production. Production remains a separately approved network cutover; never infer production
+  activation from source, tests, package ABIs, the mounted staging script, or Base-staging artifacts.
+- `IntentGuardian` and `WhitelistPolicy` remain part of the V2 policy history and are reused where the mounted V3
+  lifecycle lane specifies. Do not redeploy a core stack merely to change an independently owned policy component.
 - The payment-verifier cutover is one-way. In the same governance batch, authorize UPV3 on `NullifierRegistryV2`,
   permanently revoke the retired verifier's legacy-registry write permission, and route the shared
   `PaymentVerifierRegistry` to UPV3. Never route a payment method back to the retired verifier: the legacy registry
@@ -24,9 +27,9 @@
 
 ## Architecture Overview (v2.1)
 - Core: `Escrow` holds maker deposits and per-deposit config (methods, currencies, min rates, intent limits/expiry); `Orchestrator` manages intents, routes to verifiers, collects protocol/referrer fees; `ProtocolViewer` provides aggregated read views.
-- Registries: `PaymentVerifierRegistry` maps `paymentMethod` → verifier + currencies; `EscrowRegistry` whitelists escrows; `PostIntentHookRegistry` whitelists post‑intent hooks; `NullifierRegistry` records consumed nullifiers. `RelayerRegistry` backs the deployed legacy V1 stack and the deployed prod `OrchestratorV2` (whose in-repo source mirrors the prod deployment, including relayer-gated multi-intent admission).
+- Registries: `PaymentVerifierRegistry` maps `paymentMethod` → verifier + currencies; `EscrowRegistry` whitelists escrows; `PostIntentHookRegistry` whitelists post‑intent hooks; `NullifierRegistry` records consumed nullifiers. `RelayerRegistry` backs the deployed legacy V1 stack, deployed production `OrchestratorV2`, and current `OrchestratorV3` source and staging wiring, including relayer-gated multi-intent admission.
 - Unified Verifier: `unifiedVerifier/UnifiedPaymentVerifier.sol` validates EIP‑712 attestations, checks provider hashes and timestamp buffers (from `BaseUnifiedPaymentVerifier`), and nullifies payments.
-- Wiring: Deploy registries → deploy `Escrow` → deploy `Orchestrator` with registry addresses → `Escrow.setOrchestrator(...)` → deploy `UnifiedPaymentVerifier` and register it per `paymentMethod` in `PaymentVerifierRegistry` (also set provider hashes/timestamp buffers) → whitelist escrows/hooks as needed. The future V3 orchestrator has no relayer registry dependency; `OrchestratorV2` keeps its relayer constructor arg because its source mirrors the deployed prod contract.
+- Wiring: Deploy registries → deploy `Escrow` → deploy `Orchestrator` with registry addresses → `Escrow.setOrchestrator(...)` → deploy `UnifiedPaymentVerifier` and register it per `paymentMethod` in `PaymentVerifierRegistry` (also set provider hashes/timestamp buffers) → whitelist escrows/hooks as needed. Current `OrchestratorV3` deliberately retains the relayer admission boundary while replacing the V2 deposit-whitelist-hook path with snapshotted, fail-closed lifecycle callbacks; review those differences as designed behavior, not accidental parity drift.
 - Flow: Maker `createDeposit` on `Escrow` → Taker `signalIntent` on `Orchestrator` (escrow locks funds) → `fulfillIntent` calls method verifier → on success, `Orchestrator` unlocks/transfers from `Escrow`, applies fees, runs optional post‑intent hook.
 
 ### Minimal Diagram

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,290 +2,174 @@
 
 ## Project
 
-ZKP2P V2 Contracts -- Solidity 0.8.18 smart contracts for trustless P2P fiat-to-crypto exchange on Base. Off-chain fiat payments (Venmo, PayPal, Wise, Revolut, CashApp, Zelle, MercadoPago, Monzo, N26, Alipay, Chime, Luxon) are verified on-chain via EIP-712 attestations from a zkTLS attestation service, then escrowed USDC is released to the buyer.
+ZKP2P contracts is the canonical Solidity 0.8.18 repository for the protocol's
+on-chain escrow, orchestration, verifier, registry, policy, deployment, and npm
+package artifacts.
 
-## Build and Test
+Read `AGENTS.md` before acting. Treat deployment status as network-scoped:
+
+- V2 escrow and orchestrator are the active source lane.
+- `IntentGuardian` and `WhitelistPolicy` extend that V2 lane.
+- `UnifiedPaymentVerifierV3` is current source, test, staging-artifact, and
+  package-ABI material. `deployments/base_staging/` contains a V3 artifact;
+  `deployments/base/` does not. Do not call V3 active in production from source
+  or ABI presence alone.
+- The planned verifier cutover is one-way. Resolve the live
+  `PaymentVerifierRegistry`, nullifier permissions, network artifact, and
+  approved governance batch before stating which verifier is active.
+- V1 source and deployment artifacts are historical evidence, not an active
+  development or compatibility lane. Never route new work through V1.
+
+## Build and test
 
 ```bash
-yarn                              # Install dependencies
-yarn compile                      # Compile Solidity
-yarn build                        # Clean + compile + typechain + transpile
+yarn
+yarn compile
+yarn build
 
-# Hardhat tests (TypeScript, ethers v5)
-yarn test                         # Core test suite
-yarn test:fast                    # Skip compilation
-npx hardhat test test/escrowV2/*  # Specific suite
+# Foundry is the only contract test system.
+yarn test
+yarn test:deterministic
+yarn test:fuzz
+yarn test:invariant
+forge test --match-path '<test-foundry/path>'
 
-# Foundry tests (Solidity)
-yarn test:forge                   # All foundry tests
-yarn test:forge:fuzz              # Fuzz tests (100 runs)
-yarn test:forge:invariant         # Invariant tests
-yarn test:forge:fork              # Fork tests (cancun EVM)
-
-# Coverage
-yarn coverage                     # Hardhat coverage
-yarn test:forge:coverage          # Foundry coverage
-
-# Deploy
-yarn deploy:localhost             # Local hardhat node
-yarn deploy:base_staging          # Base mainnet (staging deployer)
-yarn deploy:base                  # Base mainnet (production)
-
-# Verify
-yarn etherscan:base               # Verify on Basescan
-yarn etherscan:base_staging
+yarn coverage
 ```
+
+Use the change-aware verification ladder in `AGENTS.md`. Start with the
+smallest Foundry target that can disprove the changed invariant. Do not run a
+clean build, the full suite, or coverage for documentation-only work.
 
 ## Architecture
 
-Two contract generations coexist. V1 is legacy; V2 is active development.
+The active V2 flow is:
 
-### Contract Flow (V2)
-
-```
-Maker -- createDeposit --> EscrowV2
-Taker -- signalIntent --> OrchestratorV2 -- lockFunds --> EscrowV2
-                                         -- preIntentHook (optional)
-Off-chain: taker pays fiat, gets zkTLS proof, submits to attestation-service
-Attestation service signs EIP-712 typed data with payment details
-Anyone -- fulfillIntent --> OrchestratorV2 -- verifyPayment --> UnifiedPaymentVerifier
-                                           -- nullify(paymentId) --> NullifierRegistry
-                                           -- unlockAndTransfer --> EscrowV2 --> USDC to buyer
+```text
+maker -> EscrowV2.createDeposit
+taker -> OrchestratorV2.signalIntent -> EscrowV2 locks funds
+attestation-service -> EIP-712 payment attestation
+OrchestratorV2.fulfillIntent
+  -> PaymentVerifierRegistry resolves the network's configured verifier
+  -> verifier validates the attestation and nullifies the payment
+  -> EscrowV2 releases funds and fees
 ```
 
-### Core Contracts
+Important ownership boundaries:
 
-| Contract | Purpose |
-|----------|---------|
-| `EscrowV2.sol` (1565 lines) | Deposit management, fund locking/release, oracle rate support, delegated rate managers |
-| `OrchestratorV2.sol` (788 lines) | Intent lifecycle, fee collection (protocol + referrer + manager), pre-intent hooks, whitelist hooks |
-| `RateManagerV1.sol` (366 lines) | Delegated rate management for deposits (managers can set rates on behalf of depositors) |
-| `ProtocolViewerV2.sol` | Read-only aggregated state queries |
-| `UnifiedPaymentVerifier.sol` | Single verifier for all payment methods via EIP-712 attestation signatures |
-| `SimpleAttestationVerifier.sol` | Validates zkTLS attestation signatures from authorized witnesses |
+- `EscrowV2` owns deposits, locking, and release.
+- `OrchestratorV2` owns intent lifecycle and fee routing.
+- `PaymentVerifierRegistry` owns payment-method-to-verifier routing.
+- `OrchestratorRegistry` and `EscrowRegistry` own allowed callers/systems.
+- `NullifierRegistry` and `NullifierRegistryV2` are distinct replay domains.
+  Never infer a safe rollback between them.
+- `MultiAttestationVerifier` owns the configured witness threshold used by the
+  current verifier wiring.
+- `IntentGuardian`, `AddressGroupRegistry`, and `WhitelistPolicy` are separate
+  V2 policy components. Do not redeploy the V2 core merely to change policy.
 
-### V1 Contracts (Legacy, still deployed)
+`UnifiedPaymentVerifier` is both a Solidity implementation name and, in some
+deployment lanes, the implementation behind the
+`UnifiedPaymentVerifierV2` deployment artifact. Resolve source, deployment
+name, artifact, address, registry routing, and nullifier permissions together;
+do not reason from the name alone.
 
-| Contract | Purpose |
-|----------|---------|
-| `Escrow.sol` (1113 lines) | Original escrow (V1 deposits still active) |
-| `Orchestrator.sol` (594 lines) | Original orchestrator |
-| `ProtocolViewer.sol` | V1 viewer |
+`OrchestratorV3` remains source/parity scaffold material. It has no current
+active deploy script. A separate approved design and deployment lane is
+required before activation.
 
-### Registry System
+## Code layout
 
-| Registry | Purpose |
-|----------|---------|
-| `PaymentVerifierRegistry` | Maps `paymentMethod` bytes32 -> verifier address + supported currencies |
-| `EscrowRegistry` | Whitelists escrow contracts (V1 + V2 both registered) |
-| `OrchestratorRegistry` | Whitelists orchestrator contracts (used by EscrowV2) |
-| `NullifierRegistry` | Prevents payment proof replay; write-gated to verifiers |
-| `RelayerRegistry` | Whitelists relayers for gasless tx submission |
-| `PostIntentHookRegistry` | Whitelists post-intent hooks (V1 only) |
-
-### Hooks
-
-| Hook | Purpose |
-|------|---------|
-| `SignatureGatingPreIntentHook` | Pre-intent hook requiring EIP-712 gating signature |
-| `WhitelistPreIntentHook` | Pre-intent hook restricting to whitelisted addresses |
-
-### Oracles
-
-| Oracle | Purpose |
-|--------|---------|
-| `ChainlinkOracleAdapter` | Wraps Chainlink price feeds for deposit rate floors |
-| `PythOracleAdapter` | Wraps Pyth price feeds for deposit rate floors |
-
-### Libraries
-
-| Library | Purpose |
-|---------|---------|
-| `ThresholdSigVerifierUtils` | Threshold signature verification utilities |
-| `ReferralFeeLib` | Referral fee validation and hashing (max 50% total, max 5 recipients) |
-
-## Code Layout
-
-```
-contracts/
-  Escrow.sol, EscrowV2.sol           # Escrow contracts (V1, V2)
-  Orchestrator.sol, OrchestratorV2.sol  # Orchestrators (V1, V2)
-  RateManagerV1.sol                   # Delegated rate management
-  ProtocolViewer.sol, ProtocolViewerV2.sol  # Read-only viewers
-  registries/                         # 6 registry contracts
-  unifiedVerifier/                    # EIP-712 payment verification
-  hooks/                              # Pre/post intent hooks (4 contracts)
-  oracles/                            # Chainlink + Pyth adapters
-  interfaces/                         # All interfaces (23 files)
-  lib/                                # ThresholdSigVerifierUtils, ReferralFeeLib
-  external/                           # Array utils (Address, Bytes32, String, Uint256), Across interface
-  mocks/                              # 30 mock contracts for testing
-
-test/                                 # Hardhat tests (*.spec.ts)
-  escrow/, escrowV2/                  # V1 and V2 escrow tests
-  orchestrator/, orchestratorV2/      # V1 and V2 orchestrator tests
-  registries/                         # Registry tests
-  unifiedVerifier/                    # Verifier tests
-  hooks/                              # Hook tests
-  rateManager/                        # Rate manager + oracle adapter tests
-  periphery/                          # ProtocolViewer tests
-  libs/                               # ThresholdSigVerifierUtils tests
-  deploy/                             # Deployment script validation tests
-  patchCoverage/                      # Targeted coverage gap tests
-
-test-foundry/                         # Foundry tests (*.t.sol)
-  fuzz/                               # EscrowCriticalPathFuzz, OrchestratorCriticalPathFuzz, PythOracleAdapterFuzz
-  invariant/                          # EscrowInvariant, OrchestratorInvariant, V2RateFlowInvariantSkeleton
-  unit/                               # OrchestratorPruneOnSignal, PythOracleAdapter
-
-deploy/                               # Hardhat Deploy scripts (NN_description.ts)
-  00-13: V1 system + payment methods
-  14: V2 system (EscrowV2, OrchestratorV2, OrchestratorRegistry)
-  15: V2 periphery (ProtocolViewerV2, hooks)
-  16: V2 payment method configuration
-  17: Pyth oracle deployment
-  18-22: Redeployments (EscrowV2, RateManagerV1, OrchestratorV2, ProtocolViewerV2, UPV V2)
-  deploy_summary.ts: Post-deploy address summary
-
-deployments/                          # Network artifacts
-  base/                               # Production (chain 8453, 22 contracts)
-  base_staging/                       # Staging (chain 8453, separate deployer)
-  localhost/                          # Local dev (chain 31337)
-  parameters.ts                       # Network-specific config values
-  helpers.ts                          # Deployment helper functions
-  safeBatchCollector.ts               # Safe multisig batch transaction builder
-  verifiers/                          # Payment method provider hashes (12 platforms)
-  outputs/                            # Exported contract addresses (JSON/TS)
-
-utils/                                # TypeScript utilities
-  deploys.ts                          # DeployHelper class
-  protocolUtils.ts                    # Intent hashes, currency constants, ID hashing
-  reclaimUtils.ts                     # Proof encoding/parsing
-  unifiedVerifierUtils.ts             # Unified verifier test helpers
-  constants.ts                        # ADDRESS_ZERO, time constants
-  types.ts                            # ReclaimProof, ClaimInfo types
-  common/                             # Blockchain, units (ether, usdc)
-  test/                               # Account helpers, snapshot mgmt
-
-packages/contracts/                   # @zkp2p/contracts-v2 NPM package (v0.2.0)
-archive/                              # Legacy verifier contracts (pre-unified)
-tasks/                                # Hardhat custom tasks (etherscan verify with delay)
+```text
+contracts/               Solidity source
+  unifiedVerifier/       verifier implementations and bases
+  interfaces/            interfaces
+  registries/            registry contracts
+  hooks/                 pre/post-intent hooks
+  mocks/                 test support
+test-foundry/
+  deterministic/         focused success, revert, deployment, regression tests
+  fuzz/                  input-space properties
+  invariant/             stateful handlers and invariants
+deploy/                  ordered Hardhat Deploy scripts
+deployments/             network artifacts, parameters, Safe batches, outputs
+scripts/                 deployment and release support
+packages/contracts/      @zkp2p/contracts-v2 package
 ```
 
-## Testing Patterns
+Do not embed file, contract, or artifact counts in agent guidance. Derive them
+from the current checkout when they matter.
 
-### Subject Pattern (Hardhat)
-```typescript
-describe("#methodName", () => {
-  let subjectCaller: Account;
+## Deployment source of truth
 
-  beforeEach(async () => { subjectCaller = user; });
+The active deployment runner is `scripts/deployActive.ts`, which mounts the
+current `deploy/*.ts` files. Inspect every mounted script, its `skip` behavior,
+network guard, dependencies, and matching tests before a deployment claim.
 
-  async function subject(): Promise<any> {
-    return contract.connect(subjectCaller.wallet).methodName(params);
-  }
+Current numbered lanes include:
 
-  it("should do X", async () => {
-    await subject();
-    expect(await contract.state()).to.equal(expected);
-  });
+- `00`-`13`: original system and payment-method scripts retained as deployment
+  history/current mounted files;
+- `14`-`22`: V2 system, periphery, payment methods, oracle, and redeployments;
+- `23`: whitelist pre-intent hook redeployment;
+- `24`: `MultiAttestationVerifier` deployment and V2 verifier wiring;
+- `25`: generic Zelle payment-method configuration;
+- `27`: legacy Zelle method removal;
+- `28`: `IntentGuardian`;
+- `29`: V2 whitelist policy.
 
-  describe("when caller is not authorized", () => {
-    beforeEach(async () => { subjectCaller = attacker; });
-    it("should revert", async () => {
-      await expect(subject()).to.be.revertedWith("Unauthorized");
-    });
-  });
-});
-```
+There is no `26` script. Numbered files are identities, not proof that every
+script should execute. Deployment is a separately approved mutation for the
+exact network, source SHA, and governance/deployer path.
 
-### Snapshot Isolation
-```typescript
-import { addSnapshotBeforeRestoreAfterEach } from "@utils/test";
-addSnapshotBeforeRestoreAfterEach();
-```
-
-### Key Utilities
-```typescript
-import { usdc, ether } from "@utils/common";
-import { calculateIntentHash, Currency } from "@utils/protocolUtils";
-import { Blockchain } from "@utils/common";
-import DeployHelper from "@utils/deploys";
-import { getAccounts } from "@utils/test";
-```
-
-### Path Aliases
-- `@utils/*` -> `utils/`
-- `@typechain/*` -> `typechain/`
-
-## Deployment Wiring Order (V2)
-
-1. Deploy registries (reuse V1: NullifierRegistry, PaymentVerifierRegistry, EscrowRegistry, RelayerRegistry)
-2. Deploy OrchestratorRegistry (new for V2)
-3. Deploy EscrowV2 with OrchestratorRegistry + PaymentVerifierRegistry
-4. Deploy OrchestratorV2 with EscrowRegistry + PaymentVerifierRegistry + RelayerRegistry
-5. Deploy UnifiedPaymentVerifierV2 with OrchestratorRegistry + NullifierRegistry + SimpleAttestationVerifier
-6. Register OrchestratorV2 in OrchestratorRegistry
-7. Register EscrowV2 in EscrowRegistry
-8. Add NullifierRegistry write permission for UnifiedPaymentVerifierV2
-9. Configure payment methods on UnifiedPaymentVerifierV2
-10. Transfer ownership to multisig
-
-## Networks
-
-| Network | Chain ID | USDC | Intent Expiry | Max Intents |
-|---------|----------|------|---------------|-------------|
-| Base | 8453 | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` | 6 hours | 200 |
-| Base Staging | 8453 | same | 1 hour | 200 |
-| Localhost | 31337 | mock | 24 hours | 100 |
-
-## Key Addresses
-
-- **Multisig / Fee Recipient**: `0x0bC26FF515411396DD588Abd6Ef6846E04470227` (Base mainnet)
-- **Witness (prod staging)**: `0x4ab950AE1e3326578Bf7e643a2031E858aBa2927`
-- **Witness (prod)**: `0x5106A86819ED6Bb82c77CcBfC151250E1d369DbA`
-- **Pyth (Base)**: `0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a`
-
-## Configuration
-
-- `hardhat.config.ts`: Solidity 0.8.18, optimizer 200 runs, viaIR enabled, ethers v5
-- `foundry.toml`: Solidity 0.8.18, optimizer 800 runs, viaIR enabled, fuzz 256 runs, invariant depth 15
-- `.env`: `BASE_DEPLOY_PRIVATE_KEY`, `TESTNET_DEPLOY_PRIVATE_KEY`, `ALCHEMY_API_KEY`, `BASESCAN_API_KEY`
-- `tsconfig.json`: CommonJS, strict mode, path aliases
-
-## Style
-
-- **Solidity**: 4-space indent, explicit visibility, custom errors (not require strings), NatSpec on external functions
-- **Naming**: Contracts `PascalCase`, interfaces `IName`, constants `UPPER_CASE`, state vars `camelCase`
-- **TypeScript**: Strict mode, CommonJS, use `@utils` and `@typechain` aliases
-- **Tests**: `*.spec.ts`, subject pattern, AAA, snapshot isolation
-- **Deploy scripts**: `NN_description.ts` prefix ordering
-- **Commits**: Conventional format (`feat:`, `fix:`, `chore:`, `refactor:`, `test:`)
-
-## NPM Package
+Use:
 
 ```bash
-yarn pkg:extract    # Build + extract deployment artifacts
-yarn pkg:build      # Build @zkp2p/contracts-v2 package
+yarn deploy:localhost
+yarn deploy:base_staging
+yarn deploy:base
+yarn etherscan:base_staging
+yarn etherscan:base
 ```
 
-```typescript
-import OrchestratorABI from "@zkp2p/contracts-v2/abis/Orchestrator";
-import addresses from "@zkp2p/contracts-v2/addresses";
-import { Orchestrator } from "@zkp2p/contracts-v2/typechain";
+Only run a live command after the `ship-contracts` boundary for that exact
+action is approved.
+
+## Package boundary
+
+```bash
+yarn pkg:extract
+yarn pkg:build
+yarn workspace @zkp2p/contracts-v2 verify:release
 ```
 
-## Agents
+Source ABI exports and active address/runtime exports are different contracts.
+The package intentionally exports selected V3 source ABIs for consumers and
+release verification even when a network has no active V3 address. Never
+invent a zero address, publish an inactive address as active, or remove an ABI
+merely because the contract is not deployed on every network.
 
-| Agent | Description |
-|-------|-------------|
-| [contracts-developer](.claude/agents/contracts-developer.md) | ZKP2P contracts expert for EscrowV2, payment verifiers, registry system, hook system |
-| [security-auditor](.claude/agents/security-auditor.md) | Security auditor using Trail of Bits skills for structured audit workflows |
+Any publication must use
+`.agents/skills/zkp2p-contracts-publish/SKILL.md`; never publish locally or
+request an OTP/token.
 
 ## Skills
 
-| Skill | Description |
-|-------|-------------|
-| [zkp2p-contracts-publish](.agents/skills/zkp2p-contracts-publish/SKILL.md) | Bump, build, test, and publish @zkp2p/contracts-v2 to npm |
-| [ship-contracts](.claude/skills/ship-contracts/SKILL.md) | Full deployment pipeline: script + tests, local, staging, prod, publish |
-| [audit](.claude/skills/audit/SKILL.md) | Security audits: full, differential, or single checks |
+| Skill | Use |
+| --- | --- |
+| `.claude/skills/audit/SKILL.md` | Read-only full, differential, or focused security review |
+| `.claude/skills/ship-contracts/SKILL.md` | Separately approved source, staging, production, export, and release boundaries |
+| `.agents/skills/zkp2p-contracts-publish/SKILL.md` | Trusted-workflow RC/stable package release |
+
+## Style
+
+- Solidity: four-space indentation, explicit visibility, custom errors where
+  appropriate, and NatSpec on external functions.
+- TypeScript: strict mode, CommonJS, and existing `@utils`/`@typechain` aliases.
+- Tests: `*.t.sol` under the smallest applicable Foundry layer.
+- Deploy scripts: two-digit prefix and concise verb-noun name.
+- Commits: conventional prefixes where practical.
+
+Never commit secrets, edit generated artifacts by hand, infer live state from a
+stale artifact, add rollback compatibility, or combine source, staging,
+production, package, and publication approval into one implied action.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,15 +8,19 @@ package artifacts.
 
 Read `AGENTS.md` before acting. Treat deployment status as network-scoped:
 
-- V2 escrow and orchestrator are the active source lane.
-- `IntentGuardian` and `WhitelistPolicy` extend that V2 lane.
-- `UnifiedPaymentVerifierV3` is current source, test, staging-artifact, and
-  package-ABI material. `deployments/base_staging/` contains a V3 artifact;
-  `deployments/base/` does not. Do not call V3 active in production from source
-  or ABI presence alone.
-- The planned verifier cutover is one-way. Resolve the live
-  `PaymentVerifierRegistry`, nullifier permissions, network artifact, and
-  approved governance batch before stating which verifier is active.
+- `EscrowV2` remains the shared escrow in the mounted V3 lifecycle lane.
+  `OrchestratorV2` and `OrchestratorV3` are distinct current implementations;
+  never infer which one is active from the version number alone.
+- `deploy/30_deploy_v3_lifecycle_stack.ts` is mounted by
+  `scripts/deployActive.ts` for `localhost`, `hardhat`, and Base staging. Current
+  Base-staging artifacts include the V3 orchestrator, verifier/nullifier,
+  lifecycle hook, stake vault, and chargeback components.
+- Lane `30` skips Base production. Source, tests, package ABIs, a mounted script,
+  and checked-in artifacts are not proof of live state. Resolve registries,
+  permissions, ownership, deployed bytecode, and on-chain wiring before stating
+  what is active on either network.
+- Verifier and nullifier cutovers are one-way. Never route a payment method back
+  to a verifier whose replay domain cannot observe the current nullifier writes.
 - V1 source and deployment artifacts are historical evidence, not an active
   development or compatibility lane. Never route new work through V1.
 
@@ -43,7 +47,8 @@ clean build, the full suite, or coverage for documentation-only work.
 
 ## Architecture
 
-The active V2 flow is:
+The V2 flow remains relevant wherever current network state routes through
+`OrchestratorV2`:
 
 ```text
 maker -> EscrowV2.createDeposit
@@ -59,14 +64,22 @@ Important ownership boundaries:
 
 - `EscrowV2` owns deposits, locking, and release.
 - `OrchestratorV2` owns intent lifecycle and fee routing.
+- `OrchestratorV3` owns the V3 intent lifecycle and snapshots the
+  governance-selected `IIntentLifecycleHook` for each intent.
+- `IntentLifecycleHookV1` composes whitelist admission with fail-closed
+  lifecycle callbacks into `ChargebackPolicy`; `StakeVault`, the chargeback
+  verifier, and its dedicated nullifier registry retain their separate
+  accounting, proof, and replay boundaries.
 - `PaymentVerifierRegistry` owns payment-method-to-verifier routing.
 - `OrchestratorRegistry` and `EscrowRegistry` own allowed callers/systems.
 - `NullifierRegistry` and `NullifierRegistryV2` are distinct replay domains.
   Never infer a safe rollback between them.
 - `MultiAttestationVerifier` owns the configured witness threshold used by the
   current verifier wiring.
-- `IntentGuardian`, `AddressGroupRegistry`, and `WhitelistPolicy` are separate
-  V2 policy components. Do not redeploy the V2 core merely to change policy.
+- `IntentGuardian`, `AddressGroupRegistry`, and `WhitelistPolicy` remain
+  separately owned policy components. The V3 lifecycle lane reuses
+  `WhitelistPolicy` through its lifecycle hook; do not collapse those ownership
+  boundaries or redeploy a core stack merely to change policy.
 
 `UnifiedPaymentVerifier` is both a Solidity implementation name and, in some
 deployment lanes, the implementation behind the
@@ -74,9 +87,11 @@ deployment lanes, the implementation behind the
 name, artifact, address, registry routing, and nullifier permissions together;
 do not reason from the name alone.
 
-`OrchestratorV3` remains source/parity scaffold material. It has no current
-active deploy script. A separate approved design and deployment lane is
-required before activation.
+`OrchestratorV3` is not a textual V2 parity scaffold. It deliberately retains
+the relayer-gated admission, escrow, fee, registry, and payment boundaries while
+replacing the V2 deposit-whitelist-hook path with a snapshotted lifecycle hook
+and fail-closed callbacks for signal, cancel/prune, fulfill, and manual release.
+Review shared invariants and those explicit deltas separately.
 
 ## Code layout
 
@@ -117,6 +132,7 @@ Current numbered lanes include:
 - `27`: legacy Zelle method removal;
 - `28`: `IntentGuardian`;
 - `29`: V2 whitelist policy.
+- `30`: V3 lifecycle stack for local, Hardhat, and Base staging only.
 
 There is no `26` script. Numbered files are identities, not proof that every
 script should execute. Deployment is a separately approved mutation for the
@@ -143,11 +159,12 @@ yarn pkg:build
 yarn workspace @zkp2p/contracts-v2 verify:release
 ```
 
-Source ABI exports and active address/runtime exports are different contracts.
-The package intentionally exports selected V3 source ABIs for consumers and
-release verification even when a network has no active V3 address. Never
-invent a zero address, publish an inactive address as active, or remove an ABI
-merely because the contract is not deployed on every network.
+Source ABI exports and network address/runtime exports are different contracts.
+The package intentionally exports V3 source ABIs and current Base-staging
+lifecycle addresses while Base production may have no corresponding active V3
+address. Never invent a zero address, copy a staging address into Base, publish
+an inactive address as active, or remove an ABI merely because the contract is
+not deployed on every network.
 
 Any publication must use
 `.agents/skills/zkp2p-contracts-publish/SKILL.md`; never publish locally or


### PR DESCRIPTION
## Summary

- Rebase the skills-only change onto canonical `main` at `caf1a1d` and resolve the current RC recovery guidance without dropping the original validated-tarball boundary.
- Make audit, ship, and publish workflows fetch an explicit `zkp2p/zkp2p-contracts` canonical ref instead of trusting `origin`, a fork, or a legacy redirect.
- Apply branch-introduction and ownership blocker gates only to differential/PR reviews; full and focused audits still report material findings at the selected revision.
- Re-ground repository guidance to the mounted `deploy/30_deploy_v3_lifecycle_stack.ts` lane, current Base-staging V3 lifecycle artifacts, and the intentional V3 lifecycle/hook/settlement differences.
- Preserve network separation, one-way hard cuts, independent approvals, and the no-local-publish boundary.

## Validation

- PASS: skill-creator `quick_validate.py` for all 3 changed skills
- PASS: explicit canonical fetch resolves `zkp2p-canonical/main` and `origin/main` to `caf1a1d`
- PASS: `yarn install --immutable`
- PASS: `yarn test:release-policy` — 5/5
- PASS: `yarn compile` using the repository's public `.env.default` test-key values
- PASS: `yarn pkg:build`
- PASS: `yarn workspace @zkp2p/contracts-v2 verify:release` — 56 deployment-backed ABI/address entries and 6 canonical source ABI exports
- PASS: `yarn pkg:test` — 1/1
- PASS: `npm pack --dry-run --ignore-scripts --json` with an isolated temporary npm cache
- PASS: `git diff --check origin/main...HEAD`

Documentation and skills only. No contract deployment, governance transaction, tag, package publication, dist-tag change, or live-network mutation was performed.