### PR TITLE
chore(release): prepare contracts v2 0.4.0-rc.1

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -2,6 +2,13 @@
 
 Official npm package for ZKP2P V2 smart contract interfaces, ABIs, addresses, and utilities.
 
+## Release candidate 0.4.0-rc.1
+
+- Refreshes the canonical `OrchestratorV3` source ABI for the governance-set intent lifecycle hook and shared
+  settlement flow.
+- Keeps the network-backed V2 addresses and ABIs unchanged; `OrchestratorV3` remains a future implementation with
+  no published deployment address.
+
 ## Installation
 
 ```bash

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/contracts-v2",
-  "version": "0.4.0-rc.0",
+  "version": "0.4.0-rc.1",
   "description": "ZKP2P V2 smart contract interfaces and utilities",
   "main": "./_cjs/index.js",
   "module": "./_esm/index.js",


### PR DESCRIPTION
## Summary
- advances `@zkp2p/contracts-v2` to the first unused `0.4.0-rc.1` version
- documents the refreshed `OrchestratorV3` source ABI and unchanged deployed V2 address surface
- preserves the repository URL required for npm OIDC provenance

## Changes
- `packages/contracts/package.json`: set version to `0.4.0-rc.1`
- `packages/contracts/README.md`: add consumer-visible RC notes

## Spec Alignment
- No design spec applies; this is the focused version PR required by `NPM_RELEASE.md`.

## Test Plan
- [x] `yarn install --immutable`
- [x] `yarn compile`
- [x] `yarn pkg:build`
- [x] `yarn pkg:test`
- [x] `yarn workspace @zkp2p/contracts-v2 verify:release`
- [x] `yarn test:release-policy`
- [x] `(cd packages/contracts && npm pack --dry-run)`
- [x] confirmed `0.4.0-rc.1` is unused on npm
- [x] confirmed package `repository.url` remains canonical