### PR TITLE
fix(deploy): restore immutable production lanes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,12 +9,17 @@
 - `deployments/`: Network artifacts and exported addresses; update on live deploys.
 - `tasks/`: Custom Hardhat tasks (e.g., Etherscan verification with delay).
 - `typechain/`, `artifacts/`, `out/`, `dist/`: Generated output; do not edit by hand.
+- A numbered deployment script becomes immutable after any production execution. Never edit that source again;
+  add a new numbered lane for new behavior and keep retirement, live-state checks, and active mounting in current
+  helpers or runner metadata outside the historical file.
 
 ## V3 Lifecycle Deployment Status
 
-- `deploy/30_deploy_v3_lifecycle_stack.ts` is the mounted whitelist-only V3 lifecycle lane for `localhost`, `hardhat`,
-  Base staging, and Base. Its lane-29 dependency supplies `WhitelistPolicy`; lane 30 deploys
-  `WhitelistLifecycleHook` and `OrchestratorV3` without activating the staking/dispute lane.
+- `deploy/30_deploy_v3_lifecycle_stack.ts` is immutable production provenance for the whitelist-only V3 lifecycle
+  deployment. The supported runner verifies its deployed-source hash and mounts
+  `deployments/activeDeploymentLanes/30_deploy_v3_lifecycle_stack.ts` under lane 30's filename. That current wrapper
+  preserves the exact tags and lane-29 dependency, refuses to roll a verified predecessor or successor dispute hook
+  back to `WhitelistLifecycleHook`, and otherwise delegates to the immutable historical implementation.
 - Base staging removes only the explicitly drained staging predecessors. Base keeps the existing orchestrators
   registered and queues exactly one Safe call to register the fresh O3. Base execution requires
   `ENABLE_BASE_V3_GROUPS_CUTOVER=true`, a separately approved exact source SHA, and the production governance path.
@@ -23,9 +28,11 @@
   closed. Base staging is verification-only because its EOA-owned registries cannot provide an atomic cutover.
   On Base, the explicit cutover opt-in preserves the audited method order and currencies while atomically routing
   all active methods to UPV3 and revoking both retired verifiers from the legacy registry.
-- Lane `32` is immutable, read-only predecessor evidence. It verifies the exact historical Base-staging and Base
-  deployment records and runtime hashes, always skips execution, and must never deploy, transfer ownership, mutate
-  writers, prepare governance, or activate a hook.
+- `deploy/32_deploy_and_activate_dispute_lifecycle_stack.ts` is executable immutable production history, not current
+  read-only logic. `scripts/deployActive.ts` verifies its deployed-source hash and excludes the exact file from every
+  supported tagged and untagged run; both historical lane-32 tags are rejected. Never invoke the historical file
+  directly. Current read-only predecessor address and bytecode checks live in
+  `deployments/predecessorDisputeStack.ts`.
 - Lane `33` is the independently owned IntentGuardian fee update.
 - Lane `34` is the only opt-in dispute successor lane. Its tag-scoped live commands deploy and configure a fresh
   `StakeVault`, `DisputeProtectionPolicy`, and `IntentLifecycleHookV1` while reusing the pinned verifier and dispute
@@ -76,7 +83,9 @@ Orchestrator ── net ──▶ Recipient OR PostIntentHook (then executes)
 - Focused iteration: `forge test --match-path '<test-file>'`, `forge test --match-contract <Contract>`, or
   `forge test --match-test <testName>`.
 - `yarn coverage`: Run the deterministic Foundry coverage pipeline. It is intentionally much heavier than tests.
-- Deploy: `yarn deploy:localhost`, `yarn deploy:base`, `yarn deploy:base_staging`.
+- Deploy: `yarn deploy:localhost`, `yarn deploy:base`, `yarn deploy:base_staging`. These supported commands route
+  through `scripts/deployActive.ts`; direct `hardhat deploy` invocation bypasses immutable-lane retirement and is
+  unsupported.
 - Verify: `yarn etherscan:base` and `yarn etherscan:base_staging`.
 
 ## Fast Development Workflow

--- a/README.md
+++ b/README.md
@@ -645,35 +645,25 @@ contract deployment or duplicate staging artifact is required.
 - `yarn deploy:base`
 - `yarn deploy:base_staging`
 
+These are the supported deployment entrypoints and all route through `scripts/deployActive.ts`. Do not invoke
+`hardhat deploy` directly: it bypasses the immutable-lane hash and retirement filter.
+
 ### V3 Groups Cutover
 
-The lifecycle rollout is split into explicit lanes. Lane 30 supports the whitelist-only groups
-deployment on Base staging and Base. Lane 31 verifies and cuts over the V3 payment-binding pair. Lane
-32 is immutable predecessor evidence, lane 33 owns the IntentGuardian fee update, and lane 34 is the
-only lane allowed to deploy or prepare activation of the opt-in dispute/staking successor.
+The lifecycle rollout is split into explicit lanes. Production-executed numbered scripts are immutable
+provenance: new behavior gets a new lane, while retirement and live-state checks stay in current helpers
+or runner metadata. Lane 31 verifies and cuts over the V3 payment-binding pair, lane 33 owns the
+IntentGuardian fee update, and lane 34 is the only supported lane allowed to deploy or prepare activation
+of the opt-in dispute/staking successor.
 
-`deploy/30_deploy_v3_lifecycle_stack.ts` is the groups-only lane. Its lane-29 dependency supplies a
-fresh `WhitelistPolicy`; lane 30 deploys a fresh `WhitelistLifecycleHook` and `OrchestratorV3`, sets
-the hook after O3 construction, registers the new O3, and removes the two drained staging
-predecessors. It reuses the existing registries, UPV3, NullifierRegistryV2, dispute stack, and
-payment routing without mutating them. On Base it leaves existing orchestrators registered and queues
-exactly one Safe transaction to add the fresh O3 to `OrchestratorRegistry`.
-
-Before a separately authorized live cutover, move these three artifacts aside for the selected
-environment in the deployment worktree:
-
-- `deployments/<environment>/WhitelistPolicy.json`
-- `deployments/<environment>/WhitelistLifecycleHook.json` when present
-- `deployments/<environment>/OrchestratorV3.json`
-
-Do not commit the temporary removals: the authorized deployment must replace all three artifacts with fresh
-creation records. Keep `AddressGroupRegistry` and every other deployment artifact intact. After an
-external read-only check proves both registered predecessor O3s have no unresolved intents, run
-`--tags V3LifecycleStack`. Base staging requires `ENABLE_STAGING_V3_GROUPS_CUTOVER=true` and
-`CONFIRM_STAGING_V3_PREDECESSORS_DRAINED=true`; Base requires `ENABLE_BASE_V3_GROUPS_CUTOVER=true`.
-The staging confirmation is an operator acknowledgement; the deploy script intentionally contains no
-indexer client or drain-query implementation. Base fails unless O2 and EscrowV2 are already registered,
-the existing stack remains intact, and the generated Safe batch contains only the fresh O3 registration.
+`deploy/30_deploy_v3_lifecycle_stack.ts` is the exact historical groups-only source used in production.
+Its original implementation deploys `WhitelistLifecycleHook` and `OrchestratorV3` with the lane-29
+`WhitelistPolicy` dependency. The supported runner first verifies the historical source digest, then mounts
+`deployments/activeDeploymentLanes/30_deploy_v3_lifecycle_stack.ts` under lane 30's filename. The wrapper
+returns without invoking the historical implementation when the live O3 already uses a bytecode- and
+configuration-verified predecessor or successor dispute hook; otherwise it delegates to lane 30's exact
+historical function and skip behavior. Do not move live artifacts aside or rerun lane 30 to replace the
+current stack. A future O3 deployment requires a new numbered lane.
 
 `deploy/31_deploy_v3_payment_binding_stack.ts` is the state-aware payment-binding and hard-cutover lane.
 On Base staging and Base it pins the existing `NullifierRegistryV2` and `UnifiedPaymentVerifierV3`
@@ -686,9 +676,12 @@ original order against UPV3, and revokes UPV1 and UPV2 from the legacy nullifier
 the registry order and produces exactly 22 atomic Safe calls. Never route a method back to a retired verifier
 after this one-way cutover.
 
-`deploy/32_deploy_and_activate_dispute_lifecycle_stack.ts` is retained only as read-only historical
-evidence. It pins the predecessor records and runtime hashes on Base staging and Base and always skips;
-there is no supported lane-32 deployment or activation flag.
+`deploy/32_deploy_and_activate_dispute_lifecycle_stack.ts` is the exact executable source used for the
+production dispute-stack deployment. It remains at its original path only as immutable audit provenance;
+it is not current read-only code. The supported runner verifies its digest, excludes the exact file from
+all tagged and untagged runs, and rejects both historical lane-32 tags. Never invoke it directly.
+`deployments/predecessorDisputeStack.ts` owns current read-only predecessor address, deployment-bytecode,
+and runtime-bytecode verification used by lane 34 and the Safe tooling.
 
 `deploy/34_deploy_opt_in_dispute_lifecycle_stack.ts` owns the successor. Use only the dedicated
 `yarn deploy:dispute-opt-in:base_staging` or `yarn deploy:dispute-opt-in:base` command. With

--- a/deploy/30_deploy_v3_lifecycle_stack.ts
+++ b/deploy/30_deploy_v3_lifecycle_stack.ts
@@ -16,11 +16,6 @@ import {
   waitForDeploymentDelay,
 } from "../deployments/helpers";
 import { safeBatchCollector } from "../deployments/safeBatchCollector";
-import { PREDECESSOR_DISPUTE_STACKS } from "./32_deploy_and_activate_dispute_lifecycle_stack";
-
-const { getActiveDisputeDeploymentName } = require("../deployments/activeDisputeStack.cjs") as {
-  getActiveDisputeDeploymentName(network: string, canonicalName: string): string;
-};
 
 const SUPPORTED_NETWORKS = new Set(["localhost", "hardhat", "base_staging", "base"]);
 const RETIRED_STAGING_WHITELIST_POLICY = "0xe3d3E798AbF1c021730d951d0589bCa63d9CB3F0";
