### PR TITLE
Verify generic chargeback attestations

### DIFF
--- a/contracts/hooks/ChargebackPolicy.sol
+++ b/contracts/hooks/ChargebackPolicy.sol
@@ -216,9 +216,10 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
      * @param _attestation Signed chargeback evidence for a settled intent.
      */
     function submitChargeback(IChargebackVerifier.ChargebackAttestation calldata _attestation) external nonReentrant {
-        ChargebackIntent storage chargebackIntent = chargebackIntentByIntentHash[_attestation.intentHash];
+        bytes32 intentHash = abi.decode(_attestation.input, (bytes32));
+        ChargebackIntent storage chargebackIntent = chargebackIntentByIntentHash[intentHash];
         if (chargebackIntent.status != ChargebackIntentStatus.SETTLED) {
-            revert ChargebackIntentNotSettled(_attestation.intentHash, chargebackIntent.status);
+            revert ChargebackIntentNotSettled(intentHash, chargebackIntent.status);
         }
 
         (bytes32 disputeId, bytes32 disputeNullifier) = chargebackVerifier.verifyChargeback(
@@ -231,14 +232,10 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
 
         IStakeVault.Claim[] memory claims = new IStakeVault.Claim[](1);
         claims[0] = IStakeVault.Claim({beneficiary: chargebackIntent.depositor, amount: compensatedAmount});
-        stakeVault.resolveLock(_attestation.intentHash, claims);
+        stakeVault.resolveLock(intentHash, claims);
 
         emit ChargebackSettled(
-            _attestation.intentHash,
-            chargebackIntent.stakeOwner,
-            chargebackIntent.depositor,
-            compensatedAmount,
-            disputeId
+            intentHash, chargebackIntent.stakeOwner, chargebackIntent.depositor, compensatedAmount, disputeId
         );
     }
 

--- a/contracts/interfaces/IChargebackVerifier.sol
+++ b/contracts/interfaces/IChargebackVerifier.sol
@@ -10,12 +10,14 @@ pragma solidity ^0.8.18;
 interface IChargebackVerifier {
     /**
      * @notice Generic attestation produced by the attestation service.
+     * @param schemaId Versioned identifier for the ABI schema consumed by this verifier.
      * @param transformerId Identifier committed to by the attestation service.
      * @param input ABI-encoded `(bytes32 intentHash)` supplied by the caller.
      * @param output ABI-encoded `(bytes32 originalPaymentId, bytes32 disputeId)` verified from evidence.
      * @param signatures Witness signatures over the EIP-712 attestation.
      */
     struct ChargebackAttestation {
+        bytes32 schemaId;
         bytes32 transformerId;
         bytes input;
         bytes output;
@@ -27,6 +29,7 @@ interface IChargebackVerifier {
     error ZeroAddress();
     error InvalidContract(address dependency);
     error InvalidAttestation();
+    error InvalidAttestationSchema(bytes32 schemaId);
     error ManualReleaseNotChargebackable();
     error InvalidPaymentBinding(bytes32 intentHash, bytes32 nullifier);
     error AttestationVerificationFailed();

--- a/contracts/interfaces/IChargebackVerifier.sol
+++ b/contracts/interfaces/IChargebackVerifier.sol
@@ -9,33 +9,17 @@ pragma solidity ^0.8.18;
  */
 interface IChargebackVerifier {
     /**
-     * @notice Signed evidence tying a chargeback payload to one intent.
-     * @param intentHash Intent whose off-chain payment was disputed.
-     * @param dataHash Hash of the ABI-encoded `ChargebackDetails`.
-     * @param signatures Witness signatures over the verifier's EIP-712 digest.
-     * @param data ABI-encoded `ChargebackDetails`.
+     * @notice Generic attestation produced by the attestation service.
+     * @param transformerId Identifier committed to by the attestation service.
+     * @param input ABI-encoded `(bytes32 intentHash)` supplied by the caller.
+     * @param output ABI-encoded `(bytes32 originalPaymentId, bytes32 disputeId)` verified from evidence.
+     * @param signatures Witness signatures over the EIP-712 attestation.
      */
     struct ChargebackAttestation {
-        bytes32 intentHash;
-        bytes32 dataHash;
+        bytes32 transformerId;
+        bytes input;
+        bytes output;
         bytes[] signatures;
-        bytes data;
-    }
-
-    /**
-     * @notice Payment and dispute identifiers attested by the chargeback witnesses.
-     * @param paymentMethod Payment rail used by the original payment.
-     * @param originalPaymentId Provider identifier for the original payment.
-     * @param disputeId Provider identifier for the chargeback or reversal.
-     * @param paymentAmount Attested off-chain payment amount.
-     * @param paymentCurrency Attested off-chain payment currency.
-     */
-    struct ChargebackDetails {
-        bytes32 paymentMethod;
-        bytes32 originalPaymentId;
-        bytes32 disputeId;
-        uint256 paymentAmount;
-        bytes32 paymentCurrency;
     }
 
     event AttestationVerifierUpdated(address indexed previousVerifier, address indexed newVerifier);
@@ -43,18 +27,19 @@ interface IChargebackVerifier {
     error ZeroAddress();
     error InvalidContract(address dependency);
     error InvalidAttestation();
+    error ManualReleaseNotChargebackable();
     error InvalidPaymentBinding(bytes32 intentHash, bytes32 nullifier);
     error AttestationVerificationFailed();
     error OwnershipRenunciationDisabled();
 
     /**
      * @notice Validates chargeback evidence against the intent context supplied by the policy.
-     * @dev View-only and stateless. Reverts when the payload is malformed, mismatched, unsigned, or—on the
-     * proof-based path—not bound to the intent's original payment nullifier.
+     * @dev View-only and stateless. The trusted witness determines which transformer is acceptable. This contract
+     * validates the signed input/output against live protocol state and does not maintain a transformer allowlist.
      * @param _attestation Signed chargeback evidence for an intent.
      * @param _paymentMethod Payment method snapshotted by the policy when the intent was admitted.
-     * @param _isManualRelease Whether settlement occurred without an on-chain payment proof. Manual releases skip
-     * original-payment binding because no payment nullifier was recorded during settlement.
+     * @param _isManualRelease Whether settlement occurred without an on-chain payment proof. Manual releases are
+     * rejected because no original-payment nullifier exists to bind the dispute.
      * @return disputeId Payment-platform dispute identifier decoded from the evidence.
      * @return disputeNullifier Payment-method-scoped replay key for the dispute.
      */

--- a/contracts/unifiedVerifier/ChargebackVerifier.sol
+++ b/contracts/unifiedVerifier/ChargebackVerifier.sol
@@ -21,8 +21,9 @@ import {INullifierRegistryV2} from "../interfaces/INullifierRegistryV2.sol";
 contract ChargebackVerifier is IChargebackVerifier, Ownable2Step, EIP712 {
     /* ============ Constants ============ */
 
+    bytes32 public constant DISPUTE_SCHEMA_ID = keccak256("zkp2p.attestation.dispute.v1");
     bytes32 public constant ATTESTATION_TYPEHASH =
-        keccak256("Attestation(bytes32 transformerId,bytes input,bytes output)");
+        keccak256("Attestation(bytes32 schemaId,bytes32 transformerId,bytes input,bytes output)");
 
     /* ============ State Variables ============ */
 
@@ -54,6 +55,9 @@ contract ChargebackVerifier is IChargebackVerifier, Ownable2Step, EIP712 {
         bool _isManualRelease
     ) external view override returns (bytes32 disputeId, bytes32 disputeNullifier) {
         if (_isManualRelease) revert ManualReleaseNotChargebackable();
+        if (_attestation.schemaId != DISPUTE_SCHEMA_ID) {
+            revert InvalidAttestationSchema(_attestation.schemaId);
+        }
         if (_attestation.transformerId == bytes32(0)) revert InvalidAttestation();
         if (_attestation.input.length != 32 || _attestation.output.length != 64) revert InvalidAttestation();
         if (_attestation.signatures.length == 0) revert InvalidAttestation();
@@ -118,6 +122,7 @@ contract ChargebackVerifier is IChargebackVerifier, Ownable2Step, EIP712 {
         return keccak256(
             abi.encode(
                 ATTESTATION_TYPEHASH,
+                _attestation.schemaId,
                 _attestation.transformerId,
                 keccak256(_attestation.input),
                 keccak256(_attestation.output)

--- a/contracts/unifiedVerifier/ChargebackVerifier.sol
+++ b/contracts/unifiedVerifier/ChargebackVerifier.sol
@@ -21,8 +21,8 @@ import {INullifierRegistryV2} from "../interfaces/INullifierRegistryV2.sol";
 contract ChargebackVerifier is IChargebackVerifier, Ownable2Step, EIP712 {
     /* ============ Constants ============ */
 
-    bytes32 public constant CHARGEBACK_ATTESTATION_TYPEHASH =
-        keccak256("ChargebackAttestation(bytes32 intentHash,bytes32 dataHash)");
+    bytes32 public constant ATTESTATION_TYPEHASH =
+        keccak256("Attestation(bytes32 transformerId,bytes input,bytes output)");
 
     /* ============ State Variables ============ */
 
@@ -32,7 +32,7 @@ contract ChargebackVerifier is IChargebackVerifier, Ownable2Step, EIP712 {
     /* ============ Constructor ============ */
 
     constructor(address _owner, INullifierRegistryV2 _nullifierRegistry, IAttestationVerifier _attestationVerifier)
-        EIP712("ZKP2P ChargebackVerifier", "1")
+        EIP712("ZKP2P Attestation", "1")
     {
         if (_owner == address(0)) revert ZeroAddress();
         _validateDependency(address(_nullifierRegistry));
@@ -53,28 +53,32 @@ contract ChargebackVerifier is IChargebackVerifier, Ownable2Step, EIP712 {
         bytes32 _paymentMethod,
         bool _isManualRelease
     ) external view override returns (bytes32 disputeId, bytes32 disputeNullifier) {
-        if (keccak256(_attestation.data) != _attestation.dataHash) revert InvalidAttestation();
+        if (_isManualRelease) revert ManualReleaseNotChargebackable();
+        if (_attestation.transformerId == bytes32(0)) revert InvalidAttestation();
+        if (_attestation.input.length != 32 || _attestation.output.length != 64) revert InvalidAttestation();
+        if (_attestation.signatures.length == 0) revert InvalidAttestation();
 
-        ChargebackDetails memory details = abi.decode(_attestation.data, (ChargebackDetails));
-        if (details.paymentMethod != _paymentMethod) revert InvalidAttestation();
+        bytes32 intentHash = abi.decode(_attestation.input, (bytes32));
+        (bytes32 originalPaymentId, bytes32 decodedDisputeId) = abi.decode(_attestation.output, (bytes32, bytes32));
+        if (intentHash == bytes32(0) || originalPaymentId == bytes32(0) || decodedDisputeId == bytes32(0)) {
+            revert InvalidAttestation();
+        }
 
-        bytes32 digest = _hashTypedDataV4(_chargebackAttestationStructHash(_attestation));
-        if (!attestationVerifier.verify(digest, _attestation.signatures, _attestation.data)) {
+        bytes32 digest = _hashTypedDataV4(_attestationStructHash(_attestation));
+        if (!attestationVerifier.verify(digest, _attestation.signatures, _attestation.output)) {
             revert AttestationVerificationFailed();
         }
 
-        if (!_isManualRelease) {
-            bytes32 paymentNullifier = keccak256(abi.encodePacked(details.paymentMethod, details.originalPaymentId));
-            if (
-                nullifierRegistry.intentHashByNullifier(paymentNullifier) != _attestation.intentHash
-                    || nullifierRegistry.nullifierByIntentHash(_attestation.intentHash) != paymentNullifier
-            ) {
-                revert InvalidPaymentBinding(_attestation.intentHash, paymentNullifier);
-            }
+        bytes32 paymentNullifier = keccak256(abi.encodePacked(_paymentMethod, originalPaymentId));
+        if (
+            nullifierRegistry.intentHashByNullifier(paymentNullifier) != intentHash
+                || nullifierRegistry.nullifierByIntentHash(intentHash) != paymentNullifier
+        ) {
+            revert InvalidPaymentBinding(intentHash, paymentNullifier);
         }
 
-        disputeId = details.disputeId;
-        disputeNullifier = keccak256(abi.encodePacked(details.paymentMethod, details.disputeId));
+        disputeId = decodedDisputeId;
+        disputeNullifier = keccak256(abi.encodePacked(_paymentMethod, decodedDisputeId));
     }
 
     /* ============ Governance Functions ============ */
@@ -101,21 +105,24 @@ contract ChargebackVerifier is IChargebackVerifier, Ownable2Step, EIP712 {
 
     /**
      * @notice Returns the EIP-712 digest that witnesses sign for a chargeback attestation.
-     * @param _attestation Chargeback evidence whose intent hash and data hash are included in the digest.
+     * @param _attestation Generic chargeback attestation included in the digest.
      * @return EIP-712 digest bound to this verifier's address and the current chain.
      */
     function hashChargebackAttestation(ChargebackAttestation calldata _attestation) external view returns (bytes32) {
-        return _hashTypedDataV4(_chargebackAttestationStructHash(_attestation));
+        return _hashTypedDataV4(_attestationStructHash(_attestation));
     }
 
     /* ============ Internal Functions ============ */
 
-    function _chargebackAttestationStructHash(ChargebackAttestation calldata _attestation)
-        internal
-        pure
-        returns (bytes32)
-    {
-        return keccak256(abi.encode(CHARGEBACK_ATTESTATION_TYPEHASH, _attestation.intentHash, _attestation.dataHash));
+    function _attestationStructHash(ChargebackAttestation calldata _attestation) internal pure returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                ATTESTATION_TYPEHASH,
+                _attestation.transformerId,
+                keccak256(_attestation.input),
+                keccak256(_attestation.output)
+            )
+        );
     }
 
     function _validateDependency(address _dependency) internal view {

--- a/test-foundry/deterministic/hooks/ChargebackPolicy.t.sol
+++ b/test-foundry/deterministic/hooks/ChargebackPolicy.t.sol
@@ -254,7 +254,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         _admitAndSettle(INTENT, 40e6, false);
         bytes32 paymentId = keccak256("payment");
         IChargebackVerifier.ChargebackAttestation memory attestation =
-            _attestation(INTENT, METHOD, paymentId, keccak256("dispute"));
+            _attestation(INTENT, paymentId, keccak256("dispute"));
         bytes32 paymentNullifier = keccak256(abi.encodePacked(METHOD, paymentId));
 
         vm.expectRevert(
@@ -277,7 +277,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
 
     function test_SubmitChargebackRequiresSettledIntent() public {
         IChargebackVerifier.ChargebackAttestation memory attestation =
-            _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
+            _attestation(INTENT, keccak256("payment"), keccak256("dispute"));
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -299,36 +299,38 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         policy.submitChargeback(attestation);
     }
 
-    function test_SubmitChargebackManualPathSkipsPaymentBindingAndRejectsReplay() public {
+    function test_SubmitChargebackRejectsManualRelease() public {
         _admitAndSettle(INTENT, 40e6, true);
-        bytes32 disputeId = keccak256("dispute");
         IChargebackVerifier.ChargebackAttestation memory attestation =
-            _attestation(INTENT, METHOD, keccak256("unbound-payment"), disputeId);
-        policy.submitChargeback(attestation);
+            _attestation(INTENT, keccak256("unbound-payment"), keccak256("dispute"));
 
-        bytes32 disputeNullifier = keccak256(abi.encodePacked(METHOD, disputeId));
-        assertTrue(chargebackNullifierRegistry.isNullified(disputeNullifier));
-
-        bytes32 secondIntent = keccak256("second");
-        _admitAndSettle(secondIntent, 40e6, true);
-        attestation = _attestation(secondIntent, METHOD, keccak256("other-payment"), disputeId);
-        vm.expectRevert(bytes("Nullifier already exists"));
+        vm.expectRevert(IChargebackVerifier.ManualReleaseNotChargebackable.selector);
         policy.submitChargeback(attestation);
     }
 
     function test_SubmitChargebackRejectsInvalidEvidenceButRemainsValidUntilCollateralRelease() public {
-        _admitAndSettle(INTENT, 40e6, true);
+        _admitAndSettle(INTENT, 40e6, false);
+        bytes32 paymentId = keccak256("payment");
         IChargebackVerifier.ChargebackAttestation memory attestation =
-            _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
-        attestation.dataHash = keccak256("tampered");
+            _attestation(INTENT, paymentId, keccak256("dispute"));
+        attestation.transformerId = bytes32(0);
         vm.expectRevert(IChargebackVerifier.InvalidAttestation.selector);
         policy.submitChargeback(attestation);
 
-        attestation = _attestation(INTENT, keccak256("wrong"), keccak256("payment"), keccak256("dispute"));
-        vm.expectRevert(IChargebackVerifier.InvalidAttestation.selector);
+        attestation = _attestation(keccak256("wrong-intent"), paymentId, keccak256("dispute"));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.ChargebackIntentNotSettled.selector,
+                keccak256("wrong-intent"),
+                IChargebackPolicy.ChargebackIntentStatus.NONE
+            )
+        );
         policy.submitChargeback(attestation);
 
-        attestation = _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
+        bytes32 paymentNullifier = keccak256(abi.encodePacked(METHOD, paymentId));
+        nullifierRegistry.addWritePermission(address(this));
+        nullifierRegistry.addNullifier(paymentNullifier, INTENT);
+        attestation = _attestation(INTENT, paymentId, keccak256("dispute"));
         attestationVerifier.setResult(false);
         vm.expectRevert(IChargebackVerifier.AttestationVerificationFailed.selector);
         policy.submitChargeback(attestation);
@@ -462,21 +464,18 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         policy.onIntentSettled(intentHash, releaseAmount, manualRelease);
     }
 
-    function _attestation(bytes32 intentHash, bytes32 paymentMethod, bytes32 paymentId, bytes32 disputeId)
+    function _attestation(bytes32 intentHash, bytes32 paymentId, bytes32 disputeId)
         internal
         pure
         returns (IChargebackVerifier.ChargebackAttestation memory attestation)
     {
-        IChargebackVerifier.ChargebackDetails memory details = IChargebackVerifier.ChargebackDetails({
-            paymentMethod: paymentMethod,
-            originalPaymentId: paymentId,
-            disputeId: disputeId,
-            paymentAmount: 100,
-            paymentCurrency: USD
-        });
-        bytes memory data = abi.encode(details);
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = hex"01";
         attestation = IChargebackVerifier.ChargebackAttestation({
-            intentHash: intentHash, dataHash: keccak256(data), signatures: new bytes[](0), data: data
+            transformerId: keccak256("transformer"),
+            input: abi.encode(intentHash),
+            output: abi.encode(paymentId, disputeId),
+            signatures: signatures
         });
     }
 }

--- a/test-foundry/deterministic/hooks/ChargebackPolicy.t.sol
+++ b/test-foundry/deterministic/hooks/ChargebackPolicy.t.sol
@@ -472,6 +472,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         bytes[] memory signatures = new bytes[](1);
         signatures[0] = hex"01";
         attestation = IChargebackVerifier.ChargebackAttestation({
+            schemaId: keccak256("zkp2p.attestation.dispute.v1"),
             transformerId: keccak256("transformer"),
             input: abi.encode(intentHash),
             output: abi.encode(paymentId, disputeId),

--- a/test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol
@@ -369,6 +369,7 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         bytes[] memory signatures = new bytes[](1);
         signatures[0] = hex"01";
         attestation = IChargebackVerifier.ChargebackAttestation({
+            schemaId: keccak256("zkp2p.attestation.dispute.v1"),
             transformerId: keccak256("transformer"),
             input: abi.encode(intentHash),
             output: abi.encode(paymentId, disputeId),

--- a/test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol
@@ -366,16 +366,13 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         pure
         returns (IChargebackVerifier.ChargebackAttestation memory attestation)
     {
-        IChargebackVerifier.ChargebackDetails memory details = IChargebackVerifier.ChargebackDetails({
-            paymentMethod: METHOD,
-            originalPaymentId: paymentId,
-            disputeId: disputeId,
-            paymentAmount: 100,
-            paymentCurrency: USD
-        });
-        bytes memory data = abi.encode(details);
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = hex"01";
         attestation = IChargebackVerifier.ChargebackAttestation({
-            intentHash: intentHash, dataHash: keccak256(data), signatures: new bytes[](0), data: data
+            transformerId: keccak256("transformer"),
+            input: abi.encode(intentHash),
+            output: abi.encode(paymentId, disputeId),
+            signatures: signatures
         });
     }
 }

--- a/test-foundry/deterministic/verifiers/ChargebackVerifier.t.sol
+++ b/test-foundry/deterministic/verifiers/ChargebackVerifier.t.sol
@@ -17,7 +17,7 @@ contract ChargebackVerifierTest is Test {
 
     bytes32 internal constant METHOD = keccak256("method");
     bytes32 internal constant INTENT = keccak256("intent");
-    bytes32 internal constant USD = keccak256("USD");
+    bytes32 internal constant TRANSFORMER = keccak256("transformer");
 
     NullifierRegistryV2 internal nullifierRegistry;
     AttestationVerifierMock internal attestationVerifier;
@@ -30,56 +30,99 @@ contract ChargebackVerifierTest is Test {
         verifier = new ChargebackVerifier(address(this), nullifierRegistry, attestationVerifier);
     }
 
-    function test_VerifyChargebackManualPathReturnsDisputeData() public {
-        IChargebackVerifier.ChargebackAttestation memory attestation =
-            _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
+    function test_VerifyChargebackValidatesSignatureAndPaymentBinding() public {
+        bytes32 paymentId = keccak256("payment");
+        bytes32 disputeId = keccak256("dispute");
+        IChargebackVerifier.ChargebackAttestation memory attestation = _attestation(INTENT, paymentId, disputeId);
+        bytes32 paymentNullifier = keccak256(abi.encodePacked(METHOD, paymentId));
+        nullifierRegistry.addWritePermission(address(this));
+        nullifierRegistry.addNullifier(paymentNullifier, INTENT);
 
-        (bytes32 disputeId, bytes32 disputeNullifier) =
-            verifier.verifyChargeback(attestation, METHOD, true);
+        (bytes32 actualDisputeId, bytes32 disputeNullifier) = verifier.verifyChargeback(attestation, METHOD, false);
 
-        assertEq(disputeId, keccak256("dispute"));
-        assertEq(disputeNullifier, keccak256(abi.encodePacked(METHOD, keccak256("dispute"))));
+        assertEq(actualDisputeId, disputeId);
+        assertEq(disputeNullifier, keccak256(abi.encodePacked(METHOD, disputeId)));
     }
 
-    function test_VerifyChargebackRejectsTamperedDataHash() public {
+    function test_VerifyChargebackDoesNotMaintainTransformerAllowlist() public {
+        bytes32 paymentId = keccak256("payment");
         IChargebackVerifier.ChargebackAttestation memory attestation =
-            _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
-        attestation.dataHash = keccak256("tampered");
+            _attestation(INTENT, paymentId, keccak256("dispute"));
+        attestation.transformerId = keccak256("another-trusted-service-transformer");
+        bytes32 paymentNullifier = keccak256(abi.encodePacked(METHOD, paymentId));
+        nullifierRegistry.addWritePermission(address(this));
+        nullifierRegistry.addNullifier(paymentNullifier, INTENT);
 
-        vm.expectRevert(IChargebackVerifier.InvalidAttestation.selector);
+        verifier.verifyChargeback(attestation, METHOD, false);
+    }
+
+    function test_VerifyChargebackRejectsManualRelease() public {
+        IChargebackVerifier.ChargebackAttestation memory attestation =
+            _attestation(INTENT, keccak256("payment"), keccak256("dispute"));
+
+        vm.expectRevert(IChargebackVerifier.ManualReleaseNotChargebackable.selector);
         verifier.verifyChargeback(attestation, METHOD, true);
     }
 
-    function test_VerifyChargebackRejectsMethodMismatch() public {
+    function test_VerifyChargebackRejectsMalformedEnvelope() public {
         IChargebackVerifier.ChargebackAttestation memory attestation =
-            _attestation(INTENT, keccak256("wrong"), keccak256("payment"), keccak256("dispute"));
+            _attestation(INTENT, keccak256("payment"), keccak256("dispute"));
 
+        attestation.transformerId = bytes32(0);
         vm.expectRevert(IChargebackVerifier.InvalidAttestation.selector);
-        verifier.verifyChargeback(attestation, METHOD, true);
+        verifier.verifyChargeback(attestation, METHOD, false);
+
+        attestation = _attestation(INTENT, keccak256("payment"), keccak256("dispute"));
+        attestation.input = hex"01";
+        vm.expectRevert(IChargebackVerifier.InvalidAttestation.selector);
+        verifier.verifyChargeback(attestation, METHOD, false);
+
+        attestation = _attestation(INTENT, keccak256("payment"), keccak256("dispute"));
+        attestation.output = hex"01";
+        vm.expectRevert(IChargebackVerifier.InvalidAttestation.selector);
+        verifier.verifyChargeback(attestation, METHOD, false);
+
+        attestation = _attestation(INTENT, keccak256("payment"), keccak256("dispute"));
+        attestation.signatures = new bytes[](0);
+        vm.expectRevert(IChargebackVerifier.InvalidAttestation.selector);
+        verifier.verifyChargeback(attestation, METHOD, false);
+    }
+
+    function test_VerifyChargebackRejectsZeroDecodedValues() public {
+        IChargebackVerifier.ChargebackAttestation memory attestation =
+            _attestation(bytes32(0), keccak256("payment"), keccak256("dispute"));
+        vm.expectRevert(IChargebackVerifier.InvalidAttestation.selector);
+        verifier.verifyChargeback(attestation, METHOD, false);
+
+        attestation = _attestation(INTENT, bytes32(0), keccak256("dispute"));
+        vm.expectRevert(IChargebackVerifier.InvalidAttestation.selector);
+        verifier.verifyChargeback(attestation, METHOD, false);
+
+        attestation = _attestation(INTENT, keccak256("payment"), bytes32(0));
+        vm.expectRevert(IChargebackVerifier.InvalidAttestation.selector);
+        verifier.verifyChargeback(attestation, METHOD, false);
     }
 
     function test_VerifyChargebackRejectsSignatureFailure() public {
         IChargebackVerifier.ChargebackAttestation memory attestation =
-            _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
+            _attestation(INTENT, keccak256("payment"), keccak256("dispute"));
         attestationVerifier.setResult(false);
 
         vm.expectRevert(IChargebackVerifier.AttestationVerificationFailed.selector);
-        verifier.verifyChargeback(attestation, METHOD, true);
+        verifier.verifyChargeback(attestation, METHOD, false);
     }
 
-    function test_VerifyChargebackProofPathRequiresBothDirectionBinding() public {
+    function test_VerifyChargebackRequiresBothDirectionsOfPaymentBinding() public {
         bytes32 paymentId = keccak256("payment");
         IChargebackVerifier.ChargebackAttestation memory attestation =
-            _attestation(INTENT, METHOD, paymentId, keccak256("dispute"));
+            _attestation(INTENT, paymentId, keccak256("dispute"));
         bytes32 paymentNullifier = keccak256(abi.encodePacked(METHOD, paymentId));
-        bytes memory bindingRevert = abi.encodeWithSelector(
-            IChargebackVerifier.InvalidPaymentBinding.selector, INTENT, paymentNullifier
-        );
+        bytes memory bindingRevert =
+            abi.encodeWithSelector(IChargebackVerifier.InvalidPaymentBinding.selector, INTENT, paymentNullifier);
 
         vm.expectRevert(bindingRevert);
         verifier.verifyChargeback(attestation, METHOD, false);
 
-        // Forward direction only: nullifier -> intent resolves, intent -> nullifier does not.
         vm.mockCall(
             address(nullifierRegistry),
             abi.encodeCall(INullifierRegistryV2.intentHashByNullifier, (paymentNullifier)),
@@ -89,7 +132,6 @@ contract ChargebackVerifierTest is Test {
         verifier.verifyChargeback(attestation, METHOD, false);
         vm.clearMockedCalls();
 
-        // Reverse direction only: intent -> nullifier resolves, nullifier -> intent does not.
         vm.mockCall(
             address(nullifierRegistry),
             abi.encodeCall(INullifierRegistryV2.nullifierByIntentHash, (INTENT)),
@@ -97,40 +139,31 @@ contract ChargebackVerifierTest is Test {
         );
         vm.expectRevert(bindingRevert);
         verifier.verifyChargeback(attestation, METHOD, false);
-        vm.clearMockedCalls();
-
-        nullifierRegistry.addWritePermission(address(this));
-        nullifierRegistry.addNullifier(paymentNullifier, INTENT);
-
-        (bytes32 disputeId,) = verifier.verifyChargeback(attestation, METHOD, false);
-        assertEq(disputeId, keccak256("dispute"));
     }
 
-    function test_VerifyChargebackForwardsDigestSignaturesAndDataToAttestationVerifier() public {
+    function test_VerifyChargebackForwardsDigestSignaturesAndOutput() public {
+        bytes32 paymentId = keccak256("payment");
         IChargebackVerifier.ChargebackAttestation memory attestation =
-            _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
+            _attestation(INTENT, paymentId, keccak256("dispute"));
+        bytes32 paymentNullifier = keccak256(abi.encodePacked(METHOD, paymentId));
+        nullifierRegistry.addWritePermission(address(this));
+        nullifierRegistry.addNullifier(paymentNullifier, INTENT);
         bytes32 expectedDigest = verifier.hashChargebackAttestation(attestation);
 
         vm.expectCall(
             address(attestationVerifier),
-            abi.encodeCall(
-                IAttestationVerifier.verify,
-                (expectedDigest, attestation.signatures, attestation.data)
-            )
+            abi.encodeCall(IAttestationVerifier.verify, (expectedDigest, attestation.signatures, attestation.output))
         );
-        verifier.verifyChargeback(attestation, METHOD, true);
+        verifier.verifyChargeback(attestation, METHOD, false);
     }
 
-    function test_HashChargebackAttestationMatchesEip712Digest() public {
+    function test_HashChargebackAttestationMatchesGenericEip712Digest() public view {
         IChargebackVerifier.ChargebackAttestation memory attestation =
-            _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
-
+            _attestation(INTENT, keccak256("payment"), keccak256("dispute"));
         bytes32 domainSeparator = keccak256(
             abi.encode(
-                keccak256(
-                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
-                ),
-                keccak256(bytes("ZKP2P ChargebackVerifier")),
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256(bytes("ZKP2P Attestation")),
                 keccak256(bytes("1")),
                 block.chainid,
                 address(verifier)
@@ -138,9 +171,10 @@ contract ChargebackVerifierTest is Test {
         );
         bytes32 structHash = keccak256(
             abi.encode(
-                keccak256("ChargebackAttestation(bytes32 intentHash,bytes32 dataHash)"),
-                attestation.intentHash,
-                attestation.dataHash
+                keccak256("Attestation(bytes32 transformerId,bytes input,bytes output)"),
+                attestation.transformerId,
+                keccak256(attestation.input),
+                keccak256(attestation.output)
             )
         );
         bytes32 expected = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
@@ -156,9 +190,7 @@ contract ChargebackVerifierTest is Test {
         vm.expectRevert(IChargebackVerifier.ZeroAddress.selector);
         verifier.setAttestationVerifier(address(0));
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IChargebackVerifier.InvalidContract.selector, other)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IChargebackVerifier.InvalidContract.selector, other));
         verifier.setAttestationVerifier(other);
 
         AttestationVerifierMock replacement = new AttestationVerifierMock();
@@ -173,21 +205,15 @@ contract ChargebackVerifierTest is Test {
         new ChargebackVerifier(address(0), nullifierRegistry, attestationVerifier);
 
         vm.expectRevert(IChargebackVerifier.ZeroAddress.selector);
-        new ChargebackVerifier(
-            address(this), NullifierRegistryV2(address(0)), attestationVerifier
-        );
+        new ChargebackVerifier(address(this), NullifierRegistryV2(address(0)), attestationVerifier);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IChargebackVerifier.InvalidContract.selector, other)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IChargebackVerifier.InvalidContract.selector, other));
         new ChargebackVerifier(address(this), NullifierRegistryV2(other), attestationVerifier);
 
         vm.expectRevert(IChargebackVerifier.ZeroAddress.selector);
         new ChargebackVerifier(address(this), nullifierRegistry, IAttestationVerifier(address(0)));
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IChargebackVerifier.InvalidContract.selector, other)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IChargebackVerifier.InvalidContract.selector, other));
         new ChargebackVerifier(address(this), nullifierRegistry, AttestationVerifierMock(other));
     }
 
@@ -196,25 +222,18 @@ contract ChargebackVerifierTest is Test {
         verifier.renounceOwnership();
     }
 
-    function _attestation(
-        bytes32 intentHash,
-        bytes32 paymentMethod,
-        bytes32 paymentId,
-        bytes32 disputeId
-    ) internal pure returns (IChargebackVerifier.ChargebackAttestation memory attestation) {
-        IChargebackVerifier.ChargebackDetails memory details = IChargebackVerifier.ChargebackDetails({
-            paymentMethod: paymentMethod,
-            originalPaymentId: paymentId,
-            disputeId: disputeId,
-            paymentAmount: 100,
-            paymentCurrency: USD
-        });
-        bytes memory data = abi.encode(details);
+    function _attestation(bytes32 intentHash, bytes32 paymentId, bytes32 disputeId)
+        internal
+        pure
+        returns (IChargebackVerifier.ChargebackAttestation memory attestation)
+    {
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = hex"01";
         attestation = IChargebackVerifier.ChargebackAttestation({
-            intentHash: intentHash,
-            dataHash: keccak256(data),
-            signatures: new bytes[](0),
-            data: data
+            transformerId: TRANSFORMER,
+            input: abi.encode(intentHash),
+            output: abi.encode(paymentId, disputeId),
+            signatures: signatures
         });
     }
 }

--- a/test-foundry/deterministic/verifiers/ChargebackVerifier.t.sol
+++ b/test-foundry/deterministic/verifiers/ChargebackVerifier.t.sol
@@ -18,6 +18,7 @@ contract ChargebackVerifierTest is Test {
     bytes32 internal constant METHOD = keccak256("method");
     bytes32 internal constant INTENT = keccak256("intent");
     bytes32 internal constant TRANSFORMER = keccak256("transformer");
+    bytes32 internal constant DISPUTE_SCHEMA_ID = keccak256("zkp2p.attestation.dispute.v1");
 
     NullifierRegistryV2 internal nullifierRegistry;
     AttestationVerifierMock internal attestationVerifier;
@@ -53,6 +54,17 @@ contract ChargebackVerifierTest is Test {
         nullifierRegistry.addWritePermission(address(this));
         nullifierRegistry.addNullifier(paymentNullifier, INTENT);
 
+        verifier.verifyChargeback(attestation, METHOD, false);
+    }
+
+    function test_VerifyChargebackRejectsNonDisputeSchema() public {
+        IChargebackVerifier.ChargebackAttestation memory attestation =
+            _attestation(INTENT, keccak256("payment"), keccak256("dispute"));
+        attestation.schemaId = keccak256("zkp2p.attestation.identity.v1");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IChargebackVerifier.InvalidAttestationSchema.selector, attestation.schemaId)
+        );
         verifier.verifyChargeback(attestation, METHOD, false);
     }
 
@@ -158,6 +170,7 @@ contract ChargebackVerifierTest is Test {
     }
 
     function test_HashChargebackAttestationMatchesGenericEip712Digest() public view {
+        assertEq(verifier.DISPUTE_SCHEMA_ID(), DISPUTE_SCHEMA_ID);
         IChargebackVerifier.ChargebackAttestation memory attestation =
             _attestation(INTENT, keccak256("payment"), keccak256("dispute"));
         bytes32 domainSeparator = keccak256(
@@ -171,7 +184,8 @@ contract ChargebackVerifierTest is Test {
         );
         bytes32 structHash = keccak256(
             abi.encode(
-                keccak256("Attestation(bytes32 transformerId,bytes input,bytes output)"),
+                keccak256("Attestation(bytes32 schemaId,bytes32 transformerId,bytes input,bytes output)"),
+                attestation.schemaId,
                 attestation.transformerId,
                 keccak256(attestation.input),
                 keccak256(attestation.output)
@@ -230,6 +244,7 @@ contract ChargebackVerifierTest is Test {
         bytes[] memory signatures = new bytes[](1);
         signatures[0] = hex"01";
         attestation = IChargebackVerifier.ChargebackAttestation({
+            schemaId: DISPUTE_SCHEMA_ID,
             transformerId: TRANSFORMER,
             input: abi.encode(intentHash),
             output: abi.encode(paymentId, disputeId),


### PR DESCRIPTION
## Proposal

Replace the pre-launch chargeback proof shape with the versioned generic attestation envelope consumed by Phase 1's stateless endpoint.

Review spec: https://peer-drops-1ej7p9trd-zkp2p.vercel.app/spec.html (team SSO)

## Scope

- Uses `Attestation(bytes32 schemaId,bytes32 transformerId,bytes input,bytes output)` with EIP-712 domain `ZKP2P Attestation` version `1`.
- Requires `schemaId == keccak256("zkp2p.attestation.dispute.v1")` before decoding.
- Decodes signed input as `(bytes32 intentHash)` and output as `(bytes32 originalPaymentId,bytes32 disputeId)`.
- Enforces exact ABI lengths, nonzero identifiers, nonempty signatures, and the trusted attestor signature.
- Binds the original payment to live nullifier state in both directions and returns the payment-method-scoped dispute nullifier.
- Rejects manual-release chargebacks because no original-payment proof exists to bind them.

## Minimal Phase 1 boundary

- No hardcoded Venmo or PayPal transformer IDs.
- No transformer allowlist, setters, or constructor parameters.
- No legacy dispute decoder or compatibility path; these contracts are not live.
- No deployment script or migration-lane changes.
- The configured attestor is the transformer trust boundary. The contract pins only the versioned ABI schema it decodes.

## Verification

- Hardhat compile, package build, and localhost deployment checks pass.
- The complete Foundry suite and all four coverage shards pass, including verifier coverage and Codecov.
- Tests cover wrong-schema rejection, EIP-712 digest parity, arbitrary nonzero transformer IDs, malformed envelopes, signer failure, manual release, bidirectional payment binding, and nullification.

No contracts were deployed.
