### PR TITLE
feat: stake USDC yield vault shares

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,7 +658,10 @@ the existing stack remains intact, and the generated Safe batch contains only th
 `DisputeVerifier`, `StakeVault`, `DisputePolicy`, and `IntentLifecycleHookV1`; initializes the vault
 controller; applies the canonical risk windows; authorizes the combined hook; grants the policy
 nullifier-writer permission; and transfers ownership. It deliberately leaves the active O3 hook
-unchanged.
+unchanged. The StakeVault holds shares of the governance-approved Steakhouse Prime USDC ERC-4626
+vault (`0xBEEFE94c8aD530842bfE7d8B397938fFc1cb83b2`). DisputePolicy validates that the share vault's
+underlying asset is canonical Base USDC and locks the exact `previewWithdraw` share quote for the
+USDC exposure, so collateral pricing does not depend on an external oracle.
 
 Commit the five newly generated deployment artifacts so their addresses can flow through the
 package, indexer, curator, and attestation-service releases. Activation remains blocked until every

--- a/contracts/StakeVault.sol
+++ b/contracts/StakeVault.sol
@@ -44,10 +44,10 @@ import {IStakeVault} from "./interfaces/IStakeVault.sol";
  *      not give a new policy contract the state needed to resolve predecessor locks.
  *
  * @dev TOKEN ASSUMPTION
- *      ZKP2P deployments configure the vault only with canonical USDC. USDC administration, upgrades, pauses, and
- *      blocklisting remain accepted external operational risks. Tokens with transfer fees, rebasing, or other balance
- *      transformations are unsupported; the exact inbound balance-delta check is defense in depth, not generic-token
- *      compatibility.
+ *      Each deployment is configured with one governance-approved collateral token. Tokens with transfer fees,
+ *      rebasing, or other balance transformations are unsupported; the exact inbound balance-delta check is defense
+ *      in depth, not generic-token compatibility. Policy contracts remain responsible for validating any additional
+ *      assumptions about the configured token, such as an ERC-4626 share token's underlying asset.
  *
  * @dev SECURITY INVARIANTS AND RATIONALE
  *      1. Only free stake may be withdrawn or newly locked. Existing locks remain fully backed in aggregate accounting.
