### PR TITLE
feat: add Mercury payment method to Base staging

### DIFF
--- a/deploy/31_deploy_v3_payment_binding_stack.ts
+++ b/deploy/31_deploy_v3_payment_binding_stack.ts
@@ -97,6 +97,8 @@ export const RATIFIED_PAYMENT_METHOD_CURRENCIES: Record<string, string[]> = {
   zelle: ["USD"],
   monzo: ["GBP"],
   paypal: ["USD", "EUR", "GBP", "SGD", "NZD", "AUD", "CAD"],
+  monobank: ["UAH"],
+  mercury: ["USD"],
 };
 
 export const RATIFIED_PAYMENT_METHOD_ORDER: Record<string, string[]> = {
@@ -113,7 +115,7 @@ export const RATIFIED_PAYMENT_METHOD_ORDER: Record<string, string[]> = {
     "monzo",
     "paypal",
   ],
-  // Base staging block 49,793,275. Staging was already hard-cut to UPV3 before
+  // Base staging block 50,211,289. Staging was already hard-cut to UPV3 before
   // this lane was introduced, so lane 31 verifies this live order and never
   // attempts an unsafe multi-transaction EOA cutover there.
   base_staging: [
@@ -127,6 +129,7 @@ export const RATIFIED_PAYMENT_METHOD_ORDER: Record<string, string[]> = {
     "wise",
     "mercadopago",
     "paypal",
+    "monobank",
     "mercury",
   ],
 };

--- a/deploy/31_deploy_v3_payment_binding_stack.ts
+++ b/deploy/31_deploy_v3_payment_binding_stack.ts
@@ -4,7 +4,7 @@ import { ethers } from "hardhat";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
 
-import { ACTIVE_PAYMENT_METHODS, MULTI_SIG } from "../deployments/parameters";
+import { getActivePaymentMethods, MULTI_SIG } from "../deployments/parameters";
 import {
   addPaymentMethodToRegistry,
   addPaymentMethodToUnifiedVerifier,
@@ -127,6 +127,7 @@ export const RATIFIED_PAYMENT_METHOD_ORDER: Record<string, string[]> = {
     "wise",
     "mercadopago",
     "paypal",
+    "mercury",
   ],
 };
 
@@ -543,7 +544,8 @@ export async function assertPaymentBindingReady(
     throw new Error("UnifiedPaymentVerifierV3 owner mismatch");
   }
 
-  const expectedPaymentMethods = ACTIVE_PAYMENT_METHODS.map(paymentMethodHash);
+  const expectedPaymentMethods =
+    getActivePaymentMethods(network).map(paymentMethodHash);
   const actualPaymentMethods =
     await unifiedPaymentVerifierV3.getPaymentMethods();
   if (!sameStringSet(actualPaymentMethods, expectedPaymentMethods)) {
@@ -595,7 +597,8 @@ async function assertRegistrySurface(
   }
   const actualMethods: string[] =
     await paymentVerifierRegistry.getPaymentMethods();
-  const expectedMethods = ACTIVE_PAYMENT_METHODS.map(paymentMethodHash);
+  const activePaymentMethods = getActivePaymentMethods(network);
+  const expectedMethods = activePaymentMethods.map(paymentMethodHash);
   if (!sameStringSet(actualMethods, expectedMethods)) {
     throw new Error(
       "PaymentVerifierRegistry methods do not match the active method set"
@@ -604,7 +607,7 @@ async function assertRegistrySurface(
   const ratifiedOrder = RATIFIED_PAYMENT_METHOD_ORDER[network];
   if (
     network === "base" &&
-    !sameStringArray(ACTIVE_PAYMENT_METHODS, ratifiedOrder)
+    !sameStringArray(activePaymentMethods, ratifiedOrder)
   ) {
     throw new Error(
       "ACTIVE_PAYMENT_METHODS drifted from the audited Base method order"
@@ -733,7 +736,7 @@ async function deployLocalPaymentBinding(
     "UnifiedPaymentVerifierV3",
     unifiedPaymentVerifierV3Deployment.address
   );
-  for (const methodName of ACTIVE_PAYMENT_METHODS) {
+  for (const methodName of getActivePaymentMethods(network)) {
     await addPaymentMethodToUnifiedVerifier(
       hre,
       unifiedPaymentVerifierV3,

--- a/deploy/31_deploy_v3_payment_binding_stack.ts
+++ b/deploy/31_deploy_v3_payment_binding_stack.ts
@@ -685,6 +685,7 @@ async function deployLocalPaymentBinding(
   deployer: string,
   governance: string
 ): Promise<void> {
+  const network = hre.deployments.getNetworkName();
   const legacyNullifierRegistryAddress = (
     await hre.deployments.get("NullifierRegistry")
   ).address;

--- a/deploy/35_add_mercury_payment_method.ts
+++ b/deploy/35_add_mercury_payment_method.ts
@@ -9,7 +9,12 @@ import {
   addPaymentMethodToUnifiedVerifier,
   savePaymentMethodSnapshot,
 } from "../deployments/helpers";
+import {
+  RATIFIED_PAYMENT_METHOD_CURRENCIES,
+  RATIFIED_PAYMENT_METHOD_ORDER,
+} from "./31_deploy_v3_payment_binding_stack";
 import { MERCURY_PROVIDER_CONFIG } from "../deployments/verifiers/mercury";
+import { calculatePaymentMethodHash } from "../utils/protocolUtils";
 
 const PREPARE_FLAG = "PREPARE_STAGING_MERCURY_PAYMENT_METHOD";
 const EXECUTE_FLAG = "EXECUTE_STAGING_MERCURY_PAYMENT_METHOD";
@@ -17,6 +22,8 @@ const TAG = "35_add_mercury_payment_method";
 const EXPECTED_CHAIN_ID = 8453;
 const EXPECTED_STAGING = {
   governance: "0x84e113087C97Cd80eA9D78983D4B8Ff61ECa1929",
+  legacyNullifierRegistry: "0x3FFd04f7909a16d3476263A1f4ce413A089dCc69",
+  nullifierRegistryV2: "0x2eb43d6C7c7Ec4220Aa6B8735BC053824a71778C",
   paymentVerifierRegistry: "0x2261416DA54C85f975C73FA56EF4D2D6b0aEF7Cc",
   unifiedPaymentVerifierV3: "0x4c62E99649c8Ba745E67018f5c8a483D77c429C4",
 } as const;
@@ -34,7 +41,19 @@ function sameStringArray(left: string[], right: string[]): boolean {
   );
 }
 
+function sameStringSet(left: string[], right: string[]): boolean {
+  return (
+    left.length === right.length &&
+    new Set(left.map((value) => value.toLowerCase())).size === left.length &&
+    left.every((value) =>
+      right.some((candidate) => sameAddress(value, candidate))
+    )
+  );
+}
+
 async function loadStagingContracts(hre: HardhatRuntimeEnvironment): Promise<{
+  legacyNullifierRegistry: any;
+  nullifierRegistryV2: any;
   paymentVerifierRegistry: any;
   unifiedPaymentVerifierV3: any;
 }> {
@@ -56,6 +75,12 @@ async function loadStagingContracts(hre: HardhatRuntimeEnvironment): Promise<{
   const verifierDeployment = await hre.deployments.get(
     "UnifiedPaymentVerifierV3"
   );
+  const nullifierV2Deployment = await hre.deployments.get(
+    "NullifierRegistryV2"
+  );
+  const legacyNullifierDeployment = await hre.deployments.get(
+    "NullifierRegistry"
+  );
   if (
     !sameAddress(
       registryDeployment.address,
@@ -64,6 +89,14 @@ async function loadStagingContracts(hre: HardhatRuntimeEnvironment): Promise<{
     !sameAddress(
       verifierDeployment.address,
       EXPECTED_STAGING.unifiedPaymentVerifierV3
+    ) ||
+    !sameAddress(
+      nullifierV2Deployment.address,
+      EXPECTED_STAGING.nullifierRegistryV2
+    ) ||
+    !sameAddress(
+      legacyNullifierDeployment.address,
+      EXPECTED_STAGING.legacyNullifierRegistry
     )
   ) {
     throw new Error(
@@ -74,6 +107,8 @@ async function loadStagingContracts(hre: HardhatRuntimeEnvironment): Promise<{
   for (const [label, address] of [
     ["PaymentVerifierRegistry", registryDeployment.address],
     ["UnifiedPaymentVerifierV3", verifierDeployment.address],
+    ["NullifierRegistryV2", nullifierV2Deployment.address],
+    ["NullifierRegistry", legacyNullifierDeployment.address],
   ] as const) {
     if ((await ethers.provider.getCode(address)) === "0x") {
       throw new Error(`${label} has no bytecode at ${address}`);
@@ -88,53 +123,157 @@ async function loadStagingContracts(hre: HardhatRuntimeEnvironment): Promise<{
     "UnifiedPaymentVerifierV3",
     verifierDeployment.address
   );
+  const nullifierRegistryV2 = await ethers.getContractAt(
+    "NullifierRegistryV2",
+    nullifierV2Deployment.address
+  );
+  const legacyNullifierRegistry = await ethers.getContractAt(
+    "NullifierRegistry",
+    legacyNullifierDeployment.address
+  );
   const [deployer] = await hre.getUnnamedAccounts();
-  const [registryOwner, verifierOwner] = await Promise.all([
-    paymentVerifierRegistry.owner(),
-    unifiedPaymentVerifierV3.owner(),
-  ]);
+  const [registryOwner, verifierOwner, nullifierV2Owner, legacyNullifierOwner] =
+    await Promise.all([
+      paymentVerifierRegistry.owner(),
+      unifiedPaymentVerifierV3.owner(),
+      nullifierRegistryV2.owner(),
+      legacyNullifierRegistry.owner(),
+    ]);
   if (
     !sameAddress(deployer, EXPECTED_STAGING.governance) ||
     !sameAddress(registryOwner, EXPECTED_STAGING.governance) ||
-    !sameAddress(verifierOwner, EXPECTED_STAGING.governance)
+    !sameAddress(verifierOwner, EXPECTED_STAGING.governance) ||
+    !sameAddress(nullifierV2Owner, EXPECTED_STAGING.governance) ||
+    !sameAddress(legacyNullifierOwner, EXPECTED_STAGING.governance)
   ) {
     throw new Error("Mercury activation signer or contract owner mismatch");
   }
 
-  return { paymentVerifierRegistry, unifiedPaymentVerifierV3 };
+  return {
+    legacyNullifierRegistry,
+    nullifierRegistryV2,
+    paymentVerifierRegistry,
+    unifiedPaymentVerifierV3,
+  };
+}
+
+async function assertPaymentBindingState(
+  paymentVerifierRegistry: any,
+  unifiedPaymentVerifierV3: any,
+  nullifierRegistryV2: any,
+  legacyNullifierRegistry: any
+): Promise<{ registryHasMethod: boolean; verifierHasMethod: boolean }> {
+  const paymentMethodHash = MERCURY_PROVIDER_CONFIG.paymentMethodHash;
+  const [registryMethods, verifierMethods, nullifierWriters, legacyWriters] =
+    await Promise.all([
+      paymentVerifierRegistry.getPaymentMethods(),
+      unifiedPaymentVerifierV3.getPaymentMethods(),
+      nullifierRegistryV2.getWriters(),
+      legacyNullifierRegistry.getWriters(),
+    ]);
+  const registryHasMethod = registryMethods.some((method: string) =>
+    sameAddress(method, paymentMethodHash)
+  );
+  const verifierHasMethod = verifierMethods.some((method: string) =>
+    sameAddress(method, paymentMethodHash)
+  );
+  if (registryHasMethod && !verifierHasMethod) {
+    throw new Error(
+      "PaymentVerifierRegistry contains Mercury before UnifiedPaymentVerifierV3"
+    );
+  }
+
+  const ratifiedOrder = RATIFIED_PAYMENT_METHOD_ORDER.base_staging;
+  const existingMethodNames = ratifiedOrder.filter(
+    (name) => name !== "mercury"
+  );
+  const expectedRegistryNames = registryHasMethod
+    ? ratifiedOrder
+    : existingMethodNames;
+  const expectedVerifierNames = verifierHasMethod
+    ? ratifiedOrder
+    : existingMethodNames;
+  const expectedRegistryMethods = expectedRegistryNames.map(
+    calculatePaymentMethodHash
+  );
+  const expectedVerifierMethods = expectedVerifierNames.map(
+    calculatePaymentMethodHash
+  );
+
+  if (!sameStringArray(registryMethods, expectedRegistryMethods)) {
+    throw new Error(
+      "PaymentVerifierRegistry methods drifted from the ratified staging order"
+    );
+  }
+  if (!sameStringSet(verifierMethods, expectedVerifierMethods)) {
+    throw new Error(
+      "UnifiedPaymentVerifierV3 methods drifted from the ratified staging set"
+    );
+  }
+  if (
+    !sameAddress(
+      await unifiedPaymentVerifierV3.nullifierRegistry(),
+      nullifierRegistryV2.address
+    ) ||
+    !sameAddress(
+      await nullifierRegistryV2.legacyNullifierRegistry(),
+      legacyNullifierRegistry.address
+    )
+  ) {
+    throw new Error("Mercury activation nullifier binding mismatch");
+  }
+  if (
+    nullifierWriters.length !== 1 ||
+    !sameAddress(nullifierWriters[0], unifiedPaymentVerifierV3.address) ||
+    legacyWriters.length !== 0
+  ) {
+    throw new Error("Mercury activation nullifier writer invariant failed");
+  }
+
+  for (let index = 0; index < expectedRegistryNames.length; index += 1) {
+    const methodName = expectedRegistryNames[index];
+    const methodHash = expectedRegistryMethods[index];
+    const [verifier, currencies] = await Promise.all([
+      paymentVerifierRegistry.getVerifier(methodHash),
+      paymentVerifierRegistry.getCurrencies(methodHash),
+    ]);
+    const expectedCurrencies = RATIFIED_PAYMENT_METHOD_CURRENCIES[
+      methodName
+    ].map(calculatePaymentMethodHash);
+    if (
+      !sameAddress(verifier, unifiedPaymentVerifierV3.address) ||
+      !sameStringArray(currencies, expectedCurrencies)
+    ) {
+      throw new Error(`Staging payment binding drifted for ${methodName}`);
+    }
+  }
+
+  return { registryHasMethod, verifierHasMethod };
 }
 
 export async function mercuryStagingReady(
   hre: HardhatRuntimeEnvironment
 ): Promise<boolean> {
-  const { paymentVerifierRegistry, unifiedPaymentVerifierV3 } =
-    await loadStagingContracts(hre);
-  const paymentMethodHash = MERCURY_PROVIDER_CONFIG.paymentMethodHash;
-  const verifierMethods: string[] =
-    await unifiedPaymentVerifierV3.getPaymentMethods();
-  const registryHasMethod = await paymentVerifierRegistry.isPaymentMethod(
-    paymentMethodHash
-  );
-  const verifierHasMethod = verifierMethods.some((method) =>
-    sameAddress(method, paymentMethodHash)
-  );
-
-  if (registryHasMethod) {
-    if (!verifierHasMethod) {
-      throw new Error(
-        "PaymentVerifierRegistry contains Mercury before UnifiedPaymentVerifierV3"
-      );
-    }
-    const [verifier, currencies] = await Promise.all([
-      paymentVerifierRegistry.getVerifier(paymentMethodHash),
-      paymentVerifierRegistry.getCurrencies(paymentMethodHash),
-    ]);
-    if (
-      !sameAddress(verifier, EXPECTED_STAGING.unifiedPaymentVerifierV3) ||
-      !sameStringArray(currencies, MERCURY_PROVIDER_CONFIG.currencies)
-    ) {
-      throw new Error("Existing Mercury registry configuration drifted");
-    }
+  const {
+    legacyNullifierRegistry,
+    nullifierRegistryV2,
+    paymentVerifierRegistry,
+    unifiedPaymentVerifierV3,
+  } = await loadStagingContracts(hre);
+  const { registryHasMethod, verifierHasMethod } =
+    await assertPaymentBindingState(
+      paymentVerifierRegistry,
+      unifiedPaymentVerifierV3,
+      nullifierRegistryV2,
+      legacyNullifierRegistry
+    );
+  if (
+    registryHasMethod !==
+    (await paymentVerifierRegistry.isPaymentMethod(
+      MERCURY_PROVIDER_CONFIG.paymentMethodHash
+    ))
+  ) {
+    throw new Error("Mercury registry membership views disagree");
   }
 
   return registryHasMethod && verifierHasMethod;
@@ -189,8 +328,18 @@ async function simulateMissingWrites(
 const func: DeployFunction = async function (
   hre: HardhatRuntimeEnvironment
 ): Promise<void> {
-  const { paymentVerifierRegistry, unifiedPaymentVerifierV3 } =
-    await loadStagingContracts(hre);
+  const {
+    legacyNullifierRegistry,
+    nullifierRegistryV2,
+    paymentVerifierRegistry,
+    unifiedPaymentVerifierV3,
+  } = await loadStagingContracts(hre);
+  await assertPaymentBindingState(
+    paymentVerifierRegistry,
+    unifiedPaymentVerifierV3,
+    nullifierRegistryV2,
+    legacyNullifierRegistry
+  );
   await simulateMissingWrites(
     paymentVerifierRegistry,
     unifiedPaymentVerifierV3

--- a/deploy/35_add_mercury_payment_method.ts
+++ b/deploy/35_add_mercury_payment_method.ts
@@ -1,0 +1,248 @@
+import "module-alias/register";
+
+import { ethers } from "hardhat";
+import type { HardhatRuntimeEnvironment } from "hardhat/types";
+import type { DeployFunction } from "hardhat-deploy/types";
+
+import {
+  addPaymentMethodToRegistry,
+  addPaymentMethodToUnifiedVerifier,
+  savePaymentMethodSnapshot,
+} from "../deployments/helpers";
+import { MERCURY_PROVIDER_CONFIG } from "../deployments/verifiers/mercury";
+
+const PREPARE_FLAG = "PREPARE_STAGING_MERCURY_PAYMENT_METHOD";
+const EXECUTE_FLAG = "EXECUTE_STAGING_MERCURY_PAYMENT_METHOD";
+const TAG = "35_add_mercury_payment_method";
+const EXPECTED_CHAIN_ID = 8453;
+const EXPECTED_STAGING = {
+  governance: "0x84e113087C97Cd80eA9D78983D4B8Ff61ECa1929",
+  paymentVerifierRegistry: "0x2261416DA54C85f975C73FA56EF4D2D6b0aEF7Cc",
+  unifiedPaymentVerifierV3: "0x4c62E99649c8Ba745E67018f5c8a483D77c429C4",
+} as const;
+
+function sameAddress(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function sameStringArray(left: string[], right: string[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every(
+      (value, index) => value.toLowerCase() === right[index].toLowerCase()
+    )
+  );
+}
+
+async function loadStagingContracts(hre: HardhatRuntimeEnvironment): Promise<{
+  paymentVerifierRegistry: any;
+  unifiedPaymentVerifierV3: any;
+}> {
+  const network = hre.deployments.getNetworkName();
+  if (network !== "base_staging") {
+    throw new Error("Mercury payment-method activation is Base-staging only");
+  }
+
+  const providerNetwork = await ethers.provider.getNetwork();
+  if (providerNetwork.chainId !== EXPECTED_CHAIN_ID) {
+    throw new Error(
+      `Provider chain ID ${providerNetwork.chainId} does not match Base ${EXPECTED_CHAIN_ID}`
+    );
+  }
+
+  const registryDeployment = await hre.deployments.get(
+    "PaymentVerifierRegistry"
+  );
+  const verifierDeployment = await hre.deployments.get(
+    "UnifiedPaymentVerifierV3"
+  );
+  if (
+    !sameAddress(
+      registryDeployment.address,
+      EXPECTED_STAGING.paymentVerifierRegistry
+    ) ||
+    !sameAddress(
+      verifierDeployment.address,
+      EXPECTED_STAGING.unifiedPaymentVerifierV3
+    )
+  ) {
+    throw new Error(
+      "Mercury activation deployment artifacts do not match staging"
+    );
+  }
+
+  for (const [label, address] of [
+    ["PaymentVerifierRegistry", registryDeployment.address],
+    ["UnifiedPaymentVerifierV3", verifierDeployment.address],
+  ] as const) {
+    if ((await ethers.provider.getCode(address)) === "0x") {
+      throw new Error(`${label} has no bytecode at ${address}`);
+    }
+  }
+
+  const paymentVerifierRegistry = await ethers.getContractAt(
+    "PaymentVerifierRegistry",
+    registryDeployment.address
+  );
+  const unifiedPaymentVerifierV3 = await ethers.getContractAt(
+    "UnifiedPaymentVerifierV3",
+    verifierDeployment.address
+  );
+  const [deployer] = await hre.getUnnamedAccounts();
+  const [registryOwner, verifierOwner] = await Promise.all([
+    paymentVerifierRegistry.owner(),
+    unifiedPaymentVerifierV3.owner(),
+  ]);
+  if (
+    !sameAddress(deployer, EXPECTED_STAGING.governance) ||
+    !sameAddress(registryOwner, EXPECTED_STAGING.governance) ||
+    !sameAddress(verifierOwner, EXPECTED_STAGING.governance)
+  ) {
+    throw new Error("Mercury activation signer or contract owner mismatch");
+  }
+
+  return { paymentVerifierRegistry, unifiedPaymentVerifierV3 };
+}
+
+export async function mercuryStagingReady(
+  hre: HardhatRuntimeEnvironment
+): Promise<boolean> {
+  const { paymentVerifierRegistry, unifiedPaymentVerifierV3 } =
+    await loadStagingContracts(hre);
+  const paymentMethodHash = MERCURY_PROVIDER_CONFIG.paymentMethodHash;
+  const verifierMethods: string[] =
+    await unifiedPaymentVerifierV3.getPaymentMethods();
+  const registryHasMethod = await paymentVerifierRegistry.isPaymentMethod(
+    paymentMethodHash
+  );
+  const verifierHasMethod = verifierMethods.some((method) =>
+    sameAddress(method, paymentMethodHash)
+  );
+
+  if (registryHasMethod) {
+    if (!verifierHasMethod) {
+      throw new Error(
+        "PaymentVerifierRegistry contains Mercury before UnifiedPaymentVerifierV3"
+      );
+    }
+    const [verifier, currencies] = await Promise.all([
+      paymentVerifierRegistry.getVerifier(paymentMethodHash),
+      paymentVerifierRegistry.getCurrencies(paymentMethodHash),
+    ]);
+    if (
+      !sameAddress(verifier, EXPECTED_STAGING.unifiedPaymentVerifierV3) ||
+      !sameStringArray(currencies, MERCURY_PROVIDER_CONFIG.currencies)
+    ) {
+      throw new Error("Existing Mercury registry configuration drifted");
+    }
+  }
+
+  return registryHasMethod && verifierHasMethod;
+}
+
+async function simulateMissingWrites(
+  paymentVerifierRegistry: any,
+  unifiedPaymentVerifierV3: any
+): Promise<void> {
+  const paymentMethodHash = MERCURY_PROVIDER_CONFIG.paymentMethodHash;
+  const verifierMethods: string[] =
+    await unifiedPaymentVerifierV3.getPaymentMethods();
+  const verifierHasMethod = verifierMethods.some((method) =>
+    sameAddress(method, paymentMethodHash)
+  );
+  const registryHasMethod = await paymentVerifierRegistry.isPaymentMethod(
+    paymentMethodHash
+  );
+
+  if (!verifierHasMethod) {
+    await ethers.provider.call({
+      from: EXPECTED_STAGING.governance,
+      to: unifiedPaymentVerifierV3.address,
+      data: unifiedPaymentVerifierV3.interface.encodeFunctionData(
+        "addPaymentMethod",
+        [paymentMethodHash]
+      ),
+    });
+  }
+  if (!registryHasMethod) {
+    await ethers.provider.call({
+      from: EXPECTED_STAGING.governance,
+      to: paymentVerifierRegistry.address,
+      data: paymentVerifierRegistry.interface.encodeFunctionData(
+        "addPaymentMethod",
+        [
+          paymentMethodHash,
+          EXPECTED_STAGING.unifiedPaymentVerifierV3,
+          MERCURY_PROVIDER_CONFIG.currencies,
+        ]
+      ),
+    });
+  }
+
+  console.log("Mercury Base-staging activation plan verified");
+  console.log("Payment method:", paymentMethodHash);
+  console.log("Currency:", MERCURY_PROVIDER_CONFIG.currencies[0]);
+  console.log("UnifiedPaymentVerifierV3:", unifiedPaymentVerifierV3.address);
+  console.log("PaymentVerifierRegistry:", paymentVerifierRegistry.address);
+}
+
+const func: DeployFunction = async function (
+  hre: HardhatRuntimeEnvironment
+): Promise<void> {
+  const { paymentVerifierRegistry, unifiedPaymentVerifierV3 } =
+    await loadStagingContracts(hre);
+  await simulateMissingWrites(
+    paymentVerifierRegistry,
+    unifiedPaymentVerifierV3
+  );
+
+  if (process.env[PREPARE_FLAG] === "true") {
+    return;
+  }
+
+  await addPaymentMethodToUnifiedVerifier(
+    hre,
+    unifiedPaymentVerifierV3,
+    MERCURY_PROVIDER_CONFIG.paymentMethodHash
+  );
+  await addPaymentMethodToRegistry(
+    hre,
+    paymentVerifierRegistry,
+    MERCURY_PROVIDER_CONFIG.paymentMethodHash,
+    EXPECTED_STAGING.unifiedPaymentVerifierV3,
+    MERCURY_PROVIDER_CONFIG.currencies
+  );
+
+  if (!(await mercuryStagingReady(hre))) {
+    throw new Error("Mercury Base-staging activation verification failed");
+  }
+  savePaymentMethodSnapshot("base_staging", "mercury", {
+    paymentMethodHash: MERCURY_PROVIDER_CONFIG.paymentMethodHash,
+    currencies: MERCURY_PROVIDER_CONFIG.currencies,
+  });
+  console.log("Mercury is active on Base staging");
+};
+
+func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> => {
+  if (hre.deployments.getNetworkName() !== "base_staging") return true;
+
+  const prepare = process.env[PREPARE_FLAG] === "true";
+  const execute = process.env[EXECUTE_FLAG] === "true";
+  if (prepare && execute) {
+    throw new Error("Choose either Mercury prepare or execute mode");
+  }
+  if (!prepare && !execute) {
+    if (process.env.DEPLOY_ACTIVE_TAG === TAG) {
+      throw new Error(
+        `Set ${PREPARE_FLAG}=true or ${EXECUTE_FLAG}=true for Mercury staging activation`
+      );
+    }
+    return true;
+  }
+  return false;
+};
+
+func.tags = [TAG, "MercuryPaymentMethod"];
+func.dependencies = [];
+
+export default func;

--- a/deployments/parameters.ts
+++ b/deployments/parameters.ts
@@ -151,6 +151,7 @@ export const ACTIVE_PAYMENT_METHODS: string[] = [
 // unchanged until that boundary is explicitly authorized.
 export const BASE_STAGING_ACTIVE_PAYMENT_METHODS: string[] = [
   ...ACTIVE_PAYMENT_METHODS,
+  "monobank",
   "mercury",
 ];
 

--- a/deployments/parameters.ts
+++ b/deployments/parameters.ts
@@ -1,60 +1,66 @@
-import { ONE_DAY_IN_SECONDS, THREE_MINUTES_IN_SECONDS, ZERO, ONE_HOUR_IN_SECONDS, SIX_HOURS_IN_SECONDS } from "../utils/constants";
+import {
+  ONE_DAY_IN_SECONDS,
+  THREE_MINUTES_IN_SECONDS,
+  ZERO,
+  ONE_HOUR_IN_SECONDS,
+  SIX_HOURS_IN_SECONDS,
+} from "../utils/constants";
 import { ether, usdc } from "../utils/common/units";
 
 export const INTENT_EXPIRATION_PERIOD: any = {
-  "localhost": ONE_DAY_IN_SECONDS,
-  "hardhat": ONE_DAY_IN_SECONDS,
-  "base": SIX_HOURS_IN_SECONDS,
-  "base_staging": ONE_HOUR_IN_SECONDS,
+  localhost: ONE_DAY_IN_SECONDS,
+  hardhat: ONE_DAY_IN_SECONDS,
+  base: SIX_HOURS_IN_SECONDS,
+  base_staging: ONE_HOUR_IN_SECONDS,
 };
 
 export const PROTOCOL_TAKER_FEE: any = {
-  "localhost": ether(.001),
-  "hardhat": ether(.001),
-  "base": ZERO,
-  "base_staging": ZERO,
+  localhost: ether(0.001),
+  hardhat: ether(0.001),
+  base: ZERO,
+  base_staging: ZERO,
 };
 
 export const PROTOCOL_TAKER_FEE_RECIPIENT: any = {
-  "localhost": "",
-  "hardhat": "",
-  "base": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
-  "base_staging": "",
+  localhost: "",
+  hardhat: "",
+  base: "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+  base_staging: "",
 };
 
 export const ESCROW_DUST_RECIPIENT: any = {
-  "localhost": "",
-  "hardhat": "",
-  "base": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
-  "base_staging": "",
+  localhost: "",
+  hardhat: "",
+  base: "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+  base_staging: "",
 };
 
 export const ESCROW_DUST_THRESHOLD: any = {
-  "localhost": usdc(0.1),
-  "hardhat": usdc(0.1),
-  "base": usdc(0.1),
-  "base_staging": usdc(0.1),
+  localhost: usdc(0.1),
+  hardhat: usdc(0.1),
+  base: usdc(0.1),
+  base_staging: usdc(0.1),
 };
 
 export const MAX_INTENTS_PER_DEPOSIT: any = {
-  "localhost": 100,
-  "hardhat": 100,
-  "base": 200,
-  "base_staging": 200,
+  localhost: 100,
+  hardhat: 100,
+  base: 200,
+  base_staging: 200,
 };
 
 export const MULTI_SIG: any = {
-  "localhost": "",
-  "hardhat": "",
-  "base": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
-  "base_staging": "",
+  localhost: "",
+  hardhat: "",
+  base: "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+  base_staging: "",
 };
 
 export const WITNESS_ADDRESS: any = {
-  "localhost": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-  "hardhat": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-  "base": "0x5106A86819ED6Bb82c77CcBfC151250E1d369DbA",
-  "base_staging": "0x4ab950AE1e3326578Bf7e643a2031E858aBa2927",
+  localhost: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+  hardhat: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+  base: "0x5106A86819ED6Bb82c77CcBfC151250E1d369DbA",
+  base_staging: "0x4ab950AE1e3326578Bf7e643a2031E858aBa2927",
 };
 
 export const MULTI_WITNESS_ADDRESSES: Record<string, string[]> = {
@@ -75,61 +81,61 @@ export const MULTI_WITNESS_THRESHOLD: Record<string, number> = {
 };
 
 export const USDC: any = {
-  "base": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-  "base_staging": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+  base: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  base_staging: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
 };
 
 // V2 Parameters
 export const ESCROW_V2_INTENT_EXPIRATION_PERIOD: any = {
-  "localhost": ONE_DAY_IN_SECONDS,
-  "hardhat": ONE_DAY_IN_SECONDS,
-  "base": SIX_HOURS_IN_SECONDS,
-  "base_staging": ONE_HOUR_IN_SECONDS,
+  localhost: ONE_DAY_IN_SECONDS,
+  hardhat: ONE_DAY_IN_SECONDS,
+  base: SIX_HOURS_IN_SECONDS,
+  base_staging: ONE_HOUR_IN_SECONDS,
 };
 
 export const ESCROW_V2_MAX_INTENTS_PER_DEPOSIT: any = {
-  "localhost": 100,
-  "hardhat": 100,
-  "base": 200,
-  "base_staging": 200,
+  localhost: 100,
+  hardhat: 100,
+  base: 200,
+  base_staging: 200,
 };
 
 export const ESCROW_V2_DUST_THRESHOLD: any = {
-  "localhost": usdc(0.1),
-  "hardhat": usdc(0.1),
-  "base": usdc(0.1),
-  "base_staging": usdc(0.1),
+  localhost: usdc(0.1),
+  hardhat: usdc(0.1),
+  base: usdc(0.1),
+  base_staging: usdc(0.1),
 };
 
 export const ESCROW_V2_DUST_RECIPIENT: any = {
-  "localhost": "",
-  "hardhat": "",
-  "base": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
-  "base_staging": "",
+  localhost: "",
+  hardhat: "",
+  base: "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+  base_staging: "",
 };
 
 export const ORCHESTRATOR_V2_PROTOCOL_FEE: any = {
-  "localhost": ether(.001),
-  "hardhat": ether(.001),
-  "base": ZERO,
-  "base_staging": ZERO,
+  localhost: ether(0.001),
+  hardhat: ether(0.001),
+  base: ZERO,
+  base_staging: ZERO,
 };
 
 export const ORCHESTRATOR_V2_PROTOCOL_FEE_RECIPIENT: any = {
-  "localhost": "",
-  "hardhat": "",
-  "base": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
-  "base_staging": "",
+  localhost: "",
+  hardhat: "",
+  base: "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+  base_staging: "",
 };
 
 // V3 lifecycle stack parameters. Base staging and production use the ratified 14-day dispute protection policy.
 export const STAKE_VAULT_CONTROLLER_CHANGE_DELAY = ONE_DAY_IN_SECONDS.mul(2);
 
 export const DISPUTE_RISK_WINDOW: any = {
-  "localhost": ONE_DAY_IN_SECONDS.mul(14),
-  "hardhat": ONE_DAY_IN_SECONDS.mul(14),
-  "base": ONE_DAY_IN_SECONDS.mul(14),
-  "base_staging": ONE_DAY_IN_SECONDS.mul(14),
+  localhost: ONE_DAY_IN_SECONDS.mul(14),
+  hardhat: ONE_DAY_IN_SECONDS.mul(14),
+  base: ONE_DAY_IN_SECONDS.mul(14),
+  base_staging: ONE_DAY_IN_SECONDS.mul(14),
 };
 
 // Active unified payment-method set mounted on UnifiedPaymentVerifierV3.
@@ -151,6 +157,7 @@ export const ACTIVE_PAYMENT_METHODS: string[] = [
 // unchanged until that boundary is explicitly authorized.
 export const BASE_STAGING_ACTIVE_PAYMENT_METHODS: string[] = [
   ...ACTIVE_PAYMENT_METHODS,
+  "monobank",
   "mercury",
 ];
 
@@ -168,22 +175,25 @@ export const DISPUTABLE_PAYMENT_METHODS: string[] = [
 ];
 
 export const ORCHESTRATOR_V3_PROTOCOL_FEE: any = {
-  "localhost": ether(.001),
-  "hardhat": ether(.001),
-  "base": ZERO,
-  "base_staging": ZERO,
+  localhost: ether(0.001),
+  hardhat: ether(0.001),
+  base: ZERO,
+  base_staging: ZERO,
 };
 
 export const ORCHESTRATOR_V3_PROTOCOL_FEE_RECIPIENT: any = {
-  "localhost": "",
-  "hardhat": "",
-  "base": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
-  "base_staging": "",
+  localhost: "",
+  hardhat: "",
+  base: "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+  base_staging: "",
 };
 
 // Initial hourly fee for the standalone IntentGuardian, denominated in basis points of the
 // locked intent amount. Governance can update this value on the deployed guardian.
-export const INTENT_GUARDIAN_EXTENSION_FEE_BPS_PER_HOUR: Record<string, number> = {
+export const INTENT_GUARDIAN_EXTENSION_FEE_BPS_PER_HOUR: Record<
+  string,
+  number
+> = {
   localhost: 1,
   hardhat: 1,
   base_staging: 1,
@@ -192,9 +202,9 @@ export const INTENT_GUARDIAN_EXTENSION_FEE_BPS_PER_HOUR: Record<string, number> 
 
 // Pyth Network contract addresses
 export const PYTH_CONTRACT: any = {
-  "localhost": "",
-  "base": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
-  "base_staging": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
+  localhost: "",
+  base: "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
+  base_staging: "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
 };
 
 // For Goerli and localhost

--- a/deployments/parameters.ts
+++ b/deployments/parameters.ts
@@ -1,66 +1,60 @@
-import {
-  ONE_DAY_IN_SECONDS,
-  THREE_MINUTES_IN_SECONDS,
-  ZERO,
-  ONE_HOUR_IN_SECONDS,
-  SIX_HOURS_IN_SECONDS,
-} from "../utils/constants";
+import { ONE_DAY_IN_SECONDS, THREE_MINUTES_IN_SECONDS, ZERO, ONE_HOUR_IN_SECONDS, SIX_HOURS_IN_SECONDS } from "../utils/constants";
 import { ether, usdc } from "../utils/common/units";
 
 export const INTENT_EXPIRATION_PERIOD: any = {
-  localhost: ONE_DAY_IN_SECONDS,
-  hardhat: ONE_DAY_IN_SECONDS,
-  base: SIX_HOURS_IN_SECONDS,
-  base_staging: ONE_HOUR_IN_SECONDS,
+  "localhost": ONE_DAY_IN_SECONDS,
+  "hardhat": ONE_DAY_IN_SECONDS,
+  "base": SIX_HOURS_IN_SECONDS,
+  "base_staging": ONE_HOUR_IN_SECONDS,
 };
 
 export const PROTOCOL_TAKER_FEE: any = {
-  localhost: ether(0.001),
-  hardhat: ether(0.001),
-  base: ZERO,
-  base_staging: ZERO,
+  "localhost": ether(.001),
+  "hardhat": ether(.001),
+  "base": ZERO,
+  "base_staging": ZERO,
 };
 
 export const PROTOCOL_TAKER_FEE_RECIPIENT: any = {
-  localhost: "",
-  hardhat: "",
-  base: "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
-  base_staging: "",
+  "localhost": "",
+  "hardhat": "",
+  "base": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+  "base_staging": "",
 };
 
 export const ESCROW_DUST_RECIPIENT: any = {
-  localhost: "",
-  hardhat: "",
-  base: "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
-  base_staging: "",
+  "localhost": "",
+  "hardhat": "",
+  "base": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+  "base_staging": "",
 };
 
 export const ESCROW_DUST_THRESHOLD: any = {
-  localhost: usdc(0.1),
-  hardhat: usdc(0.1),
-  base: usdc(0.1),
-  base_staging: usdc(0.1),
+  "localhost": usdc(0.1),
+  "hardhat": usdc(0.1),
+  "base": usdc(0.1),
+  "base_staging": usdc(0.1),
 };
 
 export const MAX_INTENTS_PER_DEPOSIT: any = {
-  localhost: 100,
-  hardhat: 100,
-  base: 200,
-  base_staging: 200,
+  "localhost": 100,
+  "hardhat": 100,
+  "base": 200,
+  "base_staging": 200,
 };
 
 export const MULTI_SIG: any = {
-  localhost: "",
-  hardhat: "",
-  base: "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
-  base_staging: "",
+  "localhost": "",
+  "hardhat": "",
+  "base": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+  "base_staging": "",
 };
 
 export const WITNESS_ADDRESS: any = {
-  localhost: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-  hardhat: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-  base: "0x5106A86819ED6Bb82c77CcBfC151250E1d369DbA",
-  base_staging: "0x4ab950AE1e3326578Bf7e643a2031E858aBa2927",
+  "localhost": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+  "hardhat": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+  "base": "0x5106A86819ED6Bb82c77CcBfC151250E1d369DbA",
+  "base_staging": "0x4ab950AE1e3326578Bf7e643a2031E858aBa2927",
 };
 
 export const MULTI_WITNESS_ADDRESSES: Record<string, string[]> = {
@@ -81,61 +75,61 @@ export const MULTI_WITNESS_THRESHOLD: Record<string, number> = {
 };
 
 export const USDC: any = {
-  base: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-  base_staging: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  "base": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  "base_staging": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
 };
 
 // V2 Parameters
 export const ESCROW_V2_INTENT_EXPIRATION_PERIOD: any = {
-  localhost: ONE_DAY_IN_SECONDS,
-  hardhat: ONE_DAY_IN_SECONDS,
-  base: SIX_HOURS_IN_SECONDS,
-  base_staging: ONE_HOUR_IN_SECONDS,
+  "localhost": ONE_DAY_IN_SECONDS,
+  "hardhat": ONE_DAY_IN_SECONDS,
+  "base": SIX_HOURS_IN_SECONDS,
+  "base_staging": ONE_HOUR_IN_SECONDS,
 };
 
 export const ESCROW_V2_MAX_INTENTS_PER_DEPOSIT: any = {
-  localhost: 100,
-  hardhat: 100,
-  base: 200,
-  base_staging: 200,
+  "localhost": 100,
+  "hardhat": 100,
+  "base": 200,
+  "base_staging": 200,
 };
 
 export const ESCROW_V2_DUST_THRESHOLD: any = {
-  localhost: usdc(0.1),
-  hardhat: usdc(0.1),
-  base: usdc(0.1),
-  base_staging: usdc(0.1),
+  "localhost": usdc(0.1),
+  "hardhat": usdc(0.1),
+  "base": usdc(0.1),
+  "base_staging": usdc(0.1),
 };
 
 export const ESCROW_V2_DUST_RECIPIENT: any = {
-  localhost: "",
-  hardhat: "",
-  base: "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
-  base_staging: "",
+  "localhost": "",
+  "hardhat": "",
+  "base": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+  "base_staging": "",
 };
 
 export const ORCHESTRATOR_V2_PROTOCOL_FEE: any = {
-  localhost: ether(0.001),
-  hardhat: ether(0.001),
-  base: ZERO,
-  base_staging: ZERO,
+  "localhost": ether(.001),
+  "hardhat": ether(.001),
+  "base": ZERO,
+  "base_staging": ZERO,
 };
 
 export const ORCHESTRATOR_V2_PROTOCOL_FEE_RECIPIENT: any = {
-  localhost: "",
-  hardhat: "",
-  base: "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
-  base_staging: "",
+  "localhost": "",
+  "hardhat": "",
+  "base": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+  "base_staging": "",
 };
 
 // V3 lifecycle stack parameters. Base staging and production use the ratified 14-day dispute protection policy.
 export const STAKE_VAULT_CONTROLLER_CHANGE_DELAY = ONE_DAY_IN_SECONDS.mul(2);
 
 export const DISPUTE_RISK_WINDOW: any = {
-  localhost: ONE_DAY_IN_SECONDS.mul(14),
-  hardhat: ONE_DAY_IN_SECONDS.mul(14),
-  base: ONE_DAY_IN_SECONDS.mul(14),
-  base_staging: ONE_DAY_IN_SECONDS.mul(14),
+  "localhost": ONE_DAY_IN_SECONDS.mul(14),
+  "hardhat": ONE_DAY_IN_SECONDS.mul(14),
+  "base": ONE_DAY_IN_SECONDS.mul(14),
+  "base_staging": ONE_DAY_IN_SECONDS.mul(14),
 };
 
 // Active unified payment-method set mounted on UnifiedPaymentVerifierV3.
@@ -157,7 +151,6 @@ export const ACTIVE_PAYMENT_METHODS: string[] = [
 // unchanged until that boundary is explicitly authorized.
 export const BASE_STAGING_ACTIVE_PAYMENT_METHODS: string[] = [
   ...ACTIVE_PAYMENT_METHODS,
-  "monobank",
   "mercury",
 ];
 
@@ -175,25 +168,22 @@ export const DISPUTABLE_PAYMENT_METHODS: string[] = [
 ];
 
 export const ORCHESTRATOR_V3_PROTOCOL_FEE: any = {
-  localhost: ether(0.001),
-  hardhat: ether(0.001),
-  base: ZERO,
-  base_staging: ZERO,
+  "localhost": ether(.001),
+  "hardhat": ether(.001),
+  "base": ZERO,
+  "base_staging": ZERO,
 };
 
 export const ORCHESTRATOR_V3_PROTOCOL_FEE_RECIPIENT: any = {
-  localhost: "",
-  hardhat: "",
-  base: "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
-  base_staging: "",
+  "localhost": "",
+  "hardhat": "",
+  "base": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+  "base_staging": "",
 };
 
 // Initial hourly fee for the standalone IntentGuardian, denominated in basis points of the
 // locked intent amount. Governance can update this value on the deployed guardian.
-export const INTENT_GUARDIAN_EXTENSION_FEE_BPS_PER_HOUR: Record<
-  string,
-  number
-> = {
+export const INTENT_GUARDIAN_EXTENSION_FEE_BPS_PER_HOUR: Record<string, number> = {
   localhost: 1,
   hardhat: 1,
   base_staging: 1,
@@ -202,9 +192,9 @@ export const INTENT_GUARDIAN_EXTENSION_FEE_BPS_PER_HOUR: Record<
 
 // Pyth Network contract addresses
 export const PYTH_CONTRACT: any = {
-  localhost: "",
-  base: "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
-  base_staging: "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
+  "localhost": "",
+  "base": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
+  "base_staging": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
 };
 
 // For Goerli and localhost

--- a/deployments/parameters.ts
+++ b/deployments/parameters.ts
@@ -146,6 +146,20 @@ export const ACTIVE_PAYMENT_METHODS: string[] = [
   "paypal",
 ];
 
+// Base staging can carry a reviewed payment-method candidate before the
+// separately approved production activation. Keep the production list above
+// unchanged until that boundary is explicitly authorized.
+export const BASE_STAGING_ACTIVE_PAYMENT_METHODS: string[] = [
+  ...ACTIVE_PAYMENT_METHODS,
+  "mercury",
+];
+
+export function getActivePaymentMethods(network: string): string[] {
+  return network === "base_staging"
+    ? BASE_STAGING_ACTIVE_PAYMENT_METHODS
+    : ACTIVE_PAYMENT_METHODS;
+}
+
 // Only payment methods with a chargeback mechanism receive dispute protection.
 export const DISPUTABLE_PAYMENT_METHODS: string[] = [
   "paypal",

--- a/deployments/verifiers/mercury.ts
+++ b/deployments/verifiers/mercury.ts
@@ -1,0 +1,11 @@
+import { calculatePaymentMethodHash, Currency } from "@utils/protocolUtils";
+
+export const MERCURY_PAYMENT_METHOD_HASH =
+  calculatePaymentMethodHash("mercury");
+
+export const MERCURY_CURRENCIES: string[] = [Currency.USD];
+
+export const MERCURY_PROVIDER_CONFIG = {
+  paymentMethodHash: MERCURY_PAYMENT_METHOD_HASH,
+  currencies: MERCURY_CURRENCIES,
+};

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "deploy:sepolia": "ts-node --transpile-only scripts/deployActive.ts sepolia",
     "deploy:base": "ts-node --transpile-only scripts/deployActive.ts base && hardhat export --network base --export ./deployments/outputs/baseContracts.ts && ts-node --transpile-only scripts/canonicalizeDeploymentOutput.ts base ./deployments/outputs/baseContracts.ts && yarn workspace @zkp2p/contracts-v2 extract",
     "deploy:base_staging": "ts-node --transpile-only scripts/deployActive.ts base_staging && hardhat export --network base_staging --export ./deployments/outputs/baseStagingContracts.ts && ts-node --transpile-only scripts/canonicalizeDeploymentOutput.ts base_staging ./deployments/outputs/baseStagingContracts.ts && yarn workspace @zkp2p/contracts-v2 extract",
+    "prepare:mercury:base_staging": "PREPARE_STAGING_MERCURY_PAYMENT_METHOD=true ts-node --transpile-only scripts/deployActive.ts base_staging 35_add_mercury_payment_method",
+    "deploy:mercury:base_staging": "EXECUTE_STAGING_MERCURY_PAYMENT_METHOD=true ts-node --transpile-only scripts/deployActive.ts base_staging 35_add_mercury_payment_method && hardhat export --network base_staging --export ./deployments/outputs/baseStagingContracts.ts && ts-node --transpile-only scripts/canonicalizeDeploymentOutput.ts base_staging ./deployments/outputs/baseStagingContracts.ts && yarn workspace @zkp2p/contracts-v2 extract",
     "deploy:dispute-opt-in:base": "ts-node --transpile-only scripts/deployActive.ts base 34_deploy_opt_in_dispute_lifecycle_stack",
     "deploy:dispute-opt-in:base_staging": "ts-node --transpile-only scripts/deployActive.ts base_staging 34_deploy_opt_in_dispute_lifecycle_stack",
     "whitelist:bootstrap": "ts-node --transpile-only scripts/bootstrapWhitelistPolicy.ts",

--- a/packages/contracts/scripts/extractors/paymentMethods.ts
+++ b/packages/contracts/scripts/extractors/paymentMethods.ts
@@ -37,6 +37,7 @@ const PUBLISHED_PAYMENT_METHOD_NAMES = new Set([
   'cashapp',
   'chime',
   'mercadopago',
+  'mercury',
   'monzo',
   'paypal',
   'revolut',


### PR DESCRIPTION
## Summary
- add Mercury as a Base-staging-only active payment method
- add an exact-target prepare/execute activation lane for the existing staging registry and UnifiedPaymentVerifierV3
- include Mercury in contracts package extraction once the staging snapshot exists
- leave the Base production active catalog unchanged

## Validation
- yarn tsc --noEmit
- Hardhat compile: 131 Solidity files
- contracts package tests: 5 passed
- V3 deployment group tests passed
- live Base staging prepare simulation passed at 815595b62e5f27ed40d0c00f584b144c4da075b5
- full Forge suite is running after initializing forge-std; no Solidity source changed

## Rollout
1. Review and merge this source PR.
2. Execute the Mercury staging activation from the exact reviewed SHA.
3. Commit the generated staging snapshot/package artifacts separately if publication is desired.

No production activation or package publication is included.