### PR TITLE
docs(skill): link contracts publishing discovery

### DIFF
--- a/.claude/skills/zkp2p-contracts-publish
+++ b/.claude/skills/zkp2p-contracts-publish
@@ -1,0 +1,1 @@
+../../.agents/skills/zkp2p-contracts-publish


### PR DESCRIPTION
## Summary

- add the repository-relative Claude discovery link for the canonical `zkp2p-contracts-publish` skill
- preserve `.agents/skills/zkp2p-contracts-publish` as the only canonical source
- change no publishing instructions, scripts, application code, release policy, or runtime behavior

## Evidence

- current `origin/main` already carries the canonical publishing skill
- the sibling `audit` skill uses the same relative discovery-link pattern
- drift fingerprint: `615b5d1bdfe1acacb32b9996b6cb7d0b021dcbc7f8a6b5b99f719d99e37bc29e`
- trailing-24-hour chat review did not drive this change; it closes a previously recorded inventory warning

## Validation

- skill-creator `quick_validate.py` via `uv --with pyyaml`: pass
- discovery target resolves inside this repository and `SKILL.md` is byte-identical: pass
- `git diff --check`: pass
- changed diff sensitive/absolute-personal-path scan: pass
- bundled script tests: not applicable; no script changed
- `agents/openai.yaml`: optional metadata remains absent and unchanged

## Risk

Classified critical under the automation policy because this broadens discovery of a publishing workflow. The diff is a single relative symlink and does not grant publication authority; the PR remains draft and will not be auto-merged.

## Rollback

Remove `.claude/skills/zkp2p-contracts-publish`; the canonical `.agents` skill remains unchanged.