### PR TITLE
docs(agent): keep contract impact checks repository-owned

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,8 +68,9 @@ iteration loop.
 
 - Inspect the requested change and `git diff` first. List the production files, interfaces, deploy/package consumers,
   and test files that can actually be affected.
-- Use direct searches (`rg` for imports, calls, fixtures, and selectors) to map impact. Do not invoke, recreate, or use
-  `zkp2p-stack-impact` or another generic "stack impact" skill in this repository.
+- Use direct searches (`rg` for imports, calls, fixtures, and selectors) during implementation. Do not run a generic
+  impact workflow at task start. After a stabilized PR diff changes a public cross-repository boundary, use the
+  workspace-level `$zkp2p-merge-impact-check` as the final read-only gate before marking ready or merging.
 - For architecture, explanation, documentation, or read-only review tasks, do not compile or test unless the answer
   depends on executing code.
 - Do not expand a focused request into repository cleanup, unrelated test repair, coverage work, or extra review

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,9 +68,9 @@ iteration loop.
 
 - Inspect the requested change and `git diff` first. List the production files, interfaces, deploy/package consumers,
   and test files that can actually be affected.
-- Use direct searches (`rg` for imports, calls, fixtures, and selectors) during implementation. Do not run a generic
-  impact workflow at task start. After a stabilized PR diff changes a public cross-repository boundary, use the
-  workspace-level `$zkp2p-merge-impact-check` as the final read-only gate before marking ready or merging.
+- Use direct searches (`rg` for imports, calls, fixtures, and selectors) to map contract-specific consumers. Impact
+  analysis belongs to the contract owner and its concrete tests and review checks; do not invoke or recreate a
+  generic fleet-wide impact skill.
 - For architecture, explanation, documentation, or read-only review tasks, do not compile or test unless the answer
   depends on executing code.
 - Do not expand a focused request into repository cleanup, unrelated test repair, coverage work, or extra review


### PR DESCRIPTION
## Summary
- remove the stale generic skill reference from contract guidance; keep consumer tracing with contract-owner searches, tests, and review checks
- delete the generic impact abstraction rather than replacing or renaming it
- no application runtime, deployment, package, migration, or production behavior changes

## Validation
- official skill validation for changed remaining skills where applicable
- changed discovery-link checks
- `git diff --check`

## Related cleanup
https://github.com/0xSachinK/zkp2p-workspace-control/pull/50 removes the generic root workflow. There is intentionally no replacement gate.