@@ -139,7 +139,7 @@ contract StakeVault is IStakeVault, Ownable2Step, ReentrancyGuard {
      *      before any liabilities exist. The owner and token must be non-zero, and the handover delay must be at least
      *      one day. Future ownership transfers use Ownable2Step.
      * @param _owner Governance owner responsible for controller selection and recovery.
-     * @param _stakeToken Canonical USDC token held and accounted by the vault.
+     * @param _stakeToken Collateral token held and accounted by the vault.
      * @param _controller Initial global lock-policy controller, or zero for later liability-free initialization.
      * @param _controllerChangeDelay Delay required before a proposed replacement controller may accept authority.
      */

--- a/contracts/hooks/DisputePolicy.sol
+++ b/contracts/hooks/DisputePolicy.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.18;
 
 import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import {IDisputePolicy} from "../interfaces/IDisputePolicy.sol";
 import {IDisputeVerifier} from "../interfaces/IDisputeVerifier.sol";
@@ -41,6 +44,12 @@ contract DisputePolicy is IDisputePolicy, Ownable2Step, ReentrancyGuard {
     /// @notice Stake custody and lock accounting controlled by this policy.
     IStakeVault public immutable stakeVault;
 
+    /// @notice Token released from Escrow and denominating covered intent amounts.
+    IERC20 public immutable settlementToken;
+
+    /// @notice ERC-4626 share token used as collateral and priced directly in settlement-token units.
+    IERC4626 public immutable collateralVault;
+
     /// @notice Dedicated replay registry for payment-method-scoped dispute nullifiers.
     INullifierRegistry public immutable disputeNullifierRegistry;
 
@@ -69,21 +78,38 @@ contract DisputePolicy is IDisputePolicy, Ownable2Step, ReentrancyGuard {
      * @dev After deployment, authorize this policy as the StakeVault controller and as a writer on the dedicated
      * dispute nullifier registry before enabling deposits.
      * @param _owner Governance owner for policy and dependency configuration.
-     * @param _stakeVault Vault holding and locking taker collateral.
+     * @param _settlementToken Token released by covered Escrow deposits, currently canonical Base USDC.
+     * @param _collateralVault ERC-4626 vault whose shares are staked and whose underlying asset is settlementToken.
+     * @param _stakeVault Vault holding and locking collateralVault shares.
      * @param _disputeVerifier Verifier for signed dispute evidence.
      * @param _disputeNullifierRegistry Dedicated registry that rejects reused dispute nullifiers.
      */
     constructor(
         address _owner,
+        IERC20 _settlementToken,
+        IERC4626 _collateralVault,
         IStakeVault _stakeVault,
         IDisputeVerifier _disputeVerifier,
         INullifierRegistry _disputeNullifierRegistry
     ) {
         if (_owner == address(0)) revert ZeroAddress();
+        _validateDependency(address(_settlementToken));
+        _validateDependency(address(_collateralVault));
         _validateDependency(address(_stakeVault));
         _validateDependency(address(_disputeVerifier));
         _validateDependency(address(_disputeNullifierRegistry));
 
+        address collateralAsset = _collateralVault.asset();
+        if (collateralAsset != address(_settlementToken)) {
+            revert CollateralAssetMismatch(address(_settlementToken), collateralAsset);
+        }
+        address stakeToken = address(_stakeVault.stakeToken());
+        if (stakeToken != address(_collateralVault)) {
+            revert StakeTokenMismatch(address(_collateralVault), stakeToken);
+        }
+
+        settlementToken = _settlementToken;
+        collateralVault = _collateralVault;
         stakeVault = _stakeVault;
         disputeVerifier = _disputeVerifier;
         disputeNullifierRegistry = _disputeNullifierRegistry;
@@ -122,6 +148,7 @@ contract DisputePolicy is IDisputePolicy, Ownable2Step, ReentrancyGuard {
         if (riskWindow == 0) return;
 
         (address stakeOwner, address depositor) = _validateIntentAdmission(_intentHash, _escrow, _depositId, _taker);
+        uint256 collateralAmount = _previewWithdrawOrRevert(_amount);
 
         disputeIntentByIntentHash[_intentHash] = DisputeIntent({
             taker: _taker,
@@ -131,11 +158,15 @@ contract DisputePolicy is IDisputePolicy, Ownable2Step, ReentrancyGuard {
             status: DisputeIntentStatus.PENDING,
             riskWindow: riskWindow,
             releaseEligibleAt: 0,
+            intentAmount: _amount,
+            collateralAmount: collateralAmount,
             releaseAmount: 0
         });
 
-        stakeVault.lockStake(stakeOwner, _intentHash, _amount, PENDING_COVERAGE_MATURITY);
-        emit DisputeIntentOpened(_intentHash, stakeOwner, depositor, _taker, _paymentMethod, _amount, riskWindow);
+        stakeVault.lockStake(stakeOwner, _intentHash, collateralAmount, PENDING_COVERAGE_MATURITY);
+        emit DisputeIntentOpened(
+            _intentHash, stakeOwner, depositor, _taker, _paymentMethod, _amount, collateralAmount, riskWindow
+        );
     }
 
     /**
@@ -169,17 +200,23 @@ contract DisputePolicy is IDisputePolicy, Ownable2Step, ReentrancyGuard {
             revert DisputeIntentNotPending(_intentHash, disputeIntent.status);
         }
 
+        uint256 intentAmount = disputeIntent.intentAmount;
+        if (_releaseAmount > intentAmount) revert ReleaseAmountExceedsIntent(intentAmount, _releaseAmount);
+        uint256 collateralAmount =
+            Math.mulDiv(disputeIntent.collateralAmount, _releaseAmount, intentAmount, Math.Rounding.Up);
         uint64 releaseEligibleAt = _calculateReleaseEligibleAt(disputeIntent.riskWindow);
+        disputeIntent.collateralAmount = collateralAmount;
         disputeIntent.releaseAmount = _releaseAmount;
         disputeIntent.releaseEligibleAt = releaseEligibleAt;
         disputeIntent.status = DisputeIntentStatus.SETTLED;
 
-        stakeVault.resizeLock(_intentHash, _releaseAmount, releaseEligibleAt);
+        stakeVault.resizeLock(_intentHash, collateralAmount, releaseEligibleAt);
         emit DisputeIntentSettled(
             _intentHash,
             disputeIntent.stakeOwner,
             disputeIntent.depositor,
             _releaseAmount,
+            collateralAmount,
             releaseEligibleAt,
             _isManualRelease
         );
@@ -223,18 +260,23 @@ contract DisputePolicy is IDisputePolicy, Ownable2Step, ReentrancyGuard {
             disputeVerifier.verifyDispute(_attestation, disputeIntent.paymentMethod);
         disputeNullifierRegistry.addNullifier(disputeNullifier);
 
-        uint256 compensatedAmount = disputeIntent.releaseAmount;
+        (, uint256 lockedCollateralAmount,) = stakeVault.locks(_attestation.intentHash);
+        (bool conversionAvailable, uint256 quotedCollateralAmount) = _tryPreviewWithdraw(disputeIntent.releaseAmount);
+        bool collateralCapped = !conversionAvailable || quotedCollateralAmount > lockedCollateralAmount;
+        uint256 compensatedCollateralAmount = collateralCapped ? lockedCollateralAmount : quotedCollateralAmount;
         disputeIntent.status = DisputeIntentStatus.DISPUTED;
 
         IStakeVault.Claim[] memory claims = new IStakeVault.Claim[](1);
-        claims[0] = IStakeVault.Claim({beneficiary: disputeIntent.depositor, amount: compensatedAmount});
+        claims[0] = IStakeVault.Claim({beneficiary: disputeIntent.depositor, amount: compensatedCollateralAmount});
         stakeVault.resolveLock(_attestation.intentHash, claims);
 
         emit DisputeResolved(
             _attestation.intentHash,
             disputeIntent.stakeOwner,
             disputeIntent.depositor,
-            compensatedAmount,
+            disputeIntent.releaseAmount,
+            compensatedCollateralAmount,
+            collateralCapped,
             disputeId
         );
     }
@@ -355,6 +397,15 @@ contract DisputePolicy is IDisputePolicy, Ownable2Step, ReentrancyGuard {
         return paymentMethodRiskWindow[_paymentMethod];
     }
 
+    /**
+     * @notice Quotes the ERC-4626 shares required to collateralize a settlement-token amount at 100%.
+     * @param _settlementAmount Settlement token amount in its native decimals.
+     * @return collateralAmount Required collateralVault shares in their native decimals.
+     */
+    function quoteCollateral(uint256 _settlementAmount) external view returns (uint256 collateralAmount) {
+        return _previewWithdrawOrRevert(_settlementAmount);
+    }
+
     /* ============ Internal Functions ============ */
 
     /**
@@ -376,7 +427,7 @@ contract DisputePolicy is IDisputePolicy, Ownable2Step, ReentrancyGuard {
         }
 
         IEscrowV2.Deposit memory deposit = IEscrowV2(_escrow).getDeposit(_depositId);
-        address expectedToken = address(stakeVault.stakeToken());
+        address expectedToken = address(settlementToken);
         if (address(deposit.token) != expectedToken) {
             revert IntentTokenMismatch(expectedToken, address(deposit.token));
         }
@@ -397,7 +448,7 @@ contract DisputePolicy is IDisputePolicy, Ownable2Step, ReentrancyGuard {
             revert DisputeIntentNotReleaseEligible(releaseEligibleAt, currentTime);
         }
 
-        uint256 releasedAmount = disputeIntent.releaseAmount;
+        uint256 releasedAmount = disputeIntent.collateralAmount;
         disputeIntent.status = DisputeIntentStatus.RELEASED;
         stakeVault.unlockStake(_intentHash);
         emit DisputeIntentReleased(_intentHash, disputeIntent.stakeOwner, releasedAmount);
@@ -407,6 +458,25 @@ contract DisputePolicy is IDisputePolicy, Ownable2Step, ReentrancyGuard {
         uint256 releaseEligibleAt = block.timestamp + _riskWindow;
         if (releaseEligibleAt > type(uint64).max) revert TimestampOverflow(releaseEligibleAt);
         return uint64(releaseEligibleAt);
+    }
+
+    function _previewWithdrawOrRevert(uint256 _settlementAmount) internal view returns (uint256 collateralAmount) {
+        (bool conversionAvailable, uint256 quotedCollateralAmount) = _tryPreviewWithdraw(_settlementAmount);
+        if (!conversionAvailable) revert CollateralConversionUnavailable();
+        return quotedCollateralAmount;
+    }
+
+    function _tryPreviewWithdraw(uint256 _settlementAmount)
+        internal
+        view
+        returns (bool conversionAvailable, uint256 collateralAmount)
+    {
+        try collateralVault.previewWithdraw(_settlementAmount) returns (uint256 quotedCollateralAmount) {
+            if (_settlementAmount != 0 && quotedCollateralAmount == 0) return (false, 0);
+            return (true, quotedCollateralAmount);
+        } catch {
+            return (false, 0);
+        }
     }
 
     function _currentTimestamp() internal view returns (uint64) {

--- a/contracts/interfaces/IDisputePolicy.sol
+++ b/contracts/interfaces/IDisputePolicy.sol
@@ -34,6 +34,8 @@ interface IDisputePolicy {
      * @param riskWindow Minimum time collateral must remain locked after intent settlement.
      * @param releaseEligibleAt Earliest timestamp at which collateral may be released. Dispute evidence remains
      * valid after this time until release actually executes.
+     * @param intentAmount Original settlement-token-denominated intent exposure.
+     * @param collateralAmount ERC-4626 share amount currently locked for the intent.
      * @param releaseAmount Amount released from Escrow before fees and therefore collateralized after settlement.
      */
     struct DisputeIntent {
@@ -44,6 +46,8 @@ interface IDisputePolicy {
         DisputeIntentStatus status;
         uint64 riskWindow;
         uint64 releaseEligibleAt;
+        uint256 intentAmount;
+        uint256 collateralAmount;
         uint256 releaseAmount;
     }
 
@@ -53,7 +57,8 @@ interface IDisputePolicy {
         address indexed depositor,
         address taker,
         bytes32 paymentMethod,
-        uint256 amount,
+        uint256 intentAmount,
+        uint256 collateralAmount,
         uint64 riskWindow
     );
     event DisputeIntentCancelled(bytes32 indexed intentHash, address indexed stakeOwner, uint256 releasedAmount);
@@ -62,6 +67,7 @@ interface IDisputePolicy {
         address indexed stakeOwner,
         address indexed depositor,
         uint256 releaseAmount,
+        uint256 collateralAmount,
         uint64 releaseEligibleAt,
         bool isManualRelease
     );
@@ -70,7 +76,9 @@ interface IDisputePolicy {
         bytes32 indexed intentHash,
         address indexed stakeOwner,
         address indexed depositor,
-        uint256 compensatedAmount,
+        uint256 compensatedSettlementAmount,
+        uint256 compensatedCollateralAmount,
+        bool collateralCapped,
         bytes32 disputeId
     );
     event DisputeEnabledUpdated(address indexed escrow, uint256 indexed depositId, bool isDisputeEnabled);
@@ -88,6 +96,10 @@ interface IDisputePolicy {
     error DisputeIntentNotPending(bytes32 intentHash, DisputeIntentStatus status);
     error DisputeIntentNotSettled(bytes32 intentHash, DisputeIntentStatus status);
     error IntentTokenMismatch(address expectedToken, address actualToken);
+    error CollateralAssetMismatch(address expectedAsset, address actualAsset);
+    error StakeTokenMismatch(address expectedToken, address actualToken);
+    error CollateralConversionUnavailable();
+    error ReleaseAmountExceedsIntent(uint256 intentAmount, uint256 releaseAmount);
     error DisputeIntentNotReleaseEligible(uint64 releaseEligibleAt, uint64 currentTime);
     error TimestampOverflow(uint256 timestamp);
     error InvalidRiskWindow(uint64 riskWindow);
@@ -104,7 +116,7 @@ interface IDisputePolicy {
      * @param _depositId Deposit supplying the intent liquidity.
      * @param _taker Account that signaled the intent.
      * @param _paymentMethod Payment method selected for the off-chain payment.
-     * @param _amount Full on-chain intent amount initially locked as collateral.
+     * @param _amount Full settlement-token-denominated intent amount converted into collateral shares.
      */
     function onIntentSignaled(
         bytes32 _intentHash,

--- a/contracts/interfaces/IStakeVault.sol
+++ b/contracts/interfaces/IStakeVault.sol
@@ -8,7 +8,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  * @title IStakeVault
  * @notice Custody, delegation, locking, and immediately claimable token accounting.
  * @dev The controller supplies all risk policy. Lock identifiers and claim allocations are opaque to the vault.
- * ZKP2P deployments support canonical USDC only; fee-on-transfer and rebasing tokens are unsupported.
+ * Each deployment holds one governance-approved token; fee-on-transfer and rebasing tokens are unsupported.
  */
 interface IStakeVault {
     struct StakeLock {

--- a/contracts/mocks/ERC4626Mock.sol
+++ b/contracts/mocks/ERC4626Mock.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+contract ERC4626Mock is ERC4626 {
+    using SafeERC20 for IERC20;
+
+    bool public isPreviewWithdrawReverting;
+
+    constructor(IERC20 _asset) ERC20("USDC Yield Vault", "yvUSDC") ERC4626(_asset) {}
+
+    function setPreviewWithdrawReverting(bool _isReverting) external {
+        isPreviewWithdrawReverting = _isReverting;
+    }
+
+    function removeAssets(address _recipient, uint256 _amount) external {
+        IERC20(asset()).safeTransfer(_recipient, _amount);
+    }
+
+    function previewWithdraw(uint256 _assets) public view override returns (uint256 shares) {
+        require(!isPreviewWithdrawReverting, "ERC4626Mock: preview unavailable");
+        return super.previewWithdraw(_assets);
+    }
+
+    function _decimalsOffset() internal pure override returns (uint8) {
+        return 12;
+    }
+}

--- a/deploy/31_deploy_dispute_lifecycle_stack.ts
+++ b/deploy/31_deploy_dispute_lifecycle_stack.ts
@@ -10,6 +10,7 @@ import {
   MULTI_SIG,
   STAKE_VAULT_CONTROLLER_CHANGE_DELAY,
   USDC,
+  USDC_YIELD_VAULT,
 } from "../deployments/parameters";
 import {
   addWritePermission,
@@ -33,12 +34,29 @@ async function assertCode(address: string, label: string): Promise<void> {
   }
 }
 
+async function getSettlementTokenAddress(hre: HardhatRuntimeEnvironment): Promise<string> {
+  const network = hre.deployments.getNetworkName();
+  const configuredAddress = USDC[network];
+  if (configuredAddress) return configuredAddress;
+
+  return (await hre.deployments.get("USDCMock")).address;
+}
+
+async function getCollateralVaultAddress(hre: HardhatRuntimeEnvironment): Promise<string> {
+  const network = hre.deployments.getNetworkName();
+  const configuredAddress = USDC_YIELD_VAULT[network];
+  if (configuredAddress) return configuredAddress;
+
+  return (await hre.deployments.get("USDCYieldVault")).address;
+}
+
 export async function disputeStackReady(hre: HardhatRuntimeEnvironment): Promise<boolean> {
   try {
     const network = hre.deployments.getNetworkName();
     const [deployer] = await hre.getUnnamedAccounts();
     const governance = MULTI_SIG[network] || deployer;
-    const stakeTokenAddress = USDC[network] || (await hre.deployments.get("USDCMock")).address;
+    const settlementTokenAddress = await getSettlementTokenAddress(hre);
+    const collateralVaultAddress = await getCollateralVaultAddress(hre);
 
     const registryAddress = (await hre.deployments.get("OrchestratorRegistry")).address;
     const whitelistPolicyAddress = (await hre.deployments.get("WhitelistPolicy")).address;
@@ -66,11 +84,13 @@ export async function disputeStackReady(hre: HardhatRuntimeEnvironment): Promise
     if (!sameAddress(await verifier.nullifierRegistry(), nullifierRegistryV2Address)) return false;
     if (!sameAddress(await verifier.attestationVerifier(), attestationVerifier.address)) return false;
     if (!sameAddress(await verifier.owner(), governance)) return false;
-    if (!sameAddress(await vault.stakeToken(), stakeTokenAddress)) return false;
+    if (!sameAddress(await vault.stakeToken(), collateralVaultAddress)) return false;
     if (!sameAddress(await vault.controller(), policyAddress)) return false;
     if (!(await vault.controllerChangeDelay()).eq(STAKE_VAULT_CONTROLLER_CHANGE_DELAY)) return false;
     if (!sameAddress(await vault.owner(), governance)) return false;
     if (!sameAddress(await policy.stakeVault(), vaultAddress)) return false;
+    if (!sameAddress(await policy.settlementToken(), settlementTokenAddress)) return false;
+    if (!sameAddress(await policy.collateralVault(), collateralVaultAddress)) return false;
     if (!sameAddress(await policy.disputeVerifier(), verifierAddress)) return false;
     if (!sameAddress(await policy.disputeNullifierRegistry(), disputeNullifierRegistryAddress)) return false;
     if (!(await policy.isLifecycleHookAuthorized(hookAddress))) return false;
@@ -94,7 +114,20 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const network = hre.deployments.getNetworkName();
   const [deployer] = await hre.getUnnamedAccounts();
   const governance = MULTI_SIG[network] || deployer;
-  const stakeTokenAddress = USDC[network] || (await hre.deployments.get("USDCMock")).address;
+  const settlementTokenAddress = await getSettlementTokenAddress(hre);
+  let collateralVaultAddress: string;
+  if (USDC_YIELD_VAULT[network]) {
+    collateralVaultAddress = await getCollateralVaultAddress(hre);
+  } else {
+    const collateralVaultDeployment = await hre.deployments.deploy("USDCYieldVault", {
+      contract: "ERC4626Mock",
+      from: deployer,
+      args: [settlementTokenAddress],
+      log: true,
+    });
+    await waitForDeploymentDelay(hre);
+    collateralVaultAddress = collateralVaultDeployment.address;
+  }
 
   const orchestratorRegistryAddress = (await hre.deployments.get("OrchestratorRegistry")).address;
   const whitelistPolicyAddress = (await hre.deployments.get("WhitelistPolicy")).address;
@@ -119,6 +152,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   await assertCode(whitelistPolicyAddress, "WhitelistPolicy");
   await assertCode(nullifierRegistryV2Address, "NullifierRegistryV2");
   await assertCode(attestationVerifier.address, "AttestationVerifier");
+  await assertCode(settlementTokenAddress, "SettlementToken");
+  await assertCode(collateralVaultAddress, "USDCYieldVault");
 
   const disputeNullifierRegistryDeployment = await hre.deployments.deploy(
     "DisputeNullifierRegistry",
@@ -140,7 +175,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const vaultDeployment = await hre.deployments.deploy("StakeVault", {
     from: deployer,
-    args: [deployer, stakeTokenAddress, ethers.constants.AddressZero, STAKE_VAULT_CONTROLLER_CHANGE_DELAY],
+    args: [deployer, collateralVaultAddress, ethers.constants.AddressZero, STAKE_VAULT_CONTROLLER_CHANGE_DELAY],
     log: true,
   });
   await waitForDeploymentDelay(hre);
@@ -149,6 +184,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     from: deployer,
     args: [
       deployer,
+      settlementTokenAddress,
+      collateralVaultAddress,
       vaultDeployment.address,
       disputeVerifierDeployment.address,
       disputeNullifierRegistryDeployment.address,
@@ -206,6 +243,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log("=== Fresh dispute lifecycle stack deployed ===");
   console.log("DisputeNullifierRegistry:", disputeNullifierRegistry.address);
   console.log("DisputeVerifier:", disputeVerifier.address);
+  console.log("USDCYieldVault:", collateralVaultAddress);
   console.log("StakeVault:", vault.address);
   console.log("DisputePolicy:", policy.address);
   console.log("IntentLifecycleHookV1:", hookDeployment.address);

--- a/deployments/parameters.ts
+++ b/deployments/parameters.ts
@@ -80,6 +80,12 @@ export const USDC: any = {
   "base_staging": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
 };
 
+// Governance-approved ERC-4626 vault whose underlying asset is canonical Base USDC.
+export const USDC_YIELD_VAULT: Record<string, string> = {
+  base: "0xBEEFE94c8aD530842bfE7d8B397938fFc1cb83b2",
+  base_staging: "0xBEEFE94c8aD530842bfE7d8B397938fFc1cb83b2",
+};
+
 // V2 Parameters
 export const ESCROW_V2_INTENT_EXPIRATION_PERIOD: any = {
   "localhost": ONE_DAY_IN_SECONDS,

--- a/scripts/test-dispute-lifecycle-deployment.cjs
+++ b/scripts/test-dispute-lifecycle-deployment.cjs
@@ -22,6 +22,7 @@ console.log = () => {};
 
 const hre = require("hardhat");
 const { ethers } = hre;
+const { USDC, USDC_YIELD_VAULT } = require("../deployments/parameters.ts");
 const deployDisputeStack = require("../deploy/31_deploy_dispute_lifecycle_stack.ts").default;
 const activateDisputeStack = require("../deploy/32_activate_dispute_lifecycle_stack.ts").default;
 
@@ -44,6 +45,18 @@ async function fixture() {
   const deployer = deployerSigner.address;
   const network = await ethers.provider.getNetwork();
 
+  const usdcImplementation = await deployContract("USDCMock", [1_000_000e6, "USD Coin", "USDC"]);
+  const usdcAddress = USDC.base_staging;
+  await ethers.provider.send("hardhat_setCode", [
+    usdcAddress,
+    await ethers.provider.getCode(usdcImplementation.address),
+  ]);
+  const usdcYieldVaultImplementation = await deployContract("ERC4626Mock", [usdcAddress]);
+  const usdcYieldVaultAddress = USDC_YIELD_VAULT.base_staging;
+  await ethers.provider.send("hardhat_setCode", [
+    usdcYieldVaultAddress,
+    await ethers.provider.getCode(usdcYieldVaultImplementation.address),
+  ]);
   const addressGroupRegistry = await deployContract("AddressGroupRegistry");
   const escrowRegistry = await deployContract("EscrowRegistry");
   const orchestratorRegistry = await deployContract("OrchestratorRegistry");

--- a/test-foundry/deterministic/hooks/DisputePolicy.t.sol
+++ b/test-foundry/deterministic/hooks/DisputePolicy.t.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.18;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import {StakeVault} from "contracts/StakeVault.sol";
 import {DisputePolicy} from "contracts/hooks/DisputePolicy.sol";
@@ -11,6 +12,7 @@ import {IDisputeVerifier} from "contracts/interfaces/IDisputeVerifier.sol";
 import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
 import {IStakeVault} from "contracts/interfaces/IStakeVault.sol";
 import {AttestationVerifierMock} from "contracts/mocks/AttestationVerifierMock.sol";
+import {ERC4626Mock} from "contracts/mocks/ERC4626Mock.sol";
 import {USDCMock} from "contracts/mocks/USDCMock.sol";
 import {NullifierRegistry} from "contracts/registries/NullifierRegistry.sol";
 import {NullifierRegistryV2} from "contracts/registries/NullifierRegistryV2.sol";
@@ -37,6 +39,7 @@ contract DisputePolicyTest is OrchestratorV3Fixture {
         address indexed stakeOwner,
         address indexed depositor,
         uint256 releaseAmount,
+        uint256 collateralAmount,
         uint64 releaseEligibleAt,
         bool isManualRelease
     );
@@ -44,36 +47,56 @@ contract DisputePolicyTest is OrchestratorV3Fixture {
     event DisputeVerifierUpdated(address indexed previousVerifier, address indexed newVerifier);
 
     uint64 internal constant RISK_WINDOW = 30 days;
-    uint256 internal constant STAKE_AMOUNT = 500e6;
+    uint256 internal constant STAKE_ASSETS = 500e6;
     bytes32 internal constant INTENT = keccak256("intent");
 
     StakeVault internal vault;
+    ERC4626Mock internal collateralVault;
     NullifierRegistryV2 internal nullifierRegistry;
     NullifierRegistry internal disputeNullifierRegistry;
     AttestationVerifierMock internal attestationVerifier;
     DisputeVerifier internal disputeVerifier;
     DisputePolicy internal policy;
+    uint256 internal stakeShares;
 
     function setUp() public override {
         super.setUp();
-        vault = new StakeVault(address(this), token, address(0), 1 days);
+        collateralVault = new ERC4626Mock(token);
+        vault = new StakeVault(address(this), collateralVault, address(0), 1 days);
         nullifierRegistry = new NullifierRegistryV2(new NullifierRegistry());
         disputeNullifierRegistry = new NullifierRegistry();
         attestationVerifier = new AttestationVerifierMock();
         disputeVerifier = new DisputeVerifier(address(this), nullifierRegistry, attestationVerifier);
-        policy = new DisputePolicy(address(this), vault, disputeVerifier, disputeNullifierRegistry);
+        policy = _newPolicy(vault, collateralVault, token);
         vault.initializeController(address(policy));
         disputeNullifierRegistry.addWritePermission(address(policy));
         policy.setLifecycleHookAuthorization(address(this), true);
         policy.setRiskWindow(METHOD, RISK_WINDOW);
         vm.prank(depositor);
         policy.setDisputeEnabled(address(escrow), depositId, true);
-        _stake(taker, STAKE_AMOUNT);
+        stakeShares = _stake(taker, STAKE_ASSETS);
     }
 
     function test_ConstructorRejectsZeroOwner() public {
         vm.expectRevert(IDisputePolicy.ZeroAddress.selector);
-        new DisputePolicy(address(0), vault, disputeVerifier, disputeNullifierRegistry);
+        new DisputePolicy(address(0), token, collateralVault, vault, disputeVerifier, disputeNullifierRegistry);
+    }
+
+    function test_ConstructorRejectsCollateralWithWrongAssetOrStakeToken() public {
+        USDCMock otherToken = new USDCMock(1_000e6, "Other", "OTHER");
+        ERC4626Mock wrongAssetVault = new ERC4626Mock(otherToken);
+        vm.expectRevert(
+            abi.encodeWithSelector(IDisputePolicy.CollateralAssetMismatch.selector, address(token), address(otherToken))
+        );
+        new DisputePolicy(address(this), token, wrongAssetVault, vault, disputeVerifier, disputeNullifierRegistry);
+
+        StakeVault wrongStakeVault = new StakeVault(address(this), token, address(0), 1 days);
+        vm.expectRevert(
+            abi.encodeWithSelector(IDisputePolicy.StakeTokenMismatch.selector, address(collateralVault), address(token))
+        );
+        new DisputePolicy(
+            address(this), token, collateralVault, wrongStakeVault, disputeVerifier, disputeNullifierRegistry
+        );
     }
 
     function test_onIntentSignaledLocksStakeAndSnapshotsConfiguration() public {
@@ -86,11 +109,13 @@ contract DisputePolicyTest is OrchestratorV3Fixture {
         assertEq(disputeIntent.stakeOwner, taker);
         assertEq(disputeIntent.depositor, depositor);
         assertEq(disputeIntent.riskWindow, RISK_WINDOW);
+        assertEq(disputeIntent.intentAmount, INTENT_AMOUNT);
+        assertEq(disputeIntent.collateralAmount, policy.quoteCollateral(INTENT_AMOUNT));
         assertEq(disputeIntent.releaseAmount, 0);
         assertEq(uint256(disputeIntent.status), uint256(IDisputePolicy.DisputeIntentStatus.PENDING));
         (address stakeOwner, uint256 amount, uint64 maturesAt) = vault.locks(INTENT);
         assertEq(stakeOwner, taker);
-        assertEq(amount, INTENT_AMOUNT);
+        assertEq(amount, policy.quoteCollateral(INTENT_AMOUNT));
         assertEq(maturesAt, type(uint64).max);
     }
 
@@ -106,9 +131,7 @@ contract DisputePolicyTest is OrchestratorV3Fixture {
 
         vm.prank(depositor);
         policy.setDisputeEnabled(address(escrow), depositId, false);
-        vm.expectRevert(
-            abi.encodeWithSelector(IDisputePolicy.DisputeNotEnabled.selector, address(escrow), depositId)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IDisputePolicy.DisputeNotEnabled.selector, address(escrow), depositId));
         policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         vm.prank(depositor);
         policy.setDisputeEnabled(address(escrow), depositId, true);
@@ -126,17 +149,13 @@ contract DisputePolicyTest is OrchestratorV3Fixture {
 
         policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, windowlessMethod, INTENT_AMOUNT);
 
-        assertEq(
-            uint256(policy.getDisputeIntent(INTENT).status), uint256(IDisputePolicy.DisputeIntentStatus.NONE)
-        );
+        assertEq(uint256(policy.getDisputeIntent(INTENT).status), uint256(IDisputePolicy.DisputeIntentStatus.NONE));
         assertEq(vault.lockedStake(taker), lockedBefore);
         assertEq(vault.freeStake(taker), freeBefore);
 
         policy.onIntentSettled(INTENT, INTENT_AMOUNT, false);
         policy.onIntentCancelled(INTENT);
-        assertEq(
-            uint256(policy.getDisputeIntent(INTENT).status), uint256(IDisputePolicy.DisputeIntentStatus.NONE)
-        );
+        assertEq(uint256(policy.getDisputeIntent(INTENT).status), uint256(IDisputePolicy.DisputeIntentStatus.NONE));
         assertEq(vault.lockedStake(taker), lockedBefore);
         assertEq(vault.freeStake(taker), freeBefore);
     }
@@ -153,14 +172,16 @@ contract DisputePolicyTest is OrchestratorV3Fixture {
 
         bytes32 secondIntent = keccak256("second-intent");
         vm.expectRevert(
-            abi.encodeWithSelector(IStakeVault.InsufficientFreeStake.selector, other, uint256(0), INTENT_AMOUNT)
+            abi.encodeWithSelector(
+                IStakeVault.InsufficientFreeStake.selector, other, uint256(0), policy.quoteCollateral(INTENT_AMOUNT)
+            )
         );
         policy.onIntentSignaled(secondIntent, address(escrow), depositId, other, METHOD, INTENT_AMOUNT);
     }
 
     function test_DelegatedStakeLocksSelectedOwnersStake() public {
         address stakeOwner = makeAddr("stakeOwner");
-        _stake(stakeOwner, STAKE_AMOUNT);
+        _stake(stakeOwner, STAKE_ASSETS);
         vm.prank(stakeOwner);
         vault.setTakerAuthorization(other, true);
         vm.prank(other);
@@ -169,7 +190,7 @@ contract DisputePolicyTest is OrchestratorV3Fixture {
         policy.onIntentSignaled(INTENT, address(escrow), depositId, other, METHOD, INTENT_AMOUNT);
 
         assertEq(policy.getDisputeIntent(INTENT).stakeOwner, stakeOwner);
-        assertEq(vault.lockedStake(stakeOwner), INTENT_AMOUNT);
+        assertEq(vault.lockedStake(stakeOwner), policy.quoteCollateral(INTENT_AMOUNT));
         assertEq(vault.lockedStake(other), 0);
     }
 
@@ -178,9 +199,7 @@ contract DisputePolicyTest is OrchestratorV3Fixture {
         policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         policy.onIntentCancelled(INTENT);
         assertEq(vault.lockedStake(taker), 0);
-        assertEq(
-            uint256(policy.getDisputeIntent(INTENT).status), uint256(IDisputePolicy.DisputeIntentStatus.CANCELLED)
-        );
+        assertEq(uint256(policy.getDisputeIntent(INTENT).status), uint256(IDisputePolicy.DisputeIntentStatus.CANCELLED));
 
         bytes32 settledIntent = keccak256("settled");
         policy.onIntentSignaled(settledIntent, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
@@ -200,7 +219,9 @@ contract DisputePolicyTest is OrchestratorV3Fixture {
         policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         uint256 releaseEligibleAt = vm.getBlockTimestamp() + RISK_WINDOW;
         vm.expectEmit(true, true, true, true);
-        emit DisputeIntentSettled(INTENT, taker, depositor, 40e6, uint64(releaseEligibleAt), true);
+        uint256 expectedCollateral =
+            Math.mulDiv(policy.quoteCollateral(INTENT_AMOUNT), 40e6, INTENT_AMOUNT, Math.Rounding.Up);
+        emit DisputeIntentSettled(INTENT, taker, depositor, 40e6, expectedCollateral, uint64(releaseEligibleAt), true);
         policy.onIntentSettled(INTENT, 40e6, true);
 
         IDisputePolicy.DisputeIntent memory disputeIntent = policy.getDisputeIntent(INTENT);
@@ -208,14 +229,12 @@ contract DisputePolicyTest is OrchestratorV3Fixture {
         assertEq(disputeIntent.releaseEligibleAt, releaseEligibleAt);
         assertEq(disputeIntent.releaseAmount, 40e6);
         (, uint256 amount, uint64 maturesAt) = vault.locks(INTENT);
-        assertEq(amount, 40e6);
+        assertEq(amount, expectedCollateral);
         assertEq(maturesAt, releaseEligibleAt);
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                IDisputePolicy.DisputeIntentNotPending.selector,
-                INTENT,
-                IDisputePolicy.DisputeIntentStatus.SETTLED
+                IDisputePolicy.DisputeIntentNotPending.selector, INTENT, IDisputePolicy.DisputeIntentStatus.SETTLED
             )
         );
         policy.onIntentSettled(INTENT, 40e6, true);
@@ -224,7 +243,15 @@ contract DisputePolicyTest is OrchestratorV3Fixture {
         policy.onIntentSignaled(fullIntent, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         policy.onIntentSettled(fullIntent, INTENT_AMOUNT, false);
         (, amount,) = vault.locks(fullIntent);
-        assertEq(amount, INTENT_AMOUNT);
+        assertEq(amount, policy.quoteCollateral(INTENT_AMOUNT));
+    }
+
+    function test_SettlementRejectsReleaseAboveOriginalIntentAmount() public {
+        policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+        vm.expectRevert(
+            abi.encodeWithSelector(IDisputePolicy.ReleaseAmountExceedsIntent.selector, INTENT_AMOUNT, INTENT_AMOUNT + 1)
+        );
+        policy.onIntentSettled(INTENT, INTENT_AMOUNT + 1, false);
     }
 
     function test_ReleaseMaturedDisputeIntentAndBatchFreeStakeAtBoundary() public {
@@ -248,12 +275,10 @@ contract DisputePolicyTest is OrchestratorV3Fixture {
         intents[1] = secondIntent;
         policy.releaseMaturedDisputeIntents(intents);
         assertEq(vault.lockedStake(taker), 0);
-        assertEq(vault.freeStake(taker), STAKE_AMOUNT);
+        assertEq(vault.freeStake(taker), stakeShares);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IDisputePolicy.DisputeIntentNotSettled.selector,
-                INTENT,
-                IDisputePolicy.DisputeIntentStatus.RELEASED
+                IDisputePolicy.DisputeIntentNotSettled.selector, INTENT, IDisputePolicy.DisputeIntentStatus.RELEASED
             )
         );
         policy.releaseMaturedDisputeIntent(INTENT);
@@ -275,13 +300,11 @@ contract DisputePolicyTest is OrchestratorV3Fixture {
         nullifierRegistry.addNullifier(paymentNullifier, INTENT);
         policy.submitDispute(attestation);
 
-        assertEq(vault.claimable(depositor), 40e6);
+        uint256 compensatedShares = collateralVault.previewWithdraw(40e6);
+        assertEq(vault.claimable(depositor), compensatedShares);
         assertEq(vault.lockedStake(taker), 0);
-        assertEq(vault.stakeBalance(taker), STAKE_AMOUNT - 40e6);
-        assertEq(
-            uint256(policy.getDisputeIntent(INTENT).status),
-            uint256(IDisputePolicy.DisputeIntentStatus.DISPUTED)
-        );
+        assertEq(vault.stakeBalance(taker), stakeShares - compensatedShares);
+        assertEq(uint256(policy.getDisputeIntent(INTENT).status), uint256(IDisputePolicy.DisputeIntentStatus.DISPUTED));
     }
 
     function test_SubmitDisputeRequiresSettledIntent() public {
@@ -298,9 +321,7 @@ contract DisputePolicyTest is OrchestratorV3Fixture {
         policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IDisputePolicy.DisputeIntentNotSettled.selector,
-                INTENT,
-                IDisputePolicy.DisputeIntentStatus.PENDING
+                IDisputePolicy.DisputeIntentNotSettled.selector, INTENT, IDisputePolicy.DisputeIntentStatus.PENDING
             )
         );
         policy.submitDispute(attestation);
@@ -320,7 +341,7 @@ contract DisputePolicyTest is OrchestratorV3Fixture {
         bytes32 disputeNullifier = keccak256(abi.encodePacked(METHOD, disputeId));
         assertFalse(disputeNullifierRegistry.isNullified(disputeNullifier));
         assertEq(vault.claimable(depositor), 0);
-        assertEq(vault.lockedStake(taker), 40e6);
+        assertEq(vault.lockedStake(taker), _settledCollateral(INTENT));
     }
 
     function test_SubmitDisputeRejectsInvalidEvidenceButRemainsValidUntilCollateralRelease() public {
@@ -348,11 +369,8 @@ contract DisputePolicyTest is OrchestratorV3Fixture {
         uint64 releaseEligibleAt = policy.getDisputeIntent(INTENT).releaseEligibleAt;
         vm.warp(releaseEligibleAt);
         policy.submitDispute(attestation);
-        assertEq(vault.claimable(depositor), 40e6);
-        assertEq(
-            uint256(policy.getDisputeIntent(INTENT).status),
-            uint256(IDisputePolicy.DisputeIntentStatus.DISPUTED)
-        );
+        assertEq(vault.claimable(depositor), collateralVault.previewWithdraw(40e6));
+        assertEq(uint256(policy.getDisputeIntent(INTENT).status), uint256(IDisputePolicy.DisputeIntentStatus.DISPUTED));
     }
 
     function test_GovernanceSettersEnforceOwnershipAndValidation() public {
@@ -445,9 +463,8 @@ contract DisputePolicyTest is OrchestratorV3Fixture {
     }
 
     function test_AcceptVaultControllerCompletesDelayedTwoStepHandover() public {
-        StakeVault secondVault = new StakeVault(address(this), token, address(0), 1 days);
-        DisputePolicy secondPolicy =
-            new DisputePolicy(address(this), secondVault, disputeVerifier, disputeNullifierRegistry);
+        StakeVault secondVault = new StakeVault(address(this), collateralVault, address(0), 1 days);
+        DisputePolicy secondPolicy = _newPolicy(secondVault, collateralVault, token);
         secondVault.initializeController(address(this));
         secondVault.proposeController(address(secondPolicy));
         uint256 acceptanceTime = vm.getBlockTimestamp() + secondVault.controllerChangeDelay();
@@ -456,12 +473,78 @@ contract DisputePolicyTest is OrchestratorV3Fixture {
         assertEq(secondVault.controller(), address(secondPolicy));
     }
 
-    function _stake(address stakeOwner, uint256 amount) internal {
-        token.transfer(stakeOwner, amount);
+    function _stake(address stakeOwner, uint256 assets) internal returns (uint256 shares) {
+        token.transfer(stakeOwner, assets);
         vm.startPrank(stakeOwner);
-        token.approve(address(vault), amount);
-        vault.depositStake(amount);
+        token.approve(address(collateralVault), assets);
+        shares = collateralVault.deposit(assets, stakeOwner);
+        collateralVault.approve(address(vault), shares);
+        vault.depositStake(shares);
         vm.stopPrank();
+    }
+
+    function _newPolicy(StakeVault stakeVault_, ERC4626Mock collateralVault_, IERC20 settlementToken_)
+        internal
+        returns (DisputePolicy)
+    {
+        return new DisputePolicy(
+            address(this), settlementToken_, collateralVault_, stakeVault_, disputeVerifier, disputeNullifierRegistry
+        );
+    }
+
+    function test_YieldReducesSharesPaidAndReturnsExcessCollateralToStaker() public {
+        _admitAndSettle(INTENT, 40e6, false);
+        uint256 lockedShares = _settledCollateral(INTENT);
+        token.transfer(address(collateralVault), STAKE_ASSETS);
+        uint256 compensatedShares = collateralVault.previewWithdraw(40e6);
+        assertLt(compensatedShares, lockedShares);
+
+        _bindPaymentAndSubmit(INTENT);
+
+        assertEq(vault.claimable(depositor), compensatedShares);
+        assertEq(vault.stakeBalance(taker), stakeShares - compensatedShares);
+        assertEq(vault.freeStake(taker), stakeShares - compensatedShares);
+        assertEq(vault.lockedStake(taker), 0);
+    }
+
+    function test_CollateralLossCapsDisputeCompensationAtLockedShares() public {
+        _admitAndSettle(INTENT, 40e6, false);
+        uint256 lockedShares = _settledCollateral(INTENT);
+        collateralVault.removeAssets(address(this), STAKE_ASSETS - 10e6);
+        assertGt(collateralVault.previewWithdraw(40e6), lockedShares);
+
+        _bindPaymentAndSubmit(INTENT);
+
+        assertEq(vault.claimable(depositor), lockedShares);
+        assertEq(vault.stakeBalance(taker), stakeShares - lockedShares);
+        assertEq(vault.lockedStake(taker), 0);
+    }
+
+    function test_PreviewFailureBlocksAdmissionButDisputeFallsBackToFullLock() public {
+        collateralVault.setPreviewWithdrawReverting(true);
+        vm.expectRevert(IDisputePolicy.CollateralConversionUnavailable.selector);
+        policy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
+
+        collateralVault.setPreviewWithdrawReverting(false);
+        _admitAndSettle(INTENT, 40e6, false);
+        uint256 lockedShares = _settledCollateral(INTENT);
+        collateralVault.setPreviewWithdrawReverting(true);
+
+        _bindPaymentAndSubmit(INTENT);
+
+        assertEq(vault.claimable(depositor), lockedShares);
+        assertEq(vault.lockedStake(taker), 0);
+    }
+
+    function _settledCollateral(bytes32 intentHash) internal view returns (uint256 amount) {
+        (, amount,) = vault.locks(intentHash);
+    }
+
+    function _bindPaymentAndSubmit(bytes32 intentHash) internal {
+        bytes32 paymentId = keccak256("payment");
+        nullifierRegistry.addWritePermission(address(this));
+        nullifierRegistry.addNullifier(keccak256(abi.encodePacked(METHOD, paymentId)), intentHash);
+        policy.submitDispute(_attestation(intentHash, METHOD, paymentId, keccak256("dispute")));
     }
 
     function _admitAndSettle(bytes32 intentHash, uint256 releaseAmount, bool manualRelease) internal {

--- a/test-foundry/deterministic/integration/DisputeLifecycleHookOrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/DisputeLifecycleHookOrchestratorV3.t.sol
@@ -12,6 +12,7 @@ import {IEscrowV2} from "contracts/interfaces/IEscrowV2.sol";
 import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
 import {IStakeVault} from "contracts/interfaces/IStakeVault.sol";
 import {AttestationVerifierMock} from "contracts/mocks/AttestationVerifierMock.sol";
+import {ERC4626Mock} from "contracts/mocks/ERC4626Mock.sol";
 import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
 import {NullifierRegistry} from "contracts/registries/NullifierRegistry.sol";
 import {NullifierRegistryV2} from "contracts/registries/NullifierRegistryV2.sol";
@@ -21,26 +22,31 @@ import {OrchestratorV3Fixture} from "../helpers/OrchestratorV3Fixture.sol";
 
 contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
     uint64 internal constant RISK_WINDOW = 30 days;
-    uint256 internal constant STAKE_AMOUNT = 500e6;
+    uint256 internal constant STAKE_ASSETS = 500e6;
     bytes32 internal constant WINDOWLESS_METHOD = keccak256("windowless");
 
     AddressGroupRegistry internal groupRegistry;
     WhitelistPolicy internal whitelistPolicy;
     StakeVault internal vault;
+    ERC4626Mock internal collateralVault;
     NullifierRegistryV2 internal nullifierRegistry;
     NullifierRegistry internal disputeNullifierRegistry;
     DisputePolicy internal disputePolicy;
     IntentLifecycleHookV1 internal lifecycleHook;
+    uint256 internal stakeShares;
 
     function setUp() public override {
         super.setUp();
         groupRegistry = new AddressGroupRegistry();
         whitelistPolicy = new WhitelistPolicy(groupRegistry, escrowRegistry, orchestratorRegistry);
-        vault = new StakeVault(address(this), token, address(0), 1 days);
+        collateralVault = new ERC4626Mock(token);
+        vault = new StakeVault(address(this), collateralVault, address(0), 1 days);
         nullifierRegistry = new NullifierRegistryV2(new NullifierRegistry());
         disputeNullifierRegistry = new NullifierRegistry();
         disputePolicy = new DisputePolicy(
             address(this),
+            token,
+            collateralVault,
             vault,
             new DisputeVerifier(address(this), nullifierRegistry, new AttestationVerifierMock()),
             disputeNullifierRegistry
@@ -51,7 +57,7 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         disputePolicy.setLifecycleHookAuthorization(address(lifecycleHook), true);
         disputePolicy.setRiskWindow(METHOD, RISK_WINDOW);
         orchestrator.setLifecycleHook(lifecycleHook);
-        _stake(taker, STAKE_AMOUNT);
+        stakeShares = _stake(taker, STAKE_ASSETS);
     }
 
     function test_WhitelistOnWhitelistedWithDisputeOnSkipsStake() public {
@@ -61,8 +67,7 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         bytes32 intentHash = _signalDefault();
 
         assertEq(
-            uint256(disputePolicy.getDisputeIntent(intentHash).status),
-            uint256(IDisputePolicy.DisputeIntentStatus.NONE)
+            uint256(disputePolicy.getDisputeIntent(intentHash).status), uint256(IDisputePolicy.DisputeIntentStatus.NONE)
         );
         assertEq(vault.lockedStake(taker), 0);
         assertEq(escrow.getDepositIntent(depositId, intentHash).intentHash, intentHash);
@@ -72,7 +77,7 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         _setWhitelist(true, false);
         _setDispute(true);
         bytes32 intentHash = _signalDefault();
-        assertEq(vault.lockedStake(taker), INTENT_AMOUNT);
+        assertEq(vault.lockedStake(taker), _collateral(INTENT_AMOUNT));
         assertEq(
             uint256(disputePolicy.getDisputeIntent(intentHash).status),
             uint256(IDisputePolicy.DisputeIntentStatus.PENDING)
@@ -82,7 +87,9 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         bytes32 rejectedIntent = _intentHash(counterBefore);
         uint256 remainingBefore = escrow.getDeposit(depositId).remainingDeposits;
         vm.expectRevert(
-            abi.encodeWithSelector(IStakeVault.InsufficientFreeStake.selector, other, uint256(0), INTENT_AMOUNT)
+            abi.encodeWithSelector(
+                IStakeVault.InsufficientFreeStake.selector, other, uint256(0), _collateral(INTENT_AMOUNT)
+            )
         );
         _signalCall(other, _paramsFor(other));
         assertEq(orchestrator.intentCounter(), counterBefore);
@@ -100,8 +107,7 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         bytes32 intentHash = _signal(other, params);
 
         assertEq(
-            uint256(disputePolicy.getDisputeIntent(intentHash).status),
-            uint256(IDisputePolicy.DisputeIntentStatus.NONE)
+            uint256(disputePolicy.getDisputeIntent(intentHash).status), uint256(IDisputePolicy.DisputeIntentStatus.NONE)
         );
         assertEq(vault.lockedStake(other), 0);
         assertEq(escrow.getDepositIntent(depositId, intentHash).intentHash, intentHash);
@@ -109,8 +115,7 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         verifier.setShouldVerifyPayment(true);
         _fulfill(intentHash, INTENT_AMOUNT, CONVERSION_RATE);
         assertEq(
-            uint256(disputePolicy.getDisputeIntent(intentHash).status),
-            uint256(IDisputePolicy.DisputeIntentStatus.NONE)
+            uint256(disputePolicy.getDisputeIntent(intentHash).status), uint256(IDisputePolicy.DisputeIntentStatus.NONE)
         );
     }
 
@@ -128,7 +133,9 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         _setDispute(true);
         assertNotEq(_signalDefault(), bytes32(0));
         vm.expectRevert(
-            abi.encodeWithSelector(IStakeVault.InsufficientFreeStake.selector, other, uint256(0), INTENT_AMOUNT)
+            abi.encodeWithSelector(
+                IStakeVault.InsufficientFreeStake.selector, other, uint256(0), _collateral(INTENT_AMOUNT)
+            )
         );
         _signalCall(other, _paramsFor(other));
     }
@@ -142,13 +149,14 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         bytes32 intentHash = _signal(other, params);
 
         assertEq(
-            uint256(disputePolicy.getDisputeIntent(intentHash).status),
-            uint256(IDisputePolicy.DisputeIntentStatus.NONE)
+            uint256(disputePolicy.getDisputeIntent(intentHash).status), uint256(IDisputePolicy.DisputeIntentStatus.NONE)
         );
         assertEq(vault.lockedStake(other), 0);
 
         vm.expectRevert(
-            abi.encodeWithSelector(IStakeVault.InsufficientFreeStake.selector, other, uint256(0), INTENT_AMOUNT)
+            abi.encodeWithSelector(
+                IStakeVault.InsufficientFreeStake.selector, other, uint256(0), _collateral(INTENT_AMOUNT)
+            )
         );
         _signalCall(other, _paramsFor(other));
     }
@@ -156,8 +164,7 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
     function test_WhitelistOffDisputeOffIsOpenAndCreatesNoDisputeIntent() public {
         bytes32 intentHash = _signal(other, _paramsFor(other));
         assertEq(
-            uint256(disputePolicy.getDisputeIntent(intentHash).status),
-            uint256(IDisputePolicy.DisputeIntentStatus.NONE)
+            uint256(disputePolicy.getDisputeIntent(intentHash).status), uint256(IDisputePolicy.DisputeIntentStatus.NONE)
         );
         assertEq(vault.lockedStake(other), 0);
     }
@@ -196,13 +203,13 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         assertEq(disputeIntent.releaseAmount, releaseAmount);
         assertEq(disputeIntent.releaseEligibleAt, releaseEligibleAt);
         (, uint256 lockedAmount, uint64 maturesAt) = vault.locks(intentHash);
-        assertEq(lockedAmount, releaseAmount);
+        assertEq(lockedAmount, disputeIntent.collateralAmount);
         assertEq(maturesAt, releaseEligibleAt);
 
         vm.warp(releaseEligibleAt);
         disputePolicy.releaseMaturedDisputeIntent(intentHash);
         assertEq(vault.lockedStake(taker), 0);
-        assertEq(vault.freeStake(taker), STAKE_AMOUNT);
+        assertEq(vault.freeStake(taker), stakeShares);
     }
 
     function test_ManualReleaseRetainsStakeButRejectsDisputeWithoutPaymentBinding() public {
@@ -216,8 +223,8 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         assertEq(disputeIntent.releaseAmount, INTENT_AMOUNT);
         assertEq(disputeIntent.releaseEligibleAt, releaseEligibleAt);
         assertEq(uint256(disputeIntent.status), uint256(IDisputePolicy.DisputeIntentStatus.SETTLED));
-        assertEq(vault.lockedStake(taker), INTENT_AMOUNT);
-        assertEq(vault.freeStake(taker), STAKE_AMOUNT - INTENT_AMOUNT);
+        assertEq(vault.lockedStake(taker), disputeIntent.collateralAmount);
+        assertEq(vault.freeStake(taker), stakeShares - disputeIntent.collateralAmount);
 
         bytes32 paymentId = keccak256("unbound-payment");
         bytes32 paymentNullifier = keccak256(abi.encodePacked(METHOD, paymentId));
@@ -239,7 +246,7 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         nullifierRegistry.addNullifier(paymentNullifier, intentHash);
         disputePolicy.submitDispute(_attestation(intentHash, paymentId, keccak256("dispute")));
 
-        assertEq(vault.claimable(depositor), INTENT_AMOUNT);
+        assertEq(vault.claimable(depositor), _collateral(INTENT_AMOUNT));
         assertEq(vault.lockedStake(taker), 0);
         assertEq(
             uint256(disputePolicy.getDisputeIntent(intentHash).status),
@@ -271,8 +278,7 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         assertEq(vault.totalStaked(), totalBefore);
         assertEq(vault.lockedStake(taker), 0);
         assertEq(
-            uint256(disputePolicy.getDisputeIntent(intentHash).status),
-            uint256(IDisputePolicy.DisputeIntentStatus.NONE)
+            uint256(disputePolicy.getDisputeIntent(intentHash).status), uint256(IDisputePolicy.DisputeIntentStatus.NONE)
         );
     }
 
@@ -308,8 +314,7 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         uint256 releaseAmount = 40e6;
         verifier.setShouldVerifyPayment(true);
         _fulfill(oldSettledIntent, releaseAmount, CONVERSION_RATE);
-        IDisputePolicy.DisputeIntent memory oldSettledIntentState =
-            disputePolicy.getDisputeIntent(oldSettledIntent);
+        IDisputePolicy.DisputeIntent memory oldSettledIntentState = disputePolicy.getDisputeIntent(oldSettledIntent);
         assertEq(uint256(oldSettledIntentState.status), uint256(IDisputePolicy.DisputeIntentStatus.SETTLED));
         assertEq(oldSettledIntentState.releaseAmount, releaseAmount);
 
@@ -321,7 +326,7 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
             uint256(disputePolicy.getDisputeIntent(newIntent).status),
             uint256(IDisputePolicy.DisputeIntentStatus.CANCELLED)
         );
-        assertEq(vault.lockedStake(taker), releaseAmount);
+        assertEq(vault.lockedStake(taker), disputePolicy.getDisputeIntent(oldSettledIntent).collateralAmount);
     }
 
     function _setWhitelist(bool enabled, bool includeTaker) internal {
@@ -355,12 +360,18 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         escrow.addPaymentMethods(depositId, paymentMethods, paymentMethodData, currencies);
     }
 
-    function _stake(address stakeOwner, uint256 amount) internal {
-        token.transfer(stakeOwner, amount);
+    function _stake(address stakeOwner, uint256 assets) internal returns (uint256 shares) {
+        token.transfer(stakeOwner, assets);
         vm.startPrank(stakeOwner);
-        token.approve(address(vault), amount);
-        vault.depositStake(amount);
+        token.approve(address(collateralVault), assets);
+        shares = collateralVault.deposit(assets, stakeOwner);
+        collateralVault.approve(address(vault), shares);
+        vault.depositStake(shares);
         vm.stopPrank();
+    }
+
+    function _collateral(uint256 assets) internal view returns (uint256) {
+        return collateralVault.previewWithdraw(assets);
     }
 
     function _paramsFor(address recipient) internal view returns (IOrchestratorV3.SignalIntentParams memory params) {

--- a/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
@@ -11,6 +11,7 @@ import {DisputePolicy} from "contracts/hooks/DisputePolicy.sol";
 import {IntentLifecycleHookV1} from "contracts/hooks/IntentLifecycleHookV1.sol";
 import {WhitelistPolicy} from "contracts/hooks/WhitelistPolicy.sol";
 import {AttestationVerifierMock} from "contracts/mocks/AttestationVerifierMock.sol";
+import {ERC4626Mock} from "contracts/mocks/ERC4626Mock.sol";
 import {IntentLifecycleHookV1Mock} from "contracts/mocks/IntentLifecycleHookV1Mock.sol";
 import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
 import {NullifierRegistry} from "contracts/registries/NullifierRegistry.sol";
@@ -40,10 +41,13 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
         PEER_MERCHANTS = groupRegistry.createGroup("Peer Merchants");
 
         policy = new WhitelistPolicy(groupRegistry, escrowRegistry, orchestratorRegistry);
-        stakeVault = new StakeVault(address(this), token, address(0), 1 days);
+        ERC4626Mock collateralVault = new ERC4626Mock(token);
+        stakeVault = new StakeVault(address(this), collateralVault, address(0), 1 days);
         NullifierRegistry disputeNullifierRegistry = new NullifierRegistry();
         disputePolicy = new DisputePolicy(
             address(this),
+            token,
+            collateralVault,
             stakeVault,
             new DisputeVerifier(
                 address(this), new NullifierRegistryV2(new NullifierRegistry()), new AttestationVerifierMock()

--- a/test-foundry/deterministic/integration/WhitelistLifecycleHookOrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/WhitelistLifecycleHookOrchestratorV3.t.sol
@@ -12,6 +12,7 @@ import {IIntentLifecycleHook} from "contracts/interfaces/IIntentLifecycleHook.so
 import {IOrchestratorRegistry} from "contracts/interfaces/IOrchestratorRegistry.sol";
 import {IWhitelistPolicy} from "contracts/interfaces/IWhitelistPolicy.sol";
 import {AttestationVerifierMock} from "contracts/mocks/AttestationVerifierMock.sol";
+import {ERC4626Mock} from "contracts/mocks/ERC4626Mock.sol";
 import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
 import {NullifierRegistry} from "contracts/registries/NullifierRegistry.sol";
 import {NullifierRegistryV2} from "contracts/registries/NullifierRegistryV2.sol";
@@ -161,10 +162,13 @@ contract WhitelistLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         internal
         returns (StakeVault vault, DisputePolicy disputePolicy, IntentLifecycleHookV1 combinedHook)
     {
-        vault = new StakeVault(address(this), token, address(0), 1 days);
+        ERC4626Mock collateralVault = new ERC4626Mock(token);
+        vault = new StakeVault(address(this), collateralVault, address(0), 1 days);
         NullifierRegistry disputeNullifierRegistry = new NullifierRegistry();
         disputePolicy = new DisputePolicy(
             address(this),
+            token,
+            collateralVault,
             vault,
             new DisputeVerifier(
                 address(this), new NullifierRegistryV2(new NullifierRegistry()), new AttestationVerifierMock()
@@ -179,8 +183,10 @@ contract WhitelistLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
 
         token.transfer(taker, STAKE_AMOUNT);
         vm.startPrank(taker);
-        token.approve(address(vault), STAKE_AMOUNT);
-        vault.depositStake(STAKE_AMOUNT);
+        token.approve(address(collateralVault), STAKE_AMOUNT);
+        uint256 shares = collateralVault.deposit(STAKE_AMOUNT, taker);
+        collateralVault.approve(address(vault), shares);
+        vault.depositStake(shares);
         vm.stopPrank();
     }
 }


### PR DESCRIPTION
## Summary

- hard-cut the unreleased dispute stack so canonical Base USDC remains the settlement token while `StakeVault` holds shares of one immutable, governance-approved USDC-backed ERC-4626 vault
- configure Base staging for Steakhouse Prime USDC (`0xBEEFE94c8aD530842bfE7d8B397938fFc1cb83b2`) and validate on construction that `collateralVault.asset() == settlementToken`
- collateralize at exactly 100% with `previewWithdraw(USDC exposure)`; no Chainlink or sequencer feed is required
- snapshot the admission share lock, resize it proportionally at settlement, and quote the current USDC-equivalent shares at dispute time, capped by the lock
- award vault shares in-kind so dispute resolution does not depend on synchronous Morpho withdrawal liquidity

## Safety behavior

- admission fails closed if the ERC-4626 share quote is unavailable or zero
- cancellation, settlement, and matured unlock remain conversion-independent
- if the quote is unavailable during a valid dispute, the depositor receives the full share lock
- accrued yield reduces the shares claimed and returns the excess to the staker; collateral impairment can consume the full lock but never more
- 100% intentionally has no loss buffer. Morpho vault impairment or withdrawal illiquidity can still prevent the received shares from redeeming for the full USDC exposure
- additional collateral can use separate deployments of this policy with other allowlisted ERC-4626 shares whose underlying asset is canonical USDC; non-USDC stablecoin vaults still need an explicit conversion/pricing design

## Validation

- `forge test --match-path test-foundry/deterministic/hooks/DisputePolicy.t.sol` (25 passed)
- `forge test --match-path 'test-foundry/deterministic/integration/*LifecycleHook*OrchestratorV3.t.sol'` (36 passed)
- `corepack yarn compile`
- `corepack yarn test:dispute-lifecycle-deployment`
- `corepack yarn tsc --noEmit`
- `corepack yarn pkg:build`
- `corepack yarn pkg:test` (5 passed)

A cold full `forge test` compile was stopped after 10 minutes with no compiler error output; CI is running the complete-suite check.
