### PR TITLE
feat(contracts): enable dispute coverage by default

### DIFF
--- a/contracts/hooks/DisputeProtectionPolicy.sol
+++ b/contracts/hooks/DisputeProtectionPolicy.sol
@@ -13,7 +13,7 @@ import {IStakeVault} from "../interfaces/IStakeVault.sol";
 
 /**
  * @title DisputeProtectionPolicy
- * @notice Deposit-scoped, stake-backed dispute coverage for intent settlement.
+ * @notice Deposit-scoped, stake-backed dispute protection that is enabled by default with depositor opt-out.
  * @dev The policy owns no tokens. StakeVault is the source of truth for collateral locks, a dedicated
  * `disputeNullifierRegistry` deployment is the source of truth for consumed dispute nullifiers, and the calling
  * Orchestrator is the source of truth for valid escrows and intents.
@@ -53,8 +53,8 @@ contract DisputeProtectionPolicy is IDisputeProtectionPolicy, Ownable2Step, Reen
     /// @dev Lifecycle-hook authorization keyed by lifecycle hook address.
     mapping(address => bool) internal isLifecycleHookAuthorizedByHook;
 
-    /// @dev Whether dispute protection is enabled for each escrow deposit.
-    mapping(address => mapping(uint256 => bool)) internal isDepositDisputeProtectionEnabled;
+    /// @dev Whether default stake-backed dispute protection is disabled for each escrow deposit.
+    mapping(address => mapping(uint256 => bool)) internal isDepositDisputeProtectionDisabled;
 
     /// @dev Minimum collateral lock window for each payment method.
     mapping(bytes32 => uint64) internal paymentMethodRiskWindow;
@@ -245,18 +245,18 @@ contract DisputeProtectionPolicy is IDisputeProtectionPolicy, Ownable2Step, Reen
     /* ============ Depositor Functions ============ */
 
     /**
-     * @notice DEPOSITOR ONLY: Enables or disables dispute protection for a deposit.
-     * @dev OrchestratorV3 validates Escrow registration before signaling an intent. This policy only verifies that
-     * the caller is the deposit's current depositor.
+     * @notice DEPOSITOR ONLY: Updates the default-on dispute protection setting for a deposit.
+     * @dev Protection is enabled by default. OrchestratorV3 validates Escrow registration before signaling an intent;
+     * this policy only verifies that the caller is the deposit's current depositor.
      * @param _escrow Escrow containing the deposit.
      * @param _depositId Deposit whose dispute protection configuration is updated.
-     * @param _isEnabled Whether non-whitelisted takers may use stake-backed dispute protection.
+     * @param _isEnabled Whether non-whitelisted takers may use stake-backed dispute protection; false opts out.
      */
     function setDisputeProtectionEnabled(address _escrow, uint256 _depositId, bool _isEnabled)
         external
         onlyDepositor(_escrow, _depositId)
     {
-        isDepositDisputeProtectionEnabled[_escrow][_depositId] = _isEnabled;
+        isDepositDisputeProtectionDisabled[_escrow][_depositId] = !_isEnabled;
         emit DisputeProtectionEnabledUpdated(_escrow, _depositId, _isEnabled);
     }
 
