### PR TITLE
refactor(deploy): make lane 31 the whitelist-only V3 cutover

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -114,7 +114,7 @@ When either V2 or V3 source changes:
 
 1. Diff both implementations and interfaces against canonical current main.
 2. Derive the intended V3 deltas from current interfaces, lifecycle tests,
-   deployment tests, and `deploy/30_deploy_v3_lifecycle_stack.ts`; do not copy an
+   deployment tests, and `deploy/31_deploy_v3_lifecycle_stack.ts`; do not copy an
    allowlist from an older review.
 3. Verify shared admission, fee, escrow, registry, payment-verifier, nullifier,
    replay, authorization, and settlement invariants semantically.

--- a/.claude/skills/ship-contracts/SKILL.md
+++ b/.claude/skills/ship-contracts/SKILL.md
@@ -59,13 +59,13 @@ the approved target state.
   activation as distinct states.
 - Do not add a deploy script merely because source exists.
 - Treat `OrchestratorV3` as a dedicated implementation. Its current lifecycle
-  design intentionally differs from V2. Its mounted lane `30` supports
+  design intentionally differs from V2. Its mounted lane `31` supports
   `localhost`, `hardhat`, Base staging, and an explicitly gated Base
   whitelist-only deployment.
-- Base lane `30` requires `ENABLE_BASE_V3_GROUPS_CUTOVER=true`, a separately
+- Base lane `31` requires `ENABLE_BASE_V3_GROUPS_CUTOVER=true`, a separately
   reviewed exact source SHA, and the production governance/deployer path. It
   must leave existing orchestrators registered and produce only the fresh O3
-  registry-add Safe call. Lane `31` remains outside that deployment.
+  registry-add Safe call. Lane `32` remains outside that deployment.
 - Remove retired active routes, permissions, exports, and aliases in the same
   hard cutover.
 - Do not add rollback compatibility to a one-way verifier or nullifier
@@ -89,7 +89,7 @@ Before activation:
 
 - verify deployer, chain ID, RPC, parameters, expected old state, and expected
   new state;
-- for lane `30`, resolve the expected `OrchestratorV3`,
+- for lane `31`, resolve the expected `OrchestratorV3`,
   `UnifiedPaymentVerifierV3`, lifecycle hook, stake vault, chargeback policy,
   verifier/nullifier, registries, ownership, and prior-orchestrator state from
   current source and artifacts;
@@ -109,7 +109,7 @@ production immediately before submission.
 The Base whitelist-only lane must be reviewed at an exact source SHA. Require
 the explicit Base cutover flag, retain existing orchestrators, and verify that
 the generated Safe batch contains only `addOrchestrator(freshO3)`. Do not reuse
-staging artifacts or include lane `31` as a shortcut.
+staging artifacts or include lane `32` as a shortcut.
 
 Fail closed on chain, address, signer, ownership, permission, or expected-state
 mismatch. Do not reuse staging approval. Do not publish a package automatically.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,13 +11,13 @@
 
 ## V3 Lifecycle Deployment Status
 
-- `deploy/30_deploy_v3_lifecycle_stack.ts` is the mounted whitelist-only V3 lifecycle lane for `localhost`, `hardhat`,
-  Base staging, and Base. Its lane-29 dependency supplies `WhitelistPolicy`; lane 30 deploys
+- `deploy/31_deploy_v3_lifecycle_stack.ts` is the mounted whitelist-only V3 lifecycle lane for `localhost`, `hardhat`,
+  Base staging, and Base. Its lane-29 dependency supplies `WhitelistPolicy`; lane 31 deploys
   `WhitelistLifecycleHook` and `OrchestratorV3` without activating the staking/chargeback lane.
 - Base staging removes only the explicitly drained staging predecessors. Base keeps the existing orchestrators
   registered and queues exactly one Safe call to register the fresh O3. Base execution requires
   `ENABLE_BASE_V3_GROUPS_CUTOVER=true`, a separately approved exact source SHA, and the production governance path.
-- Lane `31` remains staging-only and must not run during the Base whitelist-only deployment. Never infer live
+- Lane `32` remains staging-only and must not run during the Base whitelist-only deployment. Never infer live
   activation from source, tests, package ABIs, a mounted script, or checked-in artifacts.
 - `IntentGuardian` and `WhitelistPolicy` remain part of the V2 policy history and are reused where the mounted V3
   lifecycle lane specifies. Do not redeploy a core stack merely to change an independently owned policy component.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,11 +11,11 @@ Read `AGENTS.md` before acting. Treat deployment status as network-scoped:
 - `EscrowV2` remains the shared escrow in the mounted V3 lifecycle lane.
   `OrchestratorV2` and `OrchestratorV3` are distinct current implementations;
   never infer which one is active from the version number alone.
-- `deploy/30_deploy_v3_lifecycle_stack.ts` is mounted by
+- `deploy/31_deploy_v3_lifecycle_stack.ts` is mounted by
   `scripts/deployActive.ts` for `localhost`, `hardhat`, Base staging, and Base.
   Base execution is a separately approved whitelist-only deployment that queues
   one Safe registration for the fresh O3 and leaves existing orchestrators in
-  place. Lane `31` remains staging-only.
+  place. Lane `32` remains staging-only.
 - Source, tests, package ABIs, a mounted script, and checked-in artifacts are not
   proof of live state. Resolve registries, permissions, ownership, deployed
   bytecode, and on-chain wiring before stating what is active on either network.

--- a/README.md
+++ b/README.md
@@ -625,12 +625,12 @@ This script currently covers:
 
 ### V3 Groups Cutover
 
-The lifecycle cutover is split into two explicit lanes. Lane 30 supports the whitelist-only groups
-deployment on Base staging and Base; lane 31 remains staging-only until the chargeback/staking cutover
+The lifecycle cutover is split into two explicit lanes. Lane 31 supports the whitelist-only groups
+deployment on Base staging and Base; lane 32 remains staging-only until the chargeback/staking cutover
 is separately approved.
 
-`deploy/30_deploy_v3_lifecycle_stack.ts` is the groups-only lane. Its lane-29 dependency supplies a
-fresh `WhitelistPolicy`; lane 30 deploys a fresh `WhitelistLifecycleHook` and `OrchestratorV3`, sets
+`deploy/31_deploy_v3_lifecycle_stack.ts` is the groups-only lane. Its lane-29 dependency supplies a
+fresh `WhitelistPolicy`; lane 31 deploys a fresh `WhitelistLifecycleHook` and `OrchestratorV3`, sets
 the hook after O3 construction, registers the new O3, and removes the two drained staging
 predecessors. It reuses the existing registries, UPV3, NullifierRegistryV2, chargeback stack, and
 payment routing without mutating them. On Base it leaves existing orchestrators registered and queues
@@ -652,7 +652,7 @@ The staging confirmation is an operator acknowledgement; the deploy script inten
 indexer client or drain-query implementation. Base fails unless O2 and EscrowV2 are already registered,
 the existing stack remains intact, and the generated Safe batch contains only the fresh O3 registration.
 
-`deploy/31_deploy_chargeback_lifecycle_stack.ts` is the later chargeback/staking lane. Before it
+`deploy/32_deploy_chargeback_lifecycle_stack.ts` is the later chargeback/staking lane. Before it
 runs, move only these canonical artifacts aside:
 
 - `deployments/base_staging/StakeVault.json`

--- a/deploy/31_deploy_v3_lifecycle_stack.ts
+++ b/deploy/31_deploy_v3_lifecycle_stack.ts
@@ -280,7 +280,7 @@ func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> => {
   return false;
 };
 
-func.tags = ["30_deploy_v3_lifecycle_stack", "V3LifecycleStack", "OrchestratorV3"];
+func.tags = ["31_deploy_v3_lifecycle_stack", "V3LifecycleStack", "OrchestratorV3"];
 func.dependencies = ["29_deploy_whitelist_policy"];
 
 export default func;

--- a/deploy/32_deploy_chargeback_lifecycle_stack.ts
+++ b/deploy/32_deploy_chargeback_lifecycle_stack.ts
@@ -111,19 +111,19 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const existingHook = await hre.deployments.getOrNull("IntentLifecycleHookV1");
   if (network === "base_staging") {
     if (existingVault && sameAddress(existingVault.address, RETIRED_STAGING_STAKE_VAULT)) {
-      throw new Error("Move the retired StakeVault artifact aside before lane 31");
+      throw new Error("Move the retired StakeVault artifact aside before lane 32");
     }
     if (existingPolicy && sameAddress(existingPolicy.address, RETIRED_STAGING_CHARGEBACK_POLICY)) {
-      throw new Error("Move the retired ChargebackPolicy artifact aside before lane 31");
+      throw new Error("Move the retired ChargebackPolicy artifact aside before lane 32");
     }
     if (existingHook && sameAddress(existingHook.address, RETIRED_STAGING_LIFECYCLE_HOOK)) {
-      throw new Error("Move the retired IntentLifecycleHookV1 artifact aside before lane 31");
+      throw new Error("Move the retired IntentLifecycleHookV1 artifact aside before lane 32");
     }
     await assertRetiredLiabilitiesZero();
   }
   if (existingVault || existingPolicy || existingHook) {
     throw new Error(
-      "Move the StakeVault, ChargebackPolicy, and IntentLifecycleHookV1 artifacts aside before lane 31",
+      "Move the StakeVault, ChargebackPolicy, and IntentLifecycleHookV1 artifacts aside before lane 32",
     );
   }
 
@@ -176,7 +176,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const orchestrator = await ethers.getContractAt("OrchestratorV3", orchestratorAddress);
   if (!sameAddress(await orchestrator.lifecycleHook(), whitelistHookAddress)) {
-    throw new Error("Lane 31 requires the lane-30 OrchestratorV3 to still use WhitelistLifecycleHook");
+    throw new Error("Lane 32 requires the lane-31 OrchestratorV3 to still use WhitelistLifecycleHook");
   }
 
   console.log("=== Deploying chargeback lifecycle stack ===");
@@ -257,7 +257,7 @@ func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> => {
   return false;
 };
 
-func.tags = ["31_deploy_chargeback_lifecycle_stack", "V3ChargebackLifecycleStack"];
-func.dependencies = ["30_deploy_v3_lifecycle_stack"];
+func.tags = ["32_deploy_chargeback_lifecycle_stack", "V3ChargebackLifecycleStack"];
+func.dependencies = ["31_deploy_v3_lifecycle_stack"];
 
 export default func;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:deterministic": "forge test --match-path 'test-foundry/deterministic/**/*.t.sol'",
     "test:fuzz": "forge test --match-path 'test-foundry/fuzz/**/*.t.sol'",
     "test:invariant": "forge test --match-path 'test-foundry/invariant/**/*.t.sol'",
-    "test:v3-groups-deployment": "node scripts/test-v3-groups-base-deployment.cjs prepare-resume && node scripts/test-v3-groups-base-deployment.cjs reject-mismatch",
+    "test:v3-groups-deployment": "node scripts/test-v3-groups-base-deployment.cjs prepare-resume && node scripts/test-v3-groups-base-deployment.cjs reject-mismatch && node scripts/test-v3-groups-base-deployment.cjs lane-separation",
     "test:release-policy": "node --test scripts/verify-github-environment.spec.mjs",
     "typechain": "hardhat typechain",
     "transpile": "tsc"

--- a/scripts/test-v3-groups-base-deployment.cjs
+++ b/scripts/test-v3-groups-base-deployment.cjs
@@ -18,7 +18,8 @@ console.log = () => {};
 
 const hre = require("hardhat");
 const { ethers } = hre;
-const deployGroupsStack = require("../deploy/30_deploy_v3_lifecycle_stack.ts").default;
+const deployGroupsStack = require("../deploy/31_deploy_v3_lifecycle_stack.ts").default;
+const deployChargebackStack = require("../deploy/32_deploy_chargeback_lifecycle_stack.ts").default;
 const { MULTI_SIG, ORCHESTRATOR_V3_PROTOCOL_FEE, ORCHESTRATOR_V3_PROTOCOL_FEE_RECIPIENT } = require(
   "../deployments/parameters.ts",
 );
@@ -146,6 +147,16 @@ async function run() {
       rejected = error instanceof Error && error.message.includes("protocol fee mismatch");
     }
     process.stdout.write(rejected && safeBatchCollector.count() === 0 ? "0x01" : "0x00");
+    return;
+  }
+
+  if (scenario === "lane-separation") {
+    const passed = deployGroupsStack.tags.includes("31_deploy_v3_lifecycle_stack")
+      && deployGroupsStack.dependencies.includes("29_deploy_whitelist_policy")
+      && deployChargebackStack.tags.includes("32_deploy_chargeback_lifecycle_stack")
+      && deployChargebackStack.dependencies.includes("31_deploy_v3_lifecycle_stack")
+      && await deployChargebackStack.skip(state.fakeHre);
+    process.stdout.write(passed ? "0x01" : "0x00");
     return;
   }
 


### PR DESCRIPTION
## Summary

- resequence the whitelist/groups-only V3 lifecycle deployment from numeric lane 30 to lane 31
- move the staging-only staking/chargeback lifecycle deployment from lane 31 to lane 32
- preserve the semantic deployment tags, network guards, contract logic, addresses, and Safe-call invariant
- update repository guidance and add a focused rehearsal assertion that lane 32 remains skipped on Base

## Invariant

The deferred Base V3 hard cut remains whitelist/groups-only. It can prepare only the fresh OrchestratorV3 registry-add Safe call, while staking and chargeback remain outside the Base deployment and require a separately approved later lane.

## Deployment impact

- no contract source or ABI changes
- no deployment artifact or address changes
- no Safe batch generation, proposal, signature, rejection, or execution
- no package version or publication
- no staging or production mutation

## Validation

- forced Hardhat compile completed successfully
- prepare-resume deployment rehearsal: 0x01
- mismatched configuration rejection: 0x01
- lane-separation and Base chargeback-skip assertion: 0x01
- TypeScript no-emit check passed
- git diff --check passed

## Future execution boundary

A later authorized Base preparation uses lane 31 / the stable V3LifecycleStack tag with ENABLE_BASE_V3_GROUPS_CUTOVER=true at an explicitly reviewed source SHA. Lane 32 remains staging-only and is not part of that hard cut.