### PR TITLE
Add precision code style rules to agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,24 @@ iteration loop.
 - TypeScript: strict `tsconfig`, CommonJS; prefer path aliases `@utils/*`, `@typechain/*`.
 - Scripts: prefix deploy files with two-digit order `NN_` and a concise verb-noun.
 
+Protocol code is precise: validate inputs once at the boundary and trust them
+afterward; reject impossible states instead of handling them.
+
+- Reject with terse require-chains and short reason strings; no fallback
+  branches or recovery paths for states that shouldn't exist. Fail closed on
+  truncated or ambiguous data.
+- No defensive checks whose invariant another layer (escrow, registry,
+  circuit, verifier) already enforces; a guard must name the input that
+  triggers it.
+- Keep on-chain state minimal at the same security level; push complexity into
+  the layer that owns it instead of enshrining it in the protocol.
+- Delete speculative machinery: unused params, storage, modes, and flags.
+- A rename ships with a full docs-and-naming pass across the surface.
+- Tests lock exact values and cover adversarial cases (fee-on-transfer tokens,
+  replay, expiry, truncation).
+- TypeScript follows the same doctrine: boundary validation, no swallowing
+  catches, no union wire types.
+
 ## Testing Guidelines
 - Foundry is the only contract test runner. Hardhat remains for compilation, deployment, TypeChain, verification, and
   package release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,3 +190,7 @@ request an OTP/token.
 Never commit secrets, edit generated artifacts by hand, infer live state from a
 stale artifact, add rollback compatibility, or combine source, staging,
 production, package, and publication approval into one implied action.
+
+## Code Style
+
+Follow the precision rules in [AGENTS.md](AGENTS.md#coding-style--naming-conventions).


### PR DESCRIPTION
Adds the precision code-style doctrine to agent instructions so coding agents write to the house bar from the first draft: boundary validation then trust, reject-don't-handle, no fallback values that mask failures, no defensive checks whose invariant another layer enforces, no dead code or speculative machinery.

Mined from ~260 authored commits, 214 PR review comments, and operator corrections; the full rubric with verbatim exemplars lives in the takumi `code-taste` skill (richardliang/takumi#90).

🤖 Generated with [Claude Code](https://claude.com/claude-code)