@@ -31,86 +26,6 @@ const RETIRED_STAGING_ORCHESTRATORS = [
 
 function sameAddress(left: string, right: string): boolean {
   return left.toLowerCase() === right.toLowerCase();
-}
-
-type ManagedHookSnapshot = {
-  currentHook: string;
-  predecessor: { address: string; runtimeCodeHash: string };
-  successor?: { address: string; runtimeCodeHash: string };
-  actualRuntimeCodeHash: string;
-  actualOrchestratorRegistry: string;
-  expectedOrchestratorRegistry: string;
-  actualWhitelistPolicy: string;
-  expectedWhitelistPolicy: string;
-};
-
-export function validateManagedDisputeHookSnapshot(snapshot: ManagedHookSnapshot): boolean {
-  const expected = sameAddress(snapshot.currentHook, snapshot.predecessor.address)
-    ? snapshot.predecessor
-    : snapshot.successor && sameAddress(snapshot.currentHook, snapshot.successor.address)
-      ? snapshot.successor
-      : undefined;
-  if (!expected) return false;
-  if (snapshot.actualRuntimeCodeHash !== expected.runtimeCodeHash) {
-    throw new Error("Managed dispute lifecycle hook runtime bytecode mismatch");
-  }
-  if (!sameAddress(snapshot.actualOrchestratorRegistry, snapshot.expectedOrchestratorRegistry)) {
-    throw new Error("Managed dispute lifecycle hook registry mismatch");
-  }
-  if (!sameAddress(snapshot.actualWhitelistPolicy, snapshot.expectedWhitelistPolicy)) {
-    throw new Error("Managed dispute lifecycle hook whitelist policy mismatch");
-  }
-  return true;
-}
-
-export async function guardManagedDisputeLifecycleHook(
-  hre: HardhatRuntimeEnvironment,
-): Promise<boolean> {
-  const network = hre.deployments.getNetworkName();
-  if (network !== "base" && network !== "base_staging") return false;
-  const predecessor = PREDECESSOR_DISPUTE_STACKS[network];
-  const orchestratorDeployment = await hre.deployments.getOrNull("OrchestratorV3");
-  if (!orchestratorDeployment) return false;
-  const orchestrator = await ethers.getContractAt("OrchestratorV3", orchestratorDeployment.address);
-  const currentHook = await orchestrator.lifecycleHook();
-  const successorName = getActiveDisputeDeploymentName(network, "IntentLifecycleHookV1");
-  const successorDeployment = await hre.deployments.getOrNull(successorName);
-  const matched = sameAddress(currentHook, predecessor.activeLifecycleHook.address)
-    || (successorDeployment && sameAddress(currentHook, successorDeployment.address));
-  if (!matched) return false;
-
-  const runtimeCode = await ethers.provider.getCode(currentHook);
-  if (runtimeCode === "0x") throw new Error("Managed dispute lifecycle hook has no bytecode");
-  const hook = new ethers.Contract(
-    currentHook,
-    [
-      "function orchestratorRegistry() view returns (address)",
-      "function whitelistPolicy() view returns (address)",
-    ],
-    ethers.provider,
-  );
-  const orchestratorRegistry = await hre.deployments.get("OrchestratorRegistry");
-  const whitelistPolicy = await hre.deployments.get("WhitelistPolicy");
-  let successor: { address: string; runtimeCodeHash: string } | undefined;
-  if (successorDeployment && !sameAddress(successorDeployment.address, predecessor.activeLifecycleHook.address)) {
-    if (typeof successorDeployment.deployedBytecode !== "string") {
-      throw new Error("Managed successor lifecycle hook lacks deployment bytecode evidence");
-    }
-    successor = {
-      address: successorDeployment.address,
-      runtimeCodeHash: ethers.utils.keccak256(successorDeployment.deployedBytecode),
-    };
-  }
-  return validateManagedDisputeHookSnapshot({
-    currentHook,
-    predecessor: predecessor.activeLifecycleHook,
-    successor,
-    actualRuntimeCodeHash: ethers.utils.keccak256(runtimeCode),
-    actualOrchestratorRegistry: await hook.orchestratorRegistry(),
-    expectedOrchestratorRegistry: orchestratorRegistry.address,
-    actualWhitelistPolicy: await hook.whitelistPolicy(),
-    expectedWhitelistPolicy: whitelistPolicy.address,
-  });
 }
 
 async function assertCode(address: string, label: string): Promise<void> {
@@ -171,9 +86,7 @@ async function systemReady(
     if (!sameAddress(await hook.orchestratorRegistry(), registryAddress)) return false;
     if (!sameAddress(await hook.whitelistPolicy(), policy.address)) return false;
     if (!sameAddress(currentLifecycleHook, hook.address)) {
-      const combinedHookDeployment = await hre.deployments.get(
-        getActiveDisputeDeploymentName(network, "IntentLifecycleHookV1"),
-      );
+      const combinedHookDeployment = await hre.deployments.get("IntentLifecycleHookV1");
       if (!sameAddress(currentLifecycleHook, combinedHookDeployment.address)) return false;
       const combinedHook = await ethers.getContractAt("IntentLifecycleHookV1", combinedHookDeployment.address);
       if (!sameAddress(await combinedHook.orchestratorRegistry(), registryAddress)) return false;
@@ -207,7 +120,6 @@ async function systemFullyWired(hre: HardhatRuntimeEnvironment): Promise<boolean
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const network = hre.deployments.getNetworkName();
-  if (await guardManagedDisputeLifecycleHook(hre)) return;
   const chainId = (await ethers.provider.getNetwork()).chainId;
   const [deployer] = await hre.getUnnamedAccounts();
   const governance = MULTI_SIG[network] || deployer;
@@ -270,7 +182,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       args: [orchestratorRegistryAddress, policyDeployment.address],
       log: true,
     });
-    if (!(hookDeployment as any).newlyDeployed) throw new Error("WhitelistLifecycleHook was not freshly deployed");
+    if (!hookDeployment.newlyDeployed) throw new Error("WhitelistLifecycleHook was not freshly deployed");
     await waitForDeploymentDelay(hre);
 
     orchestratorDeployment = await hre.deployments.deploy("OrchestratorV3", {
@@ -286,7 +198,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       ],
       log: true,
     });
-    if (!(orchestratorDeployment as any).newlyDeployed) throw new Error("OrchestratorV3 was not freshly deployed");
+    if (!orchestratorDeployment.newlyDeployed) throw new Error("OrchestratorV3 was not freshly deployed");
     await waitForDeploymentDelay(hre);
   } else {
     console.log("Resuming the prepared whitelist-only V3 groups deployment");
@@ -362,7 +274,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> => {
   const network = hre.deployments.getNetworkName();
   if (!SUPPORTED_NETWORKS.has(network)) return true;
-  if (await guardManagedDisputeLifecycleHook(hre)) return true;
   if (await systemFullyWired(hre)) return true;
   if (network === "base_staging" && process.env.ENABLE_STAGING_V3_GROUPS_CUTOVER !== "true") return true;
   if (network === "base" && process.env.ENABLE_BASE_V3_GROUPS_CUTOVER !== "true") return true;

--- a/deploy/32_deploy_and_activate_dispute_lifecycle_stack.ts
+++ b/deploy/32_deploy_and_activate_dispute_lifecycle_stack.ts
@@ -1,149 +1,2152 @@
-import { ethers } from "ethers";
+import "module-alias/register";
 
-type HistoricalRuntimeEnvironment = {
-  deployments: {
-    getNetworkName(): string;
-    get(name: string): Promise<{ address: string; deployedBytecode?: string }>;
-  };
-  ethers: {
-    provider: {
-      getCode(address: string): Promise<string>;
-    };
-  };
+import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+import {
+  ACTIVE_PAYMENT_METHODS,
+  DISPUTE_RISK_WINDOW,
+  DISPUTABLE_PAYMENT_METHODS,
+  MULTI_SIG,
+  STAKE_VAULT_CONTROLLER_CHANGE_DELAY,
+  USDC,
+} from "../deployments/parameters";
+import {
+  addWritePermission,
+  setNewOwner,
+  waitForDeploymentDelay,
+} from "../deployments/helpers";
+import { safeBatchCollector } from "../deployments/safeBatchCollector";
+import { paymentBindingCutoverReady } from "./31_deploy_v3_payment_binding_stack";
+
+const SUPPORTED_NETWORKS = new Set([
+  "localhost",
+  "hardhat",
+  "base_staging",
+  "base",
+]);
+const STACK_DEPLOYMENT_NAMES = [
+  "DisputeNullifierRegistry",
+  "DisputeVerifier",
+  "StakeVault",
+  "DisputeProtectionPolicy",
+  "IntentLifecycleHookV1",
+] as const;
+const STACK_ARTIFACT_NAMES: Record<
+  (typeof STACK_DEPLOYMENT_NAMES)[number],
+  string
+> = {
+  DisputeNullifierRegistry: "NullifierRegistry",
+  DisputeVerifier: "DisputeVerifier",
+  StakeVault: "StakeVault",
+  DisputeProtectionPolicy: "DisputeProtectionPolicy",
+  IntentLifecycleHookV1: "IntentLifecycleHookV1",
 };
-
-type HistoricalDeployFunction = {
-  (hre: HistoricalRuntimeEnvironment): Promise<void>;
-  skip(hre: HistoricalRuntimeEnvironment): Promise<boolean>;
-  dependencies: string[];
-  tags: string[];
-};
-
-type HistoricalContractEvidence = {
-  address: string;
-  deploymentBytecodeHash: string;
-  runtimeCodeHash: string;
-};
-
-type HistoricalDisputeStack = {
-  activeLifecycleHook: Omit<HistoricalContractEvidence, "deploymentBytecodeHash">;
-  contracts: Record<string, HistoricalContractEvidence>;
-};
-
-export const PREDECESSOR_DISPUTE_STACKS: Record<string, HistoricalDisputeStack> = {
+export const EXPECTED_ORCHESTRATOR: Record<
+  string,
+  {
+    address: string;
+    runtimeCodeHash: string;
+    predecessorHook: string;
+    predecessorHookCodeHash: string;
+    protocolFeeRecipient: string;
+    chainId: number;
+  }
+> = {
   base: {
-    activeLifecycleHook: {
-      address: "0x251d78fb6bBb4071995Bce74bAfC9E4168638622",
-      runtimeCodeHash: "0x03d02863ed5eaa096d4089cb1e126681c0621d99409124f4af5be7ed83e341fe",
-    },
-    contracts: {
-      StakeVault: {
-        address: "0x8B8e853f47e6e0d3944e3689197B35216933dDea",
-        deploymentBytecodeHash: "0x3ceac244f2d721614975457b041e95f661feba8ef6bbfc73c23b55aaac27d3e6",
-        runtimeCodeHash: "0xfd8d2a910b9ac2c55675ae06d0504f9aac43b02b7022755cf229b571156c681d",
-      },
-      DisputeProtectionPolicy: {
-        address: "0xc086b6120B5e61EF48221E6A78c69737c9948dF9",
-        deploymentBytecodeHash: "0x6146f8eb152848ddfd40d67a152a44230ed783b6c1e768d023b88fc2a09cb38f",
-        runtimeCodeHash: "0xf08bce9ad622b9d45ce310493627cbef3bf6c4ac915661d5bc572bb59b61e084",
-      },
-      IntentLifecycleHookV1: {
-        address: "0x5B0017FCA6A2131701ef718e470a3930c1b6C12c",
-        deploymentBytecodeHash: "0xad298e1829958f431833bf1c0e53311f27e95dd29806c4d55aa75163e6dbcc21",
-        runtimeCodeHash: "0xff9db07ce83908b7cedb31f8c085004aa78c91bb86e0565f11fad3e4bc36c5cb",
-      },
-      DisputeVerifier: {
-        address: "0x30d4947f005653637005eed991005119D9eB2f34",
-        deploymentBytecodeHash: "0x7aae03ea4bd5bc953dc87b7a272ef967dc093a71b39417f4b7bd88f46210e876",
-        runtimeCodeHash: "0x65246e11392befc33d92246cf3ac2467d1f338a8b73c6514b76fab0a70a01ead",
-      },
-      DisputeNullifierRegistry: {
-        address: "0xA845615b5203F7a21321DdF5e3a1ca024D93a443",
-        deploymentBytecodeHash: "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
-        runtimeCodeHash: "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
-      },
-    },
+    address: "0x014025fDE093f8701d86e9f38e2C3a9b779cb5c7",
+    runtimeCodeHash:
+      "0x4e58f26129559301c017ff264b61dd2255ed2107593d308472ef32d07b8745e9",
+    predecessorHook: "0x251d78fb6bBb4071995Bce74bAfC9E4168638622",
+    predecessorHookCodeHash:
+      "0x03d02863ed5eaa096d4089cb1e126681c0621d99409124f4af5be7ed83e341fe",
+    protocolFeeRecipient: "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+    chainId: 8453,
   },
   base_staging: {
-    activeLifecycleHook: {
-      address: "0x19D9F0Fcb08C60D8bd0CD061C34eae27eF8b6e65",
-      runtimeCodeHash: "0xba70239e37624f5808e2f79e100e83a17daeb1558f310543187f5d8a121ec367",
-    },
-    contracts: {
-      StakeVault: {
-        address: "0xEc9f801e2a9Cc22bdc217aD3BB1E3058d0668f43",
-        deploymentBytecodeHash: "0x3ceac244f2d721614975457b041e95f661feba8ef6bbfc73c23b55aaac27d3e6",
-        runtimeCodeHash: "0xfd8d2a910b9ac2c55675ae06d0504f9aac43b02b7022755cf229b571156c681d",
-      },
-      DisputeProtectionPolicy: {
-        address: "0x21517b7743E727ae47A66FafF93550B689c15020",
-        deploymentBytecodeHash: "0x6146f8eb152848ddfd40d67a152a44230ed783b6c1e768d023b88fc2a09cb38f",
-        runtimeCodeHash: "0x4e6617a94819ad15693289b173a9a66a78cfe1dd706f6b4fdc5a5f6ad6a32971",
-      },
-      IntentLifecycleHookV1: {
-        address: "0x19D9F0Fcb08C60D8bd0CD061C34eae27eF8b6e65",
-        deploymentBytecodeHash: "0xad298e1829958f431833bf1c0e53311f27e95dd29806c4d55aa75163e6dbcc21",
-        runtimeCodeHash: "0xba70239e37624f5808e2f79e100e83a17daeb1558f310543187f5d8a121ec367",
-      },
-      DisputeVerifier: {
-        address: "0x973578148c5Fd49b9f68B50B26066555325AC708",
-        deploymentBytecodeHash: "0x7aae03ea4bd5bc953dc87b7a272ef967dc093a71b39417f4b7bd88f46210e876",
-        runtimeCodeHash: "0xb3b34734cfd162cd129d0c84285461c751321545213ec20164745b8e72f9dd6c",
-      },
-      DisputeNullifierRegistry: {
-        address: "0xE0B05a9655AF0f31E32904267baa50FbC7f217ea",
-        deploymentBytecodeHash: "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
-        runtimeCodeHash: "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
-      },
-    },
+    address: "0x2b5E8Ab562e45fA89D73802605E145ED3E3EeF4f",
+    runtimeCodeHash:
+      "0x4e58f26129559301c017ff264b61dd2255ed2107593d308472ef32d07b8745e9",
+    predecessorHook: "0xE8Fe714f848fAf7ecff7960AfD0C395771C22AA1",
+    predecessorHookCodeHash:
+      "0xfe6624ddbdcca7a2469af6ad6aecd50eda492aae017ad959093b3db1fd7f298a",
+    protocolFeeRecipient: "0x84e113087C97Cd80eA9D78983D4B8Ff61ECa1929",
+    chainId: 8453,
   },
 };
+const EXPECTED_ATTESTATION_VERIFIER: Record<
+  string,
+  {
+    address: string;
+    runtimeCodeHash: string;
+    witnesses: [string, string];
+    requiredSignatures: number;
+  }
+> = {
+  base: {
+    address: "0x9Fe920b24e50e6a6362BA71a1BeB502A99c402d5",
+    runtimeCodeHash:
+      "0x828a5dae520d3eaed904dfed56994dc6e892eb6416b58ad952c079e220ef841a",
+    witnesses: [
+      "0xDB4Ed7FAF170F0f6493E3adaaCaaFaF47092c754",
+      "0xE078D93bFdd87A8c5C5cCA5905DCbA0Dd7A1F0BD",
+    ],
+    requiredSignatures: 1,
+  },
+  base_staging: {
+    address: "0x9855a39aC5975069632e91160d8712CBfF19e864",
+    runtimeCodeHash:
+      "0x828a5dae520d3eaed904dfed56994dc6e892eb6416b58ad952c079e220ef841a",
+    witnesses: [
+      "0x66649F896521b0fb487fE2077b4FBDA283d7f19a",
+      "0x4ab950AE1e3326578Bf7e643a2031E858aBa2927",
+    ],
+    requiredSignatures: 1,
+  },
+};
+export const EXPECTED_NETWORK_DEPENDENCIES: Record<
+  string,
+  {
+    deployer: string;
+    orchestratorRegistry: string;
+    escrowRegistry: string;
+    paymentVerifierRegistry: string;
+    relayerRegistry: string;
+    whitelistPolicy: string;
+    addressGroupRegistry: string;
+    nullifierRegistryV2: string;
+    stakeToken: string;
+    controllerChangeDelay: number;
+  }
+> = {
+  base: {
+    deployer: "0x84e113087C97Cd80eA9D78983D4B8Ff61ECa1929",
+    orchestratorRegistry: "0xBe9fED15ED7A4B915C03EFcEcb9662739C3382A9",
+    escrowRegistry: "0xeD0e847B101abc96E796260AC358e12BAa2f5B21",
+    paymentVerifierRegistry: "0x2b82D24437ff66Fb173eabDfD67ee2ACeb8bEb1e",
+    relayerRegistry: "0xEbA979889a9c97382A92472fF3703786fF180083",
+    whitelistPolicy: "0xBC53641b4B2504f0061D6a9426C61B8eBE9B4Ff0",
+    addressGroupRegistry: "0x39F80118f9eB619135f116171b6Cb91D372C5AF2",
+    nullifierRegistryV2: "0x5455e761b866dfa6A2f5Dc6d6525825bf9C09aeB",
+    stakeToken: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    controllerChangeDelay: 172_800,
+  },
+  base_staging: {
+    deployer: "0x84e113087C97Cd80eA9D78983D4B8Ff61ECa1929",
+    orchestratorRegistry: "0xfA6384EB6176cfEC049540526A3d2126C3666d8A",
+    escrowRegistry: "0xc545f336eC77E69bf115729acCbf2e557A00ac91",
+    paymentVerifierRegistry: "0x2261416DA54C85f975C73FA56EF4D2D6b0aEF7Cc",
+    relayerRegistry: "0xB214650b424E6b5fdcB1259566eB7A512D8Bd25E",
+    whitelistPolicy: "0x7d9277cb8bb78a51eeaafB7CFF306E7DA4C972fD",
+    addressGroupRegistry: "0x54Ff7788Cb42B46FE2F016a65Fd0f654Bb9BcF3D",
+    nullifierRegistryV2: "0x2eb43d6C7c7Ec4220Aa6B8735BC053824a71778C",
+    stakeToken: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    controllerChangeDelay: 172_800,
+  },
+};
+const STAGING_PREDECESSOR = {
+  fromBlock: 49_316_251,
+  orchestratorFromBlock: 49_486_337,
+  owner: "0x84e113087C97Cd80eA9D78983D4B8Ff61ECa1929",
+  hook: {
+    address: "0xE8Fe714f848fAf7ecff7960AfD0C395771C22AA1",
+    runtimeCodeHash:
+      "0xfe6624ddbdcca7a2469af6ad6aecd50eda492aae017ad959093b3db1fd7f298a",
+  },
+  policy: {
+    address: "0xC1E16Bf824fA7cee8770Fb72F49349091D4e583B",
+    runtimeCodeHash:
+      "0x427e40f30c699f0b69e430233ebfa5e14fec2ae725d69dd0cf121df1207b8cad",
+  },
+  vault: {
+    address: "0x224a45C65eB9A4D1dB00eD6Bfe21aD7Ec0a9b0E4",
+    runtimeCodeHash:
+      "0x77d59eb29bff6ca33dfa666c8074f907e10c4ad4ac6664989e5174ad2e2061b8",
+  },
+  verifier: {
+    address: "0xd297CD116D7F6EFb807f855237A2EF72C0854579",
+    runtimeCodeHash:
+      "0x8668eb54450b595143a0bab37774fd5b08802e5b4346d7e09633525086ad8ec2",
+  },
+  nullifierRegistry: {
+    address: "0xaDa339E7d3542ee636FA2cda6BFbFE5720F0EEF5",
+    runtimeCodeHash:
+      "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
+  },
+  retiredDepositSetting: {
+    escrow: "0x77e8f808FE201075e0bD651CD46fdF239fc83265",
+    depositId: 87,
+    events: [
+      {
+        blockNumber: 49_612_788,
+        transactionHash:
+          "0xb2f56cd2d74fdc660132c5e13966302a7a4f67d94945fa908b132c63f00019ff",
+        isEnabled: true,
+      },
+      {
+        blockNumber: 49_612_804,
+        transactionHash:
+          "0x455c91175c36ec8c9d616e7b2977f5d39130d3559e76aeca8881ce07dd491649",
+        isEnabled: false,
+      },
+    ],
+    closedBlockNumber: 49_612_806,
+    closedTransactionHash:
+      "0xbd5a4ce4c32de20a1cb0f8fb2f29a56de6aca99c8377ad0afd13d0b0433937dc",
+  },
+} as const;
 
 function sameAddress(left: string, right: string): boolean {
   return left.toLowerCase() === right.toLowerCase();
 }
 
-export async function assertHistoricalDisputeStack(hre: HistoricalRuntimeEnvironment): Promise<void> {
-  const network = hre.deployments.getNetworkName();
-  if (network === "localhost" || network === "hardhat") return;
+function sameAddressArray(actual: string[], expected: string[]): boolean {
+  return (
+    actual.length === expected.length &&
+    actual.every((address, index) => sameAddress(address, expected[index]))
+  );
+}
 
-  const expectedStack = PREDECESSOR_DISPUTE_STACKS[network];
-  if (!expectedStack) return;
+export function assertStagingRetiredDepositSettingEvidence(
+  logs: Array<{
+    escrow: string;
+    depositId: number;
+    isEnabled: boolean;
+    blockNumber: number;
+    transactionHash: string;
+  }>,
+  tombstone: {
+    canonicalEscrow: string;
+    allZeroDeposit: boolean;
+    depositCounterGreater: boolean;
+    paymentMethodsEmpty: boolean;
+    intentHashesEmpty: boolean;
+    closedBlockNumber?: number;
+    closedTransactionHash?: string;
+  }
+): void {
+  const expected = STAGING_PREDECESSOR.retiredDepositSetting;
+  if (
+    !sameAddress(tombstone.canonicalEscrow, expected.escrow) ||
+    logs.length !== expected.events.length ||
+    logs.some((log, index) => {
+      const expectedEvent = expected.events[index];
+      return (
+        !sameAddress(log.escrow, expected.escrow) ||
+        log.depositId !== expected.depositId ||
+        log.isEnabled !== expectedEvent.isEnabled ||
+        log.blockNumber !== expectedEvent.blockNumber ||
+        log.transactionHash.toLowerCase() !== expectedEvent.transactionHash
+      );
+    })
+  ) {
+    throw new Error("Staging predecessor deposit setting history drifted");
+  }
+  if (
+    !tombstone.allZeroDeposit ||
+    !tombstone.depositCounterGreater ||
+    !tombstone.paymentMethodsEmpty ||
+    !tombstone.intentHashesEmpty
+  ) {
+    throw new Error(
+      "Staging predecessor deposit setting belongs to a live or nonempty deposit"
+    );
+  }
+  if (
+    tombstone.closedBlockNumber !== expected.closedBlockNumber ||
+    tombstone.closedTransactionHash?.toLowerCase() !==
+      expected.closedTransactionHash
+  ) {
+    throw new Error("Staging predecessor deposit tombstone evidence drifted");
+  }
+}
 
-  for (const [name, expected] of Object.entries(expectedStack.contracts)) {
-    let deployment;
-    try {
-      deployment = await hre.deployments.get(name);
-    } catch {
-      throw new Error(`Missing predecessor deployment ${name} on ${network}`);
+export function assertLifecycleHookPhase(
+  currentHook: string,
+  predecessorHook: string,
+  freshHook: string,
+  phase: "prepared" | "ready"
+): void {
+  const expectedHook = phase === "prepared" ? predecessorHook : freshHook;
+  if (!sameAddress(currentHook, expectedHook)) {
+    throw new Error(
+      `OrchestratorV3 lifecycle hook is not in the expected ${phase} phase`
+    );
+  }
+}
+
+function paymentMethodHash(name: string): string {
+  return ethers.utils.keccak256(ethers.utils.toUtf8Bytes(name));
+}
+
+async function assertCode(address: string, label: string): Promise<string> {
+  const code = await ethers.provider.getCode(address);
+  if (code === "0x") {
+    throw new Error(`${label} has no bytecode: ${address}`);
+  }
+  return code;
+}
+
+function zeroImmutableValues(
+  bytecode: string,
+  immutableReferences: Record<string, Array<{ start: number; length: number }>>
+): string {
+  let normalized = bytecode.slice(2).toLowerCase();
+  for (const references of Object.values(immutableReferences)) {
+    for (const reference of references) {
+      const start = reference.start * 2;
+      const length = reference.length * 2;
+      normalized =
+        normalized.slice(0, start) +
+        "0".repeat(length) +
+        normalized.slice(start + length);
     }
-    if (!sameAddress(deployment.address, expected.address)) {
-      throw new Error(`${name} predecessor address mismatch on ${network}`);
+  }
+  return `0x${normalized}`;
+}
+
+async function assertDeploymentRuntime(
+  hre: HardhatRuntimeEnvironment,
+  deployment: any,
+  label: (typeof STACK_DEPLOYMENT_NAMES)[number]
+): Promise<void> {
+  const code = await assertCode(deployment.address, label);
+  const artifact = await hre.deployments.getExtendedArtifact(
+    STACK_ARTIFACT_NAMES[label]
+  );
+  if (
+    typeof deployment.deployedBytecode !== "string" ||
+    deployment.deployedBytecode === "0x" ||
+    typeof deployment.solcInputHash !== "string" ||
+    deployment.solcInputHash.length === 0
+  ) {
+    throw new Error(
+      `${label} artifact lacks reviewed bytecode/source evidence`
+    );
+  }
+  if (deployment.solcInputHash !== artifact.solcInputHash) {
+    throw new Error(
+      `${label} artifact does not match the approved compiler input`
+    );
+  }
+  const immutableReferences =
+    artifact.evm?.deployedBytecode?.immutableReferences || {};
+  const normalizedCode = zeroImmutableValues(code, immutableReferences);
+  if (
+    normalizedCode !==
+      zeroImmutableValues(deployment.deployedBytecode, immutableReferences) ||
+    normalizedCode !==
+      zeroImmutableValues(artifact.deployedBytecode, immutableReferences)
+  ) {
+    throw new Error(`${label} runtime bytecode is not the canonical build`);
+  }
+}
+
+async function assertExpectedAttestationVerifier(
+  hre: HardhatRuntimeEnvironment,
+  deployment: any,
+  governance: string
+): Promise<void> {
+  const expected =
+    EXPECTED_ATTESTATION_VERIFIER[hre.deployments.getNetworkName()];
+  if (!expected) return;
+  if (!sameAddress(deployment.address, expected.address)) {
+    throw new Error("MultiAttestationVerifier address mismatch");
+  }
+  const code = await assertCode(deployment.address, "MultiAttestationVerifier");
+  if (ethers.utils.keccak256(code) !== expected.runtimeCodeHash) {
+    throw new Error("MultiAttestationVerifier runtime bytecode mismatch");
+  }
+  const contract = await ethers.getContractAt(
+    "MultiAttestationVerifier",
+    deployment.address
+  );
+  if (!sameAddress(await contract.owner(), governance)) {
+    throw new Error("MultiAttestationVerifier owner mismatch");
+  }
+  if (
+    !sameAddressArray(await contract.witnesses(), expected.witnesses) ||
+    !(await contract.requiredSignatures()).eq(expected.requiredSignatures)
+  ) {
+    throw new Error("MultiAttestationVerifier witness configuration mismatch");
+  }
+}
+
+async function assertExpectedNetworkDependencies(
+  hre: HardhatRuntimeEnvironment
+): Promise<void> {
+  const expected =
+    EXPECTED_NETWORK_DEPENDENCIES[hre.deployments.getNetworkName()];
+  if (!expected) return;
+  const [deployer] = await hre.getUnnamedAccounts();
+  if (!sameAddress(deployer, expected.deployer)) {
+    throw new Error("Deployment signer does not match the approved deployer");
+  }
+  const configuredStakeToken =
+    USDC[hre.deployments.getNetworkName()] ||
+    (await hre.deployments.get("USDCMock")).address;
+  if (!sameAddress(configuredStakeToken, expected.stakeToken)) {
+    throw new Error("StakeVault token does not match the approved USDC target");
+  }
+  if (!STAKE_VAULT_CONTROLLER_CHANGE_DELAY.eq(expected.controllerChangeDelay)) {
+    throw new Error("StakeVault controller delay drifted from 172800 seconds");
+  }
+  await assertCode(expected.stakeToken, "USDC");
+  const names: Array<
+    [
+      (
+        | "orchestratorRegistry"
+        | "escrowRegistry"
+        | "paymentVerifierRegistry"
+        | "relayerRegistry"
+        | "whitelistPolicy"
+        | "addressGroupRegistry"
+        | "nullifierRegistryV2"
+      ),
+      (
+        | "OrchestratorRegistry"
+        | "EscrowRegistry"
+        | "PaymentVerifierRegistry"
+        | "RelayerRegistry"
+        | "WhitelistPolicy"
+        | "AddressGroupRegistry"
+        | "NullifierRegistryV2"
+      )
+    ]
+  > = [
+    ["orchestratorRegistry", "OrchestratorRegistry"],
+    ["escrowRegistry", "EscrowRegistry"],
+    ["paymentVerifierRegistry", "PaymentVerifierRegistry"],
+    ["relayerRegistry", "RelayerRegistry"],
+    ["whitelistPolicy", "WhitelistPolicy"],
+    ["addressGroupRegistry", "AddressGroupRegistry"],
+    ["nullifierRegistryV2", "NullifierRegistryV2"],
+  ];
+  for (const [key, deploymentName] of names) {
+    const deployment = await hre.deployments.get(deploymentName);
+    if (!sameAddress(deployment.address, expected[key])) {
+      throw new Error(`${deploymentName} artifact address mismatch`);
     }
-    if (
-      typeof deployment.deployedBytecode !== "string" ||
-      ethers.utils.keccak256(deployment.deployedBytecode) !== expected.deploymentBytecodeHash
-    ) {
-      throw new Error(`${name} predecessor deployment bytecode hash mismatch on ${network}`);
-    }
-    const runtimeCode = await hre.ethers.provider.getCode(expected.address);
-    if (runtimeCode === "0x" || ethers.utils.keccak256(runtimeCode) !== expected.runtimeCodeHash) {
-      throw new Error(`${name} predecessor runtime bytecode hash mismatch on ${network}`);
+  }
+  const governance =
+    MULTI_SIG[hre.deployments.getNetworkName()] || expected.deployer;
+  const whitelistPolicy = await ethers.getContractAt(
+    "WhitelistPolicy",
+    expected.whitelistPolicy
+  );
+  if (
+    !sameAddress(await whitelistPolicy.owner(), governance) ||
+    !sameAddress(
+      await whitelistPolicy.groupRegistry(),
+      expected.addressGroupRegistry
+    ) ||
+    !sameAddress(
+      await whitelistPolicy.escrowRegistry(),
+      expected.escrowRegistry
+    ) ||
+    !sameAddress(
+      await whitelistPolicy.orchestratorRegistry(),
+      expected.orchestratorRegistry
+    )
+  ) {
+    throw new Error("WhitelistPolicy configuration mismatch");
+  }
+}
+
+async function getStackDeployments(
+  hre: HardhatRuntimeEnvironment,
+  allowPartial = false
+): Promise<Record<string, any> | null> {
+  const entries = await Promise.all(
+    STACK_DEPLOYMENT_NAMES.map(
+      async (name) => [name, await hre.deployments.getOrNull(name)] as const
+    )
+  );
+  const present = entries.filter(([, deployment]) => deployment != null);
+  if (present.length === 0) return null;
+  if (!allowPartial && present.length !== STACK_DEPLOYMENT_NAMES.length) {
+    throw new Error(
+      `Partial dispute deployment artifacts found: ${present
+        .map(([name]) => name)
+        .join(", ")}`
+    );
+  }
+  return Object.fromEntries(present) as Record<string, any>;
+}
+
+function completeStackExists(
+  deployments: Record<string, any> | null
+): deployments is Record<string, any> {
+  return (
+    deployments !== null &&
+    STACK_DEPLOYMENT_NAMES.every((name) => deployments[name] != null)
+  );
+}
+
+function assertContiguousStackPrefix(
+  deployments: Record<string, any> | null
+): void {
+  if (!deployments) return;
+  let foundMissing = false;
+  for (const name of STACK_DEPLOYMENT_NAMES) {
+    if (!deployments[name]) {
+      foundMissing = true;
+    } else if (foundMissing) {
+      throw new Error(
+        `Dispute deployment artifacts are not a contiguous recognized prefix: unexpected ${name}`
+      );
     }
   }
 }
 
-const func = (async function (hre: HistoricalRuntimeEnvironment): Promise<void> {
-  await assertHistoricalDisputeStack(hre);
-  console.log("Lane 32 is immutable predecessor evidence; lane 34 owns the opt-in successor stack.");
-}) as HistoricalDeployFunction;
+async function ownershipIsResumable(
+  contract: any,
+  deployer: string,
+  governance: string
+): Promise<boolean> {
+  const owner = await contract.owner();
+  const pendingOwner = await contract.pendingOwner();
+  return (
+    (sameAddress(owner, deployer) || sameAddress(owner, governance)) &&
+    (sameAddress(pendingOwner, ethers.constants.AddressZero) ||
+      sameAddress(pendingOwner, governance))
+  );
+}
 
-func.skip = async (hre: HistoricalRuntimeEnvironment): Promise<boolean> => {
-  await assertHistoricalDisputeStack(hre);
+async function getStackContracts(
+  hre: HardhatRuntimeEnvironment,
+  deployments: Record<string, any>
+) {
+  const disputeNullifierRegistry = await ethers.getContractAt(
+    "NullifierRegistry",
+    deployments.DisputeNullifierRegistry.address
+  );
+  const disputeVerifier = await ethers.getContractAt(
+    "DisputeVerifier",
+    deployments.DisputeVerifier.address
+  );
+  const vault = await ethers.getContractAt(
+    "StakeVault",
+    deployments.StakeVault.address
+  );
+  const disputeProtectionPolicy = await ethers.getContractAt(
+    "DisputeProtectionPolicy",
+    deployments.DisputeProtectionPolicy.address
+  );
+  const hook = await ethers.getContractAt(
+    "IntentLifecycleHookV1",
+    deployments.IntentLifecycleHookV1.address
+  );
+  const orchestrator = await ethers.getContractAt(
+    "OrchestratorV3",
+    (
+      await hre.deployments.get("OrchestratorV3")
+    ).address
+  );
+  return {
+    disputeNullifierRegistry,
+    disputeVerifier,
+    vault,
+    disputeProtectionPolicy,
+    hook,
+    orchestrator,
+  };
+}
+
+async function assertPartialStackIsResumable(
+  hre: HardhatRuntimeEnvironment,
+  deployments: Record<string, any> | null
+): Promise<void> {
+  if (!deployments) return;
+  assertContiguousStackPrefix(deployments);
+
+  const network = hre.deployments.getNetworkName();
+  const [deployer] = await hre.getUnnamedAccounts();
+  const governance = MULTI_SIG[network] || deployer;
+  const stakeTokenAddress =
+    USDC[network] || (await hre.deployments.get("USDCMock")).address;
+  const orchestratorRegistryAddress = (
+    await hre.deployments.get("OrchestratorRegistry")
+  ).address;
+  const whitelistPolicyAddress = (await hre.deployments.get("WhitelistPolicy"))
+    .address;
+  const nullifierRegistryV2Address = (
+    await hre.deployments.get("NullifierRegistryV2")
+  ).address;
+  const attestationVerifier =
+    (await hre.deployments.getOrNull("MultiAttestationVerifier")) ||
+    (await hre.deployments.get("SimpleAttestationVerifier"));
+  await assertExpectedAttestationVerifier(hre, attestationVerifier, governance);
+
+  for (const name of STACK_DEPLOYMENT_NAMES) {
+    if (deployments[name]) {
+      await assertDeploymentRuntime(hre, deployments[name], name);
+    }
+  }
+
+  const disputeNullifierRegistry = deployments.DisputeNullifierRegistry
+    ? await ethers.getContractAt(
+        "NullifierRegistry",
+        deployments.DisputeNullifierRegistry.address
+      )
+    : null;
+  const disputeVerifier = deployments.DisputeVerifier
+    ? await ethers.getContractAt(
+        "DisputeVerifier",
+        deployments.DisputeVerifier.address
+      )
+    : null;
+  const vault = deployments.StakeVault
+    ? await ethers.getContractAt("StakeVault", deployments.StakeVault.address)
+    : null;
+  const policy = deployments.DisputeProtectionPolicy
+    ? await ethers.getContractAt(
+        "DisputeProtectionPolicy",
+        deployments.DisputeProtectionPolicy.address
+      )
+    : null;
+  const hook = deployments.IntentLifecycleHookV1
+    ? await ethers.getContractAt(
+        "IntentLifecycleHookV1",
+        deployments.IntentLifecycleHookV1.address
+      )
+    : null;
+
+  if (disputeNullifierRegistry) {
+    const registryOwner = await disputeNullifierRegistry.owner();
+    if (
+      !sameAddress(registryOwner, deployer) &&
+      !sameAddress(registryOwner, governance)
+    ) {
+      throw new Error("Partial DisputeNullifierRegistry owner mismatch");
+    }
+    const writers: string[] = await disputeNullifierRegistry.getWriters();
+    if (
+      writers.length > 1 ||
+      (writers.length === 1 &&
+        (!policy || !sameAddress(writers[0], policy.address)))
+    ) {
+      throw new Error("Partial DisputeNullifierRegistry writer mismatch");
+    }
+  }
+
+  if (disputeVerifier) {
+    if (
+      !sameAddress(
+        await disputeVerifier.nullifierRegistry(),
+        nullifierRegistryV2Address
+      ) ||
+      !sameAddress(
+        await disputeVerifier.attestationVerifier(),
+        attestationVerifier.address
+      ) ||
+      !(await ownershipIsResumable(disputeVerifier, deployer, governance))
+    ) {
+      throw new Error("Partial DisputeVerifier configuration mismatch");
+    }
+  }
+
+  if (vault) {
+    const ownerIsRecognized = await ownershipIsResumable(
+      vault,
+      deployer,
+      governance
+    );
+    const expectedController = policy?.address || ethers.constants.AddressZero;
+    const actualController = await vault.controller();
+    if (
+      !ownerIsRecognized ||
+      !sameAddress(await vault.stakeToken(), stakeTokenAddress) ||
+      !(await vault.controllerChangeDelay()).eq(
+        STAKE_VAULT_CONTROLLER_CHANGE_DELAY
+      ) ||
+      (!sameAddress(actualController, ethers.constants.AddressZero) &&
+        !sameAddress(actualController, expectedController)) ||
+      !sameAddress(
+        await vault.pendingController(),
+        ethers.constants.AddressZero
+      ) ||
+      !(await vault.pendingControllerValidAt()).isZero()
+    ) {
+      throw new Error("Partial StakeVault configuration mismatch");
+    }
+  }
+
+  if (policy) {
+    const ownerIsRecognized = await ownershipIsResumable(
+      policy,
+      deployer,
+      governance
+    );
+    if (
+      !ownerIsRecognized ||
+      (await policy.admissionsPaused()) ||
+      !sameAddress(await policy.stakeVault(), vault?.address || "") ||
+      !sameAddress(
+        await policy.disputeVerifier(),
+        disputeVerifier?.address || ""
+      ) ||
+      !sameAddress(
+        await policy.disputeNullifierRegistry(),
+        disputeNullifierRegistry?.address || ""
+      )
+    ) {
+      throw new Error("Partial DisputeProtectionPolicy configuration mismatch");
+    }
+    const disputableMethods = new Set(DISPUTABLE_PAYMENT_METHODS);
+    for (const methodName of ACTIVE_PAYMENT_METHODS) {
+      const riskWindow = await policy.getRiskWindow(
+        paymentMethodHash(methodName)
+      );
+      const expectedRiskWindow = disputableMethods.has(methodName)
+        ? DISPUTE_RISK_WINDOW[network]
+        : ethers.constants.Zero;
+      if (!riskWindow.isZero() && !riskWindow.eq(expectedRiskWindow)) {
+        throw new Error(`Partial risk window mismatch for ${methodName}`);
+      }
+    }
+    const fromBlock = deployments.DisputeProtectionPolicy.receipt?.blockNumber;
+    if (typeof fromBlock !== "number" || !Number.isSafeInteger(fromBlock)) {
+      throw new Error(
+        "Partial DisputeProtectionPolicy lacks deployment-block evidence"
+      );
+    }
+    const authorizationLogs = await policy.queryFilter(
+      policy.filters.LifecycleHookAuthorizationUpdated(),
+      fromBlock,
+      await ethers.provider.getBlockNumber()
+    );
+    const authorization = new Map<string, boolean>();
+    for (const log of authorizationLogs) {
+      const authorizedHook = log.args?.hook || log.args?.[0];
+      const isAuthorized = log.args?.isAuthorized ?? log.args?.[1];
+      if (!authorizedHook || typeof isAuthorized !== "boolean") {
+        throw new Error(
+          "Unable to decode partial lifecycle-hook authorization history"
+        );
+      }
+      authorization.set(authorizedHook.toLowerCase(), isAuthorized);
+    }
+    const expectedHook = hook?.address.toLowerCase();
+    if (
+      [...authorization.entries()].some(
+        ([authorizedHook, isAuthorized]) =>
+          isAuthorized && authorizedHook !== expectedHook
+      )
+    ) {
+      throw new Error(
+        "Partial DisputeProtectionPolicy has an unexpected authorized hook"
+      );
+    }
+  }
+
+  if (
+    hook &&
+    (!sameAddress(
+      await hook.orchestratorRegistry(),
+      orchestratorRegistryAddress
+    ) ||
+      !sameAddress(await hook.whitelistPolicy(), whitelistPolicyAddress) ||
+      !sameAddress(await hook.disputeProtectionPolicy(), policy?.address || ""))
+  ) {
+    throw new Error("Partial IntentLifecycleHookV1 configuration mismatch");
+  }
+}
+
+async function assertExpectedOrchestratorCore(
+  hre: HardhatRuntimeEnvironment,
+  orchestrator: any
+): Promise<(typeof EXPECTED_ORCHESTRATOR)[string] | null> {
+  const network = hre.deployments.getNetworkName();
+  const expected = EXPECTED_ORCHESTRATOR[network];
+  if (!expected) return null;
+
+  if (!sameAddress(orchestrator.address, expected.address)) {
+    throw new Error("OrchestratorV3 address does not match the audited target");
+  }
+  const code = await ethers.provider.getCode(orchestrator.address);
+  if (ethers.utils.keccak256(code) !== expected.runtimeCodeHash) {
+    throw new Error("OrchestratorV3 runtime bytecode hash mismatch");
+  }
+  const governance =
+    MULTI_SIG[network] || EXPECTED_NETWORK_DEPENDENCIES[network].deployer;
+  if (!sameAddress(await orchestrator.owner(), governance)) {
+    throw new Error("OrchestratorV3 owner mismatch");
+  }
+  const orchestratorRegistry = await ethers.getContractAt(
+    "OrchestratorRegistry",
+    (
+      await hre.deployments.get("OrchestratorRegistry")
+    ).address
+  );
+  if (!(await orchestratorRegistry.isOrchestrator(orchestrator.address))) {
+    throw new Error("OrchestratorV3 is not registered");
+  }
+  if (await orchestrator.paused()) {
+    throw new Error("OrchestratorV3 is paused");
+  }
+  const [chain, escrowRegistry, paymentVerifierRegistry, relayerRegistry] =
+    await Promise.all([
+      ethers.provider.getNetwork(),
+      hre.deployments.get("EscrowRegistry"),
+      hre.deployments.get("PaymentVerifierRegistry"),
+      hre.deployments.get("RelayerRegistry"),
+    ]);
+  if (
+    chain.chainId !== expected.chainId ||
+    !(await orchestrator.chainId()).eq(expected.chainId) ||
+    !sameAddress(await orchestrator.escrowRegistry(), escrowRegistry.address) ||
+    !sameAddress(
+      await orchestrator.paymentVerifierRegistry(),
+      paymentVerifierRegistry.address
+    ) ||
+    !sameAddress(
+      await orchestrator.relayerRegistry(),
+      relayerRegistry.address
+    ) ||
+    !(await orchestrator.protocolFee()).isZero() ||
+    !sameAddress(
+      await orchestrator.protocolFeeRecipient(),
+      expected.protocolFeeRecipient
+    ) ||
+    (await orchestrator.allowMultipleIntents())
+  ) {
+    throw new Error("OrchestratorV3 mutable configuration mismatch");
+  }
+  return expected;
+}
+
+async function assertExpectedOrchestrator(
+  hre: HardhatRuntimeEnvironment,
+  contracts: Awaited<ReturnType<typeof getStackContracts>>
+): Promise<void> {
+  const expected = await assertExpectedOrchestratorCore(
+    hre,
+    contracts.orchestrator
+  );
+  if (!expected) return;
+  const currentHook = await contracts.orchestrator.lifecycleHook();
+  if (
+    !sameAddress(currentHook, expected.predecessorHook) &&
+    !sameAddress(currentHook, contracts.hook.address)
+  ) {
+    throw new Error(
+      "OrchestratorV3 lifecycle hook drifted from the audited predecessor"
+    );
+  }
+  const hook = new ethers.Contract(
+    currentHook,
+    ["function whitelistPolicy() view returns (address)"],
+    ethers.provider
+  );
+  if (
+    !sameAddress(
+      await hook.whitelistPolicy(),
+      EXPECTED_NETWORK_DEPENDENCIES[hre.deployments.getNetworkName()]
+        .whitelistPolicy
+    )
+  ) {
+    throw new Error("Active lifecycle hook whitelist policy mismatch");
+  }
+}
+
+async function assertOrchestratorPreflight(
+  hre: HardhatRuntimeEnvironment
+): Promise<void> {
+  const expected = EXPECTED_ORCHESTRATOR[hre.deployments.getNetworkName()];
+  if (!expected) return;
+  const deployment = await hre.deployments.get("OrchestratorV3");
+  const orchestrator = await ethers.getContractAt(
+    "OrchestratorV3",
+    deployment.address
+  );
+  await assertExpectedOrchestratorCore(hre, orchestrator);
+  assertLifecycleHookPhase(
+    await orchestrator.lifecycleHook(),
+    expected.predecessorHook,
+    ethers.constants.AddressZero,
+    "prepared"
+  );
+  const predecessorCode = await assertCode(
+    expected.predecessorHook,
+    "PredecessorLifecycleHook"
+  );
+  if (
+    ethers.utils.keccak256(predecessorCode) !== expected.predecessorHookCodeHash
+  ) {
+    throw new Error("Predecessor lifecycle hook runtime bytecode mismatch");
+  }
+  const predecessorHook = new ethers.Contract(
+    expected.predecessorHook,
+    ["function whitelistPolicy() view returns (address)"],
+    ethers.provider
+  );
+  if (
+    !sameAddress(
+      await predecessorHook.whitelistPolicy(),
+      EXPECTED_NETWORK_DEPENDENCIES[hre.deployments.getNetworkName()]
+        .whitelistPolicy
+    )
+  ) {
+    throw new Error("Predecessor hook whitelist policy mismatch");
+  }
+}
+
+async function assertOrchestratorStillOnPredecessor(
+  hre: HardhatRuntimeEnvironment,
+  contracts: Awaited<ReturnType<typeof getStackContracts>>
+): Promise<void> {
+  const expected = EXPECTED_ORCHESTRATOR[hre.deployments.getNetworkName()];
+  if (!expected) return;
+  assertLifecycleHookPhase(
+    await contracts.orchestrator.lifecycleHook(),
+    expected.predecessorHook,
+    contracts.hook.address,
+    "prepared"
+  );
+}
+
+export async function assertStagingPredecessorDrained(
+  hre: HardhatRuntimeEnvironment,
+  contracts: Awaited<ReturnType<typeof getStackContracts>>
+): Promise<void> {
+  if (hre.deployments.getNetworkName() !== "base_staging") return;
+  const governance = STAGING_PREDECESSOR.owner;
+  const currentBlock = await ethers.provider.getBlockNumber();
+
+  for (const [label, expected] of Object.entries({
+    predecessorHook: STAGING_PREDECESSOR.hook,
+    predecessorPolicy: STAGING_PREDECESSOR.policy,
+    predecessorVault: STAGING_PREDECESSOR.vault,
+    predecessorVerifier: STAGING_PREDECESSOR.verifier,
+    predecessorNullifierRegistry: STAGING_PREDECESSOR.nullifierRegistry,
+  })) {
+    const code = await assertCode(expected.address, label);
+    if (ethers.utils.keccak256(code) !== expected.runtimeCodeHash) {
+      throw new Error(`${label} runtime bytecode hash mismatch`);
+    }
+  }
+
+  const policy = new ethers.Contract(
+    STAGING_PREDECESSOR.policy.address,
+    [
+      "function owner() view returns (address)",
+      "function pendingOwner() view returns (address)",
+      "function admissionsPaused() view returns (bool)",
+      "function stakeVault() view returns (address)",
+      "function chargebackVerifier() view returns (address)",
+      "function chargebackNullifierRegistry() view returns (address)",
+      "function isLifecycleHookAuthorized(address) view returns (bool)",
+    ],
+    ethers.provider
+  );
+  const vault = new ethers.Contract(
+    STAGING_PREDECESSOR.vault.address,
+    [
+      "function owner() view returns (address)",
+      "function pendingOwner() view returns (address)",
+      "function controller() view returns (address)",
+      "function pendingController() view returns (address)",
+      "function pendingControllerValidAt() view returns (uint64)",
+      "function controllerChangeDelay() view returns (uint256)",
+      "function stakeToken() view returns (address)",
+      "function totalStaked() view returns (uint256)",
+      "function totalClaimable() view returns (uint256)",
+      "function totalAccounted() view returns (uint256)",
+      "function unaccountedBalance() view returns (uint256)",
+    ],
+    ethers.provider
+  );
+  const verifier = new ethers.Contract(
+    STAGING_PREDECESSOR.verifier.address,
+    [
+      "function owner() view returns (address)",
+      "function pendingOwner() view returns (address)",
+      "function nullifierRegistry() view returns (address)",
+      "function attestationVerifier() view returns (address)",
+    ],
+    ethers.provider
+  );
+  const nullifierRegistry = new ethers.Contract(
+    STAGING_PREDECESSOR.nullifierRegistry.address,
+    [
+      "function owner() view returns (address)",
+      "function getWriters() view returns (address[])",
+    ],
+    ethers.provider
+  );
+  const hook = new ethers.Contract(
+    STAGING_PREDECESSOR.hook.address,
+    [
+      "function orchestratorRegistry() view returns (address)",
+      "function whitelistPolicy() view returns (address)",
+      "function chargebackPolicy() view returns (address)",
+    ],
+    ethers.provider
+  );
+  const usdc = new ethers.Contract(
+    USDC.base_staging,
+    ["function balanceOf(address) view returns (uint256)"],
+    ethers.provider
+  );
+  const expectedOrchestratorRegistry = (
+    await hre.deployments.get("OrchestratorRegistry")
+  ).address;
+  const expectedWhitelistPolicy = (await hre.deployments.get("WhitelistPolicy"))
+    .address;
+  const expectedNullifierRegistryV2 = (
+    await hre.deployments.get("NullifierRegistryV2")
+  ).address;
+  const expectedEscrowV2 = (await hre.deployments.get("EscrowV2")).address;
+  const expectedAttestationVerifier =
+    (await hre.deployments.getOrNull("MultiAttestationVerifier")) ||
+    (await hre.deployments.get("SimpleAttestationVerifier"));
+
+  if (
+    !sameAddress(
+      await hook.orchestratorRegistry(),
+      expectedOrchestratorRegistry
+    ) ||
+    !sameAddress(await hook.whitelistPolicy(), expectedWhitelistPolicy) ||
+    !sameAddress(await hook.chargebackPolicy(), policy.address)
+  ) {
+    throw new Error("Staging predecessor hook dependency mismatch");
+  }
+  if (
+    !sameAddress(await policy.owner(), governance) ||
+    !sameAddress(await policy.pendingOwner(), ethers.constants.AddressZero) ||
+    !sameAddress(await policy.stakeVault(), vault.address) ||
+    !sameAddress(await policy.chargebackVerifier(), verifier.address) ||
+    !sameAddress(
+      await policy.chargebackNullifierRegistry(),
+      nullifierRegistry.address
+    ) ||
+    !(await policy.isLifecycleHookAuthorized(hook.address))
+  ) {
+    throw new Error("Staging predecessor policy configuration mismatch");
+  }
+  if (await policy.admissionsPaused()) {
+    throw new Error("Staging predecessor policy pause state drifted");
+  }
+  if (
+    !sameAddress(await verifier.owner(), governance) ||
+    !sameAddress(await verifier.pendingOwner(), ethers.constants.AddressZero) ||
+    !sameAddress(
+      await verifier.nullifierRegistry(),
+      expectedNullifierRegistryV2
+    ) ||
+    !sameAddress(
+      await verifier.attestationVerifier(),
+      expectedAttestationVerifier.address
+    )
+  ) {
+    throw new Error("Staging predecessor verifier configuration mismatch");
+  }
+  if (
+    !sameAddress(await vault.owner(), governance) ||
+    !sameAddress(await vault.pendingOwner(), ethers.constants.AddressZero) ||
+    !sameAddress(await vault.controller(), policy.address) ||
+    !sameAddress(
+      await vault.pendingController(),
+      ethers.constants.AddressZero
+    ) ||
+    !(await vault.pendingControllerValidAt()).isZero() ||
+    !(await vault.controllerChangeDelay()).eq(
+      STAKE_VAULT_CONTROLLER_CHANGE_DELAY
+    ) ||
+    !sameAddress(await vault.stakeToken(), USDC.base_staging)
+  ) {
+    throw new Error("Staging predecessor vault configuration mismatch");
+  }
+  const vaultBalances = await Promise.all([
+    vault.totalStaked(),
+    vault.totalClaimable(),
+    vault.totalAccounted(),
+    vault.unaccountedBalance(),
+    usdc.balanceOf(vault.address),
+  ]);
+  if (vaultBalances.some((value) => !value.isZero())) {
+    throw new Error("Staging predecessor vault is not drained");
+  }
+  const writers: string[] = await nullifierRegistry.getWriters();
+  if (
+    !sameAddress(await nullifierRegistry.owner(), governance) ||
+    writers.length !== 1 ||
+    !sameAddress(writers[0], policy.address)
+  ) {
+    throw new Error("Staging predecessor nullifier registry drifted");
+  }
+
+  const policyLifecycleTopics = [
+    "ChargebackIntentOpened(bytes32,address,address,address,bytes32,uint256,uint64)",
+    "ChargebackIntentCancelled(bytes32,address,uint256)",
+    "ChargebackIntentSettled(bytes32,address,address,uint256,uint64,bool)",
+    "ChargebackIntentReleased(bytes32,address,uint256)",
+    "ChargebackSettled(bytes32,address,address,uint256,bytes32)",
+  ].map(ethers.utils.id);
+  const authorizationInterface = new ethers.utils.Interface([
+    "event LifecycleHookAuthorizationUpdated(address indexed hook,bool isAuthorized)",
+  ]);
+  const chargebackEnabledInterface = new ethers.utils.Interface([
+    "event ChargebackEnabledUpdated(address indexed escrow,uint256 indexed depositId,bool isChargebackEnabled)",
+  ]);
+  const [
+    policyLifecycleLogs,
+    chargebackEnabledLogs,
+    authorizationLogs,
+    nullifierLogs,
+    signaledLogs,
+  ] = await Promise.all([
+    ethers.provider.getLogs({
+      address: policy.address,
+      fromBlock: STAGING_PREDECESSOR.fromBlock,
+      toBlock: currentBlock,
+      topics: [policyLifecycleTopics],
+    }),
+    ethers.provider.getLogs({
+      address: policy.address,
+      fromBlock: STAGING_PREDECESSOR.fromBlock,
+      toBlock: currentBlock,
+      topics: [
+        ethers.utils.id("ChargebackEnabledUpdated(address,uint256,bool)"),
+      ],
+    }),
+    ethers.provider.getLogs({
+      address: policy.address,
+      fromBlock: STAGING_PREDECESSOR.fromBlock,
+      toBlock: currentBlock,
+      topics: [
+        ethers.utils.id("LifecycleHookAuthorizationUpdated(address,bool)"),
+      ],
+    }),
+    ethers.provider.getLogs({
+      address: nullifierRegistry.address,
+      fromBlock: STAGING_PREDECESSOR.fromBlock,
+      toBlock: currentBlock,
+      topics: [ethers.utils.id("NullifierAdded(bytes32,address)")],
+    }),
+    contracts.orchestrator.queryFilter(
+      contracts.orchestrator.filters.IntentSignaled(),
+      STAGING_PREDECESSOR.orchestratorFromBlock,
+      currentBlock
+    ),
+  ]);
+  if (policyLifecycleLogs.length !== 0) {
+    throw new Error("Staging predecessor policy has lifecycle activity");
+  }
+  const retiredSetting = STAGING_PREDECESSOR.retiredDepositSetting;
+  const normalizedSettingLogs = chargebackEnabledLogs.map((log) => {
+    const decoded = chargebackEnabledInterface.parseLog(log);
+    return {
+      escrow: decoded.args.escrow as string,
+      depositId: decoded.args.depositId.toNumber(),
+      isEnabled: decoded.args.isChargebackEnabled as boolean,
+      blockNumber: log.blockNumber,
+      transactionHash: log.transactionHash,
+    };
+  });
+  const retiredEscrow = await ethers.getContractAt(
+    "EscrowV2",
+    retiredSetting.escrow
+  );
+  const retiredDeposit = await retiredEscrow.getDeposit(
+    retiredSetting.depositId
+  );
+  const retiredPaymentMethods = await retiredEscrow.getDepositPaymentMethods(
+    retiredSetting.depositId
+  );
+  const retiredIntentHashes = await retiredEscrow.getDepositIntentHashes(
+    retiredSetting.depositId
+  );
+  const closedEvents = await retiredEscrow.queryFilter(
+    retiredEscrow.filters.DepositClosed(),
+    retiredSetting.events[retiredSetting.events.length - 1].blockNumber,
+    currentBlock
+  );
+  const matchingClose: any = closedEvents.find(
+    (event: any) =>
+      event.args?.depositId?.eq(retiredSetting.depositId) &&
+      event.blockNumber === retiredSetting.closedBlockNumber &&
+      event.transactionHash.toLowerCase() ===
+        retiredSetting.closedTransactionHash
+  );
+  assertStagingRetiredDepositSettingEvidence(normalizedSettingLogs, {
+    canonicalEscrow: expectedEscrowV2,
+    allZeroDeposit:
+      sameAddress(retiredDeposit.depositor, ethers.constants.AddressZero) &&
+      sameAddress(retiredDeposit.delegate, ethers.constants.AddressZero) &&
+      sameAddress(retiredDeposit.token, ethers.constants.AddressZero) &&
+      retiredDeposit.intentAmountRange.min.isZero() &&
+      retiredDeposit.intentAmountRange.max.isZero() &&
+      !retiredDeposit.acceptingIntents &&
+      retiredDeposit.remainingDeposits.isZero() &&
+      retiredDeposit.outstandingIntentAmount.isZero() &&
+      sameAddress(
+        retiredDeposit.intentGuardian,
+        ethers.constants.AddressZero
+      ) &&
+      !retiredDeposit.retainOnEmpty,
+    depositCounterGreater: (await retiredEscrow.depositCounter()).gt(
+      retiredSetting.depositId
+    ),
+    paymentMethodsEmpty: retiredPaymentMethods.length === 0,
+    intentHashesEmpty: retiredIntentHashes.length === 0,
+    closedBlockNumber: matchingClose?.blockNumber,
+    closedTransactionHash: matchingClose?.transactionHash,
+  });
+  const authorization = new Map<string, boolean>();
+  for (const log of authorizationLogs) {
+    const decoded = authorizationInterface.parseLog(log);
+    authorization.set(
+      decoded.args.hook.toLowerCase(),
+      decoded.args.isAuthorized
+    );
+  }
+  const activeHooks = [...authorization.entries()]
+    .filter(([, isAuthorized]) => isAuthorized)
+    .map(([authorizedHook]) => authorizedHook);
+  if (
+    activeHooks.length !== 1 ||
+    activeHooks[0] !== STAGING_PREDECESSOR.hook.address.toLowerCase()
+  ) {
+    throw new Error("Staging predecessor has unexpected authorized hooks");
+  }
+  if (nullifierLogs.length !== 0) {
+    throw new Error(
+      "Staging predecessor registry has dispute nullifier activity"
+    );
+  }
+  if (!(await contracts.orchestrator.intentCounter()).eq(signaledLogs.length)) {
+    throw new Error(
+      "Staging OrchestratorV3 intent event history is incomplete"
+    );
+  }
+  for (const log of signaledLogs) {
+    const intentHash = log.args?.intentHash || log.args?.[0];
+    if (!intentHash) throw new Error("Unable to decode staging intent hash");
+    if (
+      !sameAddress(
+        await contracts.orchestrator.getIntentLifecycleHook(intentHash),
+        ethers.constants.AddressZero
+      )
+    ) {
+      throw new Error(`Staging predecessor still owns intent ${intentHash}`);
+    }
+  }
+  console.log(
+    `=== Staging predecessor drained through block ${currentBlock} ===`
+  );
+}
+
+export async function assertFreshStackUnusedBeforeActivation(
+  hre: HardhatRuntimeEnvironment,
+  deployments: Record<string, any>,
+  contracts: Awaited<ReturnType<typeof getStackContracts>>
+): Promise<void> {
+  const deploymentBlocks = STACK_DEPLOYMENT_NAMES.map(
+    (name) => deployments[name].receipt?.blockNumber
+  );
+  if (
+    deploymentBlocks.some(
+      (blockNumber) =>
+        typeof blockNumber !== "number" || !Number.isSafeInteger(blockNumber)
+    )
+  ) {
+    throw new Error("Fresh dispute artifacts lack deployment-block evidence");
+  }
+  const fromBlock = Math.min(...(deploymentBlocks as number[]));
+  const currentBlock = await ethers.provider.getBlockNumber();
+  const policyLifecycleTopics = [
+    "DisputeProtectionIntentOpened(bytes32,address,address,address,bytes32,uint256,uint64)",
+    "DisputeProtectionIntentCancelled(bytes32,address,uint256)",
+    "DisputeProtectionIntentSettled(bytes32,address,address,uint256,uint64,bool)",
+    "DisputeProtectionIntentReleased(bytes32,address,uint256)",
+    "DisputeResolved(bytes32,address,address,uint256,bytes32)",
+    "DisputeProtectionEnabledUpdated(address,uint256,bool)",
+  ].map(ethers.utils.id);
+  const vaultFinancialTopics = [
+    "StakeDeposited(address,uint256,uint256)",
+    "StakeWithdrawn(address,uint256,uint256)",
+    "TakerAuthorizationUpdated(address,address,bool)",
+    "StakeOwnerSelected(address,address,address)",
+    "StakeLocked(bytes32,address,uint256,uint64,uint256)",
+    "LockFunded(bytes32,address,uint256,uint256)",
+    "StakeLockIncreased(bytes32,address,uint256,uint256,uint256)",
+    "StakeLockResized(bytes32,address,uint256,uint256,uint64,uint64,uint256)",
+    "StakeUnlocked(bytes32,address,uint256,uint256)",
+    "StakeLockResolved(bytes32,address,uint256,uint256,uint256,uint256)",
+    "ClaimCreated(bytes32,address,uint256,uint256)",
+    "ClaimWithdrawn(address,uint256)",
+  ].map(ethers.utils.id);
+  const [policyLogs, nullifierLogs, vaultLogs] = await Promise.all([
+    ethers.provider.getLogs({
+      address: contracts.disputeProtectionPolicy.address,
+      fromBlock,
+      toBlock: currentBlock,
+      topics: [policyLifecycleTopics],
+    }),
+    ethers.provider.getLogs({
+      address: contracts.disputeNullifierRegistry.address,
+      fromBlock,
+      toBlock: currentBlock,
+      topics: [ethers.utils.id("NullifierAdded(bytes32,address)")],
+    }),
+    ethers.provider.getLogs({
+      address: contracts.vault.address,
+      fromBlock,
+      toBlock: currentBlock,
+      topics: [vaultFinancialTopics],
+    }),
+  ]);
+  if (policyLogs.length !== 0 || nullifierLogs.length !== 0) {
+    throw new Error(
+      "Fresh dispute stack has pre-activation lifecycle activity"
+    );
+  }
+  if (vaultLogs.length !== 0) {
+    throw new Error("Fresh StakeVault has pre-activation financial activity");
+  }
+  const stakeTokenAddress =
+    USDC[hre.deployments.getNetworkName()] ||
+    (await hre.deployments.get("USDCMock")).address;
+  const stakeToken = new ethers.Contract(
+    stakeTokenAddress,
+    ["function balanceOf(address) view returns (uint256)"],
+    ethers.provider
+  );
+  const balances = await Promise.all([
+    contracts.vault.totalStaked(),
+    contracts.vault.totalClaimable(),
+    contracts.vault.totalAccounted(),
+    contracts.vault.unaccountedBalance(),
+    stakeToken.balanceOf(contracts.vault.address),
+  ]);
+  if (balances.some((balance) => !balance.isZero())) {
+    throw new Error("Fresh StakeVault is not empty before activation");
+  }
+}
+
+async function assertOnlyExpectedLifecycleHookAuthorized(
+  deployments: Record<string, any>,
+  contracts: Awaited<ReturnType<typeof getStackContracts>>,
+  requireExpected: boolean
+): Promise<void> {
+  const fromBlock = deployments.DisputeProtectionPolicy.receipt?.blockNumber;
+  if (typeof fromBlock !== "number" || !Number.isSafeInteger(fromBlock)) {
+    throw new Error("DisputeProtectionPolicy lacks deployment-block evidence");
+  }
+  const logs = await contracts.disputeProtectionPolicy.queryFilter(
+    contracts.disputeProtectionPolicy.filters.LifecycleHookAuthorizationUpdated(),
+    fromBlock,
+    await ethers.provider.getBlockNumber()
+  );
+  const authorization = new Map<string, boolean>();
+  for (const log of logs) {
+    const hook = log.args?.hook || log.args?.[0];
+    const isAuthorized = log.args?.isAuthorized ?? log.args?.[1];
+    if (!hook || typeof isAuthorized !== "boolean") {
+      throw new Error("Unable to decode lifecycle-hook authorization history");
+    }
+    authorization.set(hook.toLowerCase(), isAuthorized);
+  }
+  const activeHooks = [...authorization.entries()]
+    .filter(([, isAuthorized]) => isAuthorized)
+    .map(([hook]) => hook);
+  const expectedHook = contracts.hook.address.toLowerCase();
+  if (
+    activeHooks.some((hook) => hook !== expectedHook) ||
+    (requireExpected &&
+      (activeHooks.length !== 1 || activeHooks[0] !== expectedHook))
+  ) {
+    throw new Error(
+      "DisputeProtectionPolicy has an unexpected authorized hook"
+    );
+  }
+}
+
+async function assertStackDependenciesAreResumable(
+  hre: HardhatRuntimeEnvironment,
+  deployments: Record<string, any>
+): Promise<Awaited<ReturnType<typeof getStackContracts>>> {
+  const network = hre.deployments.getNetworkName();
+  const [deployer] = await hre.getUnnamedAccounts();
+  const governance = MULTI_SIG[network] || deployer;
+  const stakeTokenAddress =
+    USDC[network] || (await hre.deployments.get("USDCMock")).address;
+  const orchestratorRegistryAddress = (
+    await hre.deployments.get("OrchestratorRegistry")
+  ).address;
+  const whitelistPolicyAddress = (await hre.deployments.get("WhitelistPolicy"))
+    .address;
+  const nullifierRegistryV2Address = (
+    await hre.deployments.get("NullifierRegistryV2")
+  ).address;
+  const attestationVerifier =
+    (await hre.deployments.getOrNull("MultiAttestationVerifier")) ||
+    (await hre.deployments.get("SimpleAttestationVerifier"));
+  await assertExpectedAttestationVerifier(hre, attestationVerifier, governance);
+  const contracts = await getStackContracts(hre, deployments);
+
+  for (const name of STACK_DEPLOYMENT_NAMES) {
+    await assertDeploymentRuntime(hre, deployments[name], name);
+  }
+  await assertOnlyExpectedLifecycleHookAuthorized(
+    deployments,
+    contracts,
+    false
+  );
+  await assertExpectedOrchestrator(hre, contracts);
+  if (
+    !sameAddress(
+      await contracts.disputeVerifier.nullifierRegistry(),
+      nullifierRegistryV2Address
+    ) ||
+    !sameAddress(
+      await contracts.disputeVerifier.attestationVerifier(),
+      attestationVerifier.address
+    )
+  ) {
+    throw new Error("DisputeVerifier constructor dependency mismatch");
+  }
+  if (
+    !sameAddress(await contracts.vault.stakeToken(), stakeTokenAddress) ||
+    !(await contracts.vault.controllerChangeDelay()).eq(
+      STAKE_VAULT_CONTROLLER_CHANGE_DELAY
+    ) ||
+    !sameAddress(
+      await contracts.vault.pendingController(),
+      ethers.constants.AddressZero
+    ) ||
+    !(await contracts.vault.pendingControllerValidAt()).isZero()
+  ) {
+    throw new Error("StakeVault constructor dependency mismatch");
+  }
+  const currentController = await contracts.vault.controller();
+  if (
+    !sameAddress(currentController, ethers.constants.AddressZero) &&
+    !sameAddress(currentController, contracts.disputeProtectionPolicy.address)
+  ) {
+    throw new Error("StakeVault has an unexpected controller");
+  }
+  if (
+    (await contracts.disputeProtectionPolicy.admissionsPaused()) ||
+    !sameAddress(
+      await contracts.disputeProtectionPolicy.stakeVault(),
+      contracts.vault.address
+    ) ||
+    !sameAddress(
+      await contracts.disputeProtectionPolicy.disputeVerifier(),
+      contracts.disputeVerifier.address
+    ) ||
+    !sameAddress(
+      await contracts.disputeProtectionPolicy.disputeNullifierRegistry(),
+      contracts.disputeNullifierRegistry.address
+    )
+  ) {
+    throw new Error("DisputeProtectionPolicy constructor dependency mismatch");
+  }
+  if (
+    !sameAddress(
+      await contracts.hook.orchestratorRegistry(),
+      orchestratorRegistryAddress
+    ) ||
+    !sameAddress(
+      await contracts.hook.whitelistPolicy(),
+      whitelistPolicyAddress
+    ) ||
+    !sameAddress(
+      await contracts.hook.disputeProtectionPolicy(),
+      contracts.disputeProtectionPolicy.address
+    )
+  ) {
+    throw new Error("IntentLifecycleHookV1 constructor dependency mismatch");
+  }
+
+  const registryOwner = await contracts.disputeNullifierRegistry.owner();
+  if (
+    !sameAddress(registryOwner, deployer) &&
+    !sameAddress(registryOwner, governance)
+  ) {
+    throw new Error("DisputeNullifierRegistry has an unexpected owner");
+  }
+  for (const contract of [
+    contracts.disputeVerifier,
+    contracts.vault,
+    contracts.disputeProtectionPolicy,
+  ]) {
+    const owner = await contract.owner();
+    if (!sameAddress(owner, deployer) && !sameAddress(owner, governance)) {
+      throw new Error(`Unexpected owner on ${contract.address}`);
+    }
+    const pendingOwner = await contract.pendingOwner();
+    if (
+      !sameAddress(pendingOwner, ethers.constants.AddressZero) &&
+      !sameAddress(pendingOwner, governance)
+    ) {
+      throw new Error(`Unexpected pending owner on ${contract.address}`);
+    }
+  }
+  const writers: string[] =
+    await contracts.disputeNullifierRegistry.getWriters();
+  if (
+    writers.length > 1 ||
+    (writers.length === 1 &&
+      !sameAddress(writers[0], contracts.disputeProtectionPolicy.address))
+  ) {
+    throw new Error("DisputeNullifierRegistry has an unexpected writer");
+  }
+  const disputableMethods = new Set(DISPUTABLE_PAYMENT_METHODS);
+  for (const methodName of ACTIVE_PAYMENT_METHODS) {
+    const riskWindow = await contracts.disputeProtectionPolicy.getRiskWindow(
+      paymentMethodHash(methodName)
+    );
+    const expectedRiskWindow = disputableMethods.has(methodName)
+      ? DISPUTE_RISK_WINDOW[network]
+      : ethers.constants.Zero;
+    if (!riskWindow.isZero() && !riskWindow.eq(expectedRiskWindow)) {
+      throw new Error(`Unexpected resumable risk window for ${methodName}`);
+    }
+  }
+  return contracts;
+}
+
+async function assertStackConfiguration(
+  hre: HardhatRuntimeEnvironment,
+  deployments: Record<string, any>
+): Promise<Awaited<ReturnType<typeof getStackContracts>>> {
+  const network = hre.deployments.getNetworkName();
+  const [deployer] = await hre.getUnnamedAccounts();
+  const governance = MULTI_SIG[network] || deployer;
+  const stakeTokenAddress =
+    USDC[network] || (await hre.deployments.get("USDCMock")).address;
+  const orchestratorRegistryAddress = (
+    await hre.deployments.get("OrchestratorRegistry")
+  ).address;
+  const whitelistPolicyAddress = (await hre.deployments.get("WhitelistPolicy"))
+    .address;
+  const nullifierRegistryV2Address = (
+    await hre.deployments.get("NullifierRegistryV2")
+  ).address;
+  const attestationVerifier =
+    (await hre.deployments.getOrNull("MultiAttestationVerifier")) ||
+    (await hre.deployments.get("SimpleAttestationVerifier"));
+  await assertExpectedAttestationVerifier(hre, attestationVerifier, governance);
+  const contracts = await getStackContracts(hre, deployments);
+
+  for (const name of STACK_DEPLOYMENT_NAMES) {
+    await assertDeploymentRuntime(hre, deployments[name], name);
+  }
+  await assertOnlyExpectedLifecycleHookAuthorized(deployments, contracts, true);
+  await assertExpectedOrchestrator(hre, contracts);
+  if (
+    !sameAddress(
+      await contracts.disputeVerifier.nullifierRegistry(),
+      nullifierRegistryV2Address
+    )
+  ) {
+    throw new Error("DisputeVerifier nullifier registry mismatch");
+  }
+  if (
+    !sameAddress(
+      await contracts.disputeVerifier.attestationVerifier(),
+      attestationVerifier.address
+    )
+  ) {
+    throw new Error("DisputeVerifier attestation verifier mismatch");
+  }
+  if (!sameAddress(await contracts.vault.stakeToken(), stakeTokenAddress)) {
+    throw new Error("StakeVault token mismatch");
+  }
+  if (
+    !sameAddress(
+      await contracts.vault.controller(),
+      contracts.disputeProtectionPolicy.address
+    ) ||
+    !sameAddress(
+      await contracts.vault.pendingController(),
+      ethers.constants.AddressZero
+    ) ||
+    !(await contracts.vault.pendingControllerValidAt()).isZero()
+  ) {
+    throw new Error("StakeVault controller mismatch");
+  }
+  if (
+    !(await contracts.vault.controllerChangeDelay()).eq(
+      STAKE_VAULT_CONTROLLER_CHANGE_DELAY
+    )
+  ) {
+    throw new Error("StakeVault controller change delay mismatch");
+  }
+  if (
+    (await contracts.disputeProtectionPolicy.admissionsPaused()) ||
+    !sameAddress(
+      await contracts.disputeProtectionPolicy.stakeVault(),
+      contracts.vault.address
+    )
+  ) {
+    throw new Error("DisputeProtectionPolicy vault mismatch");
+  }
+  if (
+    !sameAddress(
+      await contracts.disputeProtectionPolicy.disputeVerifier(),
+      contracts.disputeVerifier.address
+    )
+  ) {
+    throw new Error("DisputeProtectionPolicy verifier mismatch");
+  }
+  if (
+    !sameAddress(
+      await contracts.disputeProtectionPolicy.disputeNullifierRegistry(),
+      contracts.disputeNullifierRegistry.address
+    )
+  ) {
+    throw new Error("DisputeProtectionPolicy dispute registry mismatch");
+  }
+  if (
+    !(await contracts.disputeProtectionPolicy.isLifecycleHookAuthorized(
+      contracts.hook.address
+    ))
+  ) {
+    throw new Error(
+      "IntentLifecycleHookV1 is not authorized by DisputeProtectionPolicy"
+    );
+  }
+  const writers: string[] =
+    await contracts.disputeNullifierRegistry.getWriters();
+  if (
+    writers.length !== 1 ||
+    !sameAddress(writers[0], contracts.disputeProtectionPolicy.address)
+  ) {
+    throw new Error(
+      "DisputeNullifierRegistry writers must contain only DisputeProtectionPolicy"
+    );
+  }
+  if (
+    !sameAddress(
+      await contracts.hook.orchestratorRegistry(),
+      orchestratorRegistryAddress
+    )
+  ) {
+    throw new Error("IntentLifecycleHookV1 orchestrator registry mismatch");
+  }
+  if (
+    !sameAddress(await contracts.hook.whitelistPolicy(), whitelistPolicyAddress)
+  ) {
+    throw new Error("IntentLifecycleHookV1 whitelist policy mismatch");
+  }
+  if (
+    !sameAddress(
+      await contracts.hook.disputeProtectionPolicy(),
+      contracts.disputeProtectionPolicy.address
+    )
+  ) {
+    throw new Error("IntentLifecycleHookV1 dispute policy mismatch");
+  }
+
+  const disputableMethods = new Set(DISPUTABLE_PAYMENT_METHODS);
+  for (const methodName of ACTIVE_PAYMENT_METHODS) {
+    const actualRiskWindow =
+      await contracts.disputeProtectionPolicy.getRiskWindow(
+        paymentMethodHash(methodName)
+      );
+    const expectedRiskWindow = disputableMethods.has(methodName)
+      ? DISPUTE_RISK_WINDOW[network]
+      : ethers.constants.Zero;
+    if (!actualRiskWindow.eq(expectedRiskWindow)) {
+      throw new Error(`Unexpected dispute risk window for ${methodName}`);
+    }
+  }
+  return contracts;
+}
+
+async function assertNoPendingGovernanceTakeovers(
+  governance: string,
+  contracts: Awaited<ReturnType<typeof getStackContracts>>
+): Promise<void> {
+  for (const contract of [
+    contracts.disputeVerifier,
+    contracts.vault,
+    contracts.disputeProtectionPolicy,
+  ]) {
+    if (
+      sameAddress(await contract.owner(), governance) &&
+      !sameAddress(await contract.pendingOwner(), ethers.constants.AddressZero)
+    ) {
+      throw new Error(
+        `Governance-owned contract has a pending ownership takeover: ${contract.address}`
+      );
+    }
+  }
+}
+
+export async function disputeStackReady(
+  hre: HardhatRuntimeEnvironment
+): Promise<boolean> {
+  const deployments = await getStackDeployments(hre, true);
+  if (!completeStackExists(deployments)) return false;
+  await assertExpectedNetworkDependencies(hre);
+  const network = hre.deployments.getNetworkName();
+  const [deployer] = await hre.getUnnamedAccounts();
+  const governance = MULTI_SIG[network] || deployer;
+  const contracts = await assertStackConfiguration(hre, deployments);
+  await assertNoPendingGovernanceTakeovers(governance, contracts);
+
+  if (
+    !sameAddress(await contracts.disputeNullifierRegistry.owner(), governance)
+  )
+    return false;
+  if (!sameAddress(await contracts.disputeVerifier.owner(), governance))
+    return false;
+  if (!sameAddress(await contracts.vault.owner(), governance)) return false;
+  if (!sameAddress(await contracts.disputeProtectionPolicy.owner(), governance))
+    return false;
+  return sameAddress(
+    await contracts.orchestrator.lifecycleHook(),
+    contracts.hook.address
+  );
+}
+
+export async function disputeStackPrepared(
+  hre: HardhatRuntimeEnvironment
+): Promise<boolean> {
+  const deployments = await getStackDeployments(hre, true);
+  if (!completeStackExists(deployments)) return false;
+  await assertExpectedNetworkDependencies(hre);
+  const network = hre.deployments.getNetworkName();
+  const [deployer] = await hre.getUnnamedAccounts();
+  const governance = MULTI_SIG[network] || deployer;
+  const contracts = await assertStackConfiguration(hre, deployments);
+  await assertOrchestratorStillOnPredecessor(hre, contracts);
+  await assertNoPendingGovernanceTakeovers(governance, contracts);
+
+  return (
+    sameAddress(await contracts.disputeNullifierRegistry.owner(), governance) &&
+    sameAddress(await contracts.disputeVerifier.owner(), governance) &&
+    sameAddress(await contracts.vault.owner(), governance) &&
+    sameAddress(await contracts.disputeProtectionPolicy.owner(), governance)
+  );
+}
+
+export function stagingDisputeActivationRequested(
+  stackWasPreparedAtStart: boolean
+): boolean {
+  const requested = process.env.ENABLE_STAGING_V3_DISPUTE_ACTIVATION === "true";
+  if (!requested) return false;
+  if (!stackWasPreparedAtStart) {
+    throw new Error(
+      "Base staging dispute activation requires a prior completed deploy-only run so fresh addresses can be reviewed and propagated downstream"
+    );
+  }
+  if (process.env.CONFIRM_STAGING_V3_DISPUTE_DOWNSTREAM_READY !== "true") {
+    throw new Error(
+      "Base staging dispute activation requires CONFIRM_STAGING_V3_DISPUTE_DOWNSTREAM_READY=true"
+    );
+  }
+  if (process.env.CONFIRM_STAGING_V3_DISPUTE_PREDECESSOR_DRAINED !== "true") {
+    throw new Error(
+      "Base staging dispute activation requires CONFIRM_STAGING_V3_DISPUTE_PREDECESSOR_DRAINED=true"
+    );
+  }
   return true;
+}
+
+export function mayPrepareBeforePaymentBindingCutover(
+  network: string
+): boolean {
+  return network === "base";
+}
+
+async function assertStackPreparedForGovernance(
+  governance: string,
+  contracts: Awaited<ReturnType<typeof getStackContracts>>
+): Promise<void> {
+  if (
+    !sameAddress(await contracts.disputeNullifierRegistry.owner(), governance)
+  ) {
+    throw new Error(
+      "DisputeNullifierRegistry ownership transfer did not complete"
+    );
+  }
+  for (const contract of [
+    contracts.disputeVerifier,
+    contracts.vault,
+    contracts.disputeProtectionPolicy,
+  ]) {
+    const owner = await contract.owner();
+    const pendingOwner = await contract.pendingOwner();
+    if (sameAddress(owner, governance)) {
+      if (!sameAddress(pendingOwner, ethers.constants.AddressZero)) {
+        throw new Error(
+          `Governance-owned contract has a pending ownership takeover: ${contract.address}`
+        );
+      }
+    } else {
+      if (!sameAddress(pendingOwner, governance)) {
+        throw new Error(
+          `Ownership is neither held nor pending for governance on ${contract.address}`
+        );
+      }
+      const acceptData =
+        contract.interface.encodeFunctionData("acceptOwnership");
+      if (!safeBatchCollector.hasQueued(contract.address, acceptData)) {
+        throw new Error(
+          `Missing Safe acceptOwnership call for ${contract.address}`
+        );
+      }
+    }
+  }
+
+  if (
+    !sameAddress(
+      await contracts.orchestrator.lifecycleHook(),
+      contracts.hook.address
+    )
+  ) {
+    const activationData = contracts.orchestrator.interface.encodeFunctionData(
+      "setLifecycleHook",
+      [contracts.hook.address]
+    );
+    if (
+      !safeBatchCollector.hasQueued(
+        contracts.orchestrator.address,
+        activationData
+      )
+    ) {
+      throw new Error("Missing Safe lifecycle-hook activation call");
+    }
+  }
+}
+
+async function activateLifecycleHook(
+  hre: HardhatRuntimeEnvironment,
+  orchestrator: any,
+  hookAddress: string
+): Promise<void> {
+  if (sameAddress(await orchestrator.lifecycleHook(), hookAddress)) return;
+  const owner = await orchestrator.owner();
+  const activationData = orchestrator.interface.encodeFunctionData(
+    "setLifecycleHook",
+    [hookAddress]
+  );
+  if (
+    (await hre.getUnnamedAccounts()).some((account) =>
+      sameAddress(account, owner)
+    )
+  ) {
+    await (await orchestrator.setLifecycleHook(hookAddress)).wait();
+    await waitForDeploymentDelay(hre);
+  } else {
+    safeBatchCollector.add(
+      orchestrator.address,
+      activationData,
+      `OrchestratorV3.setLifecycleHook(${hookAddress})`
+    );
+  }
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const network = hre.deployments.getNetworkName();
+  await assertExpectedNetworkDependencies(hre);
+  await assertOrchestratorPreflight(hre);
+  const paymentBindingReady = await paymentBindingCutoverReady(hre);
+  if (!paymentBindingReady && !mayPrepareBeforePaymentBindingCutover(network)) {
+    throw new Error(
+      "V3 payment binding must be fully cut over before the dispute stack is deployed"
+    );
+  }
+  if (!paymentBindingReady) {
+    console.log(
+      "Base payment binding is not cut over; deploying the passive dispute stack and preparing an unsigned Safe activation batch only"
+    );
+  }
+  const [deployer] = await hre.getUnnamedAccounts();
+  const governance = MULTI_SIG[network] || deployer;
+  const safeTransactionsBefore = safeBatchCollector.count();
+  const stakeTokenAddress =
+    USDC[network] || (await hre.deployments.get("USDCMock")).address;
+  const orchestratorRegistryAddress = (
+    await hre.deployments.get("OrchestratorRegistry")
+  ).address;
+  const whitelistPolicyAddress = (await hre.deployments.get("WhitelistPolicy"))
+    .address;
+  const nullifierRegistryV2Address = (
+    await hre.deployments.get("NullifierRegistryV2")
+  ).address;
+  const attestationVerifier =
+    (await hre.deployments.getOrNull("MultiAttestationVerifier")) ||
+    (await hre.deployments.get("SimpleAttestationVerifier"));
+  await assertExpectedAttestationVerifier(hre, attestationVerifier, governance);
+
+  await assertCode(orchestratorRegistryAddress, "OrchestratorRegistry");
+  await assertCode(whitelistPolicyAddress, "WhitelistPolicy");
+  await assertCode(nullifierRegistryV2Address, "NullifierRegistryV2");
+  await assertCode(attestationVerifier.address, "AttestationVerifier");
+
+  let deployments = await getStackDeployments(hre, true);
+  await assertPartialStackIsResumable(hre, deployments);
+  const stackExistedAtStart = completeStackExists(deployments);
+  let stagingStackWasPreparedAtStart = false;
+  if (
+    network === "base_staging" &&
+    process.env.ENABLE_STAGING_V3_DISPUTE_ACTIVATION === "true" &&
+    stackExistedAtStart
+  ) {
+    stagingStackWasPreparedAtStart = await disputeStackPrepared(hre);
+  }
+  const activateNow =
+    network === "base_staging"
+      ? stagingDisputeActivationRequested(stagingStackWasPreparedAtStart)
+      : true;
+  if (
+    network === "base_staging" &&
+    !stackExistedAtStart &&
+    process.env.ENABLE_STAGING_V3_DISPUTE_DEPLOYMENT !== "true"
+  ) {
+    throw new Error(
+      "Base staging dispute deployment or partial-deployment resume requires ENABLE_STAGING_V3_DISPUTE_DEPLOYMENT=true"
+    );
+  }
+  if (
+    network === "base" &&
+    !stackExistedAtStart &&
+    process.env.ENABLE_BASE_V3_DISPUTE_DEPLOYMENT !== "true"
+  ) {
+    throw new Error(
+      "Base dispute deployment or partial-deployment resume requires ENABLE_BASE_V3_DISPUTE_DEPLOYMENT=true"
+    );
+  }
+
+  const deployMissing = async (
+    name: string,
+    options: Record<string, unknown>
+  ): Promise<any> => {
+    const existing = await hre.deployments.getOrNull(name);
+    if (existing) {
+      await assertDeploymentRuntime(
+        hre,
+        existing,
+        name as (typeof STACK_DEPLOYMENT_NAMES)[number]
+      );
+      return existing;
+    }
+    const deployment = await hre.deployments.deploy(name, options as any);
+    if (!deployment.newlyDeployed) {
+      throw new Error(`${name} was neither persisted nor freshly deployed`);
+    }
+    await waitForDeploymentDelay(hre);
+    await assertPartialStackIsResumable(
+      hre,
+      await getStackDeployments(hre, true)
+    );
+    return deployment;
+  };
+
+  if (!stackExistedAtStart) {
+    const disputeNullifierRegistry = await deployMissing(
+      "DisputeNullifierRegistry",
+      {
+        contract: "NullifierRegistry",
+        from: deployer,
+        args: [],
+        log: true,
+      }
+    );
+    const disputeVerifier = await deployMissing("DisputeVerifier", {
+      from: deployer,
+      args: [deployer, nullifierRegistryV2Address, attestationVerifier.address],
+      log: true,
+    });
+    const vault = await deployMissing("StakeVault", {
+      from: deployer,
+      args: [
+        deployer,
+        stakeTokenAddress,
+        ethers.constants.AddressZero,
+        STAKE_VAULT_CONTROLLER_CHANGE_DELAY,
+      ],
+      log: true,
+    });
+    const disputeProtectionPolicy = await deployMissing(
+      "DisputeProtectionPolicy",
+      {
+        from: deployer,
+        args: [
+          deployer,
+          vault.address,
+          disputeVerifier.address,
+          disputeNullifierRegistry.address,
+        ],
+        log: true,
+      }
+    );
+    await deployMissing("IntentLifecycleHookV1", {
+      from: deployer,
+      args: [
+        orchestratorRegistryAddress,
+        whitelistPolicyAddress,
+        disputeProtectionPolicy.address,
+      ],
+      log: true,
+    });
+    deployments = await getStackDeployments(hre);
+    if (!deployments)
+      throw new Error(
+        "Complete dispute deployment artifacts were not persisted"
+      );
+  }
+
+  if (!deployments || !completeStackExists(deployments)) {
+    throw new Error(
+      "Dispute deployment resume did not produce a complete stack"
+    );
+  }
+  const contracts = await assertStackDependenciesAreResumable(hre, deployments);
+  await assertOrchestratorStillOnPredecessor(hre, contracts);
+  await assertFreshStackUnusedBeforeActivation(hre, deployments, contracts);
+  if (activateNow) {
+    await assertStagingPredecessorDrained(hre, contracts);
+  }
+  if (
+    sameAddress(
+      await contracts.vault.controller(),
+      ethers.constants.AddressZero
+    )
+  ) {
+    await (
+      await contracts.vault.initializeController(
+        contracts.disputeProtectionPolicy.address
+      )
+    ).wait();
+    await waitForDeploymentDelay(hre);
+  }
+  await addWritePermission(
+    hre,
+    contracts.disputeNullifierRegistry,
+    contracts.disputeProtectionPolicy.address
+  );
+  if (
+    !(await contracts.disputeProtectionPolicy.isLifecycleHookAuthorized(
+      contracts.hook.address
+    ))
+  ) {
+    await (
+      await contracts.disputeProtectionPolicy.setLifecycleHookAuthorization(
+        contracts.hook.address,
+        true
+      )
+    ).wait();
+    await waitForDeploymentDelay(hre);
+  }
+  for (const methodName of DISPUTABLE_PAYMENT_METHODS) {
+    const paymentMethod = paymentMethodHash(methodName);
+    if (
+      !(
+        await contracts.disputeProtectionPolicy.getRiskWindow(paymentMethod)
+      ).eq(DISPUTE_RISK_WINDOW[network])
+    ) {
+      await (
+        await contracts.disputeProtectionPolicy.setRiskWindow(
+          paymentMethod,
+          DISPUTE_RISK_WINDOW[network]
+        )
+      ).wait();
+      await waitForDeploymentDelay(hre);
+    }
+  }
+
+  await assertStackConfiguration(hre, deployments);
+  await setNewOwner(hre, contracts.disputeNullifierRegistry, governance);
+  for (const contract of [
+    contracts.disputeVerifier,
+    contracts.vault,
+    contracts.disputeProtectionPolicy,
+  ]) {
+    await setNewOwner(hre, contract, governance);
+    await setNewOwner(hre, contract, governance);
+  }
+  if (activateNow) {
+    await activateLifecycleHook(
+      hre,
+      contracts.orchestrator,
+      contracts.hook.address
+    );
+  }
+
+  const queuedSafeTransactions =
+    safeBatchCollector.count() - safeTransactionsBefore;
+  if (queuedSafeTransactions > 0) {
+    await assertStackPreparedForGovernance(governance, contracts);
+    if (network === "base" && queuedSafeTransactions !== 4) {
+      throw new Error(
+        `Fresh Base dispute preparation must queue exactly 4 calls, queued ${queuedSafeTransactions}`
+      );
+    }
+    console.log(
+      "=== Fresh dispute lifecycle stack deployed; Safe activation batch prepared ==="
+    );
+  } else if (activateNow && !(await disputeStackReady(hre))) {
+    throw new Error(
+      "Dispute lifecycle stack deployment and activation verification failed"
+    );
+  } else if (!activateNow && !(await disputeStackPrepared(hre))) {
+    throw new Error("Dispute lifecycle stack preparation verification failed");
+  } else if (!activateNow) {
+    console.log(
+      "=== Fresh dispute lifecycle stack deployed and prepared; activation remains gated ==="
+    );
+  } else {
+    console.log("=== Fresh dispute lifecycle stack deployed and activated ===");
+  }
+  console.log(
+    "DisputeNullifierRegistry:",
+    contracts.disputeNullifierRegistry.address
+  );
+  console.log("DisputeVerifier:", contracts.disputeVerifier.address);
+  console.log("StakeVault:", contracts.vault.address);
+  console.log(
+    "DisputeProtectionPolicy:",
+    contracts.disputeProtectionPolicy.address
+  );
+  console.log("IntentLifecycleHookV1:", contracts.hook.address);
 };
 
-func.tags = ["32_historical_dispute_lifecycle_stack"];
-func.dependencies = [];
+func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> => {
+  const network = hre.deployments.getNetworkName();
+  if (!SUPPORTED_NETWORKS.has(network)) return true;
+  if (await disputeStackReady(hre)) {
+    if (!(await paymentBindingCutoverReady(hre))) {
+      throw new Error(
+        "Dispute stack is active while the V3 payment binding is not cut over"
+      );
+    }
+    return true;
+  }
+  if (network === "base") {
+    return process.env.ENABLE_BASE_V3_DISPUTE_DEPLOYMENT !== "true";
+  }
+  if (network === "base_staging") {
+    const deployments = await getStackDeployments(hre, true);
+    if (!completeStackExists(deployments)) {
+      return process.env.ENABLE_STAGING_V3_DISPUTE_DEPLOYMENT !== "true";
+    }
+    if (process.env.ENABLE_STAGING_V3_DISPUTE_ACTIVATION === "true") {
+      return false;
+    }
+    if (!(await disputeStackPrepared(hre))) {
+      throw new Error(
+        "Existing Base staging dispute stack is neither prepared nor active"
+      );
+    }
+    return true;
+  }
+  return false;
+};
+
+func.tags = [
+  "32_deploy_and_activate_dispute_lifecycle_stack",
+  "V3DisputeLifecycleStack",
+];
+func.dependencies = ["V3PaymentBindingStack"];
 
 export default func;

--- a/deploy/34_deploy_opt_in_dispute_lifecycle_stack.ts
+++ b/deploy/34_deploy_opt_in_dispute_lifecycle_stack.ts
@@ -28,7 +28,7 @@ import { waitForDeploymentDelay } from "../deployments/helpers";
 import {
   PREDECESSOR_DISPUTE_STACKS,
   assertHistoricalDisputeStack,
-} from "./32_deploy_and_activate_dispute_lifecycle_stack";
+} from "../deployments/predecessorDisputeStack";
 import { paymentBindingCutoverReady } from "./31_deploy_v3_payment_binding_stack";
 import {
   DisputeSafeBatchManifest,

--- a/deployments/activeDeploymentLanes/30_deploy_v3_lifecycle_stack.ts
+++ b/deployments/activeDeploymentLanes/30_deploy_v3_lifecycle_stack.ts
@@ -1,0 +1,26 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+import { guardManagedDisputeLifecycleHook } from "../managedDisputeLifecycleHook";
+
+const historicalLane = require("../../deploy/30_deploy_v3_lifecycle_stack")
+  .default as DeployFunction;
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  if (await guardManagedDisputeLifecycleHook(hre)) return;
+  await historicalLane(hre);
+};
+
+func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> => {
+  if (await guardManagedDisputeLifecycleHook(hre)) return true;
+  return (await historicalLane.skip?.(hre)) ?? false;
+};
+
+func.tags = [
+  "30_deploy_v3_lifecycle_stack",
+  "V3LifecycleStack",
+  "OrchestratorV3",
+];
+func.dependencies = ["29_deploy_whitelist_policy"];
+
+export default func;

--- a/deployments/immutableDeploymentLanes.ts
+++ b/deployments/immutableDeploymentLanes.ts
@@ -1,0 +1,76 @@
+import { createHash } from "crypto";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+export const IMMUTABLE_DEPLOYMENT_LANES = {
+  "30_deploy_v3_lifecycle_stack.ts": {
+    deployedSourceSha: "3c4c1306dcce6693cf32300d8917d45c4604b84e",
+    sha256: "97ed83a35e91167186da7a1bde9d3534e6eced436a843a0afd07c0f055bf20fa",
+    activeSource:
+      "deployments/activeDeploymentLanes/30_deploy_v3_lifecycle_stack.ts",
+    retired: false,
+    tags: [
+      "30_deploy_v3_lifecycle_stack",
+      "V3LifecycleStack",
+      "OrchestratorV3",
+    ],
+  },
+  "32_deploy_and_activate_dispute_lifecycle_stack.ts": {
+    deployedSourceSha: "d5558c2888c9246448e1926135fd0c2cbeceb3e4",
+    sha256: "e103f2b9eb4168504cb226a6191a05c432e313ca5b649b0cc2a3d77fb3a5d283",
+    activeSource: null,
+    retired: true,
+    tags: [
+      "32_deploy_and_activate_dispute_lifecycle_stack",
+      "V3DisputeLifecycleStack",
+    ],
+  },
+} as const;
+
+export function assertImmutableDeploymentLanes(repositoryRoot: string): void {
+  for (const [filename, evidence] of Object.entries(
+    IMMUTABLE_DEPLOYMENT_LANES
+  )) {
+    const source = readFileSync(resolve(repositoryRoot, "deploy", filename));
+    const actual = createHash("sha256").update(source).digest("hex");
+    if (actual !== evidence.sha256) {
+      throw new Error(
+        `Invalid immutable deployment lane ${filename}: expected ${evidence.sha256}, found ${actual}`
+      );
+    }
+  }
+}
+
+export function selectActiveDeploymentScripts(
+  repositoryRoot: string,
+  filenames: readonly string[]
+): Array<{ filename: string; sourcePath: string }> {
+  return filenames.flatMap((filename) => {
+    const immutableLane =
+      IMMUTABLE_DEPLOYMENT_LANES[
+        filename as keyof typeof IMMUTABLE_DEPLOYMENT_LANES
+      ];
+    if (immutableLane?.activeSource === null) return [];
+    return [
+      {
+        filename,
+        sourcePath: immutableLane?.activeSource
+          ? resolve(repositoryRoot, immutableLane.activeSource)
+          : resolve(repositoryRoot, "deploy", filename),
+      },
+    ];
+  });
+}
+
+export function assertSupportedDeploymentTag(tag: string | undefined): void {
+  if (!tag) return;
+  if (tag.includes(",")) {
+    throw new Error("deployActive accepts exactly one deployment tag");
+  }
+  const retiredTags = IMMUTABLE_DEPLOYMENT_LANES[
+    "32_deploy_and_activate_dispute_lifecycle_stack.ts"
+  ].tags as readonly string[];
+  if (retiredTags.includes(tag)) {
+    throw new Error(`Refusing retired deployment tag: ${tag}`);
+  }
+}

--- a/deployments/managedDisputeLifecycleHook.ts
+++ b/deployments/managedDisputeLifecycleHook.ts
@@ -17,7 +17,7 @@ function sameAddress(left: string, right: string): boolean {
 
 export type ManagedHookSnapshot = {
   currentHook: string;
-  predecessor: { address: string; runtimeCodeHash: string };
+  predecessor?: { address: string; runtimeCodeHash: string };
   successor?: { address: string; runtimeCodeHash: string };
   actualRuntimeCodeHash: string;
   actualOrchestratorRegistry: string;
@@ -29,15 +29,14 @@ export type ManagedHookSnapshot = {
 export function validateManagedDisputeHookSnapshot(
   snapshot: ManagedHookSnapshot
 ): boolean {
-  const expected = sameAddress(
-    snapshot.currentHook,
-    snapshot.predecessor.address
-  )
-    ? snapshot.predecessor
-    : snapshot.successor &&
-      sameAddress(snapshot.currentHook, snapshot.successor.address)
-    ? snapshot.successor
-    : undefined;
+  const expected =
+    snapshot.predecessor &&
+    sameAddress(snapshot.currentHook, snapshot.predecessor.address)
+      ? snapshot.predecessor
+      : snapshot.successor &&
+        sameAddress(snapshot.currentHook, snapshot.successor.address)
+      ? snapshot.successor
+      : undefined;
   if (!expected) return false;
   if (snapshot.actualRuntimeCodeHash !== expected.runtimeCodeHash) {
     throw new Error("Managed dispute lifecycle hook runtime bytecode mismatch");
@@ -65,7 +64,13 @@ export async function guardManagedDisputeLifecycleHook(
   hre: HardhatRuntimeEnvironment
 ): Promise<boolean> {
   const network = hre.deployments.getNetworkName();
-  if (network !== "base" && network !== "base_staging") return false;
+  if (
+    network !== "base" &&
+    network !== "base_staging" &&
+    network !== "localhost" &&
+    network !== "hardhat"
+  )
+    return false;
   const predecessor = PREDECESSOR_DISPUTE_STACKS[network];
   const orchestratorDeployment = await hre.deployments.getOrNull(
     "OrchestratorV3"
@@ -82,7 +87,8 @@ export async function guardManagedDisputeLifecycleHook(
   );
   const successorDeployment = await hre.deployments.getOrNull(successorName);
   const matched =
-    sameAddress(currentHook, predecessor.activeLifecycleHook.address) ||
+    (predecessor &&
+      sameAddress(currentHook, predecessor.activeLifecycleHook.address)) ||
     (successorDeployment &&
       sameAddress(currentHook, successorDeployment.address));
   if (!matched) return false;
@@ -105,10 +111,11 @@ export async function guardManagedDisputeLifecycleHook(
   let successor: { address: string; runtimeCodeHash: string } | undefined;
   if (
     successorDeployment &&
-    !sameAddress(
-      successorDeployment.address,
-      predecessor.activeLifecycleHook.address
-    )
+    (!predecessor ||
+      !sameAddress(
+        successorDeployment.address,
+        predecessor.activeLifecycleHook.address
+      ))
   ) {
     if (typeof successorDeployment.deployedBytecode !== "string") {
       throw new Error(
@@ -124,7 +131,7 @@ export async function guardManagedDisputeLifecycleHook(
   }
   return validateManagedDisputeHookSnapshot({
     currentHook,
-    predecessor: predecessor.activeLifecycleHook,
+    predecessor: predecessor?.activeLifecycleHook,
     successor,
     actualRuntimeCodeHash: ethers.utils.keccak256(runtimeCode),
     actualOrchestratorRegistry: await hook.orchestratorRegistry(),

--- a/deployments/managedDisputeLifecycleHook.ts
+++ b/deployments/managedDisputeLifecycleHook.ts
@@ -1,0 +1,135 @@
+import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+import { PREDECESSOR_DISPUTE_STACKS } from "./predecessorDisputeStack";
+
+const { getActiveDisputeDeploymentName } =
+  require("./activeDisputeStack.cjs") as {
+    getActiveDisputeDeploymentName(
+      network: string,
+      canonicalName: string
+    ): string;
+  };
+
+function sameAddress(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+export type ManagedHookSnapshot = {
+  currentHook: string;
+  predecessor: { address: string; runtimeCodeHash: string };
+  successor?: { address: string; runtimeCodeHash: string };
+  actualRuntimeCodeHash: string;
+  actualOrchestratorRegistry: string;
+  expectedOrchestratorRegistry: string;
+  actualWhitelistPolicy: string;
+  expectedWhitelistPolicy: string;
+};
+
+export function validateManagedDisputeHookSnapshot(
+  snapshot: ManagedHookSnapshot
+): boolean {
+  const expected = sameAddress(
+    snapshot.currentHook,
+    snapshot.predecessor.address
+  )
+    ? snapshot.predecessor
+    : snapshot.successor &&
+      sameAddress(snapshot.currentHook, snapshot.successor.address)
+    ? snapshot.successor
+    : undefined;
+  if (!expected) return false;
+  if (snapshot.actualRuntimeCodeHash !== expected.runtimeCodeHash) {
+    throw new Error("Managed dispute lifecycle hook runtime bytecode mismatch");
+  }
+  if (
+    !sameAddress(
+      snapshot.actualOrchestratorRegistry,
+      snapshot.expectedOrchestratorRegistry
+    )
+  ) {
+    throw new Error("Managed dispute lifecycle hook registry mismatch");
+  }
+  if (
+    !sameAddress(
+      snapshot.actualWhitelistPolicy,
+      snapshot.expectedWhitelistPolicy
+    )
+  ) {
+    throw new Error("Managed dispute lifecycle hook whitelist policy mismatch");
+  }
+  return true;
+}
+
+export async function guardManagedDisputeLifecycleHook(
+  hre: HardhatRuntimeEnvironment
+): Promise<boolean> {
+  const network = hre.deployments.getNetworkName();
+  if (network !== "base" && network !== "base_staging") return false;
+  const predecessor = PREDECESSOR_DISPUTE_STACKS[network];
+  const orchestratorDeployment = await hre.deployments.getOrNull(
+    "OrchestratorV3"
+  );
+  if (!orchestratorDeployment) return false;
+  const orchestrator = await ethers.getContractAt(
+    "OrchestratorV3",
+    orchestratorDeployment.address
+  );
+  const currentHook = await orchestrator.lifecycleHook();
+  const successorName = getActiveDisputeDeploymentName(
+    network,
+    "IntentLifecycleHookV1"
+  );
+  const successorDeployment = await hre.deployments.getOrNull(successorName);
+  const matched =
+    sameAddress(currentHook, predecessor.activeLifecycleHook.address) ||
+    (successorDeployment &&
+      sameAddress(currentHook, successorDeployment.address));
+  if (!matched) return false;
+
+  const runtimeCode = await ethers.provider.getCode(currentHook);
+  if (runtimeCode === "0x")
+    throw new Error("Managed dispute lifecycle hook has no bytecode");
+  const hook = new ethers.Contract(
+    currentHook,
+    [
+      "function orchestratorRegistry() view returns (address)",
+      "function whitelistPolicy() view returns (address)",
+    ],
+    ethers.provider
+  );
+  const orchestratorRegistry = await hre.deployments.get(
+    "OrchestratorRegistry"
+  );
+  const whitelistPolicy = await hre.deployments.get("WhitelistPolicy");
+  let successor: { address: string; runtimeCodeHash: string } | undefined;
+  if (
+    successorDeployment &&
+    !sameAddress(
+      successorDeployment.address,
+      predecessor.activeLifecycleHook.address
+    )
+  ) {
+    if (typeof successorDeployment.deployedBytecode !== "string") {
+      throw new Error(
+        "Managed successor lifecycle hook lacks deployment bytecode evidence"
+      );
+    }
+    successor = {
+      address: successorDeployment.address,
+      runtimeCodeHash: ethers.utils.keccak256(
+        successorDeployment.deployedBytecode
+      ),
+    };
+  }
+  return validateManagedDisputeHookSnapshot({
+    currentHook,
+    predecessor: predecessor.activeLifecycleHook,
+    successor,
+    actualRuntimeCodeHash: ethers.utils.keccak256(runtimeCode),
+    actualOrchestratorRegistry: await hook.orchestratorRegistry(),
+    expectedOrchestratorRegistry: orchestratorRegistry.address,
+    actualWhitelistPolicy: await hook.whitelistPolicy(),
+    expectedWhitelistPolicy: whitelistPolicy.address,
+  });
+}

--- a/deployments/predecessorDisputeStack.ts
+++ b/deployments/predecessorDisputeStack.ts
@@ -1,0 +1,165 @@
+import { ethers } from "ethers";
+
+type HistoricalRuntimeEnvironment = {
+  deployments: {
+    getNetworkName(): string;
+    get(name: string): Promise<{ address: string; deployedBytecode?: string }>;
+  };
+  ethers: {
+    provider: {
+      getCode(address: string): Promise<string>;
+    };
+  };
+};
+
+type HistoricalContractEvidence = {
+  address: string;
+  deploymentBytecodeHash: string;
+  runtimeCodeHash: string;
+};
+
+type HistoricalDisputeStack = {
+  activeLifecycleHook: Omit<
+    HistoricalContractEvidence,
+    "deploymentBytecodeHash"
+  >;
+  contracts: Record<string, HistoricalContractEvidence>;
+};
+
+export const PREDECESSOR_DISPUTE_STACKS: Record<
+  string,
+  HistoricalDisputeStack
+> = {
+  base: {
+    activeLifecycleHook: {
+      address: "0x251d78fb6bBb4071995Bce74bAfC9E4168638622",
+      runtimeCodeHash:
+        "0x03d02863ed5eaa096d4089cb1e126681c0621d99409124f4af5be7ed83e341fe",
+    },
+    contracts: {
+      StakeVault: {
+        address: "0x8B8e853f47e6e0d3944e3689197B35216933dDea",
+        deploymentBytecodeHash:
+          "0x3ceac244f2d721614975457b041e95f661feba8ef6bbfc73c23b55aaac27d3e6",
+        runtimeCodeHash:
+          "0xfd8d2a910b9ac2c55675ae06d0504f9aac43b02b7022755cf229b571156c681d",
+      },
+      DisputeProtectionPolicy: {
+        address: "0xc086b6120B5e61EF48221E6A78c69737c9948dF9",
+        deploymentBytecodeHash:
+          "0x6146f8eb152848ddfd40d67a152a44230ed783b6c1e768d023b88fc2a09cb38f",
+        runtimeCodeHash:
+          "0xf08bce9ad622b9d45ce310493627cbef3bf6c4ac915661d5bc572bb59b61e084",
+      },
+      IntentLifecycleHookV1: {
+        address: "0x5B0017FCA6A2131701ef718e470a3930c1b6C12c",
+        deploymentBytecodeHash:
+          "0xad298e1829958f431833bf1c0e53311f27e95dd29806c4d55aa75163e6dbcc21",
+        runtimeCodeHash:
+          "0xff9db07ce83908b7cedb31f8c085004aa78c91bb86e0565f11fad3e4bc36c5cb",
+      },
+      DisputeVerifier: {
+        address: "0x30d4947f005653637005eed991005119D9eB2f34",
+        deploymentBytecodeHash:
+          "0x7aae03ea4bd5bc953dc87b7a272ef967dc093a71b39417f4b7bd88f46210e876",
+        runtimeCodeHash:
+          "0x65246e11392befc33d92246cf3ac2467d1f338a8b73c6514b76fab0a70a01ead",
+      },
+      DisputeNullifierRegistry: {
+        address: "0xA845615b5203F7a21321DdF5e3a1ca024D93a443",
+        deploymentBytecodeHash:
+          "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
+        runtimeCodeHash:
+          "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
+      },
+    },
+  },
+  base_staging: {
+    activeLifecycleHook: {
+      address: "0x19D9F0Fcb08C60D8bd0CD061C34eae27eF8b6e65",
+      runtimeCodeHash:
+        "0xba70239e37624f5808e2f79e100e83a17daeb1558f310543187f5d8a121ec367",
+    },
+    contracts: {
+      StakeVault: {
+        address: "0xEc9f801e2a9Cc22bdc217aD3BB1E3058d0668f43",
+        deploymentBytecodeHash:
+          "0x3ceac244f2d721614975457b041e95f661feba8ef6bbfc73c23b55aaac27d3e6",
+        runtimeCodeHash:
+          "0xfd8d2a910b9ac2c55675ae06d0504f9aac43b02b7022755cf229b571156c681d",
+      },
+      DisputeProtectionPolicy: {
+        address: "0x21517b7743E727ae47A66FafF93550B689c15020",
+        deploymentBytecodeHash:
+          "0x6146f8eb152848ddfd40d67a152a44230ed783b6c1e768d023b88fc2a09cb38f",
+        runtimeCodeHash:
+          "0x4e6617a94819ad15693289b173a9a66a78cfe1dd706f6b4fdc5a5f6ad6a32971",
+      },
+      IntentLifecycleHookV1: {
+        address: "0x19D9F0Fcb08C60D8bd0CD061C34eae27eF8b6e65",
+        deploymentBytecodeHash:
+          "0xad298e1829958f431833bf1c0e53311f27e95dd29806c4d55aa75163e6dbcc21",
+        runtimeCodeHash:
+          "0xba70239e37624f5808e2f79e100e83a17daeb1558f310543187f5d8a121ec367",
+      },
+      DisputeVerifier: {
+        address: "0x973578148c5Fd49b9f68B50B26066555325AC708",
+        deploymentBytecodeHash:
+          "0x7aae03ea4bd5bc953dc87b7a272ef967dc093a71b39417f4b7bd88f46210e876",
+        runtimeCodeHash:
+          "0xb3b34734cfd162cd129d0c84285461c751321545213ec20164745b8e72f9dd6c",
+      },
+      DisputeNullifierRegistry: {
+        address: "0xE0B05a9655AF0f31E32904267baa50FbC7f217ea",
+        deploymentBytecodeHash:
+          "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
+        runtimeCodeHash:
+          "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
+      },
+    },
+  },
+};
+
+function sameAddress(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+export async function assertHistoricalDisputeStack(
+  hre: HistoricalRuntimeEnvironment
+): Promise<void> {
+  const network = hre.deployments.getNetworkName();
+  if (network === "localhost" || network === "hardhat") return;
+
+  const expectedStack = PREDECESSOR_DISPUTE_STACKS[network];
+  if (!expectedStack) return;
+
+  for (const [name, expected] of Object.entries(expectedStack.contracts)) {
+    let deployment;
+    try {
+      deployment = await hre.deployments.get(name);
+    } catch {
+      throw new Error(`Missing predecessor deployment ${name} on ${network}`);
+    }
+    if (!sameAddress(deployment.address, expected.address)) {
+      throw new Error(`${name} predecessor address mismatch on ${network}`);
+    }
+    if (
+      typeof deployment.deployedBytecode !== "string" ||
+      ethers.utils.keccak256(deployment.deployedBytecode) !==
+        expected.deploymentBytecodeHash
+    ) {
+      throw new Error(
+        `${name} predecessor deployment bytecode hash mismatch on ${network}`
+      );
+    }
+    const runtimeCode = await hre.ethers.provider.getCode(expected.address);
+    if (
+      runtimeCode === "0x" ||
+      ethers.utils.keccak256(runtimeCode) !== expected.runtimeCodeHash
+    ) {
+      throw new Error(
+        `${name} predecessor runtime bytecode hash mismatch on ${network}`
+      );
+    }
+  }
+}

--- a/docs/plans/2026-08-20-restore-immutable-production-deployment-lanes.md
+++ b/docs/plans/2026-08-20-restore-immutable-production-deployment-lanes.md
@@ -1,0 +1,197 @@
+# Restore Immutable Production Deployment Lanes Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+>
+> **Review:** Internal reviewer ✅ | Codex CLI convergence ✅ (4 rounds)
+
+**Goal:** Restore production-executed lanes 30 and 32 byte-for-byte while enforcing lane-32 retirement outside the historical files.
+
+**Architecture:** A new immutable-lane manifest pins deployed source hashes and tells `scripts/deployActive.ts` which historical lanes to omit, replace, or reject. The filtered runner mounts a current guarded wrapper in place of immutable lane 30 and excludes retired lane 32 for both tagged and untagged runs. Predecessor dispute evidence moves to a new deployment helper so current guards and lane 34 keep their fail-closed checks without importing or editing lane 32.
+
+**Tech Stack:** TypeScript, Node.js built-in test runner, Hardhat Deploy, SHA-256.
+
+---
+
+### Task 1: Specify immutable and retired deployment selection with failing tests
+
+**Files:**
+
+- Create: `deployments/immutableDeploymentLanes.ts`
+- Modify: `scripts/test-opt-in-dispute-lifecycle-deployment.cjs`
+
+**Step 1: Write failing selection and integrity tests**
+
+Import the intended manifest API from `deployments/immutableDeploymentLanes.ts`. Assert the exact lane-30 and lane-32 source SHA and SHA-256 values from the approved design. Assert that selection maps lane 30's mounted filename to a current wrapper, excludes only the exact historical lane-32 filename, preserves `32_deploy_deposit_creation_guard.ts`, and preserves lane 34 for both tagged and untagged source sets. Assert both `32_deploy_and_activate_dispute_lifecycle_stack` and `V3DisputeLifecycleStack` are rejected, all comma-separated multi-tag input is rejected, and lane 34 is accepted. Copy both exact immutable blobs into a temporary repository fixture, prove the fixture passes, mutate one byte, and assert the integrity check reports the filename and expected digest.
+
+**Step 2: Run the focused test and verify RED**
+
+Run: `node --test scripts/test-opt-in-dispute-lifecycle-deployment.cjs`
+
+Expected: FAIL because `deployments/immutableDeploymentLanes.ts` and its API do not exist.
+
+Do not implement or commit the manifest yet: its checked-in integrity assertion must not be enabled while the repository still contains the post-PR #267 file bytes.
+
+### Task 2: Move predecessor evidence out of lane 32
+
+**Files:**
+
+- Create: `deployments/predecessorDisputeStack.ts`
+- Create: `deployments/managedDisputeLifecycleHook.ts`
+- Create: `deployments/activeDeploymentLanes/30_deploy_v3_lifecycle_stack.ts`
+- Modify: `deploy/34_deploy_opt_in_dispute_lifecycle_stack.ts`
+- Modify: `scripts/simulate-dispute-opt-in-safe-batch.ts`
+- Modify: `scripts/verify-dispute-opt-in-safe-batch.ts`
+- Modify: `scripts/test-dispute-lifecycle-deployment.cjs`
+- Modify: `scripts/test-v3-groups-base-deployment.cjs`
+- Modify: `package.json`
+
+**Step 1: Write the failing predecessor-helper test**
+
+Change the deployment regression to import `PREDECESSOR_DISPUTE_STACKS` and `assertHistoricalDisputeStack` from `deployments/predecessorDisputeStack.ts`. Remove expectations about lane 32's rewritten no-op function. Preserve the current exact address, deployment-bytecode, runtime-code, missing-artifact, address-drift, and code-drift assertions. Change the groups deployment regression to import the intended current wrapper and managed-hook validator, then add Base and Base-staging scenarios proving predecessor and successor hooks remain unchanged when the matching groups-cutover flag is set. Add asynchronous guard cases for missing successor `deployedBytecode`, missing live hook code, registry mismatch, policy mismatch, and an unknown hook that delegates to historical lane-30 behavior.
+
+**Step 2: Run the focused test and verify RED**
+
+Run: `node scripts/test-dispute-lifecycle-deployment.cjs`
+
+Expected: FAIL because the new helpers and wrapper do not exist.
+
+**Step 3: Add the helper and update all consumers**
+
+Move the current predecessor evidence types, constants, address comparison, and `assertHistoricalDisputeStack` implementation without changing their behavior. Move the current managed-hook snapshot validation and live guard out of lane 30. Add a current wrapper with lane 30's exact tags and dependencies; before both execution and skip evaluation it returns early for a verified managed hook, otherwise it delegates through a runtime `require` to immutable lane 30. Update lane 34, the Safe simulation, the Safe verifier, and both regressions to import current helpers. Confirm no current consumer imports lane 32 for successor behavior.
+
+Add `managed-hook-no-rollback` to `test:v3-groups-deployment` in `package.json` so the canonical focused command always runs the principal wrapper regression.
+
+**Step 4: Run focused deployment tests and verify GREEN**
+
+Run:
+
+```bash
+node scripts/test-dispute-lifecycle-deployment.cjs
+node scripts/test-v3-groups-base-deployment.cjs managed-hook-guard
+node scripts/test-v3-groups-base-deployment.cjs managed-hook-no-rollback
+```
+
+Expected: all three PASS.
+
+Do not commit or push this incomplete state; the wrapper is not mounted until Task 3 atomically adds the runner enforcement and restores the immutable sources.
+
+### Task 3: Restore the production-executed files exactly
+
+**Files:**
+
+- Create: `deployments/immutableDeploymentLanes.ts`
+- Modify: `deploy/30_deploy_v3_lifecycle_stack.ts`
+- Modify: `deploy/32_deploy_and_activate_dispute_lifecycle_stack.ts`
+- Modify: `scripts/deployActive.ts`
+- Modify: `tsconfig.dispute-deployment.json`
+
+**Step 1: Apply the exact historical blobs**
+
+Use the patch from `git diff HEAD fbe141161fe4138421a21e28715e540dafdfee4f -- deploy/30_deploy_v3_lifecycle_stack.ts deploy/32_deploy_and_activate_dispute_lifecycle_stack.ts` through `apply_patch`. Do not hand-edit either restored file.
+
+**Step 2: Implement the manifest and filtered runner**
+
+Create exports with these responsibilities:
+
+```ts
+export const IMMUTABLE_DEPLOYMENT_LANES = {
+  /* exact lane 30 and 32 evidence */
+} as const;
+export function assertImmutableDeploymentLanes(repositoryRoot: string): void;
+export function selectActiveDeploymentScripts(
+  repositoryRoot: string,
+  filenames: readonly string[]
+): Array<{ filename: string; sourcePath: string }>;
+export function assertSupportedDeploymentTag(tag: string | undefined): void;
+```
+
+Use `createHash("sha256")` over exact bytes. Lane 30 maps to `deployments/activeDeploymentLanes/30_deploy_v3_lifecycle_stack.ts`; only the exact historical lane-32 filename maps to no active source. Reject all comma-separated multi-tag input and either retired tag. Refactor `scripts/deployActive.ts` so both tagged and untagged paths validate hashes, build the same filtered temporary directory, mount the wrapper under lane 30's historical filename, preserve `32_deploy_deposit_creation_guard.ts`, omit only historical lane 32, pass `--deploy-scripts <temporary-directory>`, and then invoke Hardhat. Preserve `--no-compile` and set `DEPLOY_ACTIVE_TAG` for a single tagged run; explicitly delete any inherited `DEPLOY_ACTIVE_TAG` from the untagged child environment.
+
+Export an injectable runner function whose synchronous spawn dependency can be stubbed. Add a runner-level regression that inspects the temporary directory during the stubbed spawn and proves: integrity validation happens before spawn, both modes receive `--deploy-scripts`, lane 30 resolves to the wrapper, historical lane 32 is absent, the deposit-creation guard remains, non-zero child status propagates as command failure, and the temporary directory is removed after a successful child result, non-zero status, and child error.
+
+In the same executable correction, remove immutable lanes 30 and 32 from `tsconfig.dispute-deployment.json` and add the manifest, predecessor helper, managed-hook helper, and active wrapper. This keeps the pushed SHA's focused typecheck green without changing historical bytes.
+
+**Step 3: Verify exact deployed hashes**
+
+Run:
+
+```bash
+shasum -a 256 deploy/30_deploy_v3_lifecycle_stack.ts deploy/32_deploy_and_activate_dispute_lifecycle_stack.ts
+```
+
+Expected:
+
+```text
+97ed83a35e91167186da7a1bde9d3534e6eced436a843a0afd07c0f055bf20fa  deploy/30_deploy_v3_lifecycle_stack.ts
+e103f2b9eb4168504cb226a6191a05c432e313ca5b649b0cc2a3d77fb3a5d283  deploy/32_deploy_and_activate_dispute_lifecycle_stack.ts
+```
+
+Run `git diff --exit-code fbe141161fe4138421a21e28715e540dafdfee4f --` separately for each restored path. Expected: exit 0.
+
+**Step 4: Prove the supported runner and managed-hook guard**
+
+Run the focused manifest and deployment regressions again, including `yarn test:v3-groups-deployment`. Expected: PASS with exact historical hashes, the wrapper mounted for lane 30, lane 32 excluded in tagged and untagged runs, and predecessor/successor hooks protected on Base and Base staging.
+
+**Step 5: Verify the executable correction before publication**
+
+Run:
+
+```bash
+yarn test:dispute-lifecycle-deployment
+yarn test:v3-groups-deployment
+yarn typecheck:dispute-deployment
+npx prettier --check deploy/34_deploy_opt_in_dispute_lifecycle_stack.ts deployments/immutableDeploymentLanes.ts deployments/predecessorDisputeStack.ts deployments/managedDisputeLifecycleHook.ts deployments/activeDeploymentLanes/30_deploy_v3_lifecycle_stack.ts scripts/deployActive.ts scripts/simulate-dispute-opt-in-safe-batch.ts scripts/verify-dispute-opt-in-safe-batch.ts scripts/test-dispute-lifecycle-deployment.cjs scripts/test-opt-in-dispute-lifecycle-deployment.cjs scripts/test-v3-groups-base-deployment.cjs package.json tsconfig.dispute-deployment.json
+git diff --check
+```
+
+Expected: all commands exit 0 before the executable commit is created or pushed.
+
+**Step 6: Commit and push the atomic executable correction**
+
+```bash
+git add deploy/30_deploy_v3_lifecycle_stack.ts deploy/32_deploy_and_activate_dispute_lifecycle_stack.ts deploy/34_deploy_opt_in_dispute_lifecycle_stack.ts deployments/immutableDeploymentLanes.ts deployments/predecessorDisputeStack.ts deployments/managedDisputeLifecycleHook.ts deployments/activeDeploymentLanes/30_deploy_v3_lifecycle_stack.ts scripts/deployActive.ts scripts/simulate-dispute-opt-in-safe-batch.ts scripts/verify-dispute-opt-in-safe-batch.ts scripts/test-dispute-lifecycle-deployment.cjs scripts/test-opt-in-dispute-lifecycle-deployment.cjs scripts/test-v3-groups-base-deployment.cjs package.json tsconfig.dispute-deployment.json
+git commit -m "fix(deploy): restore immutable production lanes"
+git push -u origin codex/restore-immutable-deploy-lanes
+```
+
+### Task 4: Codify the rule and verify the correction
+
+**Files:**
+
+- Modify: `AGENTS.md`
+- Modify: `README.md`
+- Modify: `docs/superpowers/specs/2026-08-20-immutable-production-deployment-lanes-design.md`
+- Modify: `docs/plans/2026-08-20-restore-immutable-production-deployment-lanes.md`
+
+**Step 1: Update repository guidance**
+
+Document the production-execution immutability rule in `AGENTS.md`. Replace its now-false statement that lane 32 always skips with the exact model: lane 32 is executable immutable historical source, the supported runner excludes it, and `deployments/predecessorDisputeStack.ts` owns current read-only predecessor verification. Rewrite the README lane-30 and lane-32 paragraphs to distinguish immutable source, the active wrapper, external retirement, and predecessor verification.
+
+**Step 2: Run proportionate verification**
+
+Run:
+
+```bash
+yarn test:dispute-lifecycle-deployment
+yarn test:v3-groups-deployment
+yarn typecheck:dispute-deployment
+npx prettier --check deployments/immutableDeploymentLanes.ts deployments/predecessorDisputeStack.ts deployments/managedDisputeLifecycleHook.ts deployments/activeDeploymentLanes/30_deploy_v3_lifecycle_stack.ts scripts/deployActive.ts deploy/34_deploy_opt_in_dispute_lifecycle_stack.ts scripts/simulate-dispute-opt-in-safe-batch.ts scripts/verify-dispute-opt-in-safe-batch.ts scripts/test-dispute-lifecycle-deployment.cjs scripts/test-opt-in-dispute-lifecycle-deployment.cjs scripts/test-v3-groups-base-deployment.cjs AGENTS.md README.md docs/superpowers/specs/2026-08-20-immutable-production-deployment-lanes-design.md docs/plans/2026-08-20-restore-immutable-production-deployment-lanes.md
+git diff --check
+```
+
+Expected: all commands exit 0. No Solidity test is required because no Solidity, ABI, contract behavior, deployment artifact, or address changes.
+
+**Step 3: Review the final diff and scope**
+
+Confirm the only executable changes are the new manifest/helper, active runner integration, current lane-34 consumers, and tests. Confirm both restored historical files match their deployed hashes and that no deployment artifact, package output, Safe artifact, contract, or ABI changed.
+
+**Step 4: Commit, push, and create the correction PR**
+
+```bash
+git add AGENTS.md README.md
+git add -f docs/superpowers/specs/2026-08-20-immutable-production-deployment-lanes-design.md docs/plans/2026-08-20-restore-immutable-production-deployment-lanes.md
+git commit -m "docs(deploy): freeze production deployment lanes"
+git push
+```
+
+Create a PR against `main` describing the exact deployed-source hashes, external retirement mechanism, focused verification, and explicit absence of chain or package mutations.

--- a/docs/plans/2026-08-20-restore-immutable-production-deployment-lanes.md
+++ b/docs/plans/2026-08-20-restore-immutable-production-deployment-lanes.md
@@ -3,6 +3,8 @@
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 >
 > **Review:** Internal reviewer ✅ | Codex CLI convergence ✅ (4 rounds)
+>
+> **Implementation:** The executable correction was completed in `24f5e3b`; this plan remains the verification record.
 
 **Goal:** Restore production-executed lanes 30 and 32 byte-for-byte while enforcing lane-32 retirement outside the historical files.
 

--- a/docs/superpowers/specs/2026-08-20-immutable-production-deployment-lanes-design.md
+++ b/docs/superpowers/specs/2026-08-20-immutable-production-deployment-lanes-design.md
@@ -1,5 +1,7 @@
 # Immutable Production Deployment Lanes Design
 
+> **Implemented:** `24f5e3b` restores and externally retires the historical lanes without performing a deployment.
+
 ## Decision
 
 Once a numbered deployment script has been used to deploy production contracts, its source file is immutable provenance. New safety checks, successor deployments, and retirement behavior must be implemented in new files rather than by rewriting that historical script.

--- a/docs/superpowers/specs/2026-08-20-immutable-production-deployment-lanes-design.md
+++ b/docs/superpowers/specs/2026-08-20-immutable-production-deployment-lanes-design.md
@@ -1,0 +1,68 @@
+# Immutable Production Deployment Lanes Design
+
+## Decision
+
+Once a numbered deployment script has been used to deploy production contracts, its source file is immutable provenance. New safety checks, successor deployments, and retirement behavior must be implemented in new files rather than by rewriting that historical script.
+
+This correction restores the two production-executed files changed by PR #267:
+
+- `deploy/30_deploy_v3_lifecycle_stack.ts` to SHA-256 `97ed83a35e91167186da7a1bde9d3534e6eced436a843a0afd07c0f055bf20fa`. This is the exact file executed from reviewed source SHA `3c4c1306dcce6693cf32300d8917d45c4604b84e` for the production whitelist-only V3 deployment.
+- `deploy/32_deploy_and_activate_dispute_lifecycle_stack.ts` to SHA-256 `e103f2b9eb4168504cb226a6191a05c432e313ca5b649b0cc2a3d77fb3a5d283`. This is the exact file used from source SHA `d5558c2888c9246448e1926135fd0c2cbeceb3e4` for the production dispute-stack deployment.
+
+Both deployed versions are identical to the corresponding blobs at `fbe141161fe4138421a21e28715e540dafdfee4f`, the parent of PR #267.
+
+## Active versus immutable
+
+Immutability and retirement are separate properties:
+
+- Lane 30 remains active through a current wrapper, but its historical source cannot change. The wrapper preserves the managed predecessor/successor dispute-hook anti-rollback guard that PR #267 added directly to lane 30.
+- Lane 32 is both immutable and retired. Its original source remains at its original path for audit provenance, but supported deployment commands must not load or execute it.
+- Lane 34 remains the only supported opt-in dispute successor lane.
+
+## Enforcement
+
+Add a new manifest outside `deploy/` that records each immutable lane's deployed source SHA, SHA-256 digest, tags, and retirement state. The active deployment runner validates both immutable files before every supported deployment. A digest mismatch fails before Hardhat is launched.
+
+Every supported deployment, tagged or untagged, runs from the same filtered temporary deployment directory. The runner omits retired lane 32 and mounts a new current wrapper in place of immutable lane 30. The wrapper verifies the active predecessor or successor dispute hook and returns without invoking historical lane 30 when that managed hook is active; otherwise it delegates to lane 30's exact historical function and skip behavior. It exports the exact historical tags `30_deploy_v3_lifecycle_stack`, `V3LifecycleStack`, and `OrchestratorV3`, plus the exact `29_deploy_whitelist_policy` dependency, with regression coverage for those values and both mount modes.
+
+The wrapper uses a runtime `require`, and the focused current-surface TypeScript project removes immutable lanes 30 and 32 from its explicit roots, replacing them with the wrapper and current helpers. Exact byte-integrity checks, rather than reinterpretation under future TypeScript types, are the acceptance gate for historical source.
+
+For tagged deployments, the runner accepts exactly one tag and rejects comma-separated multi-tag input as well as either of lane 32's historical tags before Hardhat is launched. For untagged deployments, the child environment explicitly removes any inherited `DEPLOY_ACTIVE_TAG`; a stale parent value must never authorize lane 34. Raw direct Hardhat invocation remains unsupported; repository commands are the enforced operational interface.
+
+The manifest must be ordinary TypeScript with small exported functions so focused Node tests can validate:
+
+- both checked-in files match their deployed digests;
+- the current lane-30 wrapper is mounted under lane 30's filename for tagged and untagged active runs;
+- lane 32 is excluded from an untagged active run;
+- lane 32 is also absent from a tagged lane-34 run's mounted source set;
+- the unrelated `32_deploy_deposit_creation_guard.ts` remains mounted by exact filename;
+- both historical lane-32 tags are rejected;
+- multi-tag input is rejected and an untagged child receives no `DEPLOY_ACTIVE_TAG`;
+- unrelated active tags remain accepted;
+- a mutated immutable file fails the digest check.
+
+A runner-level regression injects a synchronous child-process stub and observes the actual temporary mount during invocation. It proves hash verification precedes spawning, both invocation modes pass `--deploy-scripts`, the wrapper replaces lane 30, only the exact retired lane-32 filename is absent, non-zero child status propagates as command failure, and cleanup occurs after child success, non-zero status, and spawn error.
+
+## Successor evidence
+
+PR #267 made lane 34 depend on predecessor address and bytecode evidence that was incorrectly placed inside rewritten lane 32. Move that evidence and `assertHistoricalDisputeStack` into a new `deployments/predecessorDisputeStack.ts` helper. Update lane 34 and its Safe simulation and verification consumers to import the helper.
+
+The predecessor helper is current safety logic and may evolve with a future successor. It is not part of the immutable lane-32 source. Its tests continue to prove exact Base and Base-staging addresses, deployment bytecode hashes, runtime hashes, and fail-closed behavior without invoking lane 32.
+
+Move `validateManagedDisputeHookSnapshot` and `guardManagedDisputeLifecycleHook` into a separate current helper. The lane-30 wrapper calls this helper before both execution and skip evaluation. Regression tests cover predecessor and successor hook snapshots and prove that supported Base and Base-staging lane-30 execution leaves an already managed hook unchanged even when the historical groups-cutover enable flag remains set. Asynchronous guard tests also cover missing successor deployment bytecode, missing live hook code, registry mismatch, policy mismatch, and an unknown hook falling through to historical lane-30 behavior.
+
+## Documentation rule
+
+Repository guidance must state the durable rule: a deployment script becomes immutable after a production execution. A replacement or successor gets the next unused numbered lane; retirement and live-state verification belong in separate helpers or runner metadata. Deployment artifacts remain immutable evidence as before.
+
+README deployment documentation must describe lane 32 as an immutable retired source file excluded by the supported runner, while pointing operational predecessor verification to the new helper and successor deployment to lane 34.
+
+## Safety boundary
+
+This correction changes repository deployment selection only. It must not:
+
+- execute any Base or Base-staging transaction;
+- modify deployment artifacts or exported addresses;
+- generate, propose, sign, or execute a Safe transaction;
+- publish an npm package;
+- alter Solidity contracts or public ABIs.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test:invariant": "forge test --match-path 'test-foundry/invariant/**/*.t.sol'",
     "test:intent-guardian-fee-update": "node --test scripts/intent-guardian-fee-update.spec.cjs",
     "test:dispute-lifecycle-deployment": "node --test scripts/active-dispute-stack.spec.cjs && node scripts/test-dispute-lifecycle-deployment.cjs && node scripts/test-opt-in-dispute-lifecycle-deployment.cjs",
-    "test:v3-groups-deployment": "node scripts/test-v3-groups-base-deployment.cjs prepare-resume && node scripts/test-v3-groups-base-deployment.cjs reject-mismatch && node scripts/test-v3-groups-base-deployment.cjs managed-hook-guard",
+    "test:v3-groups-deployment": "node scripts/test-v3-groups-base-deployment.cjs prepare-resume && node scripts/test-v3-groups-base-deployment.cjs reject-mismatch && node scripts/test-v3-groups-base-deployment.cjs managed-hook-guard && node scripts/test-v3-groups-base-deployment.cjs managed-hook-no-rollback",
     "test:release-policy": "node --test scripts/verify-github-environment.spec.mjs scripts/npm-release.spec.mjs",
     "typechain": "hardhat typechain",
     "transpile": "tsc",

--- a/scripts/deployActive.ts
+++ b/scripts/deployActive.ts
@@ -1,51 +1,93 @@
 import { spawnSync } from "child_process";
 import { mkdtempSync, readdirSync, rmSync, symlinkSync } from "fs";
 import { tmpdir } from "os";
-import { basename, join, resolve } from "path";
+import { join, resolve } from "path";
 
-export function buildDeployArguments(network: string, tag?: string): string[] {
+import {
+  assertImmutableDeploymentLanes,
+  assertSupportedDeploymentTag,
+  selectActiveDeploymentScripts,
+} from "../deployments/immutableDeploymentLanes";
+
+export function buildDeployArguments(
+  network: string,
+  activeDirectory: string,
+  tag?: string
+): string[] {
   const args = ["deploy", "--network", network];
   if (tag) args.push("--tags", tag, "--no-compile");
+  args.push("--deploy-scripts", activeDirectory);
   return args;
+}
+
+type SpawnResult = { error?: Error; status: number | null };
+type Spawn = (
+  command: string,
+  args: readonly string[],
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    stdio: "inherit";
+  }
+) => SpawnResult;
+
+type ActiveDeploymentOptions = {
+  repositoryRoot?: string;
+  hardhatCli?: string;
+  env?: NodeJS.ProcessEnv;
+  spawnSync?: Spawn;
+  temporaryRoot?: string;
+};
+
+export function runActiveDeployment(
+  network: string,
+  tag?: string,
+  options: ActiveDeploymentOptions = {}
+): number {
+  assertSupportedDeploymentTag(tag);
+  const repositoryRoot = options.repositoryRoot ?? resolve(__dirname, "..");
+  assertImmutableDeploymentLanes(repositoryRoot);
+  const hardhatCli =
+    options.hardhatCli ?? require.resolve("hardhat/internal/cli/cli");
+  const spawn = options.spawnSync ?? (spawnSync as Spawn);
+
+  const sourceDirectory = join(repositoryRoot, "deploy");
+  const activeDirectory = mkdtempSync(
+    join(options.temporaryRoot ?? tmpdir(), "zkp2p-active-deploy-")
+  );
+
+  try {
+    const filenames = readdirSync(sourceDirectory).filter((filename) =>
+      filename.endsWith(".ts")
+    );
+    for (const { filename, sourcePath } of selectActiveDeploymentScripts(
+      repositoryRoot,
+      filenames
+    )) {
+      symlinkSync(sourcePath, join(activeDirectory, filename), "file");
+    }
+
+    const childEnvironment = { ...(options.env ?? process.env) };
+    if (tag) childEnvironment.DEPLOY_ACTIVE_TAG = tag;
+    else delete childEnvironment.DEPLOY_ACTIVE_TAG;
+    const result = spawn(
+      process.execPath,
+      [hardhatCli, ...buildDeployArguments(network, activeDirectory, tag)],
+      { cwd: repositoryRoot, env: childEnvironment, stdio: "inherit" }
+    );
+    if (result.error) throw result.error;
+    return result.status ?? 1;
+  } finally {
+    rmSync(activeDirectory, { recursive: true, force: true });
+  }
 }
 
 function main() {
   const network = process.argv[2];
   const tag = process.argv[3];
   if (!network) throw new Error("usage: deployActive <network> [tag]");
-
-  const repositoryRoot = resolve(__dirname, "..");
-  const hardhatCli = require.resolve("hardhat/internal/cli/cli");
-  if (tag) {
-    const result = spawnSync(process.execPath, [hardhatCli, ...buildDeployArguments(network, tag)], {
-      cwd: repositoryRoot,
-      env: { ...process.env, DEPLOY_ACTIVE_TAG: tag },
-      stdio: "inherit",
-    });
-    if (result.error) throw result.error;
-    if (result.status !== 0) process.exitCode = result.status ?? 1;
-    return;
-  }
-
-  const sourceDirectory = join(repositoryRoot, "deploy");
-  const activeDirectory = mkdtempSync(join(tmpdir(), "zkp2p-active-deploy-"));
-
-  try {
-    for (const filename of readdirSync(sourceDirectory)) {
-      if (!filename.endsWith(".ts")) continue;
-      symlinkSync(join(sourceDirectory, filename), join(activeDirectory, basename(filename)), "file");
-    }
-
-    const result = spawnSync(
-      process.execPath,
-      [hardhatCli, ...buildDeployArguments(network), "--deploy-scripts", activeDirectory],
-      { cwd: repositoryRoot, env: process.env, stdio: "inherit" },
-    );
-    if (result.error) throw result.error;
-    if (result.status !== 0) process.exitCode = result.status ?? 1;
-  } finally {
-    rmSync(activeDirectory, { recursive: true, force: true });
-  }
+  const status = runActiveDeployment(network, tag);
+  if (status !== 0) process.exitCode = status;
 }
 
 if (require.main === module) main();

--- a/scripts/simulate-dispute-opt-in-safe-batch.ts
+++ b/scripts/simulate-dispute-opt-in-safe-batch.ts
@@ -14,7 +14,7 @@ import {
   DISPUTABLE_PAYMENT_METHODS,
   DISPUTE_RISK_WINDOW,
 } from "../deployments/parameters";
-import { PREDECESSOR_DISPUTE_STACKS } from "../deploy/32_deploy_and_activate_dispute_lifecycle_stack";
+import { PREDECESSOR_DISPUTE_STACKS } from "../deployments/predecessorDisputeStack";
 
 export const BASE_SAFE = "0x0bC26FF515411396DD588Abd6Ef6846E04470227";
 export const BASE_SAFE_RUNTIME_HASH =

--- a/scripts/test-dispute-lifecycle-deployment.cjs
+++ b/scripts/test-dispute-lifecycle-deployment.cjs
@@ -22,25 +22,36 @@ dotenv.config = () => ({ parsed: {} });
 moduleAlias.reset();
 moduleAlias.addAlias("@utils", process.cwd() + "/utils");
 
-const historicalLaneModule = require("../deploy/32_deploy_and_activate_dispute_lifecycle_stack.ts");
-const historicalLane = historicalLaneModule.default;
-const { PREDECESSOR_DISPUTE_STACKS } = historicalLaneModule;
+const {
+  PREDECESSOR_DISPUTE_STACKS,
+  assertHistoricalDisputeStack,
+} = require("../deployments/predecessorDisputeStack.ts");
 
 /** @type {Record<string, Record<string, string>>} */
 const EXPECTED_RUNTIME_HASHES = {
   base: {
-    StakeVault: "0xfd8d2a910b9ac2c55675ae06d0504f9aac43b02b7022755cf229b571156c681d",
-    DisputeProtectionPolicy: "0xf08bce9ad622b9d45ce310493627cbef3bf6c4ac915661d5bc572bb59b61e084",
-    IntentLifecycleHookV1: "0xff9db07ce83908b7cedb31f8c085004aa78c91bb86e0565f11fad3e4bc36c5cb",
-    DisputeVerifier: "0x65246e11392befc33d92246cf3ac2467d1f338a8b73c6514b76fab0a70a01ead",
-    DisputeNullifierRegistry: "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
+    StakeVault:
+      "0xfd8d2a910b9ac2c55675ae06d0504f9aac43b02b7022755cf229b571156c681d",
+    DisputeProtectionPolicy:
+      "0xf08bce9ad622b9d45ce310493627cbef3bf6c4ac915661d5bc572bb59b61e084",
+    IntentLifecycleHookV1:
+      "0xff9db07ce83908b7cedb31f8c085004aa78c91bb86e0565f11fad3e4bc36c5cb",
+    DisputeVerifier:
+      "0x65246e11392befc33d92246cf3ac2467d1f338a8b73c6514b76fab0a70a01ead",
+    DisputeNullifierRegistry:
+      "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
   },
   base_staging: {
-    StakeVault: "0xfd8d2a910b9ac2c55675ae06d0504f9aac43b02b7022755cf229b571156c681d",
-    DisputeProtectionPolicy: "0x4e6617a94819ad15693289b173a9a66a78cfe1dd706f6b4fdc5a5f6ad6a32971",
-    IntentLifecycleHookV1: "0xba70239e37624f5808e2f79e100e83a17daeb1558f310543187f5d8a121ec367",
-    DisputeVerifier: "0xb3b34734cfd162cd129d0c84285461c751321545213ec20164745b8e72f9dd6c",
-    DisputeNullifierRegistry: "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
+    StakeVault:
+      "0xfd8d2a910b9ac2c55675ae06d0504f9aac43b02b7022755cf229b571156c681d",
+    DisputeProtectionPolicy:
+      "0x4e6617a94819ad15693289b173a9a66a78cfe1dd706f6b4fdc5a5f6ad6a32971",
+    IntentLifecycleHookV1:
+      "0xba70239e37624f5808e2f79e100e83a17daeb1558f310543187f5d8a121ec367",
+    DisputeVerifier:
+      "0xb3b34734cfd162cd129d0c84285461c751321545213ec20164745b8e72f9dd6c",
+    DisputeNullifierRegistry:
+      "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
   },
 };
 
@@ -53,38 +64,28 @@ const MOCK_RUNTIME_CODES = {
   DisputeNullifierRegistry: "0x6005",
 };
 
-/** @param {string} network */
-function localHre(network) {
-  return {
-    deployments: {
-      getNetworkName: () => network,
-      get: async () => {
-        throw new Error("local historical lane must not read deployment records");
-      },
-    },
-    ethers: {
-      provider: {
-        getCode: async () => {
-          throw new Error("local historical lane must not read chain code");
-        },
-      },
-    },
-  };
-}
-
 /**
  * @param {"base" | "base_staging"} network
  * @param {{ omit?: string, addressDrift?: string, codeDrift?: string }} [options]
  */
 function liveHre(network, { omit, addressDrift, codeDrift } = {}) {
   const deployments = new Map();
-  for (const name of Object.keys(PREDECESSOR_DISPUTE_STACKS[network].contracts)) {
+  for (const name of Object.keys(
+    PREDECESSOR_DISPUTE_STACKS[network].contracts
+  )) {
     if (name === omit) continue;
-    const artifact = require(path.join(process.cwd(), "deployments", network, `${name}.json`));
+    const artifact = require(path.join(
+      process.cwd(),
+      "deployments",
+      network,
+      `${name}.json`
+    ));
     deployments.set(name, {
       ...artifact,
       address:
-        name === addressDrift ? "0x0000000000000000000000000000000000000001" : artifact.address,
+        name === addressDrift
+          ? "0x0000000000000000000000000000000000000001"
+          : artifact.address,
     });
   }
 
@@ -95,7 +96,8 @@ function liveHre(network, { omit, addressDrift, codeDrift } = {}) {
       deployments: {
         getNetworkName: () => network,
         get: async (/** @type {string} */ name) => {
-          if (!deployments.has(name)) throw new Error(`Missing deployment: ${name}`);
+          if (!deployments.has(name))
+            throw new Error(`Missing deployment: ${name}`);
           return deployments.get(name);
         },
         deploy: async () => {
@@ -125,64 +127,89 @@ function liveHre(network, { omit, addressDrift, codeDrift } = {}) {
 }
 
 async function run() {
-  assert.ok(PREDECESSOR_DISPUTE_STACKS, "historical predecessor evidence is not exported");
-  assert.deepEqual(PREDECESSOR_DISPUTE_STACKS.base_staging.activeLifecycleHook, {
-    address: "0x19D9F0Fcb08C60D8bd0CD061C34eae27eF8b6e65",
-    runtimeCodeHash: "0xba70239e37624f5808e2f79e100e83a17daeb1558f310543187f5d8a121ec367",
-  });
-  assert.equal(await historicalLane.skip(localHre("localhost")), true);
-  assert.equal(await historicalLane.skip(localHre("hardhat")), true);
-
+  assert.ok(
+    PREDECESSOR_DISPUTE_STACKS,
+    "historical predecessor evidence is not exported"
+  );
+  assert.deepEqual(
+    PREDECESSOR_DISPUTE_STACKS.base_staging.activeLifecycleHook,
+    {
+      address: "0x19D9F0Fcb08C60D8bd0CD061C34eae27eF8b6e65",
+      runtimeCodeHash:
+        "0xba70239e37624f5808e2f79e100e83a17daeb1558f310543187f5d8a121ec367",
+    }
+  );
   /** @type {Array<"base" | "base_staging">} */
   const liveNetworks = ["base_staging", "base"];
   for (const network of liveNetworks) {
-    for (const [name, evidence] of Object.entries(PREDECESSOR_DISPUTE_STACKS[network].contracts)) {
-      const artifact = require(path.join(process.cwd(), "deployments", network, `${name}.json`));
+    for (const [name, evidence] of Object.entries(
+      PREDECESSOR_DISPUTE_STACKS[network].contracts
+    )) {
+      const artifact = require(path.join(
+        process.cwd(),
+        "deployments",
+        network,
+        `${name}.json`
+      ));
       assert.equal(
         evidence.deploymentBytecodeHash,
         ethers.utils.keccak256(artifact.deployedBytecode),
-        `${network} ${name} must pin its deployment artifact separately from live runtime code`,
+        `${network} ${name} must pin its deployment artifact separately from live runtime code`
       );
-      assert.equal(evidence.runtimeCodeHash, EXPECTED_RUNTIME_HASHES[network][name]);
+      assert.equal(
+        evidence.runtimeCodeHash,
+        EXPECTED_RUNTIME_HASHES[network][name]
+      );
     }
 
     const originalRuntimeHashes = Object.fromEntries(
-      Object.entries(PREDECESSOR_DISPUTE_STACKS[network].contracts).map(([name, evidence]) => [
-        name,
-        evidence.runtimeCodeHash,
-      ]),
+      Object.entries(PREDECESSOR_DISPUTE_STACKS[network].contracts).map(
+        ([name, evidence]) => [name, evidence.runtimeCodeHash]
+      )
     );
     try {
-      for (const [name, evidence] of Object.entries(PREDECESSOR_DISPUTE_STACKS[network].contracts)) {
-        evidence.runtimeCodeHash = ethers.utils.keccak256(MOCK_RUNTIME_CODES[name]);
+      for (const [name, evidence] of Object.entries(
+        PREDECESSOR_DISPUTE_STACKS[network].contracts
+      )) {
+        evidence.runtimeCodeHash = ethers.utils.keccak256(
+          MOCK_RUNTIME_CODES[name]
+        );
       }
 
       const exact = liveHre(network);
-      assert.equal(await historicalLane.skip(exact.hre), true);
-      await historicalLane(exact.hre);
-      assert.deepEqual(exact.mutationCounts(), { deployCalls: 0, rawTransactions: 0 });
+      await assertHistoricalDisputeStack(exact.hre);
+      assert.deepEqual(exact.mutationCounts(), {
+        deployCalls: 0,
+        rawTransactions: 0,
+      });
 
       await assert.rejects(
-        historicalLane.skip(liveHre(network, { omit: "StakeVault" }).hre),
-        /Missing predecessor deployment StakeVault/,
+        assertHistoricalDisputeStack(
+          liveHre(network, { omit: "StakeVault" }).hre
+        ),
+        /Missing predecessor deployment StakeVault/
       );
       await assert.rejects(
-        historicalLane.skip(liveHre(network, { addressDrift: "DisputeProtectionPolicy" }).hre),
-        /predecessor address mismatch/,
+        assertHistoricalDisputeStack(
+          liveHre(network, { addressDrift: "DisputeProtectionPolicy" }).hre
+        ),
+        /predecessor address mismatch/
       );
       await assert.rejects(
-        historicalLane.skip(liveHre(network, { codeDrift: "IntentLifecycleHookV1" }).hre),
-        /predecessor runtime bytecode hash mismatch/,
+        assertHistoricalDisputeStack(
+          liveHre(network, { codeDrift: "IntentLifecycleHookV1" }).hre
+        ),
+        /predecessor runtime bytecode hash mismatch/
       );
     } finally {
-      for (const [name, runtimeCodeHash] of Object.entries(originalRuntimeHashes)) {
-        PREDECESSOR_DISPUTE_STACKS[network].contracts[name].runtimeCodeHash = runtimeCodeHash;
+      for (const [name, runtimeCodeHash] of Object.entries(
+        originalRuntimeHashes
+      )) {
+        PREDECESSOR_DISPUTE_STACKS[network].contracts[name].runtimeCodeHash =
+          runtimeCodeHash;
       }
     }
   }
-
-  assert.deepEqual(historicalLane.dependencies || [], []);
-  assert.deepEqual(historicalLane.tags, ["32_historical_dispute_lifecycle_stack"]);
 }
 
 run().catch((error) => {

--- a/scripts/test-opt-in-dispute-lifecycle-deployment.cjs
+++ b/scripts/test-opt-in-dispute-lifecycle-deployment.cjs
@@ -15,14 +15,17 @@ moduleAlias.addAlias("@utils", process.cwd() + "/utils");
 const assert = require("node:assert/strict");
 const { execFileSync, spawnSync } = require("node:child_process");
 const {
+  existsSync,
   mkdirSync,
   mkdtempSync,
+  readlinkSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } = require("node:fs");
 const { tmpdir } = require("node:os");
-const { dirname, join } = require("node:path");
+const { dirname, join, resolve } = require("node:path");
 const { test } = require("node:test");
 
 const lane34Module = require("../deploy/34_deploy_opt_in_dispute_lifecycle_stack.ts");
@@ -41,7 +44,16 @@ const {
   selectVerificationDeployments,
   verifyDeployments,
 } = require("../tasks/etherscanVerifyWithDelay.ts");
-const { buildDeployArguments } = require("./deployActive.ts");
+const {
+  buildDeployArguments,
+  runActiveDeployment,
+} = require("./deployActive.ts");
+const {
+  IMMUTABLE_DEPLOYMENT_LANES,
+  assertImmutableDeploymentLanes,
+  assertSupportedDeploymentTag,
+  selectActiveDeploymentScripts,
+} = require("../deployments/immutableDeploymentLanes.ts");
 const {
   canonicalTransactionBytes,
   canonicalTransactionHash,
@@ -88,17 +100,22 @@ test("live dependency pins use deployed runtime hashes", () => {
       },
       base_staging: {
         whitelistPolicy: EXPECTED_LIVE.base_staging.whitelistPolicyCodeHash,
-        nullifierRegistryV2: EXPECTED_LIVE.base_staging.nullifierRegistryV2CodeHash,
+        nullifierRegistryV2:
+          EXPECTED_LIVE.base_staging.nullifierRegistryV2CodeHash,
       },
     },
     {
       base: {
-        whitelistPolicy: "0xa3cf0fdf3835887de432cbac9c192edf6c93a8589748aa93f8294333d57024b2",
-        nullifierRegistryV2: "0x423e2a2183ecd538864079b6268f41957028c25514d1de57bd3d0e70fa6b9bd4",
+        whitelistPolicy:
+          "0xa3cf0fdf3835887de432cbac9c192edf6c93a8589748aa93f8294333d57024b2",
+        nullifierRegistryV2:
+          "0x423e2a2183ecd538864079b6268f41957028c25514d1de57bd3d0e70fa6b9bd4",
       },
       base_staging: {
-        whitelistPolicy: "0x917965fdc75580147ad0787c86f8b2a0f0185ef6e101567b82dc1245d6eb63bc",
-        nullifierRegistryV2: "0xd9d2f4b8bbca6fe26d7a0dfd7e0d6a6d63823ab2a1fe12971e752cf33dee72a0",
+        whitelistPolicy:
+          "0x917965fdc75580147ad0787c86f8b2a0f0185ef6e101567b82dc1245d6eb63bc",
+        nullifierRegistryV2:
+          "0xd9d2f4b8bbca6fe26d7a0dfd7e0d6a6d63823ab2a1fe12971e752cf33dee72a0",
       },
     }
   );
@@ -281,9 +298,13 @@ test("local activation and live ownership checks fail closed on drift", () => {
   );
 });
 
-test("tag-scoped deployment runs lane 34 without dependencies", () => {
+test("active deployment arguments always use the filtered deployment directory", () => {
   assert.deepEqual(
-    buildDeployArguments("base", "34_deploy_opt_in_dispute_lifecycle_stack"),
+    buildDeployArguments(
+      "base",
+      "/tmp/active-deployments",
+      "34_deploy_opt_in_dispute_lifecycle_stack"
+    ),
     [
       "deploy",
       "--network",
@@ -291,8 +312,241 @@ test("tag-scoped deployment runs lane 34 without dependencies", () => {
       "--tags",
       "34_deploy_opt_in_dispute_lifecycle_stack",
       "--no-compile",
+      "--deploy-scripts",
+      "/tmp/active-deployments",
     ]
   );
+  assert.deepEqual(buildDeployArguments("base", "/tmp/active-deployments"), [
+    "deploy",
+    "--network",
+    "base",
+    "--deploy-scripts",
+    "/tmp/active-deployments",
+  ]);
+});
+
+test("immutable lane manifest pins the exact deployed sources", () => {
+  assert.deepEqual(IMMUTABLE_DEPLOYMENT_LANES, {
+    "30_deploy_v3_lifecycle_stack.ts": {
+      deployedSourceSha: "3c4c1306dcce6693cf32300d8917d45c4604b84e",
+      sha256:
+        "97ed83a35e91167186da7a1bde9d3534e6eced436a843a0afd07c0f055bf20fa",
+      activeSource:
+        "deployments/activeDeploymentLanes/30_deploy_v3_lifecycle_stack.ts",
+      retired: false,
+      tags: [
+        "30_deploy_v3_lifecycle_stack",
+        "V3LifecycleStack",
+        "OrchestratorV3",
+      ],
+    },
+    "32_deploy_and_activate_dispute_lifecycle_stack.ts": {
+      deployedSourceSha: "d5558c2888c9246448e1926135fd0c2cbeceb3e4",
+      sha256:
+        "e103f2b9eb4168504cb226a6191a05c432e313ca5b649b0cc2a3d77fb3a5d283",
+      activeSource: null,
+      retired: true,
+      tags: [
+        "32_deploy_and_activate_dispute_lifecycle_stack",
+        "V3DisputeLifecycleStack",
+      ],
+    },
+  });
+});
+
+test("active deployment selection replaces lane 30 and retires only historical lane 32", () => {
+  const selected = selectActiveDeploymentScripts(process.cwd(), [
+    "30_deploy_v3_lifecycle_stack.ts",
+    "32_deploy_and_activate_dispute_lifecycle_stack.ts",
+    "32_deploy_deposit_creation_guard.ts",
+    "34_deploy_opt_in_dispute_lifecycle_stack.ts",
+  ]);
+  assert.deepEqual(
+    selected.map(({ filename }) => filename),
+    [
+      "30_deploy_v3_lifecycle_stack.ts",
+      "32_deploy_deposit_creation_guard.ts",
+      "34_deploy_opt_in_dispute_lifecycle_stack.ts",
+    ]
+  );
+  assert.equal(
+    selected[0].sourcePath,
+    resolve(
+      process.cwd(),
+      "deployments/activeDeploymentLanes/30_deploy_v3_lifecycle_stack.ts"
+    )
+  );
+  assert.equal(
+    selected[1].sourcePath,
+    resolve(process.cwd(), "deploy/32_deploy_deposit_creation_guard.ts")
+  );
+});
+
+test("retired and multi-tag deployment requests fail closed", () => {
+  assert.doesNotThrow(() =>
+    assertSupportedDeploymentTag("34_deploy_opt_in_dispute_lifecycle_stack")
+  );
+  assert.throws(
+    () =>
+      assertSupportedDeploymentTag(
+        "32_deploy_and_activate_dispute_lifecycle_stack"
+      ),
+    /retired deployment tag/
+  );
+  assert.throws(
+    () => assertSupportedDeploymentTag("V3DisputeLifecycleStack"),
+    /retired deployment tag/
+  );
+  assert.throws(
+    () => assertSupportedDeploymentTag("OrchestratorV3,V3LifecycleStack"),
+    /exactly one deployment tag/
+  );
+});
+
+function immutableLaneFixture() {
+  const repository = mkdtempSync(join(tmpdir(), "immutable-deploy-lanes-"));
+  for (const filename of Object.keys(IMMUTABLE_DEPLOYMENT_LANES)) {
+    const destination = join(repository, "deploy", filename);
+    mkdirSync(dirname(destination), { recursive: true });
+    writeFileSync(
+      destination,
+      execFileSync("git", [
+        "show",
+        `fbe141161fe4138421a21e28715e540dafdfee4f:deploy/${filename}`,
+      ])
+    );
+  }
+  const wrapper = join(
+    repository,
+    "deployments/activeDeploymentLanes/30_deploy_v3_lifecycle_stack.ts"
+  );
+  mkdirSync(dirname(wrapper), { recursive: true });
+  writeFileSync(wrapper, "export default async function () {}\n");
+  writeFileSync(
+    join(repository, "deploy", "32_deploy_deposit_creation_guard.ts"),
+    "export default async function () {}\n"
+  );
+  writeFileSync(
+    join(repository, "deploy", "34_deploy_opt_in_dispute_lifecycle_stack.ts"),
+    "export default async function () {}\n"
+  );
+  return repository;
+}
+
+test("immutable lane integrity detects a one-byte mutation", () => {
+  const repository = immutableLaneFixture();
+  try {
+    assert.doesNotThrow(() => assertImmutableDeploymentLanes(repository));
+    const lane = join(repository, "deploy/30_deploy_v3_lifecycle_stack.ts");
+    writeFileSync(lane, Buffer.concat([readFileSync(lane), Buffer.from(" ")]));
+    assert.throws(
+      () => assertImmutableDeploymentLanes(repository),
+      /30_deploy_v3_lifecycle_stack\.ts.*97ed83a35e91167186da7a1bde9d3534e6eced436a843a0afd07c0f055bf20fa/
+    );
+  } finally {
+    rmSync(repository, { recursive: true, force: true });
+  }
+});
+
+test("active runner mounts one filtered lane set for tagged and untagged runs", () => {
+  for (const tag of [undefined, "34_deploy_opt_in_dispute_lifecycle_stack"]) {
+    let activeDirectory;
+    const staleEnv = { ...process.env, DEPLOY_ACTIVE_TAG: "stale" };
+    const status = runActiveDeployment("base", tag, {
+      repositoryRoot: process.cwd(),
+      hardhatCli: "/virtual/hardhat-cli.js",
+      env: staleEnv,
+      spawnSync: (_command, args, options) => {
+        const deployScriptsIndex = args.indexOf("--deploy-scripts");
+        assert.notEqual(deployScriptsIndex, -1);
+        activeDirectory = args[deployScriptsIndex + 1];
+        const filenames = readdirSync(activeDirectory);
+        assert.ok(filenames.includes("30_deploy_v3_lifecycle_stack.ts"));
+        assert.ok(filenames.includes("32_deploy_deposit_creation_guard.ts"));
+        assert.ok(
+          filenames.includes("34_deploy_opt_in_dispute_lifecycle_stack.ts")
+        );
+        assert.ok(
+          !filenames.includes(
+            "32_deploy_and_activate_dispute_lifecycle_stack.ts"
+          )
+        );
+        assert.equal(
+          readlinkSync(
+            join(activeDirectory, "30_deploy_v3_lifecycle_stack.ts")
+          ),
+          resolve(
+            process.cwd(),
+            "deployments/activeDeploymentLanes/30_deploy_v3_lifecycle_stack.ts"
+          )
+        );
+        assert.equal(options.env.DEPLOY_ACTIVE_TAG, tag || undefined);
+        return { status: 0 };
+      },
+    });
+    assert.equal(status, 0);
+    assert.ok(activeDirectory);
+    assert.equal(existsSync(activeDirectory), false);
+  }
+});
+
+test("active runner validates before spawn, propagates status, and always cleans up", () => {
+  const invalidRepository = immutableLaneFixture();
+  const invalidLane = join(
+    invalidRepository,
+    "deploy/32_deploy_and_activate_dispute_lifecycle_stack.ts"
+  );
+  writeFileSync(
+    invalidLane,
+    Buffer.concat([readFileSync(invalidLane), Buffer.from(" ")])
+  );
+  let spawned = false;
+  try {
+    assert.throws(
+      () =>
+        runActiveDeployment("base", undefined, {
+          repositoryRoot: invalidRepository,
+          hardhatCli: "/virtual/hardhat-cli.js",
+          spawnSync: () => {
+            spawned = true;
+            return { status: 0 };
+          },
+        }),
+      /immutable deployment lane/
+    );
+    assert.equal(spawned, false);
+  } finally {
+    rmSync(invalidRepository, { recursive: true, force: true });
+  }
+
+  let failedDirectory;
+  const status = runActiveDeployment("base", undefined, {
+    repositoryRoot: process.cwd(),
+    hardhatCli: "/virtual/hardhat-cli.js",
+    spawnSync: (_command, args) => {
+      failedDirectory = args[args.indexOf("--deploy-scripts") + 1];
+      return { status: 7 };
+    },
+  });
+  assert.equal(status, 7);
+  assert.ok(failedDirectory);
+  assert.equal(existsSync(failedDirectory), false);
+
+  let errorDirectory;
+  assert.throws(
+    () =>
+      runActiveDeployment("base", undefined, {
+        repositoryRoot: process.cwd(),
+        hardhatCli: "/virtual/hardhat-cli.js",
+        spawnSync: (_command, args) => {
+          errorDirectory = args[args.indexOf("--deploy-scripts") + 1];
+          return { status: null, error: new Error("spawn failed") };
+        },
+      }),
+    /spawn failed/
+  );
+  assert.ok(errorDirectory);
+  assert.equal(existsSync(errorDirectory), false);
 });
 
 test("verification allowlist preserves requested order and rejects unknown records", () => {
@@ -815,7 +1069,10 @@ test("MultiSend packing and Safe deliberate-revert decoding are exact", () => {
 
 test("Safe simulation restores package resolution before loading Hardhat", () => {
   moduleAlias.addAlias("@typechain", join(process.cwd(), "typechain"));
-  assert.throws(() => require.resolve("@typechain/hardhat"), /Cannot find module/);
+  assert.throws(
+    () => require.resolve("@typechain/hardhat"),
+    /Cannot find module/
+  );
   assert.equal(typeof restoreHardhatModuleResolution, "function");
   restoreHardhatModuleResolution();
   assert.match(

--- a/scripts/test-opt-in-dispute-lifecycle-deployment.cjs
+++ b/scripts/test-opt-in-dispute-lifecycle-deployment.cjs
@@ -410,10 +410,7 @@ function immutableLaneFixture() {
     mkdirSync(dirname(destination), { recursive: true });
     writeFileSync(
       destination,
-      execFileSync("git", [
-        "show",
-        `fbe141161fe4138421a21e28715e540dafdfee4f:deploy/${filename}`,
-      ])
+      readFileSync(resolve(process.cwd(), "deploy", filename))
     );
   }
   const wrapper = join(

--- a/scripts/test-v3-groups-base-deployment.cjs
+++ b/scripts/test-v3-groups-base-deployment.cjs
@@ -155,7 +155,7 @@ async function addMismatchedArtifacts(state) {
 
 /**
  * @param {any} state
- * @param {"base" | "base_staging"} networkName
+ * @param {"base" | "base_staging" | "localhost" | "hardhat"} networkName
  * @param {{ kind: "predecessor" | "successor" | "unknown", missingRuntime?: boolean, successorBytecode?: boolean, wrongRegistry?: boolean, wrongPolicy?: boolean }} options
  */
 async function installManagedHookState(state, networkName, options) {
@@ -189,9 +189,11 @@ async function installManagedHookState(state, networkName, options) {
   state.deployments.set("OrchestratorV3", { address: orchestrator.address });
 
   const predecessor =
-    PREDECESSOR_DISPUTE_STACKS[networkName].activeLifecycleHook;
-  const originalPredecessor = { ...predecessor };
+    PREDECESSOR_DISPUTE_STACKS[networkName]?.activeLifecycleHook;
+  const originalPredecessor = predecessor ? { ...predecessor } : undefined;
   if (options.kind === "predecessor") {
+    if (!predecessor)
+      throw new Error(`No predecessor evidence for ${networkName}`);
     predecessor.address = currentHook;
     predecessor.runtimeCodeHash = options.missingRuntime
       ? ethers.utils.keccak256("0x01")
@@ -208,8 +210,10 @@ async function installManagedHookState(state, networkName, options) {
   return {
     currentHook,
     restore: () => {
-      predecessor.address = originalPredecessor.address;
-      predecessor.runtimeCodeHash = originalPredecessor.runtimeCodeHash;
+      if (predecessor && originalPredecessor) {
+        predecessor.address = originalPredecessor.address;
+        predecessor.runtimeCodeHash = originalPredecessor.runtimeCodeHash;
+      }
     },
   };
 }
@@ -306,6 +310,24 @@ async function run() {
       }
     }
 
+    for (const networkName of /** @type {Array<"localhost" | "hardhat">} */ ([
+      "localhost",
+      "hardhat",
+    ])) {
+      const state = await fixture();
+      const managed = await installManagedHookState(state, networkName, {
+        kind: "successor",
+      });
+      try {
+        passed =
+          passed &&
+          (await guardManagedDisputeLifecycleHook(state.fakeHre)) === true &&
+          (await skipGroupsStack(state.fakeHre)) === true;
+      } finally {
+        managed.restore();
+      }
+    }
+
     const missingEvidenceState = await fixture();
     const missingEvidence = await installManagedHookState(
       missingEvidenceState,
@@ -382,7 +404,10 @@ async function run() {
       else process.env.ENABLE_BASE_V3_GROUPS_CUTOVER = previousCutover;
     }
 
-    process.stdout.write(passed ? "0x01" : "0x00");
+    if (!passed) {
+      throw new Error("Managed lifecycle hook rollback regression failed");
+    }
+    process.stdout.write("0x01");
     return;
   }
 

--- a/scripts/test-v3-groups-base-deployment.cjs
+++ b/scripts/test-v3-groups-base-deployment.cjs
@@ -18,12 +18,23 @@ console.log = () => {};
 
 const hre = /** @type {any} */ (require("hardhat"));
 const { ethers } = hre;
-const groupsDeploymentModule = require("../deploy/30_deploy_v3_lifecycle_stack.ts");
+const groupsDeploymentModule = require("../deployments/activeDeploymentLanes/30_deploy_v3_lifecycle_stack.ts");
 const deployGroupsStack = groupsDeploymentModule.default;
-const { validateManagedDisputeHookSnapshot } = groupsDeploymentModule;
-const { MULTI_SIG, ORCHESTRATOR_V3_PROTOCOL_FEE, ORCHESTRATOR_V3_PROTOCOL_FEE_RECIPIENT } = require(
-  "../deployments/parameters.ts",
-);
+if (!deployGroupsStack.skip)
+  throw new Error("V3 groups wrapper must define skip");
+const skipGroupsStack = deployGroupsStack.skip;
+const {
+  guardManagedDisputeLifecycleHook,
+  validateManagedDisputeHookSnapshot,
+} = require("../deployments/managedDisputeLifecycleHook.ts");
+const {
+  PREDECESSOR_DISPUTE_STACKS,
+} = require("../deployments/predecessorDisputeStack.ts");
+const {
+  MULTI_SIG,
+  ORCHESTRATOR_V3_PROTOCOL_FEE,
+  ORCHESTRATOR_V3_PROTOCOL_FEE_RECIPIENT,
+} = require("../deployments/parameters.ts");
 const { safeBatchCollector } = require("../deployments/safeBatchCollector.ts");
 
 const scenario = process.argv[2];
@@ -45,7 +56,9 @@ async function fixture() {
   const addressGroupRegistry = await deployContract("AddressGroupRegistry");
   const escrowRegistry = await deployContract("EscrowRegistry");
   const orchestratorRegistry = await deployContract("OrchestratorRegistry");
-  const paymentVerifierRegistry = await deployContract("PaymentVerifierRegistry");
+  const paymentVerifierRegistry = await deployContract(
+    "PaymentVerifierRegistry"
+  );
   const relayerRegistry = await deployContract("RelayerRegistry");
   const whitelistPolicy = await deployContract("WhitelistPolicy", [
     addressGroupRegistry.address,
@@ -79,7 +92,10 @@ async function fixture() {
     deploy: async (name, options) => {
       const existing = deployments.get(name);
       if (existing) return { ...existing, newlyDeployed: false };
-      const contract = await deployContract(options.contract || name, options.args || []);
+      const contract = await deployContract(
+        options.contract || name,
+        options.args || []
+      );
       const deployment = {
         address: contract.address,
         args: options.args || [],
@@ -91,7 +107,10 @@ async function fixture() {
     },
     /** @param {{to: string, data: string}} transaction */
     rawTx: async (transaction) => {
-      const response = await deployerSigner.sendTransaction({ to: transaction.to, data: transaction.data });
+      const response = await deployerSigner.sendTransaction({
+        to: transaction.to,
+        data: transaction.data,
+      });
       await response.wait();
       return { transactionHash: response.hash };
     },
@@ -103,7 +122,14 @@ async function fixture() {
     getUnnamedAccounts: async () => [deployer],
   });
 
-  return { deployer, deployments, fakeHre, network, orchestratorRegistry, safe };
+  return {
+    deployer,
+    deployments,
+    fakeHre,
+    network,
+    orchestratorRegistry,
+    safe,
+  };
 }
 
 /** @param {any} state */
@@ -127,6 +153,67 @@ async function addMismatchedArtifacts(state) {
   state.deployments.set("OrchestratorV3", { address: orchestrator.address });
 }
 
+/**
+ * @param {any} state
+ * @param {"base" | "base_staging"} networkName
+ * @param {{ kind: "predecessor" | "successor" | "unknown", missingRuntime?: boolean, successorBytecode?: boolean, wrongRegistry?: boolean, wrongPolicy?: boolean }} options
+ */
+async function installManagedHookState(state, networkName, options) {
+  state.fakeHre.deployments.getNetworkName = () => networkName;
+  const orchestratorRegistry = await state.fakeHre.deployments.get(
+    "OrchestratorRegistry"
+  );
+  const whitelistPolicy = await state.fakeHre.deployments.get(
+    "WhitelistPolicy"
+  );
+  const wrongAddress = (await state.fakeHre.deployments.get("EscrowRegistry"))
+    .address;
+  const hook = await deployContract("WhitelistLifecycleHook", [
+    options.wrongRegistry ? wrongAddress : orchestratorRegistry.address,
+    options.wrongPolicy ? wrongAddress : whitelistPolicy.address,
+  ]);
+  const currentHook = hook.address;
+  const orchestrator = await deployContract("OrchestratorV3", [
+    state.deployer,
+    state.network.chainId,
+    (await state.fakeHre.deployments.get("EscrowRegistry")).address,
+    (await state.fakeHre.deployments.get("PaymentVerifierRegistry")).address,
+    (await state.fakeHre.deployments.get("RelayerRegistry")).address,
+    ORCHESTRATOR_V3_PROTOCOL_FEE.base,
+    ORCHESTRATOR_V3_PROTOCOL_FEE_RECIPIENT.base,
+  ]);
+  await (await orchestrator.setLifecycleHook(currentHook)).wait();
+  if (options.missingRuntime) {
+    await ethers.provider.send("hardhat_setCode", [currentHook, "0x"]);
+  }
+  state.deployments.set("OrchestratorV3", { address: orchestrator.address });
+
+  const predecessor =
+    PREDECESSOR_DISPUTE_STACKS[networkName].activeLifecycleHook;
+  const originalPredecessor = { ...predecessor };
+  if (options.kind === "predecessor") {
+    predecessor.address = currentHook;
+    predecessor.runtimeCodeHash = options.missingRuntime
+      ? ethers.utils.keccak256("0x01")
+      : ethers.utils.keccak256(await ethers.provider.getCode(currentHook));
+  }
+  if (options.kind === "successor") {
+    /** @type {{ address: string, deployedBytecode?: string }} */
+    const successor = { address: currentHook };
+    if (options.successorBytecode !== false) {
+      successor.deployedBytecode = await ethers.provider.getCode(currentHook);
+    }
+    state.deployments.set("IntentLifecycleHookV1OptIn", successor);
+  }
+  return {
+    currentHook,
+    restore: () => {
+      predecessor.address = originalPredecessor.address;
+      predecessor.runtimeCodeHash = originalPredecessor.runtimeCodeHash;
+    },
+  };
+}
+
 async function run() {
   if (scenario === "managed-hook-guard") {
     const predecessor = "0x0000000000000000000000000000000000000001";
@@ -136,7 +223,10 @@ async function run() {
     const predecessorHash = ethers.utils.keccak256("0x01");
     const successorHash = ethers.utils.keccak256("0x02");
     /** @param {string} currentHook @param {string} actualRuntimeCodeHash */
-    const snapshot = (currentHook, actualRuntimeCodeHash = predecessorHash) => ({
+    const snapshot = (
+      currentHook,
+      actualRuntimeCodeHash = predecessorHash
+    ) => ({
       currentHook,
       predecessor: { address: predecessor, runtimeCodeHash: predecessorHash },
       successor: { address: successor, runtimeCodeHash: successorHash },
@@ -147,7 +237,9 @@ async function run() {
       expectedWhitelistPolicy: policy,
     });
     let passed = validateManagedDisputeHookSnapshot(snapshot(predecessor));
-    passed = passed && validateManagedDisputeHookSnapshot(snapshot(successor, successorHash));
+    passed =
+      passed &&
+      validateManagedDisputeHookSnapshot(snapshot(successor, successorHash));
     try {
       validateManagedDisputeHookSnapshot({
         ...snapshot(predecessor),
@@ -155,14 +247,141 @@ async function run() {
       });
       passed = false;
     } catch (error) {
-      passed = passed && error instanceof Error && error.message.includes("whitelist policy mismatch");
+      passed =
+        passed &&
+        error instanceof Error &&
+        error.message.includes("whitelist policy mismatch");
     }
     try {
       validateManagedDisputeHookSnapshot(snapshot(predecessor, successorHash));
       passed = false;
     } catch (error) {
-      passed = passed && error instanceof Error && error.message.includes("runtime bytecode mismatch");
+      passed =
+        passed &&
+        error instanceof Error &&
+        error.message.includes("runtime bytecode mismatch");
     }
+    process.stdout.write(passed ? "0x01" : "0x00");
+    return;
+  }
+
+  if (scenario === "managed-hook-no-rollback") {
+    let passed = true;
+    for (const networkName of /** @type {Array<"base" | "base_staging">} */ ([
+      "base",
+      "base_staging",
+    ])) {
+      for (const kind of /** @type {Array<"predecessor" | "successor">} */ ([
+        "predecessor",
+        "successor",
+      ])) {
+        const state = await fixture();
+        const managed = await installManagedHookState(state, networkName, {
+          kind,
+        });
+        const flag =
+          networkName === "base"
+            ? "ENABLE_BASE_V3_GROUPS_CUTOVER"
+            : "ENABLE_STAGING_V3_GROUPS_CUTOVER";
+        const previousFlag = process.env[flag];
+        process.env[flag] = "true";
+        try {
+          await deployGroupsStack(state.fakeHre);
+          const orchestrator = await ethers.getContractAt(
+            "OrchestratorV3",
+            (
+              await state.fakeHre.deployments.get("OrchestratorV3")
+            ).address
+          );
+          passed =
+            passed &&
+            (await orchestrator.lifecycleHook()).toLowerCase() ===
+              managed.currentHook.toLowerCase() &&
+            (await skipGroupsStack(state.fakeHre)) === true;
+        } finally {
+          managed.restore();
+          if (previousFlag === undefined) delete process.env[flag];
+          else process.env[flag] = previousFlag;
+        }
+      }
+    }
+
+    const missingEvidenceState = await fixture();
+    const missingEvidence = await installManagedHookState(
+      missingEvidenceState,
+      "base",
+      { kind: "successor", successorBytecode: false }
+    );
+    try {
+      await guardManagedDisputeLifecycleHook(missingEvidenceState.fakeHre);
+      passed = false;
+    } catch (error) {
+      passed =
+        passed &&
+        error instanceof Error &&
+        error.message.includes("lacks deployment bytecode evidence");
+    } finally {
+      missingEvidence.restore();
+    }
+
+    const missingRuntimeState = await fixture();
+    const missingRuntime = await installManagedHookState(
+      missingRuntimeState,
+      "base_staging",
+      { kind: "predecessor", missingRuntime: true }
+    );
+    try {
+      await guardManagedDisputeLifecycleHook(missingRuntimeState.fakeHre);
+      passed = false;
+    } catch (error) {
+      passed =
+        passed &&
+        error instanceof Error &&
+        error.message.includes("has no bytecode");
+    } finally {
+      missingRuntime.restore();
+    }
+
+    for (const mismatch of ["wrongRegistry", "wrongPolicy"]) {
+      const mismatchState = await fixture();
+      const managed = await installManagedHookState(mismatchState, "base", {
+        kind: "successor",
+        [mismatch]: true,
+      });
+      try {
+        await guardManagedDisputeLifecycleHook(mismatchState.fakeHre);
+        passed = false;
+      } catch (error) {
+        const expected =
+          mismatch === "wrongRegistry"
+            ? "registry mismatch"
+            : "whitelist policy mismatch";
+        passed =
+          passed && error instanceof Error && error.message.includes(expected);
+      } finally {
+        managed.restore();
+      }
+    }
+
+    const unknownState = await fixture();
+    const unknown = await installManagedHookState(unknownState, "base", {
+      kind: "unknown",
+    });
+    const previousCutover = process.env.ENABLE_BASE_V3_GROUPS_CUTOVER;
+    process.env.ENABLE_BASE_V3_GROUPS_CUTOVER = "true";
+    try {
+      passed =
+        passed &&
+        (await guardManagedDisputeLifecycleHook(unknownState.fakeHre)) ===
+          false &&
+        (await skipGroupsStack(unknownState.fakeHre)) === false;
+    } finally {
+      unknown.restore();
+      if (previousCutover === undefined)
+        delete process.env.ENABLE_BASE_V3_GROUPS_CUTOVER;
+      else process.env.ENABLE_BASE_V3_GROUPS_CUTOVER = previousCutover;
+    }
+
     process.stdout.write(passed ? "0x01" : "0x00");
     return;
   }
@@ -172,12 +391,17 @@ async function run() {
   if (scenario === "prepare-resume") {
     await deployGroupsStack(state.fakeHre);
     const orchestrator = await state.fakeHre.deployments.get("OrchestratorV3");
-    const addData = state.orchestratorRegistry.interface.encodeFunctionData("addOrchestrator", [
-      orchestrator.address,
-    ]);
-    let passed = safeBatchCollector.count() === 1
-      && safeBatchCollector.hasQueued(state.orchestratorRegistry.address, addData)
-      && !(await state.orchestratorRegistry.isOrchestrator(orchestrator.address));
+    const addData = state.orchestratorRegistry.interface.encodeFunctionData(
+      "addOrchestrator",
+      [orchestrator.address]
+    );
+    let passed =
+      safeBatchCollector.count() === 1 &&
+      safeBatchCollector.hasQueued(
+        state.orchestratorRegistry.address,
+        addData
+      ) &&
+      !(await state.orchestratorRegistry.isOrchestrator(orchestrator.address));
     await deployGroupsStack(state.fakeHre);
     passed = passed && safeBatchCollector.count() === 1;
     process.stdout.write(passed ? "0x01" : "0x00");
@@ -190,9 +414,13 @@ async function run() {
     try {
       await deployGroupsStack(state.fakeHre);
     } catch (error) {
-      rejected = error instanceof Error && error.message.includes("protocol fee mismatch");
+      rejected =
+        error instanceof Error &&
+        error.message.includes("protocol fee mismatch");
     }
-    process.stdout.write(rejected && safeBatchCollector.count() === 0 ? "0x01" : "0x00");
+    process.stdout.write(
+      rejected && safeBatchCollector.count() === 0 ? "0x01" : "0x00"
+    );
     return;
   }
 

--- a/scripts/verify-dispute-opt-in-safe-batch.ts
+++ b/scripts/verify-dispute-opt-in-safe-batch.ts
@@ -110,9 +110,7 @@ export function assertBatchMatchesManifest(
   ) {
     throw new Error("Persisted Safe transaction shape is not canonical");
   }
-  const persisted = normalizeSafeTransactions(
-    batch.transactions
-  );
+  const persisted = normalizeSafeTransactions(batch.transactions);
   if (JSON.stringify(persisted) !== JSON.stringify(manifest.transactions)) {
     throw new Error("Persisted Safe transactions do not match their manifest");
   }
@@ -243,9 +241,8 @@ export async function verifyDisputeSafeArtifacts(
       owner: await orchestrator.owner(),
       currentHook: await orchestrator.lifecycleHook(),
     },
-    predecessorHook:
-      require("../deploy/32_deploy_and_activate_dispute_lifecycle_stack.ts")
-        .PREDECESSOR_DISPUTE_STACKS.base.activeLifecycleHook.address,
+    predecessorHook: require("../deployments/predecessorDisputeStack.ts")
+      .PREDECESSOR_DISPUTE_STACKS.base.activeLifecycleHook.address,
     freshHook: postconditions.freshHook,
   });
   if (

--- a/tsconfig.dispute-deployment.json
+++ b/tsconfig.dispute-deployment.json
@@ -11,9 +11,11 @@
   "files": [
     "hardhat.config.ts",
     "deployments/activeDisputeStack.cjs",
+    "deployments/activeDeploymentLanes/30_deploy_v3_lifecycle_stack.ts",
+    "deployments/immutableDeploymentLanes.ts",
+    "deployments/managedDisputeLifecycleHook.ts",
+    "deployments/predecessorDisputeStack.ts",
     "deployments/safeBatchManifest.ts",
-    "deploy/30_deploy_v3_lifecycle_stack.ts",
-    "deploy/32_deploy_and_activate_dispute_lifecycle_stack.ts",
     "deploy/34_deploy_opt_in_dispute_lifecycle_stack.ts",
     "deploy/deploy_summary.ts",
     "packages/contracts/scripts/extractors/abis.ts",


### PR DESCRIPTION
## Summary
- Restore production-executed lanes 30 and 32 byte-for-byte to their deployed source blobs.
- Enforce immutability and lane retirement outside the historical files so supported deployments cannot reload lane 32 or roll a managed dispute hook back through lane 30.
- Codify the rule that production-executed numbered deployment scripts are immutable provenance.

## Changes
### Immutable deployment selection
- Pin the deployed source SHA and SHA-256 for lanes 30 and 32 in `deployments/immutableDeploymentLanes.ts`.
- Route tagged and untagged repository deploy commands through the same filtered temporary script directory.
- Mount a current guarded lane-30 wrapper under the historical filename and omit only the retired lane-32 file.
- Reject both historical lane-32 tags and comma-separated multi-tag input before Hardhat starts.

### Current safety logic
- Move predecessor address and bytecode evidence to `deployments/predecessorDisputeStack.ts`.
- Move the managed predecessor/successor hook guard to `deployments/managedDisputeLifecycleHook.ts`.
- Keep lane 34 and Safe simulation/verification consumers on the current helpers.
- Add regressions for digest drift, mount selection, cleanup, child failure propagation, Base/Base-staging no-rollback behavior, and fail-closed hook validation.

### Historical provenance
- Lane 30 SHA-256: `97ed83a35e91167186da7a1bde9d3534e6eced436a843a0afd07c0f055bf20fa`
- Lane 32 SHA-256: `e103f2b9eb4168504cb226a6191a05c432e313ca5b649b0cc2a3d77fb3a5d283`

## Spec Alignment
- Spec: `docs/superpowers/specs/2026-08-20-immutable-production-deployment-lanes-design.md`
- Plan: `docs/plans/2026-08-20-restore-immutable-production-deployment-lanes.md`
- Implemented as designed: yes
- Divergences: none

## Deployment Impact
- No Base or Base-staging transaction was sent.
- No deployment artifact, exported address, Safe transaction, Solidity contract, ABI, or package version changed.
- Direct `hardhat deploy` is documented as unsupported because it bypasses the repository runner.

## Test Plan
- [x] `yarn test:dispute-lifecycle-deployment`
- [x] `yarn test:v3-groups-deployment`
- [x] `yarn typecheck:dispute-deployment`
- [x] Prettier checks for every changed current-source and documentation file
- [x] `git diff --check`
- [x] Exact SHA-256 and historical-blob equality checks for lanes 30 and 32
- [x] Focused differential deployment audit: no blocking findings