### PR TITLE
feat: initialize lifecycle hook policies

### DIFF
--- a/contracts/hooks/IntentLifecycleHookV1.sol
+++ b/contracts/hooks/IntentLifecycleHookV1.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.18;
 
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
 import {IIntentLifecycleHook} from "../interfaces/IIntentLifecycleHook.sol";
 import {IChargebackPolicy} from "../interfaces/IChargebackPolicy.sol";
 import {IOrchestratorRegistry} from "../interfaces/IOrchestratorRegistry.sol";
@@ -14,41 +16,85 @@ import {IWhitelistPolicy} from "../interfaces/IWhitelistPolicy.sol";
  * Whitelisted takers bypass staking; non-whitelisted takers may be admitted through a chargeback-enabled deposit.
  * Non-chargebackable payment methods give every taker direct access without a chargeback intent or stake lock, regardless of
  * whitelist state. Open deposits remain unrestricted when neither policy is enabled.
- * @dev Reads canonical intent data from the calling orchestrator and forwards cancellation and settlement accounting
- * to ChargebackPolicy. All callbacks remain fail-closed. This hook serves every registered orchestrator and forwards
- * lifecycle callbacks without provenance checks; the trust argument lives in ChargebackPolicy's header.
+ * @dev Reads canonical intent data from the calling orchestrator. WhitelistPolicy must be initialized before admission;
+ * ChargebackPolicy is optional and may be initialized later to extend whitelist-only admission. Cancellation and
+ * settlement accounting are forwarded only for intents admitted through ChargebackPolicy. All callbacks remain
+ * fail-closed. This hook serves every registered orchestrator and forwards lifecycle callbacks without provenance
+ * checks; the trust argument lives in ChargebackPolicy's header.
  * Deregistering an orchestrator with unresolved intents snapshotted to this hook permanently blocks their terminal
  * callbacks, so governance must drain its intents before removing it from OrchestratorRegistry.
  */
