### PR TITLE
chore: link audit skill for Codex

### DIFF
--- a/.codex/skills/audit
+++ b/.codex/skills/audit
@@ -1,0 +1,1 @@
+../../.agents/skills/audit


### PR DESCRIPTION
## Summary
- expose the repository-owned `audit` skill through `.codex/skills`
- keep `.agents/skills/audit` as the canonical source

## Validation
- verified the link is relative and resolves to the canonical skill
- validated SKILL.md frontmatter and `git diff --check`

No runtime code changes.