### PR TITLE
chore(release): prepare contracts v2 0.4.0-rc.2

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -2,12 +2,11 @@
 
 Official npm package for ZKP2P V2 smart contract interfaces, ABIs, addresses, and utilities.
 
-## Release candidate 0.4.0-rc.1
+## Release candidate 0.4.0-rc.2
 
-- Refreshes the canonical `OrchestratorV3` source ABI for the governance-set intent lifecycle hook and shared
-  settlement flow.
-- Keeps the network-backed V2 addresses and ABIs unchanged; `OrchestratorV3` remains a future implementation with
-  no published deployment address.
+- Publishes the Base Staging deployment addresses and ABIs for `OrchestratorV3`, `StakeVault`,
+  `ChargebackNullifierRegistry`, `ChargebackVerifier`, `ChargebackPolicy`, and `IntentLifecycleHookV1`.
+- Keeps the Base production deployment addresses and ABIs unchanged.
 
 ## Installation
 

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/contracts-v2",
-  "version": "0.4.0-rc.1",
+  "version": "0.4.0-rc.2",
   "description": "ZKP2P V2 smart contract interfaces and utilities",
   "main": "./_cjs/index.js",
   "module": "./_esm/index.js",


### PR DESCRIPTION
## Summary
- Bumps `@zkp2p/contracts-v2` to the first unused RC version, `0.4.0-rc.2`.
- Documents the newly published Base Staging addresses and ABIs for the V3 lifecycle stack.
- Keeps Base production package data unchanged and preserves the canonical repository URL required for npm OIDC provenance.

## Changes
- `packages/contracts/package.json`: set version to `0.4.0-rc.2`.
- `packages/contracts/README.md`: describe the six new Base Staging deployment-backed exports.

## Test Plan
- [x] `yarn install --immutable`
- [x] `yarn compile`
- [x] `yarn pkg:build`
- [x] `yarn pkg:test`
- [x] `yarn workspace @zkp2p/contracts-v2 verify:release`
- [x] `yarn test:release-policy`
- [x] `(cd packages/contracts && npm pack --dry-run)`

## Deployment Impact
After required checks pass and this PR merges, tag the exact canonical `main` merge commit as `contracts-v2-v0.4.0-rc.2` and dispatch **Publish contracts-v2** from `main` with release `0.4.0-rc.2` and recovery disabled.