-contract IntentLifecycleHookV1 is IIntentLifecycleHook {
+contract IntentLifecycleHookV1 is IIntentLifecycleHook, Ownable {
     /* ============ State Variables ============ */
 
     IOrchestratorRegistry public immutable orchestratorRegistry;
-    IWhitelistPolicy public immutable whitelistPolicy;
-    IChargebackPolicy public immutable chargebackPolicy;
+    IWhitelistPolicy public whitelistPolicy;
+    IChargebackPolicy public chargebackPolicy;
+
+    /// @notice Whether an intent was successfully admitted through the configured chargeback policy.
+    mapping(bytes32 => bool) public isChargebackIntent;
+
+    /* ============ Events ============ */
+
+    event WhitelistPolicyInitialized(address indexed whitelistPolicy);
+    event ChargebackPolicyInitialized(address indexed chargebackPolicy);
 
     /* ============ Errors ============ */
 
     error ZeroAddress();
     error InvalidDependency(address dependency);
+    error WhitelistPolicyNotInitialized();
+    error WhitelistPolicyAlreadyInitialized(address whitelistPolicy);
+    error ChargebackPolicyAlreadyInitialized(address chargebackPolicy);
     error UnauthorizedOrchestrator(address caller);
     error IntentNotFound(bytes32 intentHash);
     error TakerNotWhitelisted(address escrow, uint256 depositId, address taker);
 
     /* ============ Constructor ============ */
 
-    constructor(
-        IOrchestratorRegistry _orchestratorRegistry,
-        IWhitelistPolicy _whitelistPolicy,
-        IChargebackPolicy _chargebackPolicy
-    ) {
+    /**
+     * @notice Creates a lifecycle hook whose policies can be initialized after its address is known.
+     * @dev Whitelist admission remains fail-closed until `initializeWhitelistPolicy` succeeds. Chargeback admission
+     * remains disabled until `initializeChargebackPolicy` succeeds.
+     * @param _orchestratorRegistry Registry authorizing lifecycle callback callers.
+     */
+    constructor(IOrchestratorRegistry _orchestratorRegistry) Ownable() {
         _validateDependency(address(_orchestratorRegistry));
-        _validateDependency(address(_whitelistPolicy));
-        _validateDependency(address(_chargebackPolicy));
 
         orchestratorRegistry = _orchestratorRegistry;
+    }
+
+    /* ============ Policy Initialization ============ */
+
+    /**
+     * @notice GOVERNANCE ONLY: Initializes the whitelist policy used for every future admission.
+     * @dev May succeed exactly once. Admission remains fail-closed while the policy is uninitialized.
+     * @param _whitelistPolicy Non-zero deployed whitelist policy contract.
+     */
+    function initializeWhitelistPolicy(IWhitelistPolicy _whitelistPolicy) external onlyOwner {
+        _validateDependency(address(_whitelistPolicy));
+        if (address(whitelistPolicy) != address(0)) {
+            revert WhitelistPolicyAlreadyInitialized(address(whitelistPolicy));
+        }
+
         whitelistPolicy = _whitelistPolicy;
+        emit WhitelistPolicyInitialized(address(_whitelistPolicy));
+    }
+
+    /**
+     * @notice GOVERNANCE ONLY: Initializes the optional chargeback policy used for future admission.
+     * @dev May succeed exactly once. Until initialized, the hook enforces whitelist policy alone and never forwards
+     * terminal callbacks to a chargeback policy.
+     * @param _chargebackPolicy Non-zero deployed chargeback policy contract.
+     */
+    function initializeChargebackPolicy(IChargebackPolicy _chargebackPolicy) external onlyOwner {
+        _validateDependency(address(_chargebackPolicy));
+        if (address(chargebackPolicy) != address(0)) {
+            revert ChargebackPolicyAlreadyInitialized(address(chargebackPolicy));
+        }
+
         chargebackPolicy = _chargebackPolicy;
+        emit ChargebackPolicyInitialized(address(_chargebackPolicy));
     }
 
     /* ============ Lifecycle Callbacks ============ */
@@ -60,16 +106,26 @@ contract IntentLifecycleHookV1 is IIntentLifecycleHook {
         IOrchestratorV3.Intent memory intent = IOrchestratorV3(msg.sender).getIntent(_intentHash);
         if (intent.owner == address(0)) revert IntentNotFound(_intentHash);
 
-        bool isWhitelistEnabled = whitelistPolicy.enabled(intent.escrow, intent.depositId);
-        if (isWhitelistEnabled && whitelistPolicy.isTakerAllowed(intent.escrow, intent.depositId, intent.owner)) {
+        IWhitelistPolicy currentWhitelistPolicy = whitelistPolicy;
+        if (address(currentWhitelistPolicy) == address(0)) revert WhitelistPolicyNotInitialized();
+
+        bool isWhitelistEnabled = currentWhitelistPolicy.enabled(intent.escrow, intent.depositId);
+        if (isWhitelistEnabled && currentWhitelistPolicy.isTakerAllowed(intent.escrow, intent.depositId, intent.owner))
+        {
             return;
         }
+
+        IChargebackPolicy currentChargebackPolicy = chargebackPolicy;
         // Chargeback admission is stateful, so the configuration query only selects the route.
         // onIntentSignaled remains authoritative for token compatibility, collateral, and pause checks.
-        if (chargebackPolicy.isChargebackEnabled(intent.escrow, intent.depositId)) {
-            chargebackPolicy.onIntentSignaled(
+        if (
+            address(currentChargebackPolicy) != address(0)
+                && currentChargebackPolicy.isChargebackEnabled(intent.escrow, intent.depositId)
+        ) {
+            currentChargebackPolicy.onIntentSignaled(
                 _intentHash, intent.escrow, intent.depositId, intent.owner, intent.paymentMethod, intent.amount
             );
+            isChargebackIntent[_intentHash] = true;
         } else if (isWhitelistEnabled) {
             revert TakerNotWhitelisted(intent.escrow, intent.depositId, intent.owner);
         }
@@ -79,14 +135,20 @@ contract IntentLifecycleHookV1 is IIntentLifecycleHook {
      * @inheritdoc IIntentLifecycleHook
      */
     function onIntentCancelled(bytes32 _intentHash) external override onlyOrchestrator {
+        if (!isChargebackIntent[_intentHash]) return;
+
         chargebackPolicy.onIntentCancelled(_intentHash);
+        delete isChargebackIntent[_intentHash];
     }
 
     /**
      * @inheritdoc IIntentLifecycleHook
      */
     function settleIntent(SettlementContext calldata _context) external override onlyOrchestrator {
+        if (!isChargebackIntent[_context.intentHash]) return;
+
         chargebackPolicy.onIntentSettled(_context.intentHash, _context.releaseAmount, _context.isManualRelease);
+        delete isChargebackIntent[_context.intentHash];
     }
 
     /* ============ Modifiers ============ */

--- a/deploy/30_deploy_v3_lifecycle_stack.ts
+++ b/deploy/30_deploy_v3_lifecycle_stack.ts
@@ -40,6 +40,8 @@ function paymentMethodHash(name: string): string {
 
 async function systemFullyWired(hre: HardhatRuntimeEnvironment): Promise<boolean> {
   const network = hre.deployments.getNetworkName();
+  const [deployer] = await hre.getUnnamedAccounts();
+  const governance = MULTI_SIG[network] || deployer;
   const orchestratorV3 = await hre.deployments.getOrNull("OrchestratorV3");
   const lifecycleHook = await hre.deployments.getOrNull("IntentLifecycleHookV1");
   const chargebackPolicy = await hre.deployments.getOrNull("ChargebackPolicy");
@@ -49,6 +51,7 @@ async function systemFullyWired(hre: HardhatRuntimeEnvironment): Promise<boolean
   const orchestratorRegistryAddress = getDeployedContractAddress(network, "OrchestratorRegistry");
   const paymentVerifierRegistryAddress = getDeployedContractAddress(network, "PaymentVerifierRegistry");
   const unifiedPaymentVerifierV3Address = getDeployedContractAddress(network, "UnifiedPaymentVerifierV3");
+  const whitelistPolicyAddress = getDeployedContractAddress(network, "WhitelistPolicy");
 
   const orchestratorRegistry = await ethers.getContractAt("OrchestratorRegistry", orchestratorRegistryAddress);
   const paymentVerifierRegistry = await ethers.getContractAt(
@@ -56,6 +59,7 @@ async function systemFullyWired(hre: HardhatRuntimeEnvironment): Promise<boolean
     paymentVerifierRegistryAddress,
   );
   const orchestratorV3Contract = await ethers.getContractAt("OrchestratorV3", orchestratorV3.address);
+  const lifecycleHookContract = await ethers.getContractAt("IntentLifecycleHookV1", lifecycleHook.address);
   const stakeVaultContract = await ethers.getContractAt("StakeVault", stakeVault.address);
   const chargebackPolicyContract = await ethers.getContractAt("ChargebackPolicy", chargebackPolicy.address);
 
@@ -65,6 +69,9 @@ async function systemFullyWired(hre: HardhatRuntimeEnvironment): Promise<boolean
   if (oldOrchestratorV3 && (await orchestratorRegistry.isOrchestrator(oldOrchestratorV3))) return false;
 
   if (!sameAddress(await orchestratorV3Contract.lifecycleHook(), lifecycleHook.address)) return false;
+  if (!sameAddress(await lifecycleHookContract.owner(), governance)) return false;
+  if (!sameAddress(await lifecycleHookContract.whitelistPolicy(), whitelistPolicyAddress)) return false;
+  if (!sameAddress(await lifecycleHookContract.chargebackPolicy(), chargebackPolicy.address)) return false;
   if (!sameAddress(await stakeVaultContract.controller(), chargebackPolicy.address)) return false;
   if (!(await chargebackPolicyContract.isLifecycleHookAuthorized(lifecycleHook.address))) return false;
 
@@ -259,11 +266,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const lifecycleHook = await deploy("IntentLifecycleHookV1", {
     from: deployer,
-    args: [
-      orchestratorRegistryAddress,
-      whitelistPolicyAddress,
-      chargebackPolicy.address,
-    ],
+    args: [orchestratorRegistryAddress],
     log: true,
   });
   if (lifecycleHook.newlyDeployed) {
@@ -277,8 +280,19 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   );
   const chargebackVerifierContract = await ethers.getContractAt("ChargebackVerifier", chargebackVerifier.address);
   const chargebackPolicyContract = await ethers.getContractAt("ChargebackPolicy", chargebackPolicy.address);
+  const lifecycleHookContract = await ethers.getContractAt("IntentLifecycleHookV1", lifecycleHook.address);
   const orchestratorV3Contract = await ethers.getContractAt("OrchestratorV3", orchestratorV3.address);
   const orchestratorRegistry = await ethers.getContractAt("OrchestratorRegistry", orchestratorRegistryAddress);
+
+  const configuredWhitelistPolicy = await lifecycleHookContract.whitelistPolicy();
+  if (sameAddress(configuredWhitelistPolicy, ethers.constants.AddressZero)) {
+    await (await lifecycleHookContract.initializeWhitelistPolicy(whitelistPolicyAddress)).wait();
+    await waitForDeploymentDelay(hre);
+  } else if (!sameAddress(configuredWhitelistPolicy, whitelistPolicyAddress)) {
+    throw new Error(
+      `IntentLifecycleHookV1 whitelist policy mismatch: expected ${whitelistPolicyAddress}, found ${configuredWhitelistPolicy}`,
+    );
+  }
 
   const currentController = await stakeVaultContract.controller();
   if (sameAddress(currentController, ethers.constants.AddressZero)) {
@@ -309,6 +323,16 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     }
   }
 
+  const configuredChargebackPolicy = await lifecycleHookContract.chargebackPolicy();
+  if (sameAddress(configuredChargebackPolicy, ethers.constants.AddressZero)) {
+    await (await lifecycleHookContract.initializeChargebackPolicy(chargebackPolicy.address)).wait();
+    await waitForDeploymentDelay(hre);
+  } else if (!sameAddress(configuredChargebackPolicy, chargebackPolicy.address)) {
+    throw new Error(
+      `IntentLifecycleHookV1 chargeback policy mismatch: expected ${chargebackPolicy.address}, found ${configuredChargebackPolicy}`,
+    );
+  }
+
   if (!sameAddress(await orchestratorV3Contract.lifecycleHook(), lifecycleHook.address)) {
     await (await orchestratorV3Contract.setLifecycleHook(lifecycleHook.address)).wait();
     await waitForDeploymentDelay(hre);
@@ -323,6 +347,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   await setNewOwner(hre, orchestratorV3Contract, governance);
   await setNewOwner(hre, stakeVaultContract, governance);
   await setNewOwner(hre, chargebackPolicyContract, governance);
+  await setNewOwner(hre, lifecycleHookContract, governance);
   await setNewOwner(hre, chargebackVerifierContract, governance);
   await setNewOwner(hre, chargebackNullifierRegistryContract, governance);
   if (nullifierRegistryV2NewlyDeployed) {

--- a/test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol
@@ -47,7 +47,9 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         );
         vault.initializeController(address(chargebackPolicy));
         chargebackNullifierRegistry.addWritePermission(address(chargebackPolicy));
-        lifecycleHook = new IntentLifecycleHookV1(orchestratorRegistry, whitelistPolicy, chargebackPolicy);
+        lifecycleHook = new IntentLifecycleHookV1(orchestratorRegistry);
+        lifecycleHook.initializeWhitelistPolicy(whitelistPolicy);
+        lifecycleHook.initializeChargebackPolicy(chargebackPolicy);
         chargebackPolicy.setLifecycleHookAuthorization(address(lifecycleHook), true);
         chargebackPolicy.setRiskWindow(METHOD, RISK_WINDOW);
         orchestrator.setLifecycleHook(lifecycleHook);
@@ -64,6 +66,7 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
             uint256(chargebackPolicy.getChargebackIntent(intentHash).status),
             uint256(IChargebackPolicy.ChargebackIntentStatus.NONE)
         );
+        assertFalse(lifecycleHook.isChargebackIntent(intentHash));
         assertEq(vault.lockedStake(taker), 0);
         assertEq(escrow.getDepositIntent(depositId, intentHash).intentHash, intentHash);
     }
@@ -77,6 +80,7 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
             uint256(chargebackPolicy.getChargebackIntent(intentHash).status),
             uint256(IChargebackPolicy.ChargebackIntentStatus.PENDING)
         );
+        assertTrue(lifecycleHook.isChargebackIntent(intentHash));
 
         uint256 counterBefore = orchestrator.intentCounter();
         bytes32 rejectedIntent = _intentHash(counterBefore);
@@ -103,6 +107,7 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
             uint256(chargebackPolicy.getChargebackIntent(intentHash).status),
             uint256(IChargebackPolicy.ChargebackIntentStatus.NONE)
         );
+        assertTrue(lifecycleHook.isChargebackIntent(intentHash));
         assertEq(vault.lockedStake(other), 0);
         assertEq(escrow.getDepositIntent(depositId, intentHash).intentHash, intentHash);
 
@@ -112,6 +117,7 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
             uint256(chargebackPolicy.getChargebackIntent(intentHash).status),
             uint256(IChargebackPolicy.ChargebackIntentStatus.NONE)
         );
+        assertFalse(lifecycleHook.isChargebackIntent(intentHash));
     }
 
     function test_WhitelistOnNonMemberWithChargebackOffRejects() public {
@@ -165,8 +171,10 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
     function test_CancelIntentAndExpiryPruneUnlockStake() public {
         _setChargeback(true);
         bytes32 cancelledIntent = _signalDefault();
+        assertTrue(lifecycleHook.isChargebackIntent(cancelledIntent));
         vm.prank(taker);
         orchestrator.cancelIntent(cancelledIntent);
+        assertFalse(lifecycleHook.isChargebackIntent(cancelledIntent));
         assertEq(vault.lockedStake(taker), 0);
         assertEq(
             uint256(chargebackPolicy.getChargebackIntent(cancelledIntent).status),
@@ -174,9 +182,11 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         );
 
         bytes32 expiredIntent = _signalDefault();
+        assertTrue(lifecycleHook.isChargebackIntent(expiredIntent));
         IEscrowV2.Intent memory intent = escrow.getDepositIntent(depositId, expiredIntent);
         vm.warp(intent.expiryTime + 1);
         escrow.pruneExpiredIntents(depositId);
+        assertFalse(lifecycleHook.isChargebackIntent(expiredIntent));
         assertEq(vault.lockedStake(taker), 0);
         assertEq(
             uint256(chargebackPolicy.getChargebackIntent(expiredIntent).status),
@@ -190,7 +200,9 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         uint256 releaseAmount = 5e6;
         uint256 releaseEligibleAt = vm.getBlockTimestamp() + RISK_WINDOW;
         verifier.setShouldVerifyPayment(true);
+        assertTrue(lifecycleHook.isChargebackIntent(intentHash));
         _fulfill(intentHash, releaseAmount, CONVERSION_RATE);
+        assertFalse(lifecycleHook.isChargebackIntent(intentHash));
 
         IChargebackPolicy.ChargebackIntent memory chargebackIntent = chargebackPolicy.getChargebackIntent(intentHash);
         assertEq(chargebackIntent.releaseAmount, releaseAmount);
@@ -210,8 +222,10 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         _setChargeback(true);
         bytes32 intentHash = _signalDefault();
         uint256 releaseEligibleAt = vm.getBlockTimestamp() + RISK_WINDOW;
+        assertTrue(lifecycleHook.isChargebackIntent(intentHash));
         vm.prank(depositor);
         orchestrator.releaseFundsToPayer(intentHash);
+        assertFalse(lifecycleHook.isChargebackIntent(intentHash));
 
         IChargebackPolicy.ChargebackIntent memory chargebackIntent = chargebackPolicy.getChargebackIntent(intentHash);
         assertTrue(chargebackIntent.isManualRelease);
@@ -250,6 +264,7 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         vm.expectRevert(IChargebackPolicy.AdmissionsPaused.selector);
         _signalCall(taker, _defaultParams());
 
+        assertFalse(lifecycleHook.isChargebackIntent(rejectedIntent));
         assertEq(orchestrator.intentCounter(), counterBefore);
         assertEq(orchestrator.getIntent(rejectedIntent).owner, address(0));
         assertEq(escrow.getDepositIntent(depositId, rejectedIntent).intentHash, bytes32(0));
@@ -258,6 +273,7 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
 
     function test_CancellationWithoutChargebackIntentLeavesVaultUntouched() public {
         bytes32 intentHash = _signalDefault();
+        assertFalse(lifecycleHook.isChargebackIntent(intentHash));
         uint256 totalBefore = vault.totalStaked();
         vm.prank(taker);
         orchestrator.cancelIntent(intentHash);
@@ -273,8 +289,9 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         _setChargeback(true);
         bytes32 oldCancelledIntent = _signalDefault();
         bytes32 oldSettledIntent = _signalDefault();
-        IntentLifecycleHookV1 newLifecycleHook =
-            new IntentLifecycleHookV1(orchestratorRegistry, whitelistPolicy, chargebackPolicy);
+        IntentLifecycleHookV1 newLifecycleHook = new IntentLifecycleHookV1(orchestratorRegistry);
+        newLifecycleHook.initializeWhitelistPolicy(whitelistPolicy);
+        newLifecycleHook.initializeChargebackPolicy(chargebackPolicy);
 
         chargebackPolicy.setLifecycleHookAuthorization(address(newLifecycleHook), true);
         orchestrator.setLifecycleHook(newLifecycleHook);
@@ -285,6 +302,7 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         );
         vm.prank(taker);
         orchestrator.cancelIntent(oldCancelledIntent);
+        assertTrue(lifecycleHook.isChargebackIntent(oldCancelledIntent));
         assertEq(
             uint256(chargebackPolicy.getChargebackIntent(oldCancelledIntent).status),
             uint256(IChargebackPolicy.ChargebackIntentStatus.PENDING)
@@ -293,6 +311,7 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         chargebackPolicy.setLifecycleHookAuthorization(address(lifecycleHook), true);
         vm.prank(taker);
         orchestrator.cancelIntent(oldCancelledIntent);
+        assertFalse(lifecycleHook.isChargebackIntent(oldCancelledIntent));
         assertEq(
             uint256(chargebackPolicy.getChargebackIntent(oldCancelledIntent).status),
             uint256(IChargebackPolicy.ChargebackIntentStatus.CANCELLED)
@@ -301,15 +320,18 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         uint256 releaseAmount = 40e6;
         verifier.setShouldVerifyPayment(true);
         _fulfill(oldSettledIntent, releaseAmount, CONVERSION_RATE);
+        assertFalse(lifecycleHook.isChargebackIntent(oldSettledIntent));
         IChargebackPolicy.ChargebackIntent memory oldSettledIntentState =
             chargebackPolicy.getChargebackIntent(oldSettledIntent);
         assertEq(uint256(oldSettledIntentState.status), uint256(IChargebackPolicy.ChargebackIntentStatus.SETTLED));
         assertEq(oldSettledIntentState.releaseAmount, releaseAmount);
 
         bytes32 newIntent = _signalDefault();
+        assertTrue(newLifecycleHook.isChargebackIntent(newIntent));
         assertEq(address(orchestrator.getIntentLifecycleHook(newIntent)), address(newLifecycleHook));
         vm.prank(taker);
         orchestrator.cancelIntent(newIntent);
+        assertFalse(newLifecycleHook.isChargebackIntent(newIntent));
         assertEq(
             uint256(chargebackPolicy.getChargebackIntent(newIntent).status),
             uint256(IChargebackPolicy.ChargebackIntentStatus.CANCELLED)

--- a/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
@@ -3,9 +3,11 @@
 pragma solidity ^0.8.18;
 
 import {IIntentLifecycleHook} from "contracts/interfaces/IIntentLifecycleHook.sol";
+import {IChargebackPolicy} from "contracts/interfaces/IChargebackPolicy.sol";
 import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
 import {IOrchestratorRegistry} from "contracts/interfaces/IOrchestratorRegistry.sol";
 import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
+import {IWhitelistPolicy} from "contracts/interfaces/IWhitelistPolicy.sol";
 import {StakeVault} from "contracts/StakeVault.sol";
 import {ChargebackPolicy} from "contracts/hooks/ChargebackPolicy.sol";
 import {IntentLifecycleHookV1} from "contracts/hooks/IntentLifecycleHookV1.sol";
@@ -52,17 +54,100 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
         );
         stakeVault.initializeController(address(chargebackPolicy));
         chargebackNullifierRegistry.addWritePermission(address(chargebackPolicy));
-        lifecycleHook = new IntentLifecycleHookV1(orchestratorRegistry, policy, chargebackPolicy);
+        lifecycleHook = new IntentLifecycleHookV1(orchestratorRegistry);
+        lifecycleHook.initializeWhitelistPolicy(policy);
+        lifecycleHook.initializeChargebackPolicy(chargebackPolicy);
         chargebackPolicy.setLifecycleHookAuthorization(address(lifecycleHook), true);
         IOrchestratorV3(address(orchestrator)).setLifecycleHook(lifecycleHook);
     }
 
-    function test_ConstructorRejectsZeroAndNonContractDependencies() public {
+    function test_ConstructorRejectsZeroAndNonContractRegistry() public {
         vm.expectRevert(IntentLifecycleHookV1.ZeroAddress.selector);
-        new IntentLifecycleHookV1(IOrchestratorRegistry(address(0)), policy, chargebackPolicy);
+        new IntentLifecycleHookV1(IOrchestratorRegistry(address(0)));
 
         vm.expectRevert(abi.encodeWithSelector(IntentLifecycleHookV1.InvalidDependency.selector, other));
-        new IntentLifecycleHookV1(IOrchestratorRegistry(other), policy, chargebackPolicy);
+        new IntentLifecycleHookV1(IOrchestratorRegistry(other));
+    }
+
+    function test_PolicyInitializersAreOwnerOnly() public {
+        IntentLifecycleHookV1 uninitializedHook = new IntentLifecycleHookV1(orchestratorRegistry);
+
+        vm.startPrank(other);
+        vm.expectRevert(bytes("Ownable: caller is not the owner"));
+        uninitializedHook.initializeWhitelistPolicy(policy);
+        vm.expectRevert(bytes("Ownable: caller is not the owner"));
+        uninitializedHook.initializeChargebackPolicy(chargebackPolicy);
+        vm.stopPrank();
+    }
+
+    function test_PolicyInitializersRejectZeroAndNonContractDependencies() public {
+        IntentLifecycleHookV1 uninitializedHook = new IntentLifecycleHookV1(orchestratorRegistry);
+
+        vm.expectRevert(IntentLifecycleHookV1.ZeroAddress.selector);
+        uninitializedHook.initializeWhitelistPolicy(IWhitelistPolicy(address(0)));
+        vm.expectRevert(abi.encodeWithSelector(IntentLifecycleHookV1.InvalidDependency.selector, other));
+        uninitializedHook.initializeWhitelistPolicy(IWhitelistPolicy(other));
+
+        vm.expectRevert(IntentLifecycleHookV1.ZeroAddress.selector);
+        uninitializedHook.initializeChargebackPolicy(IChargebackPolicy(address(0)));
+        vm.expectRevert(abi.encodeWithSelector(IntentLifecycleHookV1.InvalidDependency.selector, other));
+        uninitializedHook.initializeChargebackPolicy(IChargebackPolicy(other));
+    }
+
+    function test_PoliciesCanOnlyBeInitializedOnce() public {
+        IntentLifecycleHookV1 initializedHook = new IntentLifecycleHookV1(orchestratorRegistry);
+        initializedHook.initializeWhitelistPolicy(policy);
+        initializedHook.initializeChargebackPolicy(chargebackPolicy);
+
+        assertEq(address(initializedHook.whitelistPolicy()), address(policy));
+        assertEq(address(initializedHook.chargebackPolicy()), address(chargebackPolicy));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IntentLifecycleHookV1.WhitelistPolicyAlreadyInitialized.selector, address(policy))
+        );
+        initializedHook.initializeWhitelistPolicy(policy);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IntentLifecycleHookV1.ChargebackPolicyAlreadyInitialized.selector, address(chargebackPolicy)
+            )
+        );
+        initializedHook.initializeChargebackPolicy(chargebackPolicy);
+    }
+
+    function test_UninitializedWhitelistFailsClosedBeforeEscrowLock() public {
+        IntentLifecycleHookV1 uninitializedHook = new IntentLifecycleHookV1(orchestratorRegistry);
+        orchestrator.setLifecycleHook(uninitializedHook);
+
+        uint256 counterBefore = orchestrator.intentCounter();
+        bytes32 rejectedIntent = _intentHash(counterBefore);
+        uint256 availableBefore = escrow.getDeposit(depositId).remainingDeposits;
+
+        vm.expectRevert(IntentLifecycleHookV1.WhitelistPolicyNotInitialized.selector);
+        _signalCall(taker, _defaultParams());
+
+        assertEq(orchestrator.intentCounter(), counterBefore);
+        assertEq(orchestrator.getIntent(rejectedIntent).owner, address(0));
+        assertEq(escrow.getDepositIntent(depositId, rejectedIntent).intentHash, bytes32(0));
+        assertEq(escrow.getDeposit(depositId).remainingDeposits, availableBefore);
+    }
+
+    function test_UninitializedChargebackPolicyEnforcesWhitelistOnly() public {
+        IntentLifecycleHookV1 whitelistOnlyHook = new IntentLifecycleHookV1(orchestratorRegistry);
+        whitelistOnlyHook.initializeWhitelistPolicy(policy);
+        orchestrator.setLifecycleHook(whitelistOnlyHook);
+
+        vm.prank(depositor);
+        policy.configureDeposit(address(escrow), depositId, true, new bytes32[](0), _addresses(taker));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IntentLifecycleHookV1.TakerNotWhitelisted.selector, address(escrow), depositId, other
+            )
+        );
+        _signalCall(other, _defaultParams());
+
+        bytes32 admittedIntent = _signalDefault();
+        assertFalse(whitelistOnlyHook.isChargebackIntent(admittedIntent));
     }
 
     function test_DisabledPolicyPassesThroughAndSnapshotsGlobalHook() public {
@@ -192,6 +277,7 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
     function test_SettlementIsNoOpAndDoesNotRecheckPointInTimeMembership() public {
         _enablePeerPolicyAndAddTaker();
         bytes32 intentHash = _signalDefault();
+        assertFalse(lifecycleHook.isChargebackIntent(intentHash));
         groupRegistry.removeMembers(PEERS, _addresses(taker));
 
         uint256 takerBalanceBefore = token.balanceOf(taker);
@@ -200,6 +286,24 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
 
         assertEq(token.balanceOf(taker) - takerBalanceBefore, INTENT_AMOUNT);
         assertEq(address(IOrchestratorV3(address(orchestrator)).getIntentLifecycleHook(intentHash)), address(0));
+    }
+
+    function test_UntrackedIntentsSkipChargebackTerminalCallbacks() public {
+        _enablePeerPolicyAndAddTaker();
+        bytes32 cancelledIntent = _signalDefault();
+        bytes32 settledIntent = _signalDefault();
+        assertFalse(lifecycleHook.isChargebackIntent(cancelledIntent));
+        assertFalse(lifecycleHook.isChargebackIntent(settledIntent));
+
+        chargebackPolicy.setLifecycleHookAuthorization(address(lifecycleHook), false);
+
+        vm.prank(taker);
+        orchestrator.cancelIntent(cancelledIntent);
+        vm.prank(depositor);
+        orchestrator.releaseFundsToPayer(settledIntent);
+
+        assertEq(escrow.getDepositIntent(depositId, cancelledIntent).intentHash, bytes32(0));
+        assertEq(escrow.getDepositIntent(depositId, settledIntent).intentHash, bytes32(0));
     }
 
     function test_GlobalHookReplacementDoesNotMutateActiveIntentSnapshot() public {


### PR DESCRIPTION
## Summary

- reduce `IntentLifecycleHookV1` constructor to the orchestrator registry and add owner-only, exactly-once policy initializers
- fail closed until whitelist initialization, preserve whitelist-only operation before optional chargeback initialization, and track only successful chargeback-route admissions
- forward terminal callbacks only for tracked intents and clear tracking after successful cancellation or settlement
- update the V3 lifecycle deployment lane to initialize dependencies safely and transfer hook ownership to governance
- add deterministic coverage for initializer controls, fail-closed behavior, whitelist-only admission, tracking, callback rollback, and terminal cleanup

## Validation

- `forge test --match-path test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol -vv` — 14 passed
- `forge test --match-path test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol -vv` — 21 passed
- `yarn compile` — 128 Solidity files compiled; 268 typings generated
- targeted `tsc --noEmit` for `hardhat.config.ts` and `deploy/30_deploy_v3_lifecycle_stack.ts` — passed
- `forge fmt --check` on changed Solidity files — passed
- `git diff --check` — passed

## Deployment impact

No contracts were deployed. A future lifecycle-stack deployment must use the new one-argument constructor, initialize whitelist first, finish chargeback dependency authorization, initialize chargeback, install the hook, and transfer hook ownership to governance. The updated lane enforces that sequence and rejects mismatched pre-existing policy wiring.