### PR TITLE
fix(release): isolate workflow test environment

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -2,7 +2,7 @@
 
 Official npm package for ZKP2P V2 smart contract interfaces, ABIs, addresses, and utilities.
 
-## Release 0.4.1-rc.1
+## Release 0.4.1-rc.2
 
 - Exports the canonical source ABIs for `DisputeNullifierRegistry`, `DisputeProtectionPolicy`,
   `DisputeVerifier`, `IntentLifecycleHookV1`, and `StakeVault`.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/contracts-v2",
-  "version": "0.4.1-rc.1",
+  "version": "0.4.1-rc.2",
   "description": "ZKP2P V2 smart contract interfaces and utilities",
   "main": "./_cjs/index.js",
   "module": "./_esm/index.js",

--- a/scripts/npm-release.spec.mjs
+++ b/scripts/npm-release.spec.mjs
@@ -60,9 +60,22 @@ function parseGitHubOutput(output) {
   );
 }
 
-function releaseEnvironment(overrides = {}) {
+const releaseWorkflowEnvironmentKeys = [
+  'DIST_TAG',
+  'EXPECTED_LATEST',
+  'EXPECTED_RC',
+  'RELEASE_ENVIRONMENT',
+  'RELEASE_TAG',
+  'RELEASE_VERSION',
+  'REQUIRE_PROVENANCE',
+];
+
+function releaseEnvironment(overrides = {}, ambientEnvironment = process.env) {
+  const environment = { ...ambientEnvironment };
+  for (const key of releaseWorkflowEnvironmentKeys) delete environment[key];
+
   return {
-    ...process.env,
+    ...environment,
     GITHUB_ACTIONS: 'false',
     LATEST_BASELINE: '0.3.0',
     RC_BASELINE: '0.4.0-rc.5',
@@ -306,8 +319,8 @@ function originalJobsFixture(overrides = {}) {
 test('resolves an RC from the committed release-line prerelease', () => {
   assert.deepEqual(
     resolveReleasePolicy({
-      release: '0.4.1-rc.1',
-      packageVersion: '0.4.1-rc.1',
+      release: '0.4.1-rc.2',
+      packageVersion: '0.4.1-rc.2',
     }),
     { channel: 'rc', distTag: 'rc', environment: 'npm-publish' },
   );
@@ -345,7 +358,7 @@ test('derives a future RC release line from the package version', () => {
 
 test('commits the next RC candidate while preserving stable release support', () => {
   const packageManifest = JSON.parse(fs.readFileSync(packageManifestPath, 'utf8'));
-  assert.equal(packageManifest.version, '0.4.1-rc.1');
+  assert.equal(packageManifest.version, '0.4.1-rc.2');
   assert.deepEqual(
     resolveReleasePolicy({
       release: '0.4.1',
@@ -353,6 +366,22 @@ test('commits the next RC candidate while preserving stable release support', ()
     }),
     { channel: 'stable', distTag: 'latest', environment: 'npm-publish' },
   );
+});
+
+test('release CLI fixtures do not inherit workflow policy variables', () => {
+  const environment = releaseEnvironment({}, {
+    PATH: process.env.PATH,
+    DIST_TAG: 'rc',
+    EXPECTED_LATEST: '0.4.0',
+    EXPECTED_RC: '0.4.0-rc.5',
+    RELEASE_ENVIRONMENT: 'npm-publish',
+    RELEASE_TAG: 'contracts-v2-v0.4.1-rc.1',
+    RELEASE_VERSION: '0.4.1-rc.1',
+    REQUIRE_PROVENANCE: 'true',
+  });
+
+  for (const key of releaseWorkflowEnvironmentKeys) assert.equal(environment[key], undefined);
+  assert.equal(environment.PATH, process.env.PATH);
 });
 
 test('publish workflow consumes the version-derived channel without RC-only paths', () => {


### PR DESCRIPTION
## Summary
- prevent workflow-level release variables from leaking into release-policy CLI fixtures
- add an explicit regression for the ambient GitHub Actions environment
- advance the unpublished package candidate to 0.4.1-rc.2 because rc.1 is already immutably tagged

## Failure evidence
Publish run 31486667787 stopped before packing or npm publication. The full Foundry suite passed, but five release-policy fixtures inherited DIST_TAG=rc while testing stable releases and failed closed.

## Validation
- full compile and package build passed
- package tests: 5/5 passed
- release verifier: 66 deployment-backed entries and 12 canonical ABIs
- release-policy tests under the workflow ambient variables: 111/111 passed
- npm pack dry run: @zkp2p/contracts-v2@0.4.1-rc.2, 701 entries
- git diff --check passed

## Release boundary
Do not move or reuse contracts-v2-v0.4.1-rc.1. After this PR merges and exact-main CI is green, create a new annotated contracts-v2-v0.4.1-rc.2 tag and dispatch the protected workflow only with fresh exact approval.