### PR TITLE
Fix contracts package publish verification

### DIFF
--- a/.github/workflows/publish-contracts-v2.yml
+++ b/.github/workflows/publish-contracts-v2.yml
@@ -274,6 +274,11 @@ jobs:
           npm install --global npm@11.9.0
           test "$(npm --version)" = "11.9.0"
 
+      - name: Install verification dependencies
+        run: |
+          corepack enable
+          corepack yarn install --immutable
+
       - name: Download validated tarball
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
@@ -352,6 +357,11 @@ jobs:
         run: |
           npm install --global npm@11.9.0
           test "$(npm --version)" = "11.9.0"
+
+      - name: Install verification dependencies
+        run: |
+          corepack enable
+          corepack yarn install --immutable
 
       - name: Re-check canonical recovery source
         run: node scripts/npm-release.mjs recover "$PACKAGE_JSON" "$RELEASE_VERSION" "$DIST_TAG"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/contracts-v2",
-  "version": "0.4.1-rc.3",
+  "version": "0.4.1-rc.4",
   "description": "ZKP2P V2 smart contract interfaces and utilities",
   "main": "./_cjs/index.js",
   "module": "./_esm/index.js",

--- a/scripts/npm-release.spec.mjs
+++ b/scripts/npm-release.spec.mjs
@@ -358,7 +358,7 @@ test('derives a future RC release line from the package version', () => {
 
 test('commits the next RC candidate while preserving stable release support', () => {
   const packageManifest = JSON.parse(fs.readFileSync(packageManifestPath, 'utf8'));
-  assert.equal(packageManifest.version, '0.4.1-rc.3');
+  assert.equal(packageManifest.version, '0.4.1-rc.4');
   assert.deepEqual(
     resolveReleasePolicy({
       release: '0.4.1',
@@ -404,6 +404,20 @@ test('publish workflow consumes the version-derived channel without RC-only path
   assert.doesNotMatch(workflow, /@zkp2p\/contracts-v2@rc\b/);
   assert.doesNotMatch(workflow, /Verify published RC recovery/);
   assert.doesNotMatch(workflow, /^\s*RELEASE_LINE:/m);
+});
+
+test('publish and recovery jobs install verification dependencies before inspecting tarballs', () => {
+  const workflow = fs.readFileSync(releaseWorkflowPath, 'utf8');
+  const publishJob = workflow.slice(workflow.indexOf('  publish:\n'), workflow.indexOf('  recover:\n'));
+  const recoveryJob = workflow.slice(workflow.indexOf('  recover:\n'));
+
+  for (const job of [publishJob, recoveryJob]) {
+    const installIndex = job.indexOf('corepack yarn install --immutable');
+    const verifyIndex = job.indexOf('node packages/contracts/scripts/verify-release.mjs');
+    assert.notEqual(installIndex, -1);
+    assert.notEqual(verifyIndex, -1);
+    assert.ok(installIndex < verifyIndex);
+  }
 });
 
 test('rejects a nested RC prerelease', () => {

--- a/scripts/npm-release.spec.mjs
+++ b/scripts/npm-release.spec.mjs
@@ -319,8 +319,8 @@ function originalJobsFixture(overrides = {}) {
 test('resolves an RC from the committed release-line prerelease', () => {
   assert.deepEqual(
     resolveReleasePolicy({
-      release: '0.4.1-rc.3',
-      packageVersion: '0.4.1-rc.3',
+      release: '0.4.1-rc.4',
+      packageVersion: '0.4.1-rc.4',
     }),
     { channel: 'rc', distTag: 'rc', environment: 'npm-publish' },
   );


### PR DESCRIPTION
## Summary

- Install immutable repository dependencies in the protected publish and recovery jobs before running the package tarball verifier.
- Add a release-policy regression test that requires dependency installation to precede tarball verification in both jobs.
- Advance the unpublished contracts candidate from 0.4.1-rc.3 to 0.4.1-rc.4; the public rc.3 Git tag is retained as the audit trail for the pre-publish workflow failure.

## Failure evidence

OIDC run 32432150123 stopped before npm publish in Verify downloaded tarball because verify-release.mjs could not resolve ethers. Registry state remained unchanged at latest=0.4.0 and rc=0.4.1-rc.2, and 0.4.1-rc.3 was not published.

## Verification

- yarn test:release-policy (112/112)
- yarn pkg:build
- yarn pkg:test (5/5)
- yarn workspace @zkp2p/contracts-v2 verify:release
- git diff --check
