### PR TITLE
refactor: remove V3 intent minimum snapshot

### DIFF
--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -52,10 +52,6 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
     mapping(bytes32 => Intent) internal intents;                       // Mapping of intentHashes to intent structs
     mapping(address => bytes32[]) internal accountIntents;             // Mapping of address to array of intentHashes
 
-    // Snapshot of the minimum per-intent amount at the time of lock (signal)
-    // Used to prevent fulfillments that pay out less than the deposit's min intent amount.
-    mapping(bytes32 => uint256) internal intentMinAtSignal;
-
     // Snapshot of per-intent manager fee terms at the time of signal
     mapping(bytes32 => address) internal intentManagerFeeRecipient;
     mapping(bytes32 => uint256) internal intentManagerFee;
@@ -124,7 +120,6 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
 
         // Effects
         bytes32 intentHash = _calculateIntentHash();
-        IEscrow.Deposit memory dep = IEscrow(_params.escrow).getDeposit(_params.depositId);
         IEscrow.DepositPaymentMethodData memory depData = IEscrow(_params.escrow).getDepositPaymentMethodData(
             _params.depositId,
             _params.paymentMethod
@@ -136,7 +131,6 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         intentManagerFeeRecipient[intentHash] = managerFeeRecipient;
         intentManagerFee[intentHash] = managerFee;
 
-        intentMinAtSignal[intentHash] = dep.intentAmountRange.min;
         Intent storage storedIntent = intents[intentHash];
         storedIntent.owner = msg.sender;
         storedIntent.to = _params.to;
@@ -263,12 +257,6 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         );
         if (!verificationResult.success) revert PaymentVerificationFailed();
         if (verificationResult.intentHash != _params.intentHash) revert HashMismatch(_params.intentHash, verificationResult.intentHash);
-
-        // Enforce snapshot min-at-signal to prevent sub-min partial fulfillments
-        uint256 minAtSignal = intentMinAtSignal[_params.intentHash];
-        if (minAtSignal > 0 && verificationResult.releaseAmount < minAtSignal) {
-            revert AmountBelowMin(verificationResult.releaseAmount, minAtSignal);
-        }
 
         // Effects
         _pruneIntent(_params.intentHash);
@@ -500,10 +488,6 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         return depositPreIntentHooks[_escrow][_depositId];
     }
 
-    function getIntentMinAtSignal(bytes32 _intentHash) external view returns (uint256) {
-        return intentMinAtSignal[_intentHash];
-    }
-
     /**
      * @notice Returns the immutable hook snapshot for an active intent.
      */
@@ -650,7 +634,6 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
 
         accountIntents[intent.owner].removeStorage(_intentHash);
         delete intents[_intentHash];
-        delete intentMinAtSignal[_intentHash];
         delete intentManagerFeeRecipient[_intentHash];
         delete intentManagerFee[_intentHash];
 

--- a/test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol
@@ -184,10 +184,10 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         );
     }
 
-    function test_FulfillResizesCoverageThenMaturityReleasesStake() public {
+    function test_SubMinimumFulfillResizesCoverageThenMaturityReleasesStake() public {
         _setChargeback(true);
         bytes32 intentHash = _signalDefault();
-        uint256 releaseAmount = 40e6;
+        uint256 releaseAmount = 5e6;
         uint256 releaseEligibleAt = vm.getBlockTimestamp() + RISK_WINDOW;
         verifier.setShouldVerifyPayment(true);
         _fulfill(intentHash, releaseAmount, CONVERSION_RATE);

--- a/test-foundry/deterministic/orchestrator/OrchestratorV3Lifecycle.t.sol
+++ b/test-foundry/deterministic/orchestrator/OrchestratorV3Lifecycle.t.sol
@@ -121,6 +121,19 @@ contract OrchestratorV3LifecycleTest is OrchestratorV3Fixture {
         assertEq(token.balanceOf(taker) - recipientBefore, INTENT_AMOUNT - 250_000);
     }
 
+    function test_FulfillBelowDepositMinimumSettlesVerifiedAmountAndReturnsRemainder() public {
+        uint256 releaseAmount = 5e6;
+        bytes32 intentHash = _signalDefault();
+        uint256 recipientBefore = token.balanceOf(taker);
+        uint256 remainingBefore = escrow.getDeposit(depositId).remainingDeposits;
+
+        _fulfill(intentHash, releaseAmount, CONVERSION_RATE);
+
+        assertEq(token.balanceOf(taker) - recipientBefore, releaseAmount);
+        assertEq(escrow.getDeposit(depositId).remainingDeposits, remainingBefore + INTENT_AMOUNT - releaseAmount);
+        assertEq(orchestrator.getIntent(intentHash).owner, address(0));
+    }
+
     function test_SettlementRevertFailsClosed() public {
         orchestrator.setLifecycleHook(lifecycleHookMock);
         lifecycleHookMock.setRevertOnCallback(true);
@@ -170,5 +183,11 @@ contract OrchestratorV3LifecycleTest is OrchestratorV3Fixture {
             .staticcall(abi.encodeWithSignature("getDepositWhitelistHook(address,uint256)", address(escrow), depositId));
         assertFalse(setter);
         assertFalse(getter);
+    }
+
+    function test_IntentMinAtSignalGetterNoLongerExists() public view {
+        (bool success,) =
+            address(orchestrator).staticcall(abi.encodeWithSignature("getIntentMinAtSignal(bytes32)", bytes32(0)));
+        assertFalse(success);
     }
 }


### PR DESCRIPTION
## Summary

- remove the V3 intent-minimum snapshot, signal-time storage write, cleanup, and getter
- stop rejecting verified V3 fulfillments whose release amount is below the deposit minimum
- cover proportional settlement accounting and V3 chargeback coverage resizing for sub-minimum releases
- leave legacy Orchestrator/OrchestratorV2 behavior and EscrowV2 signal-time range enforcement unchanged

## Verification

- PASS: focused V3 regressions (3 tests)
  - sub-minimum fulfillment transfers the verified amount and returns unused liquidity
  - removed getter selector is unavailable
  - chargeback coverage resizes to the sub-minimum released amount
- PASS: forge build contracts/OrchestratorV3.sol
- PASS: generated OrchestratorV3 ABI omits getIntentMinAtSignal
- PASS: forge fmt --check on changed tests
- PASS: git diff --check
- TIMEOUT: full yarn test exceeded the 5-minute runner cap during Solidity compilation before tests ran
- TIMEOUT: clean yarn build exceeded the 5-minute runner cap during Hardhat compilation; the affected contract build above passed independently

## Deployment and stack impact

- Existing deployed V3 contracts are immutable and unchanged. A future live cutover requires a new numbered deploy script and explicit deployment approval.
- zkp2p-clients is a required follow-up before that cutover: its SDK still reads getIntentMinAtSignal and rejects below-minimum buyer-TEE attestations, and its V3 docs describe the removed behavior.
- No direct references were found on current main in indexer, attestation-service, Curator, Pay, mobile source, relayer, notification-server, Peer Cash, or HQ Admin.