### PR TITLE
chore: add legacy nullifier writer cleanup Safe batch

### DIFF
--- a/deployments/outputs/safe-batches/base_legacy_nullifier_writer_cleanup.json
+++ b/deployments/outputs/safe-batches/base_legacy_nullifier_writer_cleanup.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.0",
+  "chainId": "8453",
+  "createdAt": 1785739293568,
+  "meta": {
+    "name": "ZKP2P Legacy Nullifier Writer Cleanup - base",
+    "description": "Post-UPV3-cutover cleanup: revoke legacy NullifierRegistry write permission from retired UnifiedPaymentVerifier and UnifiedPaymentVerifierV2. Execute only after all payment methods route to UPV3 and every production attestation signer targets UPV3.",
+    "txBuilderVersion": "1.16.5",
+    "createdFromSafeAddress": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0x8d8e1A0e5345a5cc9AA206c3ca76D6d28c514608",
+      "value": "0",
+      "data": "0x286f920100000000000000000000000016b3e4a3ca36d3a4bca281767f15c7adef4ab163",
+      "contractMethod": null,
+      "contractInputsValues": null
+    },
+    {
+      "to": "0x8d8e1A0e5345a5cc9AA206c3ca76D6d28c514608",
+      "value": "0",
+      "data": "0x286f920100000000000000000000000046a58dc65587d4d7b8198c6a25eedf5b2535da94",
+      "contractMethod": null,
+      "contractInputsValues": null
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "deploy:sepolia": "ts-node --transpile-only scripts/deployActive.ts sepolia",
     "deploy:base": "ts-node --transpile-only scripts/deployActive.ts base && hardhat export --network base --export ./deployments/outputs/baseContracts.ts && yarn workspace @zkp2p/contracts-v2 extract",
     "deploy:base_staging": "ts-node --transpile-only scripts/deployActive.ts base_staging && hardhat export --network base_staging --export ./deployments/outputs/baseStagingContracts.ts && yarn workspace @zkp2p/contracts-v2 extract",
+    "safe:legacy-nullifier-cleanup": "ts-node --transpile-only scripts/generateLegacyNullifierWriterCleanupSafe.ts",
     "etherscan:base": "yarn hardhat --network base etherscan-verify-with-delay --delay 600",
     "etherscan:base_staging": "yarn hardhat --network base_staging etherscan-verify-with-delay --delay 600",
     "test": "forge test",

--- a/scripts/generateLegacyNullifierWriterCleanupSafe.ts
+++ b/scripts/generateLegacyNullifierWriterCleanupSafe.ts
@@ -1,0 +1,93 @@
+import * as fs from "fs";
+import * as path from "path";
+import type { JsonFragment } from "@ethersproject/abi";
+import { ethers } from "ethers";
+
+interface DeploymentArtifact {
+  address: string;
+  abi: JsonFragment[];
+}
+
+interface SafeTransaction {
+  to: string;
+  value: string;
+  data: string;
+  contractMethod: null;
+  contractInputsValues: null;
+}
+
+const NETWORK = "base";
+const CHAIN_ID = "8453";
+const SAFE_ADDRESS = "0x0bC26FF515411396DD588Abd6Ef6846E04470227";
+const RETIRED_VERIFIERS = ["UnifiedPaymentVerifier", "UnifiedPaymentVerifierV2"] as const;
+const OUTPUT_FILE = path.join(
+  __dirname,
+  "..",
+  "deployments",
+  "outputs",
+  "safe-batches",
+  "base_legacy_nullifier_writer_cleanup.json",
+);
+
+function readDeployment(contractName: string): DeploymentArtifact {
+  const artifactPath = path.join(__dirname, "..", "deployments", NETWORK, `${contractName}.json`);
+  const artifact = JSON.parse(fs.readFileSync(artifactPath, "utf8")) as DeploymentArtifact;
+
+  if (!ethers.utils.isAddress(artifact.address)) {
+    throw new Error(`${contractName} has an invalid deployment address: ${artifact.address}`);
+  }
+  if (!Array.isArray(artifact.abi)) {
+    throw new Error(`${contractName} deployment artifact is missing its ABI`);
+  }
+
+  return artifact;
+}
+
+function main(): void {
+  if (!ethers.utils.isAddress(SAFE_ADDRESS)) {
+    throw new Error(`No valid Safe address configured for ${NETWORK}`);
+  }
+
+  const nullifierRegistry = readDeployment("NullifierRegistry");
+  const nullifierRegistryInterface = new ethers.utils.Interface(nullifierRegistry.abi);
+  const retiredVerifierAddresses = RETIRED_VERIFIERS.map((contractName) => ({
+    contractName,
+    address: readDeployment(contractName).address,
+  }));
+
+  const uniqueAddresses = new Set(retiredVerifierAddresses.map(({ address }) => address.toLowerCase()));
+  if (uniqueAddresses.size !== RETIRED_VERIFIERS.length) {
+    throw new Error("Retired verifier deployment artifacts resolve to duplicate addresses");
+  }
+
+  const transactions: SafeTransaction[] = retiredVerifierAddresses.map(({ address }) => ({
+    to: nullifierRegistry.address,
+    value: "0",
+    data: nullifierRegistryInterface.encodeFunctionData("removeWritePermission", [address]),
+    contractMethod: null,
+    contractInputsValues: null,
+  }));
+
+  const batch = {
+    version: "1.0",
+    chainId: CHAIN_ID,
+    createdAt: Date.now(),
+    meta: {
+      name: "ZKP2P Legacy Nullifier Writer Cleanup - base",
+      description:
+        "Post-UPV3-cutover cleanup: revoke legacy NullifierRegistry write permission from retired UnifiedPaymentVerifier and UnifiedPaymentVerifierV2. Execute only after all payment methods route to UPV3 and every production attestation signer targets UPV3.",
+      txBuilderVersion: "1.16.5",
+      createdFromSafeAddress: SAFE_ADDRESS,
+      createdFromOwnerAddress: "",
+    },
+    transactions,
+  };
+
+  fs.writeFileSync(OUTPUT_FILE, `${JSON.stringify(batch, null, 2)}\n`);
+  console.log(`Wrote ${transactions.length} transactions to ${OUTPUT_FILE}`);
+  for (const { contractName, address } of retiredVerifierAddresses) {
+    console.log(`  - NullifierRegistry.removeWritePermission(${contractName}: ${address})`);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

- add a reproducible Base Safe Transaction Builder generator
- add a two-call cleanup batch that revokes legacy `NullifierRegistry` write permission from `UnifiedPaymentVerifier` and `UnifiedPaymentVerifierV2`
- keep the existing 24-call UPV3 cutover proposal unchanged

This addresses the deferred cleanup identified in [the Safe review](https://zkp2pworkspace.slack.com/archives/C0A98D95D6H/p1785536525995119?thread_ts=1785536525.995119&cid=C0A98D95D6H).

## Execution gate

This is post-cutover cleanup. Do not execute it before:

1. the existing verifier-routing Safe has executed and every payment method resolves to UPV3;
2. every production attestation signer targets UPV3, including attestation-service, the Pay support API signer, and zkp2p-support-bot;
3. a real UPV3 proof has fulfilled successfully through OrchestratorV2; and
4. the legacy writer set and both calldata simulations have been rechecked immediately before signing.

The existing nonce-65 cutover proposal was still unexecuted with 1/2 confirmations during generation.

## Validation

- `corepack yarn safe:legacy-nullifier-cleanup`
- focused TypeScript compile of the generator
- Safe JSON shape and calldata decode checks
- both owner calls simulated successfully against live Base
- artifact replayed sequentially on a local Base fork at block `49,474,988`: both transactions succeeded, the legacy writer set became empty, and `NullifierRegistryV2` retained UPV3 as its only writer

No Solidity, deployment, package, or live-chain mutation is included.