### PR TITLE
Skip dependency builds during package verification

### DIFF
--- a/.github/workflows/publish-contracts-v2.yml
+++ b/.github/workflows/publish-contracts-v2.yml
@@ -277,7 +277,7 @@ jobs:
       - name: Install verification dependencies
         run: |
           corepack enable
-          corepack yarn install --immutable
+          corepack yarn install --immutable --mode=skip-build
 
       - name: Download validated tarball
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
@@ -361,7 +361,7 @@ jobs:
       - name: Install verification dependencies
         run: |
           corepack enable
-          corepack yarn install --immutable
+          corepack yarn install --immutable --mode=skip-build
 
       - name: Re-check canonical recovery source
         run: node scripts/npm-release.mjs recover "$PACKAGE_JSON" "$RELEASE_VERSION" "$DIST_TAG"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/contracts-v2",
-  "version": "0.4.1-rc.4",
+  "version": "0.4.1-rc.5",
   "description": "ZKP2P V2 smart contract interfaces and utilities",
   "main": "./_cjs/index.js",
   "module": "./_esm/index.js",

--- a/scripts/npm-release.spec.mjs
+++ b/scripts/npm-release.spec.mjs
@@ -319,8 +319,8 @@ function originalJobsFixture(overrides = {}) {
 test('resolves an RC from the committed release-line prerelease', () => {
   assert.deepEqual(
     resolveReleasePolicy({
-      release: '0.4.1-rc.4',
-      packageVersion: '0.4.1-rc.4',
+      release: '0.4.1-rc.5',
+      packageVersion: '0.4.1-rc.5',
     }),
     { channel: 'rc', distTag: 'rc', environment: 'npm-publish' },
   );
@@ -358,7 +358,7 @@ test('derives a future RC release line from the package version', () => {
 
 test('commits the next RC candidate while preserving stable release support', () => {
   const packageManifest = JSON.parse(fs.readFileSync(packageManifestPath, 'utf8'));
-  assert.equal(packageManifest.version, '0.4.1-rc.4');
+  assert.equal(packageManifest.version, '0.4.1-rc.5');
   assert.deepEqual(
     resolveReleasePolicy({
       release: '0.4.1',
@@ -412,7 +412,7 @@ test('publish and recovery jobs install verification dependencies before inspect
   const recoveryJob = workflow.slice(workflow.indexOf('  recover:\n'));
 
   for (const job of [publishJob, recoveryJob]) {
-    const installIndex = job.indexOf('corepack yarn install --immutable');
+    const installIndex = job.indexOf('corepack yarn install --immutable --mode=skip-build');
     const verifyIndex = job.indexOf('node packages/contracts/scripts/verify-release.mjs');
     assert.notEqual(installIndex, -1);
     assert.notEqual(verifyIndex, -1);


### PR DESCRIPTION
## Summary

- Keep immutable dependency resolution/linking in the protected publish and recovery jobs, but use Yarn mode=skip-build so unrelated native dependencies do not execute build scripts under Node 24.
- Require that exact non-building install command before tarball verification in release-policy tests.
- Advance the unpublished candidate from 0.4.1-rc.4 to 0.4.1-rc.5; the rc.4 tag remains the audit trail for the pre-publish native-build failure.

## Failure evidence

OIDC run 32433180200 stopped before npm publish while re2 attempted a Node 24 native build during verification dependency installation. Registry state remained unchanged at latest=0.4.0 and rc=0.4.1-rc.2; neither rc.3 nor rc.4 was published.

## Verification

- Node 24.14.0: corepack yarn install --immutable --mode=skip-build
- Node 24.14.0: ethers/5.7.2 resolves after install
- yarn test:release-policy (112/112)
- yarn pkg:build
- yarn pkg:test (5/5)
- yarn workspace @zkp2p/contracts-v2 verify:release
- git diff --check
