### PR TITLE
feat: prepare corrected whitelist bootstrap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,8 @@ Current numbered lanes include:
 - `28`: `IntentGuardian`;
 - `29`: V2 whitelist policy.
 - `30`: V3 lifecycle stack for local, Hardhat, and Base staging only.
+- `32`: Base-only corrected whitelist policy candidate. It retains deployer ownership for bootstrap and does not
+  change the active lifecycle hook.
 
 There is no `26` script. Numbered files are identities, not proof that every
 script should execute. Deployment is a separately approved mutation for the

--- a/README.md
+++ b/README.md
@@ -669,23 +669,45 @@ nullifier-writer permission. Existing intents retain their snapshotted whitelist
 Commit the newly generated canonical artifacts after each authorized deployment. Do not commit the
 temporary artifact removals.
 
+### Corrected WhitelistPolicy Deployment
+
+`deploy/32_deploy_corrected_whitelist_policy.ts` prepares a Base-only `WhitelistPolicyV2` deployment
+that reuses the canonical AddressGroup, Escrow, and Orchestrator registries. It is gated by
+`ENABLE_BASE_CORRECTED_WHITELIST_DEPLOYMENT=true`, leaves the current `WhitelistPolicy` and lifecycle
+hook untouched, and deliberately retains replacement-policy ownership on the deployer so the corrected
+deposit bootstrap can run directly. It never transfers ownership to the multisig.
+
+After an authorized deployment, run the bootstrap dry-run and pin its exact deposit count and selection
+digest before direct execution. The production bootstrap accepts only these verified group IDs:
+
+- Peer: `0xd75c75f345c8e5d4a9f48bc0cc458cf15adb0c4393469d6b10da1655c2c1c0f1`
+- Plus: `0x76d8468179105f4ec9ba8f553823f44dcde6eeb997ba5b70da09849effc0375e`
+- Pro: `0xe2ada1e143bc3a45398381b4b5bbb9e7ed6ccba40225168f32e9702e0c4e8260`
+- Peer Pay: `0x174b8a29536721a3eae290bfd55651b85a53fc334b971d993fa93ed8dde15e48`
+- Peer Makers: `0xdf1c64c54745aa1ce00642a5874f97e3183bf5e993c1f559d0a37a4df0b803c7`
+
+Ownership transfer and lifecycle-hook cutover are later production boundaries and are not part of this lane.
+
 ### Whitelist Bootstrap
 
 `yarn whitelist:bootstrap` discovers active deposits from a configurable raw GraphQL endpoint and
 selects only deposits with an active Venmo, Cash App, or PayPal payment method. It deduplicates the
 matching method rows by deposit and simulates canonical `WhitelistPolicy.bootstrapDeposits` batches
-for the explicitly supplied PRO, PLUS, Peer Pay, and Peer Makers group IDs. It imports no indexer
+for the explicitly supplied PRO, PLUS, Peer, Peer Pay, and Peer Makers group IDs. It imports no indexer
 schema package, so the contracts and indexer packages remain acyclic. Discovery is a dry-run by
 default; mutation and Safe output require both the exact expected deposit count and the printed
 selection digest, and all discovery modes enforce a configurable maximum.
 
 - Staging execution requires `BOOTSTRAP_EXECUTE=true` and the current policy owner's private key.
-- Production Safe preparation requires `BOOTSTRAP_SAFE_OUTPUT_FILE`; it emits unsigned Transaction
-  Builder JSON owned by the policy's onchain owner, and never signs or submits it.
+- Safe preparation requires `BOOTSTRAP_SAFE_OUTPUT_FILE` and an onchain policy owner that is already a
+  Safe; it emits unsigned Transaction Builder JSON and never signs or submits it. The Base replacement
+  policy deliberately remains deployer-owned during bootstrap, so its bootstrap uses direct execution.
 - Direct execution and Safe output are mutually exclusive. Every batch is simulated and its calldata
   decoded and checked before either execution or file output.
