### PR TITLE
chore(deploy): record Mercury Base staging activation

### DIFF
--- a/deployments/outputs/platforms/base_staging.json
+++ b/deployments/outputs/platforms/base_staging.json
@@ -149,6 +149,13 @@
         "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
       ],
       "updatedAt": "2026-03-16T12:23:24.348Z"
+    },
+    "mercury": {
+      "paymentMethodHash": "0xf81480907d808d639ad3230869e4b05a3b01b2d34e323af40f2efab807effd32",
+      "currencies": [
+        "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
+      ],
+      "updatedAt": "2026-08-20T08:12:22.843Z"
     }
   }
 }

--- a/deployments/outputs/platforms/snapshots/base_staging/mercury_2026-08-20T08-12-22.json
+++ b/deployments/outputs/platforms/snapshots/base_staging/mercury_2026-08-20T08-12-22.json
@@ -1,0 +1,7 @@
+{
+  "paymentMethodHash": "0xf81480907d808d639ad3230869e4b05a3b01b2d34e323af40f2efab807effd32",
+  "currencies": [
+    "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
+  ],
+  "updatedAt": "2026-08-20T08:12:22.843Z"
+}


### PR DESCRIPTION
## Summary
- record Mercury as active in the Base staging platform snapshot
- add the timestamped activation snapshot generated by the approved deployment lane

## Live activation
- source SHA: `fb8ac66d920f8a130817b106929eb2cdb95ef868`
- UPV3 transaction: https://basescan.org/tx/0xbd3230d0145785be7c67f40277aafa89f9768edd0bbd66fb937f965b0b17dc87
- registry transaction: https://basescan.org/tx/0xd9f1de948aca9886862f60ecfd7ec8a2eb1e250fee95936a16cbd7854eced484

## Validation
- both receipts succeeded on Base chain 8453
- UPV3 and PaymentVerifierRegistry both report Mercury active
- PaymentVerifierRegistry routes Mercury to UPV3 with USD only
- post-deploy `yarn prepare:mercury:base_staging` passed
- `git diff --check` and JSON assertions passed

## Deployment scope
Base staging only. No production activation or package publication.