### PR TITLE
fix: correct dispute deployment preflights

### DIFF
--- a/deploy/32_deploy_and_activate_dispute_lifecycle_stack.ts
+++ b/deploy/32_deploy_and_activate_dispute_lifecycle_stack.ts
@@ -23,11 +23,12 @@ type HistoricalDeployFunction = {
 
 type HistoricalContractEvidence = {
   address: string;
+  deploymentBytecodeHash: string;
   runtimeCodeHash: string;
 };
 
 type HistoricalDisputeStack = {
-  activeLifecycleHook: HistoricalContractEvidence;
+  activeLifecycleHook: Omit<HistoricalContractEvidence, "deploymentBytecodeHash">;
   contracts: Record<string, HistoricalContractEvidence>;
 };
 
@@ -40,50 +41,60 @@ export const PREDECESSOR_DISPUTE_STACKS: Record<string, HistoricalDisputeStack> 
     contracts: {
       StakeVault: {
         address: "0x8B8e853f47e6e0d3944e3689197B35216933dDea",
-        runtimeCodeHash: "0x3ceac244f2d721614975457b041e95f661feba8ef6bbfc73c23b55aaac27d3e6",
+        deploymentBytecodeHash: "0x3ceac244f2d721614975457b041e95f661feba8ef6bbfc73c23b55aaac27d3e6",
+        runtimeCodeHash: "0xfd8d2a910b9ac2c55675ae06d0504f9aac43b02b7022755cf229b571156c681d",
       },
       DisputeProtectionPolicy: {
         address: "0xc086b6120B5e61EF48221E6A78c69737c9948dF9",
-        runtimeCodeHash: "0x6146f8eb152848ddfd40d67a152a44230ed783b6c1e768d023b88fc2a09cb38f",
+        deploymentBytecodeHash: "0x6146f8eb152848ddfd40d67a152a44230ed783b6c1e768d023b88fc2a09cb38f",
+        runtimeCodeHash: "0xf08bce9ad622b9d45ce310493627cbef3bf6c4ac915661d5bc572bb59b61e084",
       },
       IntentLifecycleHookV1: {
         address: "0x5B0017FCA6A2131701ef718e470a3930c1b6C12c",
-        runtimeCodeHash: "0xad298e1829958f431833bf1c0e53311f27e95dd29806c4d55aa75163e6dbcc21",
+        deploymentBytecodeHash: "0xad298e1829958f431833bf1c0e53311f27e95dd29806c4d55aa75163e6dbcc21",
+        runtimeCodeHash: "0xff9db07ce83908b7cedb31f8c085004aa78c91bb86e0565f11fad3e4bc36c5cb",
       },
       DisputeVerifier: {
         address: "0x30d4947f005653637005eed991005119D9eB2f34",
-        runtimeCodeHash: "0x7aae03ea4bd5bc953dc87b7a272ef967dc093a71b39417f4b7bd88f46210e876",
+        deploymentBytecodeHash: "0x7aae03ea4bd5bc953dc87b7a272ef967dc093a71b39417f4b7bd88f46210e876",
+        runtimeCodeHash: "0x65246e11392befc33d92246cf3ac2467d1f338a8b73c6514b76fab0a70a01ead",
       },
       DisputeNullifierRegistry: {
         address: "0xA845615b5203F7a21321DdF5e3a1ca024D93a443",
+        deploymentBytecodeHash: "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
         runtimeCodeHash: "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
       },
     },
   },
   base_staging: {
     activeLifecycleHook: {
-      address: "0xE8Fe714f848fAf7ecff7960AfD0C395771C22AA1",
-      runtimeCodeHash: "0xfe6624ddbdcca7a2469af6ad6aecd50eda492aae017ad959093b3db1fd7f298a",
+      address: "0x19D9F0Fcb08C60D8bd0CD061C34eae27eF8b6e65",
+      runtimeCodeHash: "0xba70239e37624f5808e2f79e100e83a17daeb1558f310543187f5d8a121ec367",
     },
     contracts: {
       StakeVault: {
         address: "0xEc9f801e2a9Cc22bdc217aD3BB1E3058d0668f43",
-        runtimeCodeHash: "0x3ceac244f2d721614975457b041e95f661feba8ef6bbfc73c23b55aaac27d3e6",
+        deploymentBytecodeHash: "0x3ceac244f2d721614975457b041e95f661feba8ef6bbfc73c23b55aaac27d3e6",
+        runtimeCodeHash: "0xfd8d2a910b9ac2c55675ae06d0504f9aac43b02b7022755cf229b571156c681d",
       },
       DisputeProtectionPolicy: {
         address: "0x21517b7743E727ae47A66FafF93550B689c15020",
-        runtimeCodeHash: "0x6146f8eb152848ddfd40d67a152a44230ed783b6c1e768d023b88fc2a09cb38f",
+        deploymentBytecodeHash: "0x6146f8eb152848ddfd40d67a152a44230ed783b6c1e768d023b88fc2a09cb38f",
+        runtimeCodeHash: "0x4e6617a94819ad15693289b173a9a66a78cfe1dd706f6b4fdc5a5f6ad6a32971",
       },
       IntentLifecycleHookV1: {
         address: "0x19D9F0Fcb08C60D8bd0CD061C34eae27eF8b6e65",
-        runtimeCodeHash: "0xad298e1829958f431833bf1c0e53311f27e95dd29806c4d55aa75163e6dbcc21",
+        deploymentBytecodeHash: "0xad298e1829958f431833bf1c0e53311f27e95dd29806c4d55aa75163e6dbcc21",
+        runtimeCodeHash: "0xba70239e37624f5808e2f79e100e83a17daeb1558f310543187f5d8a121ec367",
       },
       DisputeVerifier: {
         address: "0x973578148c5Fd49b9f68B50B26066555325AC708",
-        runtimeCodeHash: "0x7aae03ea4bd5bc953dc87b7a272ef967dc093a71b39417f4b7bd88f46210e876",
+        deploymentBytecodeHash: "0x7aae03ea4bd5bc953dc87b7a272ef967dc093a71b39417f4b7bd88f46210e876",
+        runtimeCodeHash: "0xb3b34734cfd162cd129d0c84285461c751321545213ec20164745b8e72f9dd6c",
       },
       DisputeNullifierRegistry: {
         address: "0xE0B05a9655AF0f31E32904267baa50FbC7f217ea",
+        deploymentBytecodeHash: "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
         runtimeCodeHash: "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
       },
     },
@@ -113,7 +124,7 @@ export async function assertHistoricalDisputeStack(hre: HistoricalRuntimeEnviron
     }
     if (
       typeof deployment.deployedBytecode !== "string" ||
-      ethers.utils.keccak256(deployment.deployedBytecode) !== expected.runtimeCodeHash
+      ethers.utils.keccak256(deployment.deployedBytecode) !== expected.deploymentBytecodeHash
     ) {
       throw new Error(`${name} predecessor deployment bytecode hash mismatch on ${network}`);
     }

--- a/deploy/34_deploy_opt_in_dispute_lifecycle_stack.ts
+++ b/deploy/34_deploy_opt_in_dispute_lifecycle_stack.ts
@@ -115,7 +115,7 @@ export const DEPLOY_ONLY_STEP_KINDS: Record<LiveNetwork, readonly string[]> = {
   ],
 };
 
-const EXPECTED_LIVE: Record<
+export const EXPECTED_LIVE: Record<
   LiveNetwork,
   {
     deployer: string;
@@ -145,13 +145,13 @@ const EXPECTED_LIVE: Record<
       "0xf0d132d621ac03181a6fade6a93bd0968d33830c8bf393793236787e7978aee1",
     whitelistPolicy: "0xBC53641b4B2504f0061D6a9426C61B8eBE9B4Ff0",
     whitelistPolicyCodeHash:
-      "0x68bd91b1dbb2d87201ad7b9f8ba14c4eb5c8d28d3dd794fb6299bb596855973a",
+      "0xa3cf0fdf3835887de432cbac9c192edf6c93a8589748aa93f8294333d57024b2",
     orchestrator: "0x014025fDE093f8701d86e9f38e2C3a9b779cb5c7",
     orchestratorCodeHash:
       "0x4e58f26129559301c017ff264b61dd2255ed2107593d308472ef32d07b8745e9",
     nullifierRegistryV2: "0x5455e761b866dfa6A2f5Dc6d6525825bf9C09aeB",
     nullifierRegistryV2CodeHash:
-      "0x1f0b423f44d0df7110fccf01861f7e0a99d80943dfe0531e8e96ef23f57ad9f8",
+      "0x423e2a2183ecd538864079b6268f41957028c25514d1de57bd3d0e70fa6b9bd4",
     attestationVerifier: "0x9Fe920b24e50e6a6362BA71a1BeB502A99c402d5",
     attestationVerifierCodeHash:
       "0x828a5dae520d3eaed904dfed56994dc6e892eb6416b58ad952c079e220ef841a",
@@ -173,13 +173,13 @@ const EXPECTED_LIVE: Record<
       "0xf0d132d621ac03181a6fade6a93bd0968d33830c8bf393793236787e7978aee1",
     whitelistPolicy: "0x7d9277cb8bb78a51eeaafB7CFF306E7DA4C972fD",
     whitelistPolicyCodeHash:
-      "0x68bd91b1dbb2d87201ad7b9f8ba14c4eb5c8d28d3dd794fb6299bb596855973a",
+      "0x917965fdc75580147ad0787c86f8b2a0f0185ef6e101567b82dc1245d6eb63bc",
     orchestrator: "0x2b5E8Ab562e45fA89D73802605E145ED3E3EeF4f",
     orchestratorCodeHash:
       "0x4e58f26129559301c017ff264b61dd2255ed2107593d308472ef32d07b8745e9",
     nullifierRegistryV2: "0x2eb43d6C7c7Ec4220Aa6B8735BC053824a71778C",
     nullifierRegistryV2CodeHash:
-      "0x1f0b423f44d0df7110fccf01861f7e0a99d80943dfe0531e8e96ef23f57ad9f8",
+      "0xd9d2f4b8bbca6fe26d7a0dfd7e0d6a6d63823ab2a1fe12971e752cf33dee72a0",
     attestationVerifier: "0x9855a39aC5975069632e91160d8712CBfF19e864",
     attestationVerifierCodeHash:
       "0x828a5dae520d3eaed904dfed56994dc6e892eb6416b58ad952c079e220ef841a",
@@ -965,14 +965,15 @@ async function readBasePredecessorCancellationState(
   return completed;
 }
 
-async function getSuccessorDeployments(
+export async function getSuccessorDeployments(
   hre: HardhatRuntimeEnvironment
 ): Promise<Array<any | null>> {
-  const deployments = await Promise.all(
+  const records = await Promise.all(
     LIVE_SUCCESSOR_DEPLOYMENT_NAMES.map((name) =>
       hre.deployments.getOrNull(name)
     )
   );
+  const deployments = records.map((deployment) => deployment ?? null);
   const firstMissing = deployments.findIndex(
     (deployment) => deployment === null
   );

--- a/docs/superpowers/specs/2026-08-20-dispute-protection-opt-in-cutover-design.md
+++ b/docs/superpowers/specs/2026-08-20-dispute-protection-opt-in-cutover-design.md
@@ -50,10 +50,12 @@ The implementation must re-read all state before acting. At approval time:
   `0x251d78fb6bBb4071995Bce74bAfC9E4168638622`.
 - Base's prepared default-on `IntentLifecycleHookV1` at
   `0x5B0017FCA6A2131701ef718e470a3930c1b6C12c` is passive.
-- Base staging OrchestratorV3 uses the pinned predecessor lifecycle hook at
-  `0xE8Fe714f848fAf7ecff7960AfD0C395771C22AA1`. The old default-on
-  `IntentLifecycleHookV1` at `0x19D9F0Fcb08C60D8bd0CD061C34eae27eF8b6e65`
-  remains separate predecessor evidence and is not the active hook.
+- Base staging OrchestratorV3 uses the old default-on `IntentLifecycleHookV1`
+  at `0x19D9F0Fcb08C60D8bd0CD061C34eae27eF8b6e65`. The staging EOA changed it
+  from `0xE8Fe714f848fAf7ecff7960AfD0C395771C22AA1` in transaction
+  `0x8fde3cda70c11ee70beae1a0c56e45e83bbea3375b9dcb09bc1e8a511a00ea25`
+  at block `49806712`; the successor deployment remains independent from that
+  already-completed staging hook swap.
 - The Base and Base-staging predecessor `StakeVault` contracts report zero
   `totalStaked` and zero `totalClaimable`.
 - The Base `DisputeNullifierRegistry` is already Safe-owned. The predecessor

--- a/scripts/test-dispute-lifecycle-deployment.cjs
+++ b/scripts/test-dispute-lifecycle-deployment.cjs
@@ -14,6 +14,7 @@ require("module-alias/register");
 const assert = require("node:assert/strict");
 const path = require("node:path");
 const dotenv = require("dotenv");
+const { ethers } = require("ethers");
 // @ts-expect-error module-alias does not publish declarations.
 const moduleAlias = require("module-alias");
 
@@ -24,6 +25,33 @@ moduleAlias.addAlias("@utils", process.cwd() + "/utils");
 const historicalLaneModule = require("../deploy/32_deploy_and_activate_dispute_lifecycle_stack.ts");
 const historicalLane = historicalLaneModule.default;
 const { PREDECESSOR_DISPUTE_STACKS } = historicalLaneModule;
+
+/** @type {Record<string, Record<string, string>>} */
+const EXPECTED_RUNTIME_HASHES = {
+  base: {
+    StakeVault: "0xfd8d2a910b9ac2c55675ae06d0504f9aac43b02b7022755cf229b571156c681d",
+    DisputeProtectionPolicy: "0xf08bce9ad622b9d45ce310493627cbef3bf6c4ac915661d5bc572bb59b61e084",
+    IntentLifecycleHookV1: "0xff9db07ce83908b7cedb31f8c085004aa78c91bb86e0565f11fad3e4bc36c5cb",
+    DisputeVerifier: "0x65246e11392befc33d92246cf3ac2467d1f338a8b73c6514b76fab0a70a01ead",
+    DisputeNullifierRegistry: "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
+  },
+  base_staging: {
+    StakeVault: "0xfd8d2a910b9ac2c55675ae06d0504f9aac43b02b7022755cf229b571156c681d",
+    DisputeProtectionPolicy: "0x4e6617a94819ad15693289b173a9a66a78cfe1dd706f6b4fdc5a5f6ad6a32971",
+    IntentLifecycleHookV1: "0xba70239e37624f5808e2f79e100e83a17daeb1558f310543187f5d8a121ec367",
+    DisputeVerifier: "0xb3b34734cfd162cd129d0c84285461c751321545213ec20164745b8e72f9dd6c",
+    DisputeNullifierRegistry: "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
+  },
+};
+
+/** @type {Record<string, string>} */
+const MOCK_RUNTIME_CODES = {
+  StakeVault: "0x6001",
+  DisputeProtectionPolicy: "0x6002",
+  IntentLifecycleHookV1: "0x6003",
+  DisputeVerifier: "0x6004",
+  DisputeNullifierRegistry: "0x6005",
+};
 
 /** @param {string} network */
 function localHre(network) {
@@ -84,7 +112,7 @@ function liveHre(network, { omit, addressDrift, codeDrift } = {}) {
           getCode: async (/** @type {string} */ address) => {
             for (const [name, artifact] of deployments) {
               if (artifact.address.toLowerCase() === address.toLowerCase()) {
-                return name === codeDrift ? "0x00" : artifact.deployedBytecode;
+                return name === codeDrift ? "0x00" : MOCK_RUNTIME_CODES[name];
               }
             }
             return "0x";
@@ -98,29 +126,59 @@ function liveHre(network, { omit, addressDrift, codeDrift } = {}) {
 
 async function run() {
   assert.ok(PREDECESSOR_DISPUTE_STACKS, "historical predecessor evidence is not exported");
+  assert.deepEqual(PREDECESSOR_DISPUTE_STACKS.base_staging.activeLifecycleHook, {
+    address: "0x19D9F0Fcb08C60D8bd0CD061C34eae27eF8b6e65",
+    runtimeCodeHash: "0xba70239e37624f5808e2f79e100e83a17daeb1558f310543187f5d8a121ec367",
+  });
   assert.equal(await historicalLane.skip(localHre("localhost")), true);
   assert.equal(await historicalLane.skip(localHre("hardhat")), true);
 
   /** @type {Array<"base" | "base_staging">} */
   const liveNetworks = ["base_staging", "base"];
   for (const network of liveNetworks) {
-    const exact = liveHre(network);
-    assert.equal(await historicalLane.skip(exact.hre), true);
-    await historicalLane(exact.hre);
-    assert.deepEqual(exact.mutationCounts(), { deployCalls: 0, rawTransactions: 0 });
+    for (const [name, evidence] of Object.entries(PREDECESSOR_DISPUTE_STACKS[network].contracts)) {
+      const artifact = require(path.join(process.cwd(), "deployments", network, `${name}.json`));
+      assert.equal(
+        evidence.deploymentBytecodeHash,
+        ethers.utils.keccak256(artifact.deployedBytecode),
+        `${network} ${name} must pin its deployment artifact separately from live runtime code`,
+      );
+      assert.equal(evidence.runtimeCodeHash, EXPECTED_RUNTIME_HASHES[network][name]);
+    }
 
-    await assert.rejects(
-      historicalLane.skip(liveHre(network, { omit: "StakeVault" }).hre),
-      /Missing predecessor deployment StakeVault/,
+    const originalRuntimeHashes = Object.fromEntries(
+      Object.entries(PREDECESSOR_DISPUTE_STACKS[network].contracts).map(([name, evidence]) => [
+        name,
+        evidence.runtimeCodeHash,
+      ]),
     );
-    await assert.rejects(
-      historicalLane.skip(liveHre(network, { addressDrift: "DisputeProtectionPolicy" }).hre),
-      /predecessor address mismatch/,
-    );
-    await assert.rejects(
-      historicalLane.skip(liveHre(network, { codeDrift: "IntentLifecycleHookV1" }).hre),
-      /predecessor runtime bytecode hash mismatch/,
-    );
+    try {
+      for (const [name, evidence] of Object.entries(PREDECESSOR_DISPUTE_STACKS[network].contracts)) {
+        evidence.runtimeCodeHash = ethers.utils.keccak256(MOCK_RUNTIME_CODES[name]);
+      }
+
+      const exact = liveHre(network);
+      assert.equal(await historicalLane.skip(exact.hre), true);
+      await historicalLane(exact.hre);
+      assert.deepEqual(exact.mutationCounts(), { deployCalls: 0, rawTransactions: 0 });
+
+      await assert.rejects(
+        historicalLane.skip(liveHre(network, { omit: "StakeVault" }).hre),
+        /Missing predecessor deployment StakeVault/,
+      );
+      await assert.rejects(
+        historicalLane.skip(liveHre(network, { addressDrift: "DisputeProtectionPolicy" }).hre),
+        /predecessor address mismatch/,
+      );
+      await assert.rejects(
+        historicalLane.skip(liveHre(network, { codeDrift: "IntentLifecycleHookV1" }).hre),
+        /predecessor runtime bytecode hash mismatch/,
+      );
+    } finally {
+      for (const [name, runtimeCodeHash] of Object.entries(originalRuntimeHashes)) {
+        PREDECESSOR_DISPUTE_STACKS[network].contracts[name].runtimeCodeHash = runtimeCodeHash;
+      }
+    }
   }
 
   assert.deepEqual(historicalLane.dependencies || [], []);

--- a/scripts/test-opt-in-dispute-lifecycle-deployment.cjs
+++ b/scripts/test-opt-in-dispute-lifecycle-deployment.cjs
@@ -28,10 +28,12 @@ const { test } = require("node:test");
 const lane34Module = require("../deploy/34_deploy_opt_in_dispute_lifecycle_stack.ts");
 const {
   DEPLOY_ONLY_STEP_KINDS,
+  EXPECTED_LIVE,
   LIVE_SUCCESSOR_DEPLOYMENT_NAMES,
   LOCAL_DISPUTE_DEPLOYMENT_NAMES,
   classifyDeployOnlyPrefix,
   classifyLiveDisputePhase,
+  getSuccessorDeployments,
   ownershipStepState,
   requireLocalPaymentBindingReady,
 } = lane34Module;
@@ -73,6 +75,42 @@ test("lane 34 owns the exact local and live deployment records", () => {
     "IntentLifecycleHookV1OptIn",
   ]);
   assert.deepEqual(lane34Module.default.dependencies, []);
+});
+
+test("live dependency pins use deployed runtime hashes", () => {
+  assert.deepEqual(
+    {
+      base: {
+        whitelistPolicy: EXPECTED_LIVE.base.whitelistPolicyCodeHash,
+        nullifierRegistryV2: EXPECTED_LIVE.base.nullifierRegistryV2CodeHash,
+      },
+      base_staging: {
+        whitelistPolicy: EXPECTED_LIVE.base_staging.whitelistPolicyCodeHash,
+        nullifierRegistryV2: EXPECTED_LIVE.base_staging.nullifierRegistryV2CodeHash,
+      },
+    },
+    {
+      base: {
+        whitelistPolicy: "0xa3cf0fdf3835887de432cbac9c192edf6c93a8589748aa93f8294333d57024b2",
+        nullifierRegistryV2: "0x423e2a2183ecd538864079b6268f41957028c25514d1de57bd3d0e70fa6b9bd4",
+      },
+      base_staging: {
+        whitelistPolicy: "0x917965fdc75580147ad0787c86f8b2a0f0185ef6e101567b82dc1245d6eb63bc",
+        nullifierRegistryV2: "0xd9d2f4b8bbca6fe26d7a0dfd7e0d6a6d63823ab2a1fe12971e752cf33dee72a0",
+      },
+    }
+  );
+});
+
+test("missing successor deployment records normalize to the absent state", async () => {
+  const deployments = await getSuccessorDeployments(
+    /** @type {any} */ ({
+      deployments: {
+        getOrNull: async () => undefined,
+      },
+    })
+  );
+  assert.deepEqual(deployments, [null, null, null]);
 });
 
 test("live deployment fails closed without the network opt-in flag", async () => {


### PR DESCRIPTION
## Summary

- pin historical deployment bytecode separately from constructor-substituted live runtime bytecode
- correct Base/Base-staging live dependency hashes and the already-active staging IntentLifecycleHookV1 predecessor
- normalize missing Hardhat Deploy records so an absent successor stack resumes from step zero
- add regressions for every corrected fail-closed boundary

## Verification

- `yarn test:dispute-lifecycle-deployment`
- `yarn test:v3-groups-deployment`
- `yarn typecheck:dispute-deployment`
- `yarn transpile`
- `git diff --check`
- read-only Base staging preflight reached only `ENABLE_STAGING_V3_DISPUTE_OPT_IN_DEPLOYMENT=true` guard
- read-only Base preflight reached only `ENABLE_BASE_V3_DISPUTE_OPT_IN_DEPLOYMENT=true` guard

## Deployment impact

No transactions are included in this PR. These corrections are required before the separately gated Base staging and Base successor deployments can safely run.