@@ -301,7 +301,12 @@ contract DisputeProtectionPolicy is IDisputeProtectionPolicy, Ownable2Step, Reen
 
     /**
      * @notice GOVERNANCE ONLY: Pauses or resumes new dispute-protection admissions.
-     * @dev Cancellation, settlement, release, and dispute submission remain available while admissions are paused.
+     * @dev Protection is enabled by default, so pausing acts as a protocol-wide kill switch, not as a per-deposit
+     * control. It rejects every non-whitelisted taker on every covered deposit whose payment method has a nonzero risk
+     * window. Whitelisted takers return from the lifecycle hook before this policy is reached, and payment methods with
+     * a zero risk window return before the pause check. Deposits that opt out do not call this policy; when their
+     * whitelist is disabled, they remain open. Cancellation, settlement, release, and dispute submission remain
+     * available while admissions are paused.
      * @param _isPaused Whether new dispute protection admissions should revert.
      */
     function setAdmissionsPaused(bool _isPaused) external onlyOwner {
@@ -337,10 +342,13 @@ contract DisputeProtectionPolicy is IDisputeProtectionPolicy, Ownable2Step, Reen
     }
 
     /**
-     * @inheritdoc IDisputeProtectionPolicy
+     * @notice Returns whether default-on stake-backed dispute protection remains enabled for a deposit.
+     * @dev Returns true for untouched deposits and false only after the depositor opts out.
+     * @param _escrow Escrow containing the deposit.
+     * @param _depositId Deposit whose dispute protection configuration is queried.
      */
     function isDisputeProtectionEnabled(address _escrow, uint256 _depositId) external view override returns (bool) {
-        return isDepositDisputeProtectionEnabled[_escrow][_depositId];
+        return !isDepositDisputeProtectionDisabled[_escrow][_depositId];
     }
 
     /**
@@ -375,7 +383,7 @@ contract DisputeProtectionPolicy is IDisputeProtectionPolicy, Ownable2Step, Reen
         if (disputeProtectionIntentByIntentHash[_intentHash].status != DisputeProtectionIntentStatus.NONE) {
             revert DisputeProtectionIntentAlreadyExists(_intentHash);
         }
-        if (!isDepositDisputeProtectionEnabled[_escrow][_depositId]) {
+        if (isDepositDisputeProtectionDisabled[_escrow][_depositId]) {
             revert DisputeProtectionNotEnabled(_escrow, _depositId);
         }
 

--- a/contracts/hooks/IntentLifecycleHookV1.sol
+++ b/contracts/hooks/IntentLifecycleHookV1.sol
@@ -10,10 +10,11 @@ import {IWhitelistPolicy} from "../interfaces/IWhitelistPolicy.sol";
 
 /**
  * @title IntentLifecycleHookV1
- * @notice Lifecycle hook combining deposit-scoped whitelist admission with optional stake-backed dispute coverage.
- * Whitelisted takers bypass staking; non-whitelisted takers may be admitted through a deposit with dispute protection.
+ * @notice Lifecycle hook combining a deposit-scoped whitelist fast lane with default-on stake-backed dispute protection.
+ * Whitelisted takers bypass staking. Non-whitelisted takers use stake-backed admission for disputable payment methods
+ * unless the depositor opts out; an enabled whitelist then rejects them, while a whitelist-disabled deposit stays open.
  * Non-disputable payment methods give every taker direct access without a dispute protection intent or stake lock,
- * regardless of whitelist state. Open deposits remain unrestricted when neither policy is enabled.
+ * regardless of whitelist or dispute protection configuration.
  * @dev Reads canonical intent data from the calling orchestrator and forwards cancellation and settlement accounting
  * to DisputeProtectionPolicy. All callbacks remain fail-closed. This hook serves every registered orchestrator and
  * forwards lifecycle callbacks without provenance checks; the trust argument lives in DisputeProtectionPolicy's header.

--- a/contracts/interfaces/IDisputeProtectionPolicy.sol
+++ b/contracts/interfaces/IDisputeProtectionPolicy.sol
@@ -140,7 +140,8 @@ interface IDisputeProtectionPolicy {
     function onIntentSettled(bytes32 _intentHash, uint256 _releaseAmount, bool _isManualRelease) external;
 
     /**
-     * @notice Returns whether a deposit opted into stake-backed dispute protection.
+     * @notice Returns whether default-on stake-backed dispute protection remains enabled for a deposit.
+     * @dev Returns true unless the depositor explicitly opts out.
      * @param _escrow Escrow containing the deposit.
      * @param _depositId Deposit whose dispute protection configuration is queried.
      */

--- a/test-foundry/deterministic/hooks/DisputeProtectionPolicy.t.sol
+++ b/test-foundry/deterministic/hooks/DisputeProtectionPolicy.t.sol
@@ -42,6 +42,9 @@ contract DisputeProtectionPolicyTest is OrchestratorV3Fixture {
     );
     event LifecycleHookAuthorizationUpdated(address indexed hook, bool authorized);
     event DisputeVerifierUpdated(address indexed previousVerifier, address indexed newVerifier);
+    event DisputeProtectionEnabledUpdated(
+        address indexed escrow, uint256 indexed depositId, bool isDisputeProtectionEnabled
+    );
 
     uint64 internal constant RISK_WINDOW = 30 days;
     uint256 internal constant STAKE_AMOUNT = 500e6;
@@ -67,8 +70,6 @@ contract DisputeProtectionPolicyTest is OrchestratorV3Fixture {
         disputeNullifierRegistry.addWritePermission(address(disputeProtectionPolicy));
         disputeProtectionPolicy.setLifecycleHookAuthorization(address(this), true);
         disputeProtectionPolicy.setRiskWindow(METHOD, RISK_WINDOW);
-        vm.prank(depositor);
-        disputeProtectionPolicy.setDisputeProtectionEnabled(address(escrow), depositId, true);
         _stake(taker, STAKE_AMOUNT);
     }
 
@@ -77,7 +78,7 @@ contract DisputeProtectionPolicyTest is OrchestratorV3Fixture {
         new DisputeProtectionPolicy(address(0), vault, disputeVerifier, disputeNullifierRegistry);
     }
 
-    function test_onIntentSignaledLocksStakeAndSnapshotsConfiguration() public {
+    function test_onIntentSignaledUntouchedDepositLocksStakeAndSnapshotsConfiguration() public {
         disputeProtectionPolicy.onIntentSignaled(INTENT, address(escrow), depositId, taker, METHOD, INTENT_AMOUNT);
         disputeProtectionPolicy.setRiskWindow(METHOD, 7 days);
         assertEq(disputeProtectionPolicy.getRiskWindow(METHOD), 7 days);
@@ -157,8 +158,6 @@ contract DisputeProtectionPolicyTest is OrchestratorV3Fixture {
     function test_onIntentSignaledRejectsWrongTokenAndLetsVaultEnforceCollateral() public {
         USDCMock otherToken = new USDCMock(1_000e6, "Other", "OTHER");
         DisputeProtectionEscrowMock wrongTokenEscrow = new DisputeProtectionEscrowMock(depositor, otherToken);
-        vm.prank(depositor);
-        disputeProtectionPolicy.setDisputeProtectionEnabled(address(wrongTokenEscrow), depositId, true);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IDisputeProtectionPolicy.IntentTokenMismatch.selector, address(token), address(otherToken)
@@ -462,7 +461,12 @@ contract DisputeProtectionPolicyTest is OrchestratorV3Fixture {
         disputeProtectionPolicy.releaseMaturedDisputeProtectionIntent(INTENT);
     }
 
-    function test_SetDisputeProtectionEnabledEnforcesDepositorAndHandlesMissingDeposit() public {
+    function test_isDisputeProtectionEnabledDefaultsTrueForUntouchedAndMissingDeposits() public view {
+        assertTrue(disputeProtectionPolicy.isDisputeProtectionEnabled(address(escrow), depositId));
+        assertTrue(disputeProtectionPolicy.isDisputeProtectionEnabled(address(escrow), type(uint256).max));
+    }
+
+    function test_SetDisputeProtectionEnabledEnforcesDepositorHandlesMissingDepositAndRoundTrips() public {
         vm.expectRevert(
             abi.encodeWithSelector(IDisputeProtectionPolicy.NotDepositor.selector, address(escrow), depositId, other)
         );
@@ -477,9 +481,17 @@ contract DisputeProtectionPolicyTest is OrchestratorV3Fixture {
         );
         disputeProtectionPolicy.setDisputeProtectionEnabled(address(escrow), missingDeposit, true);
 
+        vm.expectEmit(true, true, false, true);
+        emit DisputeProtectionEnabledUpdated(address(escrow), depositId, false);
         vm.prank(depositor);
         disputeProtectionPolicy.setDisputeProtectionEnabled(address(escrow), depositId, false);
         assertFalse(disputeProtectionPolicy.isDisputeProtectionEnabled(address(escrow), depositId));
+
+        vm.expectEmit(true, true, false, true);
+        emit DisputeProtectionEnabledUpdated(address(escrow), depositId, true);
+        vm.prank(depositor);
+        disputeProtectionPolicy.setDisputeProtectionEnabled(address(escrow), depositId, true);
+        assertTrue(disputeProtectionPolicy.isDisputeProtectionEnabled(address(escrow), depositId));
     }
 
     function test_AcceptVaultControllerCompletesDelayedTwoStepHandover() public {

--- a/test-foundry/deterministic/integration/DisputeLifecycleHookOrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/DisputeLifecycleHookOrchestratorV3.t.sol
@@ -54,9 +54,9 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         _stake(taker, STAKE_AMOUNT);
     }
 
-    function test_WhitelistOnWhitelistedWithDisputeProtectionOnSkipsStake() public {
+    function test_WhitelistOnWhitelistedOptedOutSkipsStake() public {
         _setWhitelist(true, true);
-        _setDisputeProtection(true);
+        _setDisputeProtection(false);
 
         bytes32 intentHash = _signalDefault();
 
@@ -68,16 +68,18 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         assertEq(escrow.getDepositIntent(depositId, intentHash).intentHash, intentHash);
     }
 
-    function test_WhitelistOnNonMemberWithDisputeProtectionOnRequiresStakeBeforeEscrowLock() public {
+    function test_WhitelistOnNonMemberDefaultRequiresStakeBeforeEscrowLock() public {
         _setWhitelist(true, false);
-        _setDisputeProtection(true);
         bytes32 intentHash = _signalDefault();
         assertEq(vault.lockedStake(taker), INTENT_AMOUNT);
         assertEq(
             uint256(disputeProtectionPolicy.getDisputeProtectionIntent(intentHash).status),
             uint256(IDisputeProtectionPolicy.DisputeProtectionIntentStatus.PENDING)
         );
+    }
 
+    function test_WhitelistOnNonMemberDefaultRejectsInsufficientStakeViaVault() public {
+        _setWhitelist(true, false);
         uint256 counterBefore = orchestrator.intentCounter();
         bytes32 rejectedIntent = _intentHash(counterBefore);
         uint256 remainingBefore = escrow.getDeposit(depositId).remainingDeposits;
@@ -90,10 +92,9 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         assertEq(escrow.getDeposit(depositId).remainingDeposits, remainingBefore);
     }
 
-    function test_WhitelistOnNonMemberNonDisputableMethodGetsDirectAccess() public {
+    function test_WhitelistOnNonMemberDefaultNonDisputableMethodGetsDirectAccess() public {
         _addPaymentMethod(WINDOWLESS_METHOD);
         _setWhitelist(true, false);
-        _setDisputeProtection(true);
         IOrchestratorV3.SignalIntentParams memory params = _paramsFor(other);
         params.paymentMethod = WINDOWLESS_METHOD;
 
@@ -114,8 +115,9 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         );
     }
 
-    function test_WhitelistOnNonMemberWithDisputeProtectionOffRejects() public {
+    function test_WhitelistOnNonMemberOptedOutRejects() public {
         _setWhitelist(true, false);
+        _setDisputeProtection(false);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IntentLifecycleHookV1.TakerNotWhitelisted.selector, address(escrow), depositId, taker
@@ -124,8 +126,7 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         _signalCall(taker, _defaultParams());
     }
 
-    function test_WhitelistOffDisputeProtectionOnRequiresStakeForEveryTaker() public {
-        _setDisputeProtection(true);
+    function test_WhitelistOffDefaultRequiresStakeForEveryTaker() public {
         assertNotEq(_signalDefault(), bytes32(0));
         vm.expectRevert(
             abi.encodeWithSelector(IStakeVault.InsufficientFreeStake.selector, other, uint256(0), INTENT_AMOUNT)
@@ -133,9 +134,8 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         _signalCall(other, _paramsFor(other));
     }
 
-    function test_WhitelistOffDisputeProtectionOnNonDisputableMethodIsOpen() public {
+    function test_WhitelistOffDefaultNonDisputableMethodIsOpen() public {
         _addPaymentMethod(WINDOWLESS_METHOD);
-        _setDisputeProtection(true);
         IOrchestratorV3.SignalIntentParams memory params = _paramsFor(other);
         params.paymentMethod = WINDOWLESS_METHOD;
 
@@ -153,7 +153,8 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         _signalCall(other, _paramsFor(other));
     }
 
-    function test_WhitelistOffDisputeProtectionOffIsOpenAndCreatesNoDisputeProtectionIntent() public {
+    function test_WhitelistOffOptedOutIsOpenAndCreatesNoDisputeProtectionIntent() public {
+        _setDisputeProtection(false);
         bytes32 intentHash = _signal(other, _paramsFor(other));
         assertEq(
             uint256(disputeProtectionPolicy.getDisputeProtectionIntent(intentHash).status),
@@ -269,6 +270,7 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
     }
 
     function test_CancellationWithoutDisputeProtectionIntentLeavesVaultUntouched() public {
+        _setDisputeProtection(false);
         bytes32 intentHash = _signalDefault();
         uint256 totalBefore = vault.totalStaked();
         vm.prank(taker);

--- a/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/IntentLifecycleHookV1OrchestratorV3.t.sol
@@ -77,6 +77,8 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
     function test_EnabledEmptyPolicyFailsClosedBeforeEscrowLock() public {
         vm.prank(depositor);
         policy.setEnabled(address(escrow), depositId, true);
+        vm.prank(depositor);
+        disputeProtectionPolicy.setDisputeProtectionEnabled(address(escrow), depositId, false);
 
         uint256 counterBefore = orchestrator.intentCounter();
         bytes32 rejectedIntent = _intentHash(counterBefore);
@@ -98,6 +100,8 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
     function test_NonMemberRejectedAndMemberAccepted() public {
         vm.prank(depositor);
         policy.configureDeposit(address(escrow), depositId, true, _groupIds(PEERS), new address[](0));
+        vm.prank(depositor);
+        disputeProtectionPolicy.setDisputeProtectionEnabled(address(escrow), depositId, false);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -135,6 +139,8 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
 
         vm.prank(depositor);
         policy.configureDeposit(address(escrow), depositId, true, _groupIds(PEERS), new address[](0));
+        vm.prank(depositor);
+        disputeProtectionPolicy.setDisputeProtectionEnabled(address(escrow), depositId, false);
 
         IOrchestratorV3.SignalIntentParams memory otherMethodParams = _defaultParams();
         otherMethodParams.paymentMethod = OTHER_METHOD;
@@ -159,6 +165,7 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
     function test_PolicyIsScopedToDepositNotMaker() public {
         vm.startPrank(depositor);
         policy.configureDeposit(address(escrow), depositId, true, _groupIds(PEERS), new address[](0));
+        disputeProtectionPolicy.setDisputeProtectionEnabled(address(escrow), depositId, false);
         uint256 secondDepositId = _createDeposit(address(0), delegate);
         vm.stopPrank();
 
@@ -169,8 +176,10 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
         secondDepositParams.depositId = secondDepositId;
         assertNotEq(_signal(taker, secondDepositParams), bytes32(0));
 
-        vm.prank(depositor);
+        vm.startPrank(depositor);
         policy.configureDeposit(address(escrow), secondDepositId, true, _groupIds(PEERS), new address[](0));
+        disputeProtectionPolicy.setDisputeProtectionEnabled(address(escrow), secondDepositId, false);
+        vm.stopPrank();
         vm.expectPartialRevert(IntentLifecycleHookV1.TakerNotWhitelisted.selector);
         _signalCall(taker, secondDepositParams);
     }
@@ -267,6 +276,8 @@ contract IntentLifecycleHookV1OrchestratorV3Test is OrchestratorV3Fixture {
     function _enablePeerPolicyAndAddTaker() internal {
         vm.prank(depositor);
         policy.configureDeposit(address(escrow), depositId, true, _groupIds(PEERS), new address[](0));
+        vm.prank(depositor);
+        disputeProtectionPolicy.setDisputeProtectionEnabled(address(escrow), depositId, false);
         _addMembers(PEERS, taker);
     }
 

--- a/test-foundry/deterministic/integration/WhitelistLifecycleHookOrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/WhitelistLifecycleHookOrchestratorV3.t.sol
@@ -120,9 +120,6 @@ contract WhitelistLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         (StakeVault vault, DisputeProtectionPolicy disputeProtectionPolicy, IntentLifecycleHookV1 combinedHook) =
             _deployDisputeStack();
 
-        vm.prank(depositor);
-        disputeProtectionPolicy.setDisputeProtectionEnabled(address(escrow), depositId, true);
-
         bytes32 oldCancelledIntent = _signalDefault();
         bytes32 oldSettledIntent = _signalDefault();
         assertEq(address(orchestrator.getIntentLifecycleHook(oldCancelledIntent)), address(whitelistHook));


### PR DESCRIPTION
> **Rebased onto `main` @ `5974114`** (the `DisputePolicy` → `DisputeProtectionPolicy` rename, #258). The three earlier commits — `edb3cf0`, `ef51a6e`, `261ba1a` — are superseded and folded into the single commit here, because main rewrote every file this branch touched. Pre-rebase state is preserved locally at `backup/dispute-opt-out-prerebase`.

## Summary

- Flips stake-backed dispute protection from opt-in to **opt-out**. `DisputeProtectionPolicy` stored a per-deposit bool defaulting to `false`; it now stores `isDisputeProtectionDisabled` and derives `isDisputeProtectionEnabled` from its negation.
- `setDisputeProtectionEnabled(address,uint256,bool)` keeps its exact signature, its `onlyDepositor` auth, and its `DisputeProtectionEnabledUpdated` payload (the bool still means "is enabled"). No external surface moves.
- **The generated `DisputeProtectionPolicy` ABI is byte-identical to `main`** (54 entries, zero diff), so there is no package or indexer ABI churn.
- No deployment implications: the dispute stack is not live on `base_staging` or `base` (no artifacts; lanes `31`/`32` are staging-only and unrun), so there is no per-deposit state to migrate.

## Changes

**Source**
- `contracts/hooks/DisputeProtectionPolicy.sol` — mapping renamed to `isDisputeProtectionDisabled`; setter writes the negation; getter returns the negation; `_validateIntentAdmission` guard inverted. `DisputeProtectionNotEnabled` retained — it still describes the state accurately.
- `contracts/interfaces/IDisputeProtectionPolicy.sol` — `isDisputeProtectionEnabled` NatSpec restated for opt-out.
- `contracts/hooks/IntentLifecycleHookV1.sol` — **header prose only, no logic change.** Its previous claim that open deposits are unrestricted when neither policy is enabled became false.
- `setAdmissionsPaused` NatSpec — records that pausing is now a protocol-wide kill switch rather than a per-deposit control, and names both escape hatches (whitelisted takers return from the lifecycle hook before this policy is reached; zero-risk-window methods return before the pause check).

**Tests** — `DisputeProtectionPolicy.t.sol` `setUp` no longer enables protection, so the suite exercises the default path. Added: untouched-deposit admission, getter defaulting true for untouched *and* nonexistent deposits, opt-out/re-enable round-trip with event assertions, and token-mismatch revert under the default. Integration suites re-assert the admission matrix, including StakeVault's `InsufficientFreeStake` as the failure mode replacing `TakerNotWhitelisted`, and whitelist-enforcement tests now opt out explicitly.

## Admission table after this change

Rows marked **changed** differ for a deposit whose depositor never called the setter.

| WL enabled | whitelisted | protection config | method disputable | outcome |
| --- | --- | --- | --- | --- |
| yes | yes | any | any | allow, no stake |
| yes | no | default | yes | **changed** — stake-backed or revert (was `TakerNotWhitelisted`) |
| yes | no | default | no | allow, no stake, no whitelist check |
| yes | no | opted out | any | revert `TakerNotWhitelisted` |
| no | any | default | yes | **changed** — every taker stakes (was open) |
| no | any | default | no | open (pass-through) |
| no | any | opted out | any | open |

## Deliberately accepted consequences

Each was raised during design and explicitly confirmed. These are choices, not oversights:

1. A whitelist-gated deposit admits any staked taker on a disputable method — the whitelist becomes a skip-staking fast lane rather than a hard gate.
2. A payment method with `riskWindow == 0` still bypasses an enabled whitelist entirely, because the early return in `onIntentSignaled` precedes every other check. **Governance invariant: call `setRiskWindow` before adding a payment method.**
3. Non-USDC deposits revert `IntentTokenMismatch` for non-whitelisted takers until the depositor opts out. Chosen so misconfiguration fails loudly rather than silently dropping protection.
4. `admissionsPaused` becomes a protocol-wide kill switch. Now documented at the function.

## Required companion change (not in this PR)

zkp2p-indexer seeds its enablement projection from `DisputeProtectionEnabledUpdated` events. **Absence of an event now means enabled.** Tracked as zkp2p-indexer#249, stacked on zkp2p-indexer#242.

## Test Plan

- [x] `forge build` clean
- [x] `DisputeProtectionPolicy.t.sol` — 21 passed
- [x] Three lifecycle-hook integration suites — 37 passed
- [x] `yarn test` — **1451 passed, 0 failed**
- [x] ABI unchanged vs `5974114`: stashed, built main, extracted `jq -S .abi`, restored, rebuilt, diffed — 54 entries, zero diff
- [x] `yarn pkg:extract` — no package diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJGB69Mh3333JGyh1V7cfF