### PR TITLE
chore: prepare contracts-v2 0.4.0-rc.4

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/contracts-v2",
-  "version": "0.4.0-rc.3",
+  "version": "0.4.0-rc.4",
   "description": "ZKP2P V2 smart contract interfaces and utilities",
   "main": "./_cjs/index.js",
   "module": "./_esm/index.js",


### PR DESCRIPTION
## Summary
- bump `@zkp2p/contracts-v2` from `0.4.0-rc.3` to `0.4.0-rc.4`
- prepare the next RC containing the Base mainnet V3 lifecycle deployment artifacts merged in #228

## Verification
- `yarn install --immutable`
- `yarn compile`
- `yarn pkg:build`
- `yarn pkg:test`
- `yarn workspace @zkp2p/contracts-v2 verify:release`
- `yarn test:release-policy`
- `(cd packages/contracts && npm pack --dry-run --ignore-scripts --json)`

## Release
After merge, create annotated tag `contracts-v2-v0.4.0-rc.4` at the exact canonical-main commit and dispatch the protected `Publish contracts-v2` workflow with `release=0.4.0-rc.4`, `recovery=false`.