### PR TITLE
chore(deploy): reduce IntentGuardian fee to 1 bps per hour

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -85,8 +85,9 @@ jobs:
           corepack yarn compile
           corepack yarn pkg:build
           corepack yarn pkg:test
-      - name: Test V3 lifecycle deployment lanes
+      - name: Test deployment lanes
         run: |
+          corepack yarn test:intent-guardian-fee-update
           corepack yarn test:v3-groups-deployment
           corepack yarn test:dispute-lifecycle-deployment
       - name: Start local chain

--- a/deploy/33_set_intent_guardian_fee.ts
+++ b/deploy/33_set_intent_guardian_fee.ts
@@ -1,0 +1,78 @@
+import "module-alias/register";
+
+import type { Contract } from "ethers";
+import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+import {
+  INTENT_GUARDIAN_EXTENSION_FEE_BPS_PER_HOUR,
+  MULTI_SIG,
+} from "../deployments/parameters";
+import {
+  getDeployedContractAddress,
+  waitForDeploymentDelay,
+} from "../deployments/helpers";
+import { safeBatchCollector } from "../deployments/safeBatchCollector";
+
+const SUPPORTED_NETWORKS = new Set(["localhost", "hardhat", "base_staging", "base"]);
+
+function sameAddress(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+export async function setIntentGuardianFee(
+  hre: HardhatRuntimeEnvironment,
+  guardian: Contract,
+): Promise<void> {
+  const network = hre.deployments.getNetworkName();
+  const targetFee = INTENT_GUARDIAN_EXTENSION_FEE_BPS_PER_HOUR[network];
+  const currentFee = await guardian.extensionFeeBpsPerHour();
+  if (currentFee.eq(targetFee)) return;
+
+  const accounts = await hre.getUnnamedAccounts();
+  const deployer = accounts[0];
+  const expectedOwner = MULTI_SIG[network] || deployer;
+  const owner = await guardian.owner();
+  if (!sameAddress(owner, expectedOwner)) {
+    throw new Error(`IntentGuardian owner mismatch: expected ${expectedOwner}, found ${owner}`);
+  }
+
+  const data = guardian.interface.encodeFunctionData("setExtensionFeeBpsPerHour", [targetFee]);
+  if (accounts.some((account) => sameAddress(account, owner))) {
+    const signer = await hre.ethers.getSigner(owner);
+    await (await guardian.connect(signer).setExtensionFeeBpsPerHour(targetFee)).wait();
+    await waitForDeploymentDelay(hre);
+    return;
+  }
+
+  safeBatchCollector.add(
+    guardian.address,
+    data,
+    `IntentGuardian.setExtensionFeeBpsPerHour(${targetFee})`,
+  );
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const network = hre.deployments.getNetworkName();
+  const guardianAddress = getDeployedContractAddress(network, "IntentGuardian");
+  const guardian = await ethers.getContractAt("IntentGuardian", guardianAddress);
+
+  await setIntentGuardianFee(hre, guardian);
+};
+
+func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> => {
+  const network = hre.deployments.getNetworkName();
+  if (!SUPPORTED_NETWORKS.has(network)) return true;
+
+  const guardianAddress = getDeployedContractAddress(network, "IntentGuardian");
+  const guardian = await ethers.getContractAt("IntentGuardian", guardianAddress);
+  return (await guardian.extensionFeeBpsPerHour()).eq(
+    INTENT_GUARDIAN_EXTENSION_FEE_BPS_PER_HOUR[network],
+  );
+};
+
+func.tags = ["33_set_intent_guardian_fee", "IntentGuardianFee"];
+func.dependencies = ["28_deploy_intent_guardian"];
+
+export default func;

--- a/deployments/parameters.ts
+++ b/deployments/parameters.ts
@@ -171,10 +171,10 @@ export const ORCHESTRATOR_V3_PROTOCOL_FEE_RECIPIENT: any = {
 // Initial hourly fee for the standalone IntentGuardian, denominated in basis points of the
 // locked intent amount. Governance can update this value on the deployed guardian.
 export const INTENT_GUARDIAN_EXTENSION_FEE_BPS_PER_HOUR: Record<string, number> = {
-  localhost: 2,
-  hardhat: 2,
-  base_staging: 2,
-  base: 2,
+  localhost: 1,
+  hardhat: 1,
+  base_staging: 1,
+  base: 1,
 };
 
 // Pyth Network contract addresses

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:deterministic": "forge test --match-path 'test-foundry/deterministic/**/*.t.sol'",
     "test:fuzz": "forge test --match-path 'test-foundry/fuzz/**/*.t.sol'",
     "test:invariant": "forge test --match-path 'test-foundry/invariant/**/*.t.sol'",
+    "test:intent-guardian-fee-update": "node --test scripts/intent-guardian-fee-update.spec.cjs",
     "test:dispute-lifecycle-deployment": "node scripts/test-dispute-lifecycle-deployment.cjs",
     "test:v3-groups-deployment": "node scripts/test-v3-groups-base-deployment.cjs prepare-resume && node scripts/test-v3-groups-base-deployment.cjs reject-mismatch",
     "test:release-policy": "node --test scripts/verify-github-environment.spec.mjs scripts/npm-release.spec.mjs",

--- a/scripts/intent-guardian-fee-update.spec.cjs
+++ b/scripts/intent-guardian-fee-update.spec.cjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+process.env.DEPLOY_TX_DELAY_MS = "0";
+process.env.ALCHEMY_API_KEY ||= "offline";
+process.env.BASE_DEPLOY_PRIVATE_KEY ||=
+  "1111111111111111111111111111111111111111111111111111111111111111";
+process.env.TESTNET_DEPLOY_PRIVATE_KEY ||=
+  "2222222222222222222222222222222222222222222222222222222222222222";
+
+require("ts-node/register/transpile-only");
+require("module-alias/register");
+
+const moduleAlias = require("module-alias");
+moduleAlias.reset();
+moduleAlias.addAlias("@utils", process.cwd() + "/utils");
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { BigNumber, utils } = require("ethers");
+
+const { MULTI_SIG } = require("../deployments/parameters.ts");
+const { safeBatchCollector } = require("../deployments/safeBatchCollector.ts");
+const { setIntentGuardianFee } = require("../deploy/33_set_intent_guardian_fee.ts");
+
+const DEPLOYER = "0x1000000000000000000000000000000000000001";
+const OTHER = "0x2000000000000000000000000000000000000002";
+const GUARDIAN = "0x3000000000000000000000000000000000000003";
+const guardianInterface = new utils.Interface([
+  "function setExtensionFeeBpsPerHour(uint256)",
+]);
+
+function fakeHre(network, accounts) {
+  return {
+    deployments: { getNetworkName: () => network },
+    ethers: { getSigner: async (address) => ({ address }) },
+    getUnnamedAccounts: async () => accounts,
+  };
+}
+
+function fakeGuardian(initialFee, owner) {
+  let fee = BigNumber.from(initialFee);
+  let setterCalls = 0;
+
+  const guardian = {
+    address: GUARDIAN,
+    interface: guardianInterface,
+    extensionFeeBpsPerHour: async () => fee,
+    owner: async () => owner,
+    connect: () => ({
+      setExtensionFeeBpsPerHour: async (newFee) => {
+        setterCalls += 1;
+        fee = BigNumber.from(newFee);
+        return { wait: async () => undefined };
+      },
+    }),
+  };
+
+  return {
+    guardian,
+    fee: () => fee,
+    setterCalls: () => setterCalls,
+  };
+}
+
+test("sets the fee directly when the owner account is available", async () => {
+  const state = fakeGuardian(2, DEPLOYER);
+
+  await setIntentGuardianFee(fakeHre("hardhat", [DEPLOYER]), state.guardian);
+
+  assert.equal(state.fee().toString(), "1");
+  assert.equal(state.setterCalls(), 1);
+});
+
+test("queues exactly one Safe call when governance owns the guardian", async () => {
+  const state = fakeGuardian(2, MULTI_SIG.base);
+  const queuedBefore = safeBatchCollector.count();
+
+  await setIntentGuardianFee(fakeHre("base", [DEPLOYER]), state.guardian);
+
+  const queued = safeBatchCollector.getTransactionsSince(queuedBefore);
+  assert.equal(queued.length, 1);
+  assert.equal(queued[0].to, GUARDIAN);
+  assert.equal(
+    queued[0].data,
+    guardianInterface.encodeFunctionData("setExtensionFeeBpsPerHour", [1]),
+  );
+  assert.equal(state.setterCalls(), 0);
+});
+
+test("does nothing when the guardian already charges one bps per hour", async () => {
+  const state = fakeGuardian(1, OTHER);
+  const queuedBefore = safeBatchCollector.count();
+
+  await setIntentGuardianFee(fakeHre("hardhat", [DEPLOYER]), state.guardian);
+
+  assert.equal(safeBatchCollector.count(), queuedBefore);
+  assert.equal(state.setterCalls(), 0);
+});
+
+test("rejects an unexpected guardian owner", async () => {
+  const state = fakeGuardian(2, OTHER);
+  const queuedBefore = safeBatchCollector.count();
+
+  await assert.rejects(
+    setIntentGuardianFee(fakeHre("hardhat", [DEPLOYER]), state.guardian),
+    /IntentGuardian owner mismatch/,
+  );
+  assert.equal(safeBatchCollector.count(), queuedBefore);
+  assert.equal(state.setterCalls(), 0);
+});


### PR DESCRIPTION
## Summary
- set the paid IntentGuardian extension fee to 1 bps per hour on all supported networks
- add an idempotent deployment lane that updates existing guardians directly or queues one Base Safe call
- test direct execution, Safe preparation, the already-configured no-op, and owner mismatch rejection

## Verification
- `corepack yarn test:intent-guardian-fee-update`
- `corepack yarn tsc --noEmit`
- `corepack yarn compile`
- `git diff --check`

## Deployment impact
- no contract, ABI, address, or storage changes
- merging does not execute a live transaction
- Base requires execution of the generated governance Safe call; Base staging uses its configured owner account