### PR TITLE
chore(release): prepare contracts-v2 0.4.0-rc.5

### DIFF
--- a/deployments/outputs/baseContracts.ts
+++ b/deployments/outputs/baseContracts.ts
@@ -11787,7 +11787,7 @@ export default {
       ]
     },
     "OrchestratorV3": {
-      "address": "0x930B0FD444F51ca2860Ca8F368c3388d3f684030",
+      "address": "0x014025fDE093f8701d86e9f38e2C3a9b779cb5c7",
       "abi": [
         {
           "inputs": [
@@ -12794,25 +12794,6 @@ export default {
               "internalType": "contract IIntentLifecycleHook",
               "name": "",
               "type": "address"
-            }
-          ],
-          "stateMutability": "view",
-          "type": "function"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "bytes32",
-              "name": "_intentHash",
-              "type": "bytes32"
-            }
-          ],
-          "name": "getIntentMinAtSignal",
-          "outputs": [
-            {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
             }
           ],
           "stateMutability": "view",
@@ -20053,8 +20034,185 @@ export default {
         }
       ]
     },
+    "WhitelistLifecycleHook": {
+      "address": "0x251d78fb6bBb4071995Bce74bAfC9E4168638622",
+      "abi": [
+        {
+          "inputs": [
+            {
+              "internalType": "contract IOrchestratorRegistry",
+              "name": "_orchestratorRegistry",
+              "type": "address"
+            },
+            {
+              "internalType": "contract IWhitelistPolicy",
+              "name": "_whitelistPolicy",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "constructor"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "intentHash",
+              "type": "bytes32"
+            }
+          ],
+          "name": "IntentNotFound",
+          "type": "error"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "dependency",
+              "type": "address"
+            }
+          ],
+          "name": "InvalidDependency",
+          "type": "error"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "escrow",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "depositId",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "taker",
+              "type": "address"
+            }
+          ],
+          "name": "TakerNotWhitelisted",
+          "type": "error"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "caller",
+              "type": "address"
+            }
+          ],
+          "name": "UnauthorizedOrchestrator",
+          "type": "error"
+        },
+        {
+          "inputs": [],
+          "name": "ZeroAddress",
+          "type": "error"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ],
+          "name": "onIntentCancelled",
+          "outputs": [],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "_intentHash",
+              "type": "bytes32"
+            }
+          ],
+          "name": "onIntentSignaled",
+          "outputs": [],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "orchestratorRegistry",
+          "outputs": [
+            {
+              "internalType": "contract IOrchestratorRegistry",
+              "name": "",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "components": [
+                {
+                  "internalType": "bytes32",
+                  "name": "intentHash",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "address",
+                  "name": "token",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "recipient",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "releaseAmount",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "netAmount",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "isManualRelease",
+                  "type": "bool"
+                }
+              ],
+              "internalType": "struct IIntentLifecycleHook.SettlementContext",
+              "name": "",
+              "type": "tuple"
+            }
+          ],
+          "name": "settleIntent",
+          "outputs": [],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "whitelistPolicy",
+          "outputs": [
+            {
+              "internalType": "contract IWhitelistPolicy",
+              "name": "",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        }
+      ]
+    },
     "WhitelistPolicy": {
-      "address": "0xE96eD3dBc5869b98a555b137C2dcCDf157eD17B3",
+      "address": "0xBC53641b4B2504f0061D6a9426C61B8eBE9B4Ff0",
       "abi": [
         {
           "inputs": [
@@ -20076,6 +20234,38 @@ export default {
           ],
           "stateMutability": "nonpayable",
           "type": "constructor"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "escrow",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "depositId",
+              "type": "uint256"
+            }
+          ],
+          "name": "DepositAlreadyBootstrapped",
+          "type": "error"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "escrow",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "depositId",
+              "type": "uint256"
+            }
+          ],
+          "name": "DepositAlreadyEnabled",
+          "type": "error"
         },
         {
           "inputs": [
@@ -20419,6 +20609,53 @@ export default {
           "name": "addWhitelistedAddresses",
           "outputs": [],
           "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "_escrow",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "_depositIds",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "bytes32[]",
+              "name": "_groupIds",
+              "type": "bytes32[]"
+            }
+          ],
+          "name": "bootstrapDeposits",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "name": "bootstrapped",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "stateMutability": "view",
           "type": "function"
         },
         {

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -2,12 +2,14 @@
 
 Official npm package for ZKP2P V2 smart contract interfaces, ABIs, addresses, and utilities.
 
-## Release candidate 0.4.0-rc.3
+## Release candidate 0.4.0-rc.5
 
-- Refreshes the Base Staging deployment addresses for the redeployed `OrchestratorV3`, `StakeVault`,
-  `ChargebackNullifierRegistry`, `ChargebackVerifier`, `ChargebackPolicy`, and `IntentLifecycleHookV1`
-  after removing the unused `IOrchestratorV3` event declarations.
-- Keeps the Base production deployment addresses and ABIs unchanged.
+- Refreshes the Base deployment exports for the whitelist-only V3 lane: `WhitelistPolicy`,
+  `WhitelistLifecycleHook`, and `OrchestratorV3`.
+- Refreshes the Base Staging lifecycle and chargeback deployment addresses and ABIs introduced since
+  `0.4.0-rc.4`, including the new `WhitelistLifecycleHook` export.
+- Publishing these deployed addresses does not activate the fresh Base `OrchestratorV3`; its
+  governance registration remains a separate operation.
 
 ## Installation
 

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/contracts-v2",
-  "version": "0.4.0-rc.4",
+  "version": "0.4.0-rc.5",
   "description": "ZKP2P V2 smart contract interfaces and utilities",
   "main": "./_cjs/index.js",
   "module": "./_esm/index.js",


### PR DESCRIPTION
## Summary

- prepare the first unused trusted-publishing candidate, `@zkp2p/contracts-v2@0.4.0-rc.5`
- regenerate the Base package export from the checked-in deployment artifacts
- publish the fresh whitelist-only `OrchestratorV3`, `WhitelistPolicy`, and `WhitelistLifecycleHook` addresses without implying governance activation

## Changes

- update `packages/contracts/package.json` to `0.4.0-rc.5`
- refresh `deployments/outputs/baseContracts.ts` so all Base addresses and ABIs match their deployment artifacts
- update package release notes for the Base and Base Staging address changes since `0.4.0-rc.4`

## Test Plan

- [x] `yarn install --immutable`
- [x] `yarn compile`
- [x] `yarn pkg:build`
- [x] `yarn pkg:test`
- [x] `yarn workspace @zkp2p/contracts-v2 verify:release`
- [x] `yarn test:release-policy`
- [x] `(cd packages/contracts && npm pack --dry-run --ignore-scripts --json)`
- [x] `git diff --check`

## Release Notes

- live npm currently has `rc=0.4.0-rc.4` and `latest=0.3.0`; `0.4.0-rc.5` is unused
- local Foundry is `1.5.1`; the protected publish workflow pins `1.7.1` and remains the authoritative complete-suite release gate
- Base governance registration of the fresh O3 is outside this package release