-- Base execution is pinned to the canonical production indexer, deployment artifacts, and exact four
-  production group IDs. It also requires `BOOTSTRAP_CONFIRM_PRODUCTION=true`.
+- Base execution is pinned to the canonical production indexer, the separately deployed
+  `WhitelistPolicyV2` artifact, and the exact five verified production group IDs. It also requires
+  `BOOTSTRAP_CONFIRM_PRODUCTION=true`. The replacement policy remains owned by the deployer during
+  bootstrap; ownership transfer and lifecycle-hook cutover are intentionally separate actions.
 - `BOOTSTRAP_ALLOW_COMPLETED=true` resumes only batches whose deposits are still enabled and contain
   every requested group. The script rechecks policy ownership before each submitted batch.
 - Direct execution uses the receipt RPC for confirmation and bounded post-receipt state reads. It computes

--- a/deploy/32_deploy_corrected_whitelist_policy.ts
+++ b/deploy/32_deploy_corrected_whitelist_policy.ts
@@ -1,0 +1,124 @@
+import "module-alias/register";
+
+import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+import { waitForDeploymentDelay } from "../deployments/helpers";
+import type { WhitelistPolicy__factory } from "../typechain";
+
+export const CORRECTED_WHITELIST_POLICY_DEPLOYMENT = "WhitelistPolicyV2";
+const ENABLE_BASE_DEPLOYMENT = "ENABLE_BASE_CORRECTED_WHITELIST_DEPLOYMENT";
+const BASE_CHAIN_ID = 8453;
+
+function sameAddress(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+async function assertCode(address: string, label: string): Promise<void> {
+  if ((await ethers.provider.getCode(address)) === "0x") {
+    throw new Error(`${label} has no bytecode: ${address}`);
+  }
+}
+
+async function assertBaseChain(hre: HardhatRuntimeEnvironment): Promise<void> {
+  const chainId = Number(await hre.getChainId());
+  if (chainId !== BASE_CHAIN_ID) {
+    throw new Error(`Corrected WhitelistPolicy requires Base chain ${BASE_CHAIN_ID}, received ${chainId}`);
+  }
+}
+
+async function replacementReady(hre: HardhatRuntimeEnvironment): Promise<boolean> {
+  try {
+    if (hre.deployments.getNetworkName() !== "base") return false;
+    await assertBaseChain(hre);
+
+    const [deployer] = await hre.getUnnamedAccounts();
+    const currentPolicy = await hre.deployments.get("WhitelistPolicy");
+    const replacement = await hre.deployments.getOrNull(CORRECTED_WHITELIST_POLICY_DEPLOYMENT);
+    if (!replacement || sameAddress(replacement.address, currentPolicy.address)) return false;
+    await assertCode(replacement.address, CORRECTED_WHITELIST_POLICY_DEPLOYMENT);
+
+    const addressGroupRegistry = await hre.deployments.get("AddressGroupRegistry");
+    const escrowRegistry = await hre.deployments.get("EscrowRegistry");
+    const orchestratorRegistry = await hre.deployments.get("OrchestratorRegistry");
+    const policy = await ethers.getContractAt("WhitelistPolicy", replacement.address);
+
+    return sameAddress(await policy.groupRegistry(), addressGroupRegistry.address)
+      && sameAddress(await policy.escrowRegistry(), escrowRegistry.address)
+      && sameAddress(await policy.orchestratorRegistry(), orchestratorRegistry.address)
+      && sameAddress(await policy.owner(), deployer);
+  } catch {
+    return false;
+  }
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const network = hre.deployments.getNetworkName();
+  if (network !== "base") throw new Error("Corrected WhitelistPolicy deployment is Base-only");
+  await assertBaseChain(hre);
+
+  const [deployer] = await hre.getUnnamedAccounts();
+  const currentPolicy = await hre.deployments.get("WhitelistPolicy");
+  const addressGroupRegistry = await hre.deployments.get("AddressGroupRegistry");
+  const escrowRegistry = await hre.deployments.get("EscrowRegistry");
+  const orchestratorRegistry = await hre.deployments.get("OrchestratorRegistry");
+
+  await assertCode(currentPolicy.address, "Current WhitelistPolicy");
+  await assertCode(addressGroupRegistry.address, "AddressGroupRegistry");
+  await assertCode(escrowRegistry.address, "EscrowRegistry");
+  await assertCode(orchestratorRegistry.address, "OrchestratorRegistry");
+
+  const constructorArgs: Parameters<WhitelistPolicy__factory["deploy"]> = [
+    addressGroupRegistry.address,
+    escrowRegistry.address,
+    orchestratorRegistry.address,
+  ];
+  const replacement = await hre.deployments.deploy(CORRECTED_WHITELIST_POLICY_DEPLOYMENT, {
+    contract: "WhitelistPolicy",
+    from: deployer,
+    args: constructorArgs,
+    log: true,
+  });
+  if (replacement.newlyDeployed) await waitForDeploymentDelay(hre);
+
+  if (sameAddress(replacement.address, currentPolicy.address)) {
+    throw new Error("Replacement WhitelistPolicy unexpectedly matches the current policy address");
+  }
+  await assertCode(replacement.address, CORRECTED_WHITELIST_POLICY_DEPLOYMENT);
+
+  const policy = await ethers.getContractAt("WhitelistPolicy", replacement.address);
+  if (!sameAddress(await policy.groupRegistry(), addressGroupRegistry.address)) {
+    throw new Error("Replacement WhitelistPolicy group registry mismatch");
+  }
+  if (!sameAddress(await policy.escrowRegistry(), escrowRegistry.address)) {
+    throw new Error("Replacement WhitelistPolicy escrow registry mismatch");
+  }
+  if (!sameAddress(await policy.orchestratorRegistry(), orchestratorRegistry.address)) {
+    throw new Error("Replacement WhitelistPolicy orchestrator registry mismatch");
+  }
+  if (!sameAddress(await policy.owner(), deployer)) {
+    throw new Error("Replacement WhitelistPolicy owner must remain the deployer until bootstrap completes");
+  }
+
+  console.log("=== Corrected WhitelistPolicy prepared ===");
+  console.log("Current WhitelistPolicy (unchanged):", currentPolicy.address);
+  console.log("Replacement WhitelistPolicy:", replacement.address);
+  console.log("Replacement owner retained by deployer:", deployer);
+  console.log("No lifecycle hook or multisig ownership change was performed");
+};
+
+func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> => {
+  if (hre.deployments.getNetworkName() !== "base") return true;
+  if (process.env[ENABLE_BASE_DEPLOYMENT] !== "true") return true;
+  return replacementReady(hre);
+};
+
+func.tags = [
+  "32_deploy_corrected_whitelist_policy",
+  "CorrectedWhitelistPolicy",
+  CORRECTED_WHITELIST_POLICY_DEPLOYMENT,
+];
+func.dependencies = ["29_deploy_whitelist_policy"];
+
+export default func;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:fuzz": "forge test --match-path 'test-foundry/fuzz/**/*.t.sol'",
     "test:invariant": "forge test --match-path 'test-foundry/invariant/**/*.t.sol'",
     "test:v3-groups-deployment": "node scripts/test-v3-groups-base-deployment.cjs prepare-resume && node scripts/test-v3-groups-base-deployment.cjs reject-mismatch",
+    "test:corrected-whitelist-deployment": "node scripts/test-corrected-whitelist-base-deployment.cjs prepare-resume && node scripts/test-corrected-whitelist-base-deployment.cjs reject-transferred && node scripts/test-corrected-whitelist-base-deployment.cjs reject-chain",
     "test:release-policy": "node --test scripts/verify-github-environment.spec.mjs",
     "typechain": "hardhat typechain",
     "transpile": "tsc"

--- a/scripts/bootstrapWhitelistPolicy.ts
+++ b/scripts/bootstrapWhitelistPolicy.ts
@@ -96,9 +96,11 @@ const TARGET_PAYMENT_METHOD_HASHES = TARGET_PAYMENT_METHODS.map(({ hash }) => ha
 const TARGET_PAYMENT_METHOD_HASH_SET = new Set<string>(TARGET_PAYMENT_METHOD_HASHES);
 
 const PRODUCTION_INDEXER_URL = "https://indexer.zkp2p.xyz/v1/graphql";
+const PRODUCTION_POLICY_DEPLOYMENT = "WhitelistPolicyV2";
 const PRODUCTION_GROUP_IDS = {
-  pro: "0xf030f72e772f954059ca28f94974088aaf6ba37bb1f264df48843a3d0c221dc3",
-  plus: "0xb8747401b308d4891385620071b5916e9c61284f25c4611541c529703de5babf",
+  pro: "0xe2ada1e143bc3a45398381b4b5bbb9e7ed6ccba40225168f32e9702e0c4e8260",
+  plus: "0x76d8468179105f4ec9ba8f553823f44dcde6eeb997ba5b70da09849effc0375e",
+  peer: "0xd75c75f345c8e5d4a9f48bc0cc458cf15adb0c4393469d6b10da1655c2c1c0f1",
   peerPay: "0x174b8a29536721a3eae290bfd55651b85a53fc334b971d993fa93ed8dde15e48",
   peerMakers: "0xdf1c64c54745aa1ce00642a5874f97e3183bf5e993c1f559d0a37a4df0b803c7",
 } as const;
@@ -185,6 +187,7 @@ Required environment:
   BOOTSTRAP_INDEXER_GRAPHQL_URL
   WHITELIST_PRO_GROUP_ID
   WHITELIST_PLUS_GROUP_ID
+  WHITELIST_PEER_GROUP_ID
   WHITELIST_PEER_PAY_GROUP_ID
   WHITELIST_PEER_MAKERS_GROUP_ID
 
@@ -301,9 +304,10 @@ function loadConfig(): BootstrapConfig {
     throw new Error("BOOTSTRAP_NETWORK must be base_staging or base");
   }
   const network = networkValue;
+  const policyDeployment = network === "base" ? PRODUCTION_POLICY_DEPLOYMENT : "WhitelistPolicy";
   const policyAddress = normalizeAddress(
     process.env.BOOTSTRAP_WHITELIST_POLICY_ADDRESS?.trim()
-      || deploymentAddress(network, "WhitelistPolicy"),
+      || deploymentAddress(network, policyDeployment),
     "WhitelistPolicy",
   );
   const configuredEscrows = process.env.BOOTSTRAP_ESCROW_ADDRESSES
@@ -319,13 +323,14 @@ function loadConfig(): BootstrapConfig {
   ];
 
   const groupIds = [
-    normalizeGroupId(requireEnvironment("WHITELIST_PRO_GROUP_ID"), "WHITELIST_PRO_GROUP_ID"),
+    normalizeGroupId(requireEnvironment("WHITELIST_PEER_GROUP_ID"), "WHITELIST_PEER_GROUP_ID"),
     normalizeGroupId(requireEnvironment("WHITELIST_PLUS_GROUP_ID"), "WHITELIST_PLUS_GROUP_ID"),
+    normalizeGroupId(requireEnvironment("WHITELIST_PRO_GROUP_ID"), "WHITELIST_PRO_GROUP_ID"),
     normalizeGroupId(requireEnvironment("WHITELIST_PEER_PAY_GROUP_ID"), "WHITELIST_PEER_PAY_GROUP_ID"),
     normalizeGroupId(requireEnvironment("WHITELIST_PEER_MAKERS_GROUP_ID"), "WHITELIST_PEER_MAKERS_GROUP_ID"),
   ];
   if (new Set(groupIds).size !== groupIds.length) {
-    throw new Error("PRO, PLUS, Peer Pay, and Peer Makers group ids must be distinct");
+    throw new Error("PRO, PLUS, Peer, Peer Pay, and Peer Makers group ids must be distinct");
   }
 
   const execute = process.env.BOOTSTRAP_EXECUTE === "true";
@@ -376,7 +381,7 @@ function loadConfig(): BootstrapConfig {
   }
 
   if (network === "base") {
-    const expectedPolicyAddress = deploymentAddress("base", "WhitelistPolicy");
+    const expectedPolicyAddress = deploymentAddress("base", PRODUCTION_POLICY_DEPLOYMENT);
     const expectedEscrowAddress = deploymentAddress("base", "EscrowV2");
     if (policyAddress.toLowerCase() !== expectedPolicyAddress.toLowerCase()) {
       throw new Error(`Base bootstrap must use deployed WhitelistPolicy ${expectedPolicyAddress}`);
@@ -391,13 +396,16 @@ function loadConfig(): BootstrapConfig {
       throw new Error(`Base bootstrap must use production indexer ${PRODUCTION_INDEXER_URL}`);
     }
     const expectedGroupIds = [
-      PRODUCTION_GROUP_IDS.pro,
+      PRODUCTION_GROUP_IDS.peer,
       PRODUCTION_GROUP_IDS.plus,
+      PRODUCTION_GROUP_IDS.pro,
       PRODUCTION_GROUP_IDS.peerPay,
       PRODUCTION_GROUP_IDS.peerMakers,
     ];
     if (!groupIds.every((groupId, index) => groupId === expectedGroupIds[index])) {
-      throw new Error("Base bootstrap group ids do not match the exact PRO, PLUS, Peer Pay, and Peer Makers groups");
+      throw new Error(
+        "Base bootstrap group ids do not match the exact PRO, PLUS, Peer, Peer Pay, and Peer Makers groups",
+      );
     }
     if (mode === "execute" && process.env.BOOTSTRAP_CONFIRM_PRODUCTION !== "true") {
       throw new Error("BOOTSTRAP_CONFIRM_PRODUCTION=true is required for direct execution on Base");
@@ -642,6 +650,7 @@ function runSelfTest(): void {
     `0x${"22".repeat(32)}`,
     `0x${"33".repeat(32)}`,
     `0x${"44".repeat(32)}`,
+    `0x${"55".repeat(32)}`,
   ];
   const transaction = buildSafeTransaction(policyAddress, escrowAddress, depositIds, groupIds);
   const decoded = new ethers.utils.Interface(POLICY_ABI)

--- a/scripts/test-corrected-whitelist-base-deployment.cjs
+++ b/scripts/test-corrected-whitelist-base-deployment.cjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+process.env.DEPLOY_TX_DELAY_MS = "0";
+process.env.ALCHEMY_API_KEY ||= "offline";
+process.env.BASE_DEPLOY_PRIVATE_KEY ||=
+  "1111111111111111111111111111111111111111111111111111111111111111";
+process.env.TESTNET_DEPLOY_PRIVATE_KEY ||=
+  "2222222222222222222222222222222222222222222222222222222222222222";
+
+require("ts-node/register/transpile-only");
+require("module-alias/register");
+
+const moduleAlias = require("module-alias");
+moduleAlias.reset();
+moduleAlias.addAlias("@utils", process.cwd() + "/utils");
+
+console.log = () => {};
+
+const hre = require("hardhat");
+const { ethers } = hre;
+const deployCorrectedPolicyModule = require("../deploy/32_deploy_corrected_whitelist_policy.ts");
+const deployCorrectedPolicy = deployCorrectedPolicyModule.default;
+const { CORRECTED_WHITELIST_POLICY_DEPLOYMENT } = deployCorrectedPolicyModule;
+const { MULTI_SIG } = require("../deployments/parameters.ts");
+
+const scenario = process.argv[2];
+
+async function deployContract(name, args = []) {
+  const factory = await ethers.getContractFactory(name);
+  const contract = await factory.deploy(...args);
+  await contract.deployed();
+  return contract;
+}
+
+async function fixture() {
+  const [deployerSigner] = await ethers.getSigners();
+  const deployer = deployerSigner.address;
+  const safe = MULTI_SIG.base;
+
+  const addressGroupRegistry = await deployContract("AddressGroupRegistry");
+  const escrowRegistry = await deployContract("EscrowRegistry");
+  const orchestratorRegistry = await deployContract("OrchestratorRegistry");
+  const currentPolicy = await deployContract("WhitelistPolicy", [
+    addressGroupRegistry.address,
+    escrowRegistry.address,
+    orchestratorRegistry.address,
+  ]);
+  await (await currentPolicy.transferOwnership(safe)).wait();
+
+  const deployments = new Map([
+    ["AddressGroupRegistry", { address: addressGroupRegistry.address }],
+    ["EscrowRegistry", { address: escrowRegistry.address }],
+    ["OrchestratorRegistry", { address: orchestratorRegistry.address }],
+    ["WhitelistPolicy", { address: currentPolicy.address }],
+  ]);
+  const deploymentApi = {
+    getNetworkName: () => "base",
+    get: async (name) => {
+      const deployment = deployments.get(name);
+      if (!deployment) throw new Error(`Missing deployment: ${name}`);
+      return deployment;
+    },
+    getOrNull: async (name) => deployments.get(name) || null,
+    deploy: async (name, options) => {
+      const existing = deployments.get(name);
+      if (existing) return { ...existing, newlyDeployed: false };
+      const contract = await deployContract(options.contract || name, options.args || []);
+      const deployment = {
+        address: contract.address,
+        args: options.args || [],
+        newlyDeployed: true,
+        transactionHash: contract.deployTransaction.hash,
+      };
+      deployments.set(name, deployment);
+      return deployment;
+    },
+  };
+  const fakeHre = {
+    deployments: deploymentApi,
+    ethers,
+    getChainId: async () => "8453",
+    getUnnamedAccounts: async () => [deployer],
+  };
+  return { currentPolicy, deployer, deployments, fakeHre, safe };
+}
+
+async function run() {
+  const state = await fixture();
+
+  if (scenario === "prepare-resume") {
+    delete process.env.ENABLE_BASE_CORRECTED_WHITELIST_DEPLOYMENT;
+    let passed = await deployCorrectedPolicy.skip(state.fakeHre);
+    process.env.ENABLE_BASE_CORRECTED_WHITELIST_DEPLOYMENT = "true";
+    passed = passed && !(await deployCorrectedPolicy.skip(state.fakeHre));
+
+    await deployCorrectedPolicy(state.fakeHre);
+    const replacementDeployment = await state.fakeHre.deployments.get(
+      CORRECTED_WHITELIST_POLICY_DEPLOYMENT,
+    );
+    const replacement = await ethers.getContractAt("WhitelistPolicy", replacementDeployment.address);
+    passed = passed
+      && replacementDeployment.address.toLowerCase() !== state.currentPolicy.address.toLowerCase()
+      && (await replacement.owner()).toLowerCase() === state.deployer.toLowerCase()
+      && (await state.currentPolicy.owner()).toLowerCase() === state.safe.toLowerCase()
+      && await deployCorrectedPolicy.skip(state.fakeHre);
+
+    await deployCorrectedPolicy(state.fakeHre);
+    passed = passed && (await replacement.owner()).toLowerCase() === state.deployer.toLowerCase();
+    process.stdout.write(passed ? "0x01" : "0x00");
+    return;
+  }
+
+  if (scenario === "reject-transferred") {
+    await deployCorrectedPolicy(state.fakeHre);
+    const replacementDeployment = await state.fakeHre.deployments.get(
+      CORRECTED_WHITELIST_POLICY_DEPLOYMENT,
+    );
+    const replacement = await ethers.getContractAt("WhitelistPolicy", replacementDeployment.address);
+    await (await replacement.transferOwnership(state.safe)).wait();
+
+    let rejected = false;
+    try {
+      await deployCorrectedPolicy(state.fakeHre);
+    } catch (error) {
+      rejected = error instanceof Error && error.message.includes("owner must remain the deployer");
+    }
+    process.stdout.write(rejected ? "0x01" : "0x00");
+    return;
+  }
+
+  if (scenario === "reject-chain") {
+    state.fakeHre.getChainId = async () => "1";
+    let rejected = false;
+    try {
+      await deployCorrectedPolicy(state.fakeHre);
+    } catch (error) {
+      rejected = error instanceof Error && error.message.includes("requires Base chain 8453");
+    }
+    process.stdout.write(rejected ? "0x01" : "0x00");
+    return;
+  }
+
+  throw new Error(`Unknown corrected whitelist deployment scenario: ${scenario}`);
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- add a gated Base-only lane that deploys a separate `WhitelistPolicyV2` against the canonical AddressGroup, Escrow, and Orchestrator registries
- keep the replacement owned by the deployer so bootstrap can complete; leave the current policy and lifecycle hook untouched
- retarget production bootstrap to `WhitelistPolicyV2` and pin the five verified groups: Peer, Plus, Pro, Peer Pay, and Peer Makers
- add regression coverage for Base chain isolation, resumability, and rejection after premature ownership transfer

## Correct production groups

- Peer: `0xd75c75f345c8e5d4a9f48bc0cc458cf15adb0c4393469d6b10da1655c2c1c0f1`
- Plus: `0x76d8468179105f4ec9ba8f553823f44dcde6eeb997ba5b70da09849effc0375e`
- Pro: `0xe2ada1e143bc3a45398381b4b5bbb9e7ed6ccba40225168f32e9702e0c4e8260`
- Peer Pay: `0x174b8a29536721a3eae290bfd55651b85a53fc334b971d993fa93ed8dde15e48`
- Peer Makers: `0xdf1c64c54745aa1ce00642a5874f97e3183bf5e993c1f559d0a37a4df0b803c7`

## Validation

- `yarn compile`
- `yarn transpile`
- `yarn whitelist:bootstrap --self-test`
- `yarn test:corrected-whitelist-deployment`
- `git diff --check`

## Deployment boundary

This PR prepares source and deployment tooling only. No Base transaction was submitted and no deployment artifact was generated. Ownership transfer, lifecycle-hook cutover, package export, and publication remain separate, unapproved boundaries.