### PR TITLE
fix: bind manual chargeback settlements to payment IDs

### DIFF
--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -272,6 +272,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
             _params.postIntentHookData,
             managerFeeRecipient,
             managerFee,
+            bytes32(0),
             false
         );
     }
@@ -283,12 +284,14 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
      * configured post-intent hook with empty fulfillment-time data or transfers the deposit token directly to the payer when
      * no hook is configured.
      *
-     * @param _intentHash        Hash of intent to resolve by releasing the funds
+     * @param _intentHash Hash of intent to resolve by releasing the funds.
+     * @param _paymentId Provider payment identifier that the depositor binds to this manual settlement.
      */
-    function releaseFundsToPayer(bytes32 _intentHash) external nonReentrant {
+    function releaseFundsToPayer(bytes32 _intentHash, bytes32 _paymentId) external nonReentrant {
         // Checks
         Intent memory intent = intents[_intentHash];
         if (intent.owner == address(0)) revert IntentNotFound(_intentHash);
+        if (_paymentId == bytes32(0)) revert ZeroPaymentId();
 
         IEscrow.Deposit memory deposit = IEscrow(intent.escrow).getDeposit(intent.depositId);
         if (deposit.depositor != msg.sender) revert UnauthorizedCaller(msg.sender, deposit.depositor);
@@ -311,6 +314,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
             "",
             managerFeeRecipient,
             managerFee,
+            _paymentId,
             true
         );
     }
@@ -694,6 +698,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         bytes memory _postIntentHookData,
         address _managerFeeRecipient,
         uint256 _managerFee,
+        bytes32 _paymentId,
         bool _isManualRelease
     ) internal {
         IIntentLifecycleHook snapshottedLifecycleHook = intentLifecycleHooks[_intentHash];
@@ -710,6 +715,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
                     recipient: _intent.to,
                     releaseAmount: _releaseAmount,
                     netAmount: netAmount,
+                    paymentId: _paymentId,
                     isManualRelease: _isManualRelease
                 })
             );

--- a/contracts/hooks/ChargebackPolicy.sol
+++ b/contracts/hooks/ChargebackPolicy.sol
@@ -9,14 +9,16 @@ import {IChargebackPolicy} from "../interfaces/IChargebackPolicy.sol";
 import {IChargebackVerifier} from "../interfaces/IChargebackVerifier.sol";
 import {IEscrowV2} from "../interfaces/IEscrowV2.sol";
 import {INullifierRegistry} from "../interfaces/INullifierRegistry.sol";
+import {INullifierRegistryV2} from "../interfaces/INullifierRegistryV2.sol";
 import {IStakeVault} from "../interfaces/IStakeVault.sol";
 
 /**
  * @title ChargebackPolicy
  * @notice Deposit-scoped, stake-backed chargeback coverage for intent settlement.
  * @dev The policy owns no tokens. StakeVault is the source of truth for collateral locks, a dedicated
- * `chargebackNullifierRegistry` deployment is the source of truth for consumed dispute nullifiers, and the calling
- * Orchestrator is the source of truth for valid escrows and intents.
+ * `chargebackNullifierRegistry` deployment is the source of truth for consumed dispute nullifiers,
+ * `paymentNullifierRegistry` is the source of truth for payment-to-intent bindings, and the calling Orchestrator is
+ * the source of truth for valid escrows and intents.
  *
  * TRUST: Chargeback intents are keyed by intent hash, which embeds the originating orchestrator
  * (OrchestratorV3 hashes its own address into every intent hash), so identities do not collide across orchestrators.
@@ -24,7 +26,8 @@ import {IStakeVault} from "../interfaces/IStakeVault.sol";
  * intents it created and already validated against its EscrowRegistry. Registering an orchestrator is therefore a
  * governance assertion about its callback behavior.
  *
- * Governance must authorize a lifecycle hook here before configuring it on an Orchestrator. Predecessor hooks must
+ * Governance must authorize a lifecycle hook here and grant this policy write access to the payment nullifier
+ * registry before configuring it on an Orchestrator. Predecessor hooks must
  * remain authorized until all intents snapshotted to them have been cancelled or settled. Likewise, an orchestrator
  * must be drained before it is removed from OrchestratorRegistry. This policy must also drain every active chargeback
  * intent before StakeVault controller authority moves to a replacement policy unless that replacement explicitly adopts
@@ -43,6 +46,9 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
 
     /// @notice Dedicated replay registry for payment-method-scoped chargeback dispute nullifiers.
     INullifierRegistry public immutable chargebackNullifierRegistry;
+
+    /// @notice Canonical bidirectional registry binding payment nullifiers to settled intents.
+    INullifierRegistryV2 public immutable override paymentNullifierRegistry;
 
     /// @notice Verifier used to validate signed chargeback evidence.
     IChargebackVerifier public chargebackVerifier;
@@ -66,25 +72,30 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
 
     /**
      * @notice Creates a chargeback policy over one StakeVault and one dedicated dispute-nullifier registry.
-     * @dev After deployment, authorize this policy as the StakeVault controller and as a writer on the dedicated
-     * chargeback nullifier registry before enabling deposits.
+     * @dev After deployment, authorize this policy as the StakeVault controller and as a writer on both nullifier
+     * registries before enabling deposits.
      * @param _owner Governance owner for policy and dependency configuration.
      * @param _stakeVault Vault holding and locking taker collateral.
+     * @param _paymentNullifierRegistry Canonical payment-to-intent binding registry.
      * @param _chargebackVerifier Verifier for signed chargeback evidence.
      * @param _chargebackNullifierRegistry Dedicated registry that rejects reused dispute nullifiers.
      */
     constructor(
         address _owner,
         IStakeVault _stakeVault,
+        INullifierRegistryV2 _paymentNullifierRegistry,
         IChargebackVerifier _chargebackVerifier,
         INullifierRegistry _chargebackNullifierRegistry
     ) {
         if (_owner == address(0)) revert ZeroAddress();
         _validateDependency(address(_stakeVault));
+        _validateDependency(address(_paymentNullifierRegistry));
         _validateDependency(address(_chargebackVerifier));
         _validateDependency(address(_chargebackNullifierRegistry));
 
         stakeVault = _stakeVault;
+        paymentNullifierRegistry = _paymentNullifierRegistry;
+        _validateChargebackVerifier(address(_chargebackVerifier));
         chargebackVerifier = _chargebackVerifier;
         chargebackNullifierRegistry = _chargebackNullifierRegistry;
         _transferOwnership(_owner);
@@ -158,7 +169,12 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
     /**
      * @inheritdoc IChargebackPolicy
      */
-    function onIntentSettled(bytes32 _intentHash, uint256 _releaseAmount, bool _isManualRelease)
+    function onIntentSettled(
+        bytes32 _intentHash,
+        uint256 _releaseAmount,
+        bool _isManualRelease,
+        bytes32 _paymentId
+    )
         external
         override
         onlyLifecycleHook
@@ -168,6 +184,15 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
         if (chargebackIntent.status == ChargebackIntentStatus.NONE) return;
         if (chargebackIntent.status != ChargebackIntentStatus.PENDING) {
             revert ChargebackIntentNotPending(_intentHash, chargebackIntent.status);
+        }
+        if (_isManualRelease != (_paymentId != bytes32(0))) {
+            revert InvalidSettlementPaymentId(_isManualRelease, _paymentId);
+        }
+
+        if (_isManualRelease) {
+            bytes32 paymentNullifier =
+                keccak256(abi.encodePacked(chargebackIntent.paymentMethod, _paymentId));
+            paymentNullifierRegistry.addNullifier(paymentNullifier, _intentHash);
         }
 
         uint64 releaseEligibleAt = _calculateReleaseEligibleAt(chargebackIntent.riskWindow);
@@ -222,7 +247,7 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
         }
 
         (bytes32 disputeId, bytes32 disputeNullifier) = chargebackVerifier.verifyChargeback(
-            _attestation, chargebackIntent.paymentMethod, chargebackIntent.isManualRelease
+            _attestation, chargebackIntent.paymentMethod, false
         );
         chargebackNullifierRegistry.addNullifier(disputeNullifier);
 
@@ -280,7 +305,7 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
      * @param _verifier New non-zero deployed chargeback verifier.
      */
     function setChargebackVerifier(address _verifier) external onlyOwner {
-        _validateDependency(_verifier);
+        _validateChargebackVerifier(_verifier);
         address previousVerifier = address(chargebackVerifier);
         chargebackVerifier = IChargebackVerifier(_verifier);
         emit ChargebackVerifierUpdated(previousVerifier, _verifier);
@@ -420,5 +445,14 @@ contract ChargebackPolicy is IChargebackPolicy, Ownable2Step, ReentrancyGuard {
     function _validateDependency(address _dependency) internal view {
         if (_dependency == address(0)) revert ZeroAddress();
         if (_dependency.code.length == 0) revert InvalidContract(_dependency);
+    }
+
+    function _validateChargebackVerifier(address _verifier) internal view {
+        _validateDependency(_verifier);
+        address expectedRegistry = address(paymentNullifierRegistry);
+        address configuredRegistry = address(IChargebackVerifier(_verifier).nullifierRegistry());
+        if (configuredRegistry != expectedRegistry) {
+            revert PaymentNullifierRegistryMismatch(expectedRegistry, configuredRegistry);
+        }
     }
 }

--- a/contracts/hooks/IntentLifecycleHookV1.sol
+++ b/contracts/hooks/IntentLifecycleHookV1.sol
@@ -86,7 +86,9 @@ contract IntentLifecycleHookV1 is IIntentLifecycleHook {
      * @inheritdoc IIntentLifecycleHook
      */
     function settleIntent(SettlementContext calldata _context) external override onlyOrchestrator {
-        chargebackPolicy.onIntentSettled(_context.intentHash, _context.releaseAmount, _context.isManualRelease);
+        chargebackPolicy.onIntentSettled(
+            _context.intentHash, _context.releaseAmount, _context.isManualRelease, _context.paymentId
+        );
     }
 
     /* ============ Modifiers ============ */

--- a/contracts/interfaces/IChargebackPolicy.sol
+++ b/contracts/interfaces/IChargebackPolicy.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.18;
 
+import {INullifierRegistryV2} from "./INullifierRegistryV2.sol";
+
 /**
  * @title IChargebackPolicy
  * @notice Lifecycle-hook integration surface for stake-backed chargeback coverage.
@@ -83,6 +85,8 @@ interface IChargebackPolicy {
 
     error ZeroAddress();
     error InvalidContract(address dependency);
+    error InvalidSettlementPaymentId(bool isManualRelease, bytes32 paymentId);
+    error PaymentNullifierRegistryMismatch(address expected, address actual);
     error UnauthorizedLifecycleHook(address caller);
     error AdmissionsPaused();
     error ChargebackNotEnabled(address escrow, uint256 depositId);
@@ -131,8 +135,17 @@ interface IChargebackPolicy {
      * @param _intentHash Intent completed by proof-based fulfillment or manual release.
      * @param _releaseAmount Amount released from Escrow before protocol, referral, and manager fees.
      * @param _isManualRelease Whether the depositor used the manual-release path without an on-chain payment proof.
+     * @param _paymentId Provider payment identifier supplied by the depositor for manual release. Must be nonzero
+     * for manual release and zero for payment-proof fulfillment.
      */
-    function onIntentSettled(bytes32 _intentHash, uint256 _releaseAmount, bool _isManualRelease) external;
+    function onIntentSettled(
+        bytes32 _intentHash,
+        uint256 _releaseAmount,
+        bool _isManualRelease,
+        bytes32 _paymentId
+    ) external;
+
+    function paymentNullifierRegistry() external view returns (INullifierRegistryV2);
 
     /**
      * @notice Returns whether a deposit opted into stake-backed chargeback admission.

--- a/contracts/interfaces/IChargebackVerifier.sol
+++ b/contracts/interfaces/IChargebackVerifier.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.18;
 
+import {INullifierRegistryV2} from "./INullifierRegistryV2.sol";
+
 /**
  * @title IChargebackVerifier
  * @notice Minimal verification surface consumed by ChargebackPolicy.
@@ -47,20 +49,22 @@ interface IChargebackVerifier {
     error AttestationVerificationFailed();
     error OwnershipRenunciationDisabled();
 
+    function nullifierRegistry() external view returns (INullifierRegistryV2);
+
     /**
      * @notice Validates chargeback evidence against the intent context supplied by the policy.
-     * @dev View-only and stateless. Reverts when the payload is malformed, mismatched, unsigned, or—on the
-     * proof-based path—not bound to the intent's original payment nullifier.
+     * @dev View-only and stateless. Reverts when the payload is malformed, mismatched, unsigned, or—unless the
+     * legacy bypass is explicitly selected—not bound to the intent's original payment nullifier.
      * @param _attestation Signed chargeback evidence for an intent.
      * @param _paymentMethod Payment method snapshotted by the policy when the intent was admitted.
-     * @param _isManualRelease Whether settlement occurred without an on-chain payment proof. Manual releases skip
-     * original-payment binding because no payment nullifier was recorded during settlement.
+     * @param _skipPaymentBinding Legacy compatibility switch. ChargebackPolicy always passes false because both
+     * proof and manual settlements have canonical payment-to-intent bindings.
      * @return disputeId Payment-platform dispute identifier decoded from the evidence.
      * @return disputeNullifier Payment-method-scoped replay key for the dispute.
      */
     function verifyChargeback(
         ChargebackAttestation calldata _attestation,
         bytes32 _paymentMethod,
-        bool _isManualRelease
+        bool _skipPaymentBinding
     ) external view returns (bytes32 disputeId, bytes32 disputeNullifier);
 }

--- a/contracts/interfaces/IIntentLifecycleHook.sol
+++ b/contracts/interfaces/IIntentLifecycleHook.sol
@@ -18,6 +18,8 @@ interface IIntentLifecycleHook {
      * @param releaseAmount Amount released from Escrow before protocol, referral, and manager fees.
      * @param netAmount Remainder after all fees; this is the amount transferred to the recipient or made executable
      * by the intent's post-intent hook.
+     * @param paymentId Provider payment identifier supplied by the depositor for manual releases. Zero for
+     * payment-proof fulfillment because the verifier has already registered that payment on-chain.
      * @param isManualRelease Whether the depositor used the manual-release path instead of payment-proof fulfillment.
      */
     struct SettlementContext {
@@ -26,6 +28,7 @@ interface IIntentLifecycleHook {
         address recipient;
         uint256 releaseAmount;
         uint256 netAmount;
+        bytes32 paymentId;
         bool isManualRelease;
     }
 
@@ -49,8 +52,8 @@ interface IIntentLifecycleHook {
      * @dev Called after fee transfers and before the net amount moves to the recipient or post-intent hook. The
      * lifecycle hook receives no token allowance and cannot consume settlement funds. A revert rolls back the entire
      * settlement, including Escrow release and fee transfers.
-     * @param _context Intent identifier, token, recipient, pre-fee release amount, post-fee net amount, and settlement
-     * route.
+     * @param _context Intent identifier, token, recipient, pre-fee release amount, post-fee net amount, payment ID,
+     * and settlement route.
      */
     function settleIntent(SettlementContext calldata _context) external;
 }

--- a/contracts/interfaces/IOrchestratorV3.sol
+++ b/contracts/interfaces/IOrchestratorV3.sol
@@ -132,6 +132,7 @@ interface IOrchestratorV3 {
     error InvalidPostIntentHook(address hook);
     error InvalidPreIntentHook(address hook);
     error InvalidLifecycleHook(address hook);
+    error ZeroPaymentId();
     error InvalidSignature();
     error SignatureExpired(uint256 expiration, uint256 currentTime);
 
@@ -160,7 +161,7 @@ interface IOrchestratorV3 {
 
     function fulfillIntent(FulfillIntentParams calldata params) external;
 
-    function releaseFundsToPayer(bytes32 intentHash) external;
+    function releaseFundsToPayer(bytes32 intentHash, bytes32 paymentId) external;
 
     /* ============ External Functions for Escrow ============ */
 

--- a/contracts/unifiedVerifier/ChargebackVerifier.sol
+++ b/contracts/unifiedVerifier/ChargebackVerifier.sol
@@ -26,7 +26,7 @@ contract ChargebackVerifier is IChargebackVerifier, Ownable2Step, EIP712 {
 
     /* ============ State Variables ============ */
 
-    INullifierRegistryV2 public immutable nullifierRegistry;
+    INullifierRegistryV2 public immutable override nullifierRegistry;
     IAttestationVerifier public attestationVerifier;
 
     /* ============ Constructor ============ */
@@ -51,7 +51,7 @@ contract ChargebackVerifier is IChargebackVerifier, Ownable2Step, EIP712 {
     function verifyChargeback(
         ChargebackAttestation calldata _attestation,
         bytes32 _paymentMethod,
-        bool _isManualRelease
+        bool _skipPaymentBinding
     ) external view override returns (bytes32 disputeId, bytes32 disputeNullifier) {
         if (keccak256(_attestation.data) != _attestation.dataHash) revert InvalidAttestation();
 
@@ -63,7 +63,7 @@ contract ChargebackVerifier is IChargebackVerifier, Ownable2Step, EIP712 {
             revert AttestationVerificationFailed();
         }
 
-        if (!_isManualRelease) {
+        if (!_skipPaymentBinding) {
             bytes32 paymentNullifier = keccak256(abi.encodePacked(details.paymentMethod, details.originalPaymentId));
             if (
                 nullifierRegistry.intentHashByNullifier(paymentNullifier) != _attestation.intentHash

--- a/deploy/30_deploy_v3_lifecycle_stack.ts
+++ b/deploy/30_deploy_v3_lifecycle_stack.ts
@@ -22,6 +22,7 @@ const RETIRED_STAGING_WHITELIST_POLICY = "0xe3d3E798AbF1c021730d951d0589bCa63d9C
 const RETIRED_STAGING_ORCHESTRATORS = [
   "0xF9CEE6365fB4F6354a19e95d35aaeF877CF1179d",
   "0x1734f5C9956D0DA1f48E27cd1C6167aA81F27869",
+  "0x2b5E8Ab562e45fA89D73802605E145ED3E3EeF4f",
 ];
 
 function sameAddress(left: string, right: string): boolean {
@@ -133,6 +134,15 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   if (!!existingHook !== !!existingOrchestrator) {
     throw new Error(
       "WhitelistLifecycleHook and OrchestratorV3 artifacts must either both be present or both be moved aside",
+    );
+  }
+  if (
+    network === "base_staging"
+    && existingOrchestrator
+    && RETIRED_STAGING_ORCHESTRATORS.some((retired) => sameAddress(existingOrchestrator.address, retired))
+  ) {
+    throw new Error(
+      "Move the retired WhitelistLifecycleHook and OrchestratorV3 artifacts aside before lane 30",
     );
   }
 

--- a/deploy/31_deploy_chargeback_lifecycle_stack.ts
+++ b/deploy/31_deploy_chargeback_lifecycle_stack.ts
@@ -37,6 +37,41 @@ async function assertCode(address: string, label: string): Promise<void> {
   }
 }
 
+async function assertFunctionSelector(address: string, signature: string, label: string): Promise<void> {
+  const selector = ethers.utils.id(signature).slice(2, 10).toLowerCase();
+  const bytecode = (await ethers.provider.getCode(address)).toLowerCase();
+  if (!bytecode.includes(selector)) {
+    throw new Error(`${label} does not implement ${signature}; redeploy the V3 lifecycle stack first`);
+  }
+}
+
+async function assertActivePaymentVerifiersUseRegistry(
+  hre: HardhatRuntimeEnvironment,
+  expectedRegistry: string,
+): Promise<void> {
+  if (hre.deployments.getNetworkName() !== "base_staging") return;
+
+  const paymentVerifierRegistryAddress = (await hre.deployments.get("PaymentVerifierRegistry")).address;
+  const paymentVerifierRegistry = await ethers.getContractAt(
+    "PaymentVerifierRegistry",
+    paymentVerifierRegistryAddress,
+  );
+  const nullifierRegistryAbi = ["function nullifierRegistry() view returns (address)"];
+
+  for (const methodName of CHARGEBACKABLE_PAYMENT_METHODS) {
+    const method = paymentMethodHash(methodName);
+    const verifierAddress = await paymentVerifierRegistry.getVerifier(method);
+    await assertCode(verifierAddress, `${methodName} payment verifier`);
+    const verifier = new ethers.Contract(verifierAddress, nullifierRegistryAbi, ethers.provider);
+    const configuredRegistry = await verifier.nullifierRegistry();
+    if (!sameAddress(configuredRegistry, expectedRegistry)) {
+      throw new Error(
+        `${methodName} payment verifier uses ${configuredRegistry}; expected NullifierRegistryV2 ${expectedRegistry}`,
+      );
+    }
+  }
+}
+
 async function assertRetiredLiabilitiesZero(): Promise<void> {
   await assertCode(RETIRED_STAGING_STAKE_VAULT, "Retired StakeVault");
   const retiredVault = await ethers.getContractAt("StakeVault", RETIRED_STAGING_STAKE_VAULT);
@@ -63,24 +98,40 @@ async function systemFullyWired(hre: HardhatRuntimeEnvironment): Promise<boolean
     const whitelistPolicyDeployment = await hre.deployments.get("WhitelistPolicy");
     const registryAddress = (await hre.deployments.get("OrchestratorRegistry")).address;
     const verifierAddress = (await hre.deployments.get("ChargebackVerifier")).address;
+    const paymentNullifierRegistryAddress = (await hre.deployments.get("NullifierRegistryV2")).address;
     const nullifierRegistryAddress = (await hre.deployments.get("ChargebackNullifierRegistry")).address;
 
     const vault = await ethers.getContractAt("StakeVault", vaultDeployment.address);
     const policy = await ethers.getContractAt("ChargebackPolicy", policyDeployment.address);
     const hook = await ethers.getContractAt("IntentLifecycleHookV1", hookDeployment.address);
     const orchestrator = await ethers.getContractAt("OrchestratorV3", orchestratorDeployment.address);
+    const paymentNullifierRegistry = await ethers.getContractAt(
+      "NullifierRegistryV2",
+      paymentNullifierRegistryAddress,
+    );
+    const chargebackVerifier = await ethers.getContractAt("ChargebackVerifier", verifierAddress);
     const nullifierRegistry = await ethers.getContractAt("NullifierRegistry", nullifierRegistryAddress);
+
+    await assertFunctionSelector(
+      orchestrator.address,
+      "releaseFundsToPayer(bytes32,bytes32)",
+      "OrchestratorV3",
+    );
+    await assertActivePaymentVerifiersUseRegistry(hre, paymentNullifierRegistryAddress);
 
     if (!sameAddress(await vault.stakeToken(), stakeTokenAddress)) return false;
     if (!sameAddress(await vault.controller(), policy.address)) return false;
     if (!(await vault.controllerChangeDelay()).eq(STAKE_VAULT_CONTROLLER_CHANGE_DELAY)) return false;
     if (!sameAddress(await policy.stakeVault(), vault.address)) return false;
+    if (!sameAddress(await policy.paymentNullifierRegistry(), paymentNullifierRegistryAddress)) return false;
     if (!sameAddress(await policy.chargebackVerifier(), verifierAddress)) return false;
+    if (!sameAddress(await chargebackVerifier.nullifierRegistry(), paymentNullifierRegistryAddress)) return false;
     if (!sameAddress(await policy.chargebackNullifierRegistry(), nullifierRegistryAddress)) return false;
     if (!sameAddress(await hook.orchestratorRegistry(), registryAddress)) return false;
     if (!sameAddress(await hook.whitelistPolicy(), whitelistPolicyDeployment.address)) return false;
     if (!sameAddress(await hook.chargebackPolicy(), policy.address)) return false;
     if (!(await policy.isLifecycleHookAuthorized(hook.address))) return false;
+    if (!(await paymentNullifierRegistry.isWriter(policy.address))) return false;
     if (!(await nullifierRegistry.isWriter(policy.address))) return false;
     if (!sameAddress(await orchestrator.lifecycleHook(), hook.address)) return false;
     if (!sameAddress(await vault.owner(), governance)) return false;
@@ -135,6 +186,14 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   let chargebackNullifierRegistryDeployment = await hre.deployments.getOrNull(
     "ChargebackNullifierRegistry",
   );
+  let paymentNullifierRegistryDeployment = await hre.deployments.getOrNull("NullifierRegistryV2");
+  if (!paymentNullifierRegistryDeployment) {
+    paymentNullifierRegistryDeployment = await hre.deployments.deploy("NullifierRegistryV2", {
+      from: deployer,
+      args: [(await hre.deployments.get("NullifierRegistry")).address],
+      log: true,
+    });
+  }
   let chargebackVerifierDeployment = await hre.deployments.getOrNull("ChargebackVerifier");
   if (network !== "base_staging" && !chargebackNullifierRegistryDeployment) {
     chargebackNullifierRegistryDeployment = await hre.deployments.deploy("ChargebackNullifierRegistry", {
@@ -145,20 +204,12 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     });
   }
   if (network !== "base_staging" && !chargebackVerifierDeployment) {
-    let nullifierRegistryV2 = await hre.deployments.getOrNull("NullifierRegistryV2");
-    if (!nullifierRegistryV2) {
-      nullifierRegistryV2 = await hre.deployments.deploy("NullifierRegistryV2", {
-        from: deployer,
-        args: [(await hre.deployments.get("NullifierRegistry")).address],
-        log: true,
-      });
-    }
     const attestationVerifier =
       await hre.deployments.getOrNull("MultiAttestationVerifier")
       || await hre.deployments.get("SimpleAttestationVerifier");
     chargebackVerifierDeployment = await hre.deployments.deploy("ChargebackVerifier", {
       from: deployer,
-      args: [deployer, nullifierRegistryV2.address, attestationVerifier.address],
+      args: [deployer, paymentNullifierRegistryDeployment.address, attestationVerifier.address],
       log: true,
     });
   }
@@ -167,12 +218,20 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   }
   const chargebackVerifierAddress = chargebackVerifierDeployment.address;
   const chargebackNullifierRegistryAddress = chargebackNullifierRegistryDeployment.address;
+  const paymentNullifierRegistryAddress = paymentNullifierRegistryDeployment.address;
 
   await assertCode(whitelistPolicyAddress, "WhitelistPolicy");
   await assertCode(whitelistHookAddress, "WhitelistLifecycleHook");
   await assertCode(orchestratorAddress, "OrchestratorV3");
   await assertCode(chargebackVerifierAddress, "ChargebackVerifier");
+  await assertCode(paymentNullifierRegistryAddress, "NullifierRegistryV2");
   await assertCode(chargebackNullifierRegistryAddress, "ChargebackNullifierRegistry");
+  await assertFunctionSelector(
+    orchestratorAddress,
+    "releaseFundsToPayer(bytes32,bytes32)",
+    "OrchestratorV3",
+  );
+  await assertActivePaymentVerifiersUseRegistry(hre, paymentNullifierRegistryAddress);
 
   const orchestrator = await ethers.getContractAt("OrchestratorV3", orchestratorAddress);
   if (!sameAddress(await orchestrator.lifecycleHook(), whitelistHookAddress)) {
@@ -183,6 +242,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log("Reusing OrchestratorV3:", orchestratorAddress);
   console.log("Reusing WhitelistPolicy:", whitelistPolicyAddress);
   console.log("Reusing ChargebackVerifier:", chargebackVerifierAddress);
+  console.log("Reusing NullifierRegistryV2:", paymentNullifierRegistryAddress);
   console.log("Reusing ChargebackNullifierRegistry:", chargebackNullifierRegistryAddress);
 
   const vaultDeployment = await hre.deployments.deploy("StakeVault", {
@@ -198,6 +258,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     args: [
       deployer,
       vaultDeployment.address,
+      paymentNullifierRegistryAddress,
       chargebackVerifierAddress,
       chargebackNullifierRegistryAddress,
     ],
@@ -217,10 +278,15 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const vault = await ethers.getContractAt("StakeVault", vaultDeployment.address);
   const policy = await ethers.getContractAt("ChargebackPolicy", policyDeployment.address);
   const hook = await ethers.getContractAt("IntentLifecycleHookV1", hookDeployment.address);
+  const paymentNullifierRegistry = await ethers.getContractAt(
+    "NullifierRegistryV2",
+    paymentNullifierRegistryAddress,
+  );
   const nullifierRegistry = await ethers.getContractAt("NullifierRegistry", chargebackNullifierRegistryAddress);
 
   await (await vault.initializeController(policy.address)).wait();
   await waitForDeploymentDelay(hre);
+  await addWritePermission(hre, paymentNullifierRegistry, policy.address);
   await addWritePermission(hre, nullifierRegistry, policy.address);
 
   await (await policy.setLifecycleHookAuthorization(hook.address, true)).wait();

--- a/test-foundry/deterministic/hooks/ChargebackPolicy.t.sol
+++ b/test-foundry/deterministic/hooks/ChargebackPolicy.t.sol
@@ -9,6 +9,7 @@ import {ChargebackPolicy} from "contracts/hooks/ChargebackPolicy.sol";
 import {IChargebackPolicy} from "contracts/interfaces/IChargebackPolicy.sol";
 import {IChargebackVerifier} from "contracts/interfaces/IChargebackVerifier.sol";
 import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
+import {INullifierRegistryV2} from "contracts/interfaces/INullifierRegistryV2.sol";
 import {IStakeVault} from "contracts/interfaces/IStakeVault.sol";
 import {AttestationVerifierMock} from "contracts/mocks/AttestationVerifierMock.sol";
 import {USDCMock} from "contracts/mocks/USDCMock.sol";
@@ -53,8 +54,10 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         chargebackNullifierRegistry = new NullifierRegistry();
         attestationVerifier = new AttestationVerifierMock();
         chargebackVerifier = new ChargebackVerifier(address(this), nullifierRegistry, attestationVerifier);
-        policy = new ChargebackPolicy(address(this), vault, chargebackVerifier, chargebackNullifierRegistry);
+        policy =
+            new ChargebackPolicy(address(this), vault, nullifierRegistry, chargebackVerifier, chargebackNullifierRegistry);
         vault.initializeController(address(policy));
+        nullifierRegistry.addWritePermission(address(policy));
         chargebackNullifierRegistry.addWritePermission(address(policy));
         policy.setLifecycleHookAuthorization(address(this), true);
         policy.setRiskWindow(METHOD, RISK_WINDOW);
@@ -65,7 +68,19 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
 
     function test_ConstructorRejectsZeroOwner() public {
         vm.expectRevert(IChargebackPolicy.ZeroAddress.selector);
-        new ChargebackPolicy(address(0), vault, chargebackVerifier, chargebackNullifierRegistry);
+        new ChargebackPolicy(address(0), vault, nullifierRegistry, chargebackVerifier, chargebackNullifierRegistry);
+
+        NullifierRegistryV2 otherRegistry = new NullifierRegistryV2(new NullifierRegistry());
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.PaymentNullifierRegistryMismatch.selector,
+                address(otherRegistry),
+                address(nullifierRegistry)
+            )
+        );
+        new ChargebackPolicy(
+            address(this), vault, otherRegistry, chargebackVerifier, chargebackNullifierRegistry
+        );
     }
 
     function test_onIntentSignaledLocksStakeAndSnapshotsConfiguration() public {
@@ -124,7 +139,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         assertEq(vault.lockedStake(taker), lockedBefore);
         assertEq(vault.freeStake(taker), freeBefore);
 
-        policy.onIntentSettled(INTENT, INTENT_AMOUNT, false);
+        policy.onIntentSettled(INTENT, INTENT_AMOUNT, false, bytes32(0));
         policy.onIntentCancelled(INTENT);
         assertEq(
             uint256(policy.getChargebackIntent(INTENT).status), uint256(IChargebackPolicy.ChargebackIntentStatus.NONE)
@@ -177,7 +192,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
 
         bytes32 settledIntent = keccak256("settled");
         policy.onIntentSignaled(settledIntent, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
-        policy.onIntentSettled(settledIntent, INTENT_AMOUNT, false);
+        policy.onIntentSettled(settledIntent, INTENT_AMOUNT, false, bytes32(0));
         vm.expectRevert(
             abi.encodeWithSelector(
                 IChargebackPolicy.ChargebackIntentNotPending.selector,
@@ -189,15 +204,19 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
     }
 
     function test_SettlementResizesFullAndPartialAndSnapshotsReleaseEligibilityAndManualFlag() public {
-        policy.onIntentSettled(keccak256("missing"), INTENT_AMOUNT, false);
+        policy.onIntentSettled(keccak256("missing"), INTENT_AMOUNT, false, bytes32(0));
         policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         uint256 releaseEligibleAt = vm.getBlockTimestamp() + RISK_WINDOW;
-        policy.onIntentSettled(INTENT, 40e6, true);
+        bytes32 paymentId = _manualPaymentId(INTENT);
+        policy.onIntentSettled(INTENT, 40e6, true, paymentId);
 
         IChargebackPolicy.ChargebackIntent memory chargebackIntent = policy.getChargebackIntent(INTENT);
         assertEq(chargebackIntent.releaseEligibleAt, releaseEligibleAt);
         assertEq(chargebackIntent.releaseAmount, 40e6);
         assertTrue(chargebackIntent.isManualRelease);
+        bytes32 paymentNullifier = keccak256(abi.encodePacked(METHOD, paymentId));
+        assertEq(nullifierRegistry.intentHashByNullifier(paymentNullifier), INTENT);
+        assertEq(nullifierRegistry.nullifierByIntentHash(INTENT), paymentNullifier);
         (, uint256 amount, uint64 maturesAt) = vault.locks(INTENT);
         assertEq(amount, 40e6);
         assertEq(maturesAt, releaseEligibleAt);
@@ -209,11 +228,11 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
                 IChargebackPolicy.ChargebackIntentStatus.SETTLED
             )
         );
-        policy.onIntentSettled(INTENT, 40e6, true);
+        policy.onIntentSettled(INTENT, 40e6, true, paymentId);
 
         bytes32 fullIntent = keccak256("full");
         policy.onIntentSignaled(fullIntent, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
-        policy.onIntentSettled(fullIntent, INTENT_AMOUNT, false);
+        policy.onIntentSettled(fullIntent, INTENT_AMOUNT, false, bytes32(0));
         (, amount,) = vault.locks(fullIntent);
         assertEq(amount, INTENT_AMOUNT);
     }
@@ -248,6 +267,43 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
             )
         );
         policy.releaseMaturedChargebackIntent(INTENT);
+    }
+
+    function test_SettlementRejectsMissingManualAndUnexpectedProofPaymentIds() public {
+        policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.InvalidSettlementPaymentId.selector, true, bytes32(0)
+            )
+        );
+        policy.onIntentSettled(INTENT, INTENT_AMOUNT, true, bytes32(0));
+
+        bytes32 unexpectedPaymentId = keccak256("unexpected");
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.InvalidSettlementPaymentId.selector, false, unexpectedPaymentId
+            )
+        );
+        policy.onIntentSettled(INTENT, INTENT_AMOUNT, false, unexpectedPaymentId);
+    }
+
+    function test_ManualSettlementRejectsPaymentAlreadyBoundToAnotherIntent() public {
+        bytes32 paymentId = _manualPaymentId(INTENT);
+        _admitAndSettle(INTENT, 40e6, true);
+
+        bytes32 secondIntent = keccak256("second-manual-intent");
+        policy.onIntentSignaled(secondIntent, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        bytes32 paymentNullifier = keccak256(abi.encodePacked(METHOD, paymentId));
+        vm.expectRevert(
+            abi.encodeWithSelector(INullifierRegistryV2.NullifierAlreadyExists.selector, paymentNullifier)
+        );
+        policy.onIntentSettled(secondIntent, 40e6, true, paymentId);
+
+        assertEq(
+            uint256(policy.getChargebackIntent(secondIntent).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.PENDING)
+        );
     }
 
     function test_SubmitChargebackProofPathRequiresBothDirectionBindingAndCreatesClaim() public {
@@ -299,11 +355,22 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         policy.submitChargeback(attestation);
     }
 
-    function test_SubmitChargebackManualPathSkipsPaymentBindingAndRejectsReplay() public {
+    function test_SubmitChargebackManualPathRequiresPrecommittedPaymentBindingAndRejectsReplay() public {
         _admitAndSettle(INTENT, 40e6, true);
         bytes32 disputeId = keccak256("dispute");
+        bytes32 wrongPaymentId = keccak256("unbound-payment");
         IChargebackVerifier.ChargebackAttestation memory attestation =
-            _attestation(INTENT, METHOD, keccak256("unbound-payment"), disputeId);
+            _attestation(INTENT, METHOD, wrongPaymentId, disputeId);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackVerifier.InvalidPaymentBinding.selector,
+                INTENT,
+                keccak256(abi.encodePacked(METHOD, wrongPaymentId))
+            )
+        );
+        policy.submitChargeback(attestation);
+
+        attestation = _attestation(INTENT, METHOD, _manualPaymentId(INTENT), disputeId);
         policy.submitChargeback(attestation);
 
         bytes32 disputeNullifier = keccak256(abi.encodePacked(METHOD, disputeId));
@@ -311,7 +378,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
 
         bytes32 secondIntent = keccak256("second");
         _admitAndSettle(secondIntent, 40e6, true);
-        attestation = _attestation(secondIntent, METHOD, keccak256("other-payment"), disputeId);
+        attestation = _attestation(secondIntent, METHOD, _manualPaymentId(secondIntent), disputeId);
         vm.expectRevert(bytes("Nullifier already exists"));
         policy.submitChargeback(attestation);
     }
@@ -319,16 +386,17 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
     function test_SubmitChargebackRejectsInvalidEvidenceButRemainsValidUntilCollateralRelease() public {
         _admitAndSettle(INTENT, 40e6, true);
         IChargebackVerifier.ChargebackAttestation memory attestation =
-            _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
+            _attestation(INTENT, METHOD, _manualPaymentId(INTENT), keccak256("dispute"));
         attestation.dataHash = keccak256("tampered");
         vm.expectRevert(IChargebackVerifier.InvalidAttestation.selector);
         policy.submitChargeback(attestation);
 
-        attestation = _attestation(INTENT, keccak256("wrong"), keccak256("payment"), keccak256("dispute"));
+        attestation =
+            _attestation(INTENT, keccak256("wrong"), _manualPaymentId(INTENT), keccak256("dispute"));
         vm.expectRevert(IChargebackVerifier.InvalidAttestation.selector);
         policy.submitChargeback(attestation);
 
-        attestation = _attestation(INTENT, METHOD, keccak256("payment"), keccak256("dispute"));
+        attestation = _attestation(INTENT, METHOD, _manualPaymentId(INTENT), keccak256("dispute"));
         attestationVerifier.setResult(false);
         vm.expectRevert(IChargebackVerifier.AttestationVerificationFailed.selector);
         policy.submitChargeback(attestation);
@@ -375,7 +443,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         assertTrue(policy.isLifecycleHookAuthorized(newHook));
         policy.onIntentCancelled(keccak256("old-hook-cancel"));
         vm.prank(newHook);
-        policy.onIntentSettled(keccak256("new-hook-settle"), INTENT_AMOUNT, false);
+        policy.onIntentSettled(keccak256("new-hook-settle"), INTENT_AMOUNT, false, bytes32(0));
 
         vm.expectEmit(true, false, false, true);
         emit LifecycleHookAuthorizationUpdated(address(this), false);
@@ -395,6 +463,18 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         emit ChargebackVerifierUpdated(address(chargebackVerifier), address(replacement));
         policy.setChargebackVerifier(address(replacement));
         assertEq(address(policy.chargebackVerifier()), address(replacement));
+
+        NullifierRegistryV2 otherRegistry = new NullifierRegistryV2(new NullifierRegistry());
+        ChargebackVerifier mismatchedVerifier =
+            new ChargebackVerifier(address(this), otherRegistry, attestationVerifier);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackPolicy.PaymentNullifierRegistryMismatch.selector,
+                address(nullifierRegistry),
+                address(otherRegistry)
+            )
+        );
+        policy.setChargebackVerifier(address(mismatchedVerifier));
     }
 
     function test_SettlementRejectsReleaseEligibilityTimestampOverflow() public {
@@ -405,7 +485,7 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
         vm.expectRevert(
             abi.encodeWithSelector(IChargebackPolicy.TimestampOverflow.selector, overflowingTimestamp + RISK_WINDOW)
         );
-        policy.onIntentSettled(INTENT, INTENT_AMOUNT, false);
+        policy.onIntentSettled(INTENT, INTENT_AMOUNT, false, bytes32(0));
     }
 
     function test_MaturedReleaseRejectsCurrentTimestampOverflow() public {
@@ -439,8 +519,9 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
 
     function test_AcceptVaultControllerCompletesDelayedTwoStepHandover() public {
         StakeVault secondVault = new StakeVault(address(this), token, address(0), 1 days);
-        ChargebackPolicy secondPolicy =
-            new ChargebackPolicy(address(this), secondVault, chargebackVerifier, chargebackNullifierRegistry);
+        ChargebackPolicy secondPolicy = new ChargebackPolicy(
+            address(this), secondVault, nullifierRegistry, chargebackVerifier, chargebackNullifierRegistry
+        );
         secondVault.initializeController(address(this));
         secondVault.proposeController(address(secondPolicy));
         uint256 acceptanceTime = vm.getBlockTimestamp() + secondVault.controllerChangeDelay();
@@ -459,7 +540,16 @@ contract ChargebackPolicyTest is OrchestratorV3Fixture {
 
     function _admitAndSettle(bytes32 intentHash, uint256 releaseAmount, bool manualRelease) internal {
         policy.onIntentSignaled(intentHash, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
-        policy.onIntentSettled(intentHash, releaseAmount, manualRelease);
+        policy.onIntentSettled(
+            intentHash,
+            releaseAmount,
+            manualRelease,
+            manualRelease ? _manualPaymentId(intentHash) : bytes32(0)
+        );
+    }
+
+    function _manualPaymentId(bytes32 intentHash) internal pure returns (bytes32) {
+        return keccak256(abi.encode("manual-payment", intentHash));
     }
 
     function _attestation(bytes32 intentHash, bytes32 paymentMethod, bytes32 paymentId, bytes32 disputeId)

--- a/test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/ChargebackLifecycleHookOrchestratorV3.t.sol
@@ -9,6 +9,7 @@ import {WhitelistPolicy} from "contracts/hooks/WhitelistPolicy.sol";
 import {IChargebackPolicy} from "contracts/interfaces/IChargebackPolicy.sol";
 import {IChargebackVerifier} from "contracts/interfaces/IChargebackVerifier.sol";
 import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
+import {INullifierRegistryV2} from "contracts/interfaces/INullifierRegistryV2.sol";
 import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
 import {IStakeVault} from "contracts/interfaces/IStakeVault.sol";
 import {AttestationVerifierMock} from "contracts/mocks/AttestationVerifierMock.sol";
@@ -42,10 +43,12 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         chargebackPolicy = new ChargebackPolicy(
             address(this),
             vault,
+            nullifierRegistry,
             new ChargebackVerifier(address(this), nullifierRegistry, new AttestationVerifierMock()),
             chargebackNullifierRegistry
         );
         vault.initializeController(address(chargebackPolicy));
+        nullifierRegistry.addWritePermission(address(chargebackPolicy));
         chargebackNullifierRegistry.addWritePermission(address(chargebackPolicy));
         lifecycleHook = new IntentLifecycleHookV1(orchestratorRegistry, whitelistPolicy, chargebackPolicy);
         chargebackPolicy.setLifecycleHookAuthorization(address(lifecycleHook), true);
@@ -209,15 +212,70 @@ contract ChargebackLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
     function test_ManualReleaseSettlesCoverageAndMarksManual() public {
         _setChargeback(true);
         bytes32 intentHash = _signalDefault();
+        bytes32 paymentId = keccak256("manual-payment");
         uint256 releaseEligibleAt = vm.getBlockTimestamp() + RISK_WINDOW;
         vm.prank(depositor);
-        orchestrator.releaseFundsToPayer(intentHash);
+        orchestrator.releaseFundsToPayer(intentHash, paymentId);
 
         IChargebackPolicy.ChargebackIntent memory chargebackIntent = chargebackPolicy.getChargebackIntent(intentHash);
         assertTrue(chargebackIntent.isManualRelease);
         assertEq(chargebackIntent.releaseAmount, INTENT_AMOUNT);
         assertEq(chargebackIntent.releaseEligibleAt, releaseEligibleAt);
+        bytes32 paymentNullifier = keccak256(abi.encodePacked(METHOD, paymentId));
+        assertEq(nullifierRegistry.intentHashByNullifier(paymentNullifier), intentHash);
+        assertEq(nullifierRegistry.nullifierByIntentHash(intentHash), paymentNullifier);
         assertEq(vault.lockedStake(taker), INTENT_AMOUNT);
+    }
+
+    function test_ManualChargebackRejectsDifferentPaymentAndAcceptsBoundPayment() public {
+        _setChargeback(true);
+        bytes32 intentHash = _signalDefault();
+        bytes32 paymentId = keccak256("manual-payment");
+        vm.prank(depositor);
+        orchestrator.releaseFundsToPayer(intentHash, paymentId);
+
+        bytes32 wrongPaymentId = keccak256("unrelated-payment");
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IChargebackVerifier.InvalidPaymentBinding.selector,
+                intentHash,
+                keccak256(abi.encodePacked(METHOD, wrongPaymentId))
+            )
+        );
+        chargebackPolicy.submitChargeback(
+            _attestation(intentHash, wrongPaymentId, keccak256("wrong-dispute"))
+        );
+
+        chargebackPolicy.submitChargeback(
+            _attestation(intentHash, paymentId, keccak256("bound-dispute"))
+        );
+        assertEq(vault.claimable(depositor), INTENT_AMOUNT);
+        assertEq(
+            uint256(chargebackPolicy.getChargebackIntent(intentHash).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.CHARGED_BACK)
+        );
+    }
+
+    function test_ManualReleaseRejectsPaymentAlreadyBoundToAnotherIntentAndRollsBack() public {
+        _setChargeback(true);
+        bytes32 paymentId = keccak256("shared-payment");
+        bytes32 firstIntent = _signalDefault();
+        bytes32 secondIntent = _signalDefault();
+        vm.prank(depositor);
+        orchestrator.releaseFundsToPayer(firstIntent, paymentId);
+
+        bytes32 paymentNullifier = keccak256(abi.encodePacked(METHOD, paymentId));
+        vm.expectRevert(
+            abi.encodeWithSelector(INullifierRegistryV2.NullifierAlreadyExists.selector, paymentNullifier)
+        );
+        vm.prank(depositor);
+        orchestrator.releaseFundsToPayer(secondIntent, paymentId);
+
+        assertEq(orchestrator.getIntent(secondIntent).owner, taker);
+        assertEq(
+            uint256(chargebackPolicy.getChargebackIntent(secondIntent).status),
+            uint256(IChargebackPolicy.ChargebackIntentStatus.PENDING)
+        );
     }
 
     function test_ChargebackAfterFulfillPaysDepositorClaim() public {

--- a/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
@@ -41,16 +41,17 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
 
         policy = new WhitelistPolicy(groupRegistry, escrowRegistry, orchestratorRegistry);
         stakeVault = new StakeVault(address(this), token, address(0), 1 days);
+        NullifierRegistryV2 paymentNullifierRegistry = new NullifierRegistryV2(new NullifierRegistry());
         NullifierRegistry chargebackNullifierRegistry = new NullifierRegistry();
         chargebackPolicy = new ChargebackPolicy(
             address(this),
             stakeVault,
-            new ChargebackVerifier(
-                address(this), new NullifierRegistryV2(new NullifierRegistry()), new AttestationVerifierMock()
-            ),
+            paymentNullifierRegistry,
+            new ChargebackVerifier(address(this), paymentNullifierRegistry, new AttestationVerifierMock()),
             chargebackNullifierRegistry
         );
         stakeVault.initializeController(address(chargebackPolicy));
+        paymentNullifierRegistry.addWritePermission(address(chargebackPolicy));
         chargebackNullifierRegistry.addWritePermission(address(chargebackPolicy));
         lifecycleHook = new IntentLifecycleHookV1(orchestratorRegistry, policy, chargebackPolicy);
         chargebackPolicy.setLifecycleHookAuthorization(address(lifecycleHook), true);
@@ -196,7 +197,7 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
 
         uint256 takerBalanceBefore = token.balanceOf(taker);
         vm.prank(depositor);
-        orchestrator.releaseFundsToPayer(intentHash);
+        orchestrator.releaseFundsToPayer(intentHash, keccak256("manual-payment"));
 
         assertEq(token.balanceOf(taker) - takerBalanceBefore, INTENT_AMOUNT);
         assertEq(address(IOrchestratorV3(address(orchestrator)).getIntentLifecycleHook(intentHash)), address(0));
@@ -250,6 +251,7 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
             recipient: taker,
             releaseAmount: 0,
             netAmount: 0,
+            paymentId: bytes32(0),
             isManualRelease: false
         });
         vm.expectRevert(abi.encodeWithSelector(IntentLifecycleHookV1.UnauthorizedOrchestrator.selector, other));

--- a/test-foundry/deterministic/integration/WhitelistLifecycleHookOrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/WhitelistLifecycleHookOrchestratorV3.t.sol
@@ -96,6 +96,7 @@ contract WhitelistLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
             recipient: taker,
             releaseAmount: 0,
             netAmount: 0,
+            paymentId: bytes32(0),
             isManualRelease: false
         });
         vm.expectRevert(abi.encodeWithSelector(WhitelistLifecycleHook.UnauthorizedOrchestrator.selector, other));
@@ -110,7 +111,7 @@ contract WhitelistLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         vm.prank(taker);
         orchestrator.cancelIntent(cancelledIntent);
         vm.prank(depositor);
-        orchestrator.releaseFundsToPayer(settledIntent);
+        orchestrator.releaseFundsToPayer(settledIntent, keccak256("manual-payment"));
 
         assertEq(escrow.getDepositIntent(depositId, cancelledIntent).intentHash, bytes32(0));
         assertEq(escrow.getDepositIntent(depositId, settledIntent).intentHash, bytes32(0));
@@ -163,16 +164,17 @@ contract WhitelistLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         returns (StakeVault vault, ChargebackPolicy chargebackPolicy, IntentLifecycleHookV1 combinedHook)
     {
         vault = new StakeVault(address(this), token, address(0), 1 days);
+        NullifierRegistryV2 paymentNullifierRegistry = new NullifierRegistryV2(new NullifierRegistry());
         NullifierRegistry chargebackNullifierRegistry = new NullifierRegistry();
         chargebackPolicy = new ChargebackPolicy(
             address(this),
             vault,
-            new ChargebackVerifier(
-                address(this), new NullifierRegistryV2(new NullifierRegistry()), new AttestationVerifierMock()
-            ),
+            paymentNullifierRegistry,
+            new ChargebackVerifier(address(this), paymentNullifierRegistry, new AttestationVerifierMock()),
             chargebackNullifierRegistry
         );
         vault.initializeController(address(chargebackPolicy));
+        paymentNullifierRegistry.addWritePermission(address(chargebackPolicy));
         chargebackNullifierRegistry.addWritePermission(address(chargebackPolicy));
         combinedHook = new IntentLifecycleHookV1(orchestratorRegistry, whitelistPolicy, chargebackPolicy);
         chargebackPolicy.setLifecycleHookAuthorization(address(combinedHook), true);

--- a/test-foundry/deterministic/orchestrator/OrchestratorV3Lifecycle.t.sol
+++ b/test-foundry/deterministic/orchestrator/OrchestratorV3Lifecycle.t.sol
@@ -108,6 +108,7 @@ contract OrchestratorV3LifecycleTest is OrchestratorV3Fixture {
             address recipient,
             uint256 releaseAmount,
             uint256 netAmount,
+            bytes32 paymentId,
             bool isManualRelease
         ) = lifecycleHookMock.lastSettlementContext();
         assertEq(settledIntentHash, intentHash);
@@ -115,6 +116,7 @@ contract OrchestratorV3LifecycleTest is OrchestratorV3Fixture {
         assertEq(recipient, taker);
         assertEq(releaseAmount, INTENT_AMOUNT);
         assertEq(netAmount, INTENT_AMOUNT - 250_000);
+        assertEq(paymentId, bytes32(0));
         assertFalse(isManualRelease);
         assertEq(token.balanceOf(referrer) - referrerBefore, 150_000);
         assertEq(token.balanceOf(other) - otherBefore, 100_000);
@@ -154,14 +156,27 @@ contract OrchestratorV3LifecycleTest is OrchestratorV3Fixture {
         uint256 netAmount = INTENT_AMOUNT - 250_000;
         vm.expectEmit(true, true, true, true);
         emit IntentFulfilled(intentHash, address(postIntentHook), netAmount, true);
+        bytes32 paymentId = keccak256("manual-payment");
         vm.prank(depositor);
-        orchestrator.releaseFundsToPayer(intentHash);
+        orchestrator.releaseFundsToPayer(intentHash, paymentId);
         assertEq(lifecycleHookMock.settlementCalls(), 1);
-        (,,,,, bool isManualRelease) = lifecycleHookMock.lastSettlementContext();
+        (,,,,, bytes32 settledPaymentId, bool isManualRelease) = lifecycleHookMock.lastSettlementContext();
+        assertEq(settledPaymentId, paymentId);
         assertTrue(isManualRelease);
         assertEq(token.balanceOf(taker), recipientBefore);
         assertEq(token.balanceOf(delegate) - hookRecipientBefore, netAmount);
         assertEq(postIntentHook.lastPostIntentHookData(), "");
+    }
+
+    function test_ManualReleaseRejectsZeroPaymentIdBeforePruning() public {
+        bytes32 intentHash = _signalDefault();
+
+        vm.expectRevert(IOrchestratorV3.ZeroPaymentId.selector);
+        vm.prank(depositor);
+        orchestrator.releaseFundsToPayer(intentHash, bytes32(0));
+
+        assertEq(orchestrator.getIntent(intentHash).owner, taker);
+        assertEq(escrow.getDepositIntent(depositId, intentHash).intentHash, intentHash);
     }
 
     function test_GovernanceLifecycleHookSetterValidatesOwnerAndCode() public {


### PR DESCRIPTION
## Summary

- require depositors to provide a nonzero payment ID when manually releasing an OrchestratorV3 intent
- propagate that ID through the lifecycle settlement context and bind its payment-method-scoped nullifier bidirectionally to the intent in NullifierRegistryV2
- make ChargebackPolicy enforce payment binding for both proof and manual settlements and reject chargeback verifiers wired to a different registry
- guard the staging activation lane against legacy Orchestrator and payment-verifier wiring, and authorize the policy as a writer on the shared payment-nullifier registry

This closes the manual-release rebinding path identified while reviewing zkp2p/attestation-service#306. A dispute email for payment B can no longer be used against manually settled intent A unless A was precommitted to B during settlement.

## Intent-hash binding

The chargeback attestation continues to sign the intent hash. The canonical on-chain relationship is now also stored in both directions:

- hash(paymentMethod, paymentId) -> intentHash
- intentHash -> hash(paymentMethod, paymentId)

The signature preserves explicit attestation context; the registry is the authoritative payment-to-intent association enforced by the contract.

## UPV and deployment impact

UnifiedPaymentVerifierV3 already writes the same bidirectional binding, so it needs no source change. A live Base read at block 49,577,983 showed:

- base_staging: all 10 active methods route to UPV3 at 0x4c62E99649c8Ba745E67018f5c8a483D77c429C4
- base: all 10 active methods still route to UPV2 at 0x46A58Dc65587D4D7B8198C6A25eEdf5b2535Da94

Lane 31 now refuses staging activation unless every chargebackable method's active verifier uses the same NullifierRegistryV2 as ChargebackVerifier and ChargebackPolicy. Production chargebacks must not activate until production methods migrate from UPV2 to UPV3, or UPV2 is replaced with equivalent intent-binding behavior.

This is an immutable-contract and ABI migration:

- redeploy OrchestratorV3 and its lifecycle hook; manual release is now releaseFundsToPayer(intentHash, paymentId)
- deploy the new ChargebackPolicy constructor wiring and IntentLifecycleHookV1 ABI
- grant ChargebackPolicy write permission on NullifierRegistryV2
- move the retired staging OrchestratorV3 and WhitelistLifecycleHook artifacts aside before lane 30, confirm predecessor intents are drained, then execute the staged cutover
- update SDK/application manual-release call sites to derive and pass the same canonical bytes32 payment ID used by attestations

## Validation

- Hardhat compile and TypeChain generation
- TypeScript transpile
- 85 focused deterministic Foundry tests across ChargebackVerifier, ChargebackPolicy, attack integration, OrchestratorV3 lifecycle, and both lifecycle-hook integrations
- RegistryNullifierFuzz: 4 properties x 512 runs
- V3 deployment rehearsal: prepare/resume and mismatch rejection
- contracts package extraction/build and Jest test
- git diff --check

The monolithic yarn test gate was attempted once at the final Solidity state, but its single solc/Yul compile did not return after 35 minutes and was stopped before tests began. The focused dependency graphs compiled cleanly and all scoped tests passed; the full canonical suite remains an explicit CI gate for this PR.
