### PR TITLE
feat: bootstrap whitelist deposits

### DIFF
--- a/contracts/hooks/WhitelistPolicy.sol
+++ b/contracts/hooks/WhitelistPolicy.sol
@@ -36,6 +36,7 @@ contract WhitelistPolicy is Ownable, IWhitelistPolicy {
     IOrchestratorRegistry public immutable override orchestratorRegistry;
 
     mapping(address => mapping(uint256 => bool)) public override enabled;
+    mapping(address => mapping(uint256 => bool)) public override bootstrapped;
     mapping(address => mapping(uint256 => mapping(address => bool))) public override isWhitelisted;
     mapping(address => mapping(uint256 => bytes32[])) internal allowedGroups;
 
@@ -57,6 +58,8 @@ contract WhitelistPolicy is Ownable, IWhitelistPolicy {
     error TooManyGroups(uint256 attempted, uint256 maximum);
     error EscrowNotWhitelisted(address escrow);
     error DepositNotFound(address escrow, uint256 depositId);
+    error DepositAlreadyBootstrapped(address escrow, uint256 depositId);
+    error DepositAlreadyEnabled(address escrow, uint256 depositId);
     error NotDepositor(address escrow, uint256 depositId, address caller);
     error UnauthorizedOrchestratorCaller(address caller);
     error TakerNotWhitelisted(address taker, address escrow, uint256 depositId);
@@ -80,12 +83,7 @@ contract WhitelistPolicy is Ownable, IWhitelistPolicy {
     /* ============ Modifiers ============ */
 
     modifier onlyDepositor(address _escrow, uint256 _depositId) {
-        if (!escrowRegistry.isWhitelistedEscrow(_escrow) && !escrowRegistry.isAcceptingAllEscrows()) {
-            revert EscrowNotWhitelisted(_escrow);
-        }
-
-        address depositor = IEscrow(_escrow).getDeposit(_depositId).depositor;
-        if (depositor == address(0)) revert DepositNotFound(_escrow, _depositId);
+        address depositor = _validateDeposit(_escrow, _depositId);
         if (msg.sender != depositor) revert NotDepositor(_escrow, _depositId, msg.sender);
         _;
     }
@@ -100,6 +98,28 @@ contract WhitelistPolicy is Ownable, IWhitelistPolicy {
 
         escrowRegistry = _escrowRegistry;
         emit EscrowRegistryUpdated(address(_escrowRegistry));
+    }
+
+    /**
+     * @inheritdoc IWhitelistPolicy
+     */
+    function bootstrapDeposits(address _escrow, uint256[] calldata _depositIds, bytes32[] calldata _groupIds)
+        external
+        override
+        onlyOwner
+    {
+        if (_depositIds.length == 0 || _groupIds.length == 0) revert EmptyArray();
+
+        for (uint256 i = 0; i < _depositIds.length; ++i) {
+            uint256 depositId = _depositIds[i];
+            _validateDeposit(_escrow, depositId);
+            if (bootstrapped[_escrow][depositId]) revert DepositAlreadyBootstrapped(_escrow, depositId);
+            if (enabled[_escrow][depositId]) revert DepositAlreadyEnabled(_escrow, depositId);
+
+            bootstrapped[_escrow][depositId] = true;
+            _setEnabled(_escrow, depositId, true);
+            _addGroups(_escrow, depositId, _groupIds);
+        }
     }
 
     /* ============ Depositor Functions ============ */
@@ -287,6 +307,15 @@ contract WhitelistPolicy is Ownable, IWhitelistPolicy {
             if (_groups[i] == _groupId) return i;
         }
         return _groups.length;
+    }
+
+    function _validateDeposit(address _escrow, uint256 _depositId) internal view returns (address depositor) {
+        if (!escrowRegistry.isWhitelistedEscrow(_escrow) && !escrowRegistry.isAcceptingAllEscrows()) {
+            revert EscrowNotWhitelisted(_escrow);
+        }
+
+        depositor = IEscrow(_escrow).getDeposit(_depositId).depositor;
+        if (depositor == address(0)) revert DepositNotFound(_escrow, _depositId);
     }
 
     function _validateDependency(address _dependency) internal view {

--- a/contracts/interfaces/IWhitelistPolicy.sol
+++ b/contracts/interfaces/IWhitelistPolicy.sol
@@ -12,6 +12,7 @@ interface IWhitelistPolicy is IPreIntentHook {
     function escrowRegistry() external view returns (IEscrowRegistry);
     function orchestratorRegistry() external view returns (IOrchestratorRegistry);
     function enabled(address escrow, uint256 depositId) external view returns (bool);
+    function bootstrapped(address escrow, uint256 depositId) external view returns (bool);
     function isWhitelisted(address escrow, uint256 depositId, address taker) external view returns (bool);
     function getAllowedGroups(address escrow, uint256 depositId) external view returns (bytes32[] memory);
     function isGroupAllowed(address escrow, uint256 depositId, bytes32 groupId) external view returns (bool);
@@ -46,6 +47,17 @@ interface IWhitelistPolicy is IPreIntentHook {
      * @param escrowRegistry New escrow registry used to authorize deposit configuration.
      */
     function setEscrowRegistry(IEscrowRegistry escrowRegistry) external;
+
+    /**
+     * @notice One-time governance bootstrap that enables existing deposits for the supplied curated groups.
+     * @dev Reverts atomically unless every deposit exists on the whitelisted escrow, is disabled, and has never
+     * been bootstrapped. Both arrays must be non-empty. Depositors retain normal control over the resulting policy,
+     * but disabling or removing groups does not clear the permanent bootstrap marker.
+     * @param escrow Whitelisted Escrow or EscrowV2 holding the deposits.
+     * @param depositIds Existing deposits to bootstrap.
+     * @param groupIds Existing curated group ids to append to every deposit.
+     */
+    function bootstrapDeposits(address escrow, uint256[] calldata depositIds, bytes32[] calldata groupIds) external;
 
     function setEnabled(address escrow, uint256 depositId, bool enabled) external;
     function addWhitelistedAddresses(address escrow, uint256 depositId, address[] calldata takers) external;

--- a/test-foundry/deterministic/hooks/WhitelistPolicy.t.sol
+++ b/test-foundry/deterministic/hooks/WhitelistPolicy.t.sol
@@ -154,6 +154,119 @@ contract WhitelistPolicyTest is Test {
         assertFalse(policy.isTakerAllowed(address(escrow), DEPOSIT_ONE, taker));
     }
 
+    /* ============ bootstrapDeposits ============ */
+
+    function test_BootstrapDepositsEnablesBatchAndAddsGroups() public {
+        policy.bootstrapDeposits(address(escrow), _depositIds(DEPOSIT_ONE, DEPOSIT_TWO), _groupIds(PEERS, PEER_PLUSES));
+
+        assertTrue(policy.bootstrapped(address(escrow), DEPOSIT_ONE));
+        assertTrue(policy.bootstrapped(address(escrow), DEPOSIT_TWO));
+        assertTrue(policy.enabled(address(escrow), DEPOSIT_ONE));
+        assertTrue(policy.enabled(address(escrow), DEPOSIT_TWO));
+        assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE), _groupIds(PEERS, PEER_PLUSES));
+        assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_TWO), _groupIds(PEERS, PEER_PLUSES));
+    }
+
+    function test_BootstrapDepositsIsOwnerOnly() public {
+        vm.expectRevert(bytes("Ownable: caller is not the owner"));
+        vm.prank(maker);
+        policy.bootstrapDeposits(address(escrow), _depositIds(DEPOSIT_ONE), _groupIds(PEERS));
+
+        assertFalse(policy.bootstrapped(address(escrow), DEPOSIT_ONE));
+        assertFalse(policy.enabled(address(escrow), DEPOSIT_ONE));
+    }
+
+    function test_BootstrapDepositsRejectsAlreadyBootstrappedDeposit() public {
+        policy.bootstrapDeposits(address(escrow), _depositIds(DEPOSIT_ONE), _groupIds(PEERS));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(WhitelistPolicy.DepositAlreadyBootstrapped.selector, address(escrow), DEPOSIT_ONE)
+        );
+        policy.bootstrapDeposits(address(escrow), _depositIds(DEPOSIT_ONE), _groupIds(PEER_PLUSES));
+
+        assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE), _groupIds(PEERS));
+    }
+
+    function test_BootstrapDepositsRejectsAlreadyEnabledDeposit() public {
+        vm.prank(maker);
+        policy.setEnabled(address(escrow), DEPOSIT_ONE, true);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(WhitelistPolicy.DepositAlreadyEnabled.selector, address(escrow), DEPOSIT_ONE)
+        );
+        policy.bootstrapDeposits(address(escrow), _depositIds(DEPOSIT_ONE), _groupIds(PEERS));
+
+        assertFalse(policy.bootstrapped(address(escrow), DEPOSIT_ONE));
+        assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE).length, 0);
+    }
+
+    function test_BootstrapDepositsRollsBackEntireBatchWhenLaterDepositFails() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(WhitelistPolicy.DepositNotFound.selector, address(escrow), UNKNOWN_DEPOSIT)
+        );
+        policy.bootstrapDeposits(
+            address(escrow), _depositIds(DEPOSIT_ONE, UNKNOWN_DEPOSIT), _groupIds(PEERS, PEER_PLUSES)
+        );
+
+        assertFalse(policy.bootstrapped(address(escrow), DEPOSIT_ONE));
+        assertFalse(policy.enabled(address(escrow), DEPOSIT_ONE));
+        assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE).length, 0);
+    }
+
+    function test_BootstrapDepositsRejectsEmptyArrays() public {
+        vm.expectRevert(WhitelistPolicy.EmptyArray.selector);
+        policy.bootstrapDeposits(address(escrow), new uint256[](0), _groupIds(PEERS));
+
+        vm.expectRevert(WhitelistPolicy.EmptyArray.selector);
+        policy.bootstrapDeposits(address(escrow), _depositIds(DEPOSIT_ONE), new bytes32[](0));
+    }
+
+    function test_BootstrapDepositsRejectsUnregisteredEscrow() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(WhitelistPolicy.EscrowNotWhitelisted.selector, address(unregisteredEscrow))
+        );
+        policy.bootstrapDeposits(address(unregisteredEscrow), _depositIds(DEPOSIT_ONE), _groupIds(PEERS));
+    }
+
+    function test_BootstrapDepositsRejectsUnknownGroupAndRollsBack() public {
+        bytes32 unknownGroup = bytes32(uint256(999));
+        vm.expectRevert(abi.encodeWithSelector(WhitelistPolicy.GroupDoesNotExist.selector, unknownGroup));
+        policy.bootstrapDeposits(address(escrow), _depositIds(DEPOSIT_ONE), _groupIds(PEERS, unknownGroup));
+
+        assertFalse(policy.bootstrapped(address(escrow), DEPOSIT_ONE));
+        assertFalse(policy.enabled(address(escrow), DEPOSIT_ONE));
+        assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE).length, 0);
+    }
+
+    function test_BootstrapDepositsEmitsCanonicalEvents() public {
+        vm.expectEmit(true, true, false, true, address(policy));
+        emit EnabledUpdated(address(escrow), DEPOSIT_ONE, true);
+        vm.expectEmit(true, true, true, true, address(policy));
+        emit AllowedGroupAdded(address(escrow), DEPOSIT_ONE, PEERS);
+        vm.expectEmit(true, true, true, true, address(policy));
+        emit AllowedGroupAdded(address(escrow), DEPOSIT_ONE, PEER_PLUSES);
+
+        policy.bootstrapDeposits(address(escrow), _depositIds(DEPOSIT_ONE), _groupIds(PEERS, PEER_PLUSES));
+    }
+
+    function test_DepositorCanDisableAndRemoveAllGroupsAfterBootstrap() public {
+        policy.bootstrapDeposits(address(escrow), _depositIds(DEPOSIT_ONE), _groupIds(PEERS, PEER_PLUSES));
+
+        vm.startPrank(maker);
+        policy.setEnabled(address(escrow), DEPOSIT_ONE, false);
+        policy.removeAllowedGroups(address(escrow), DEPOSIT_ONE, _groupIds(PEERS, PEER_PLUSES));
+        vm.stopPrank();
+
+        assertFalse(policy.enabled(address(escrow), DEPOSIT_ONE));
+        assertEq(policy.getAllowedGroups(address(escrow), DEPOSIT_ONE).length, 0);
+        assertTrue(policy.bootstrapped(address(escrow), DEPOSIT_ONE));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(WhitelistPolicy.DepositAlreadyBootstrapped.selector, address(escrow), DEPOSIT_ONE)
+        );
+        policy.bootstrapDeposits(address(escrow), _depositIds(DEPOSIT_ONE), _groupIds(PEER_MERCHANTS));
+    }
+
     /* ============ Authorization ============ */
 
     function test_OnlyDepositorMayConfigureDeposit() public {
@@ -623,6 +736,17 @@ contract WhitelistPolicyTest is Test {
         groupIds[0] = _first;
         groupIds[1] = _second;
         groupIds[2] = _third;
+    }
+
+    function _depositIds(uint256 _first) internal pure returns (uint256[] memory depositIds) {
+        depositIds = new uint256[](1);
+        depositIds[0] = _first;
+    }
+
+    function _depositIds(uint256 _first, uint256 _second) internal pure returns (uint256[] memory depositIds) {
+        depositIds = new uint256[](2);
+        depositIds[0] = _first;
+        depositIds[1] = _second;
     }
 
     function _addresses(address _first) internal pure returns (address[] memory addresses) {


### PR DESCRIPTION
## Summary
- add an owner-only batch bootstrap for existing WhitelistPolicy deposits
- permanently mark bootstrapped deposits while preserving depositor disable and group-removal controls
- reuse canonical enabled/group state paths and events with atomic validation

## Tests
- forge test --match-path test-foundry/deterministic/hooks/WhitelistPolicy.t.sol
- forge test --match-contract (WhitelistPreIntentHookTest|IntentLifecycleHookV1OrchestratorV3Test)
- forge fmt --check contracts/interfaces/IWhitelistPolicy.sol contracts/hooks/WhitelistPolicy.sol test-foundry/deterministic/hooks/WhitelistPolicy.t.sol
- git diff --check

## Deployment impact
- no deployment, address, event, or wiring changes in this PR
- adds public ABI surface and one storage mapping to future WhitelistPolicy deployments