### PR TITLE
chore(deploy): record Base whitelist policy, pin allowMultipleIntents per network

### DIFF
--- a/contracts/mocks/DisputeMethodScopedActivationTypes.sol
+++ b/contracts/mocks/DisputeMethodScopedActivationTypes.sol
@@ -11,6 +11,7 @@ struct TrustSurface {
     address paymentVerifierRegistry;
     address relayerRegistry;
     address protocolFeeRecipient;
+    bool allowMultipleIntents;
     address freshHook;
     address whitelistPolicy;
     address groupRegistry;
@@ -214,7 +215,9 @@ abstract contract DisputeMethodScopedTrustSurfaceChecks {
             revert OrchestratorProtocolFeeRecipientMismatch(actualAddress);
         }
         actualBool = targetOrchestrator.allowMultipleIntents();
-        if (actualBool) revert OrchestratorAllowMultipleIntentsMismatch(actualBool);
+        if (actualBool != expected.allowMultipleIntents) {
+            revert OrchestratorAllowMultipleIntentsMismatch(actualBool);
+        }
         actualBool =
             IActivationOrchestratorRegistry(expected.orchestratorRegistry).isOrchestrator(expected.orchestrator);
         if (!actualBool) revert OrchestratorRegistrationMismatch(actualBool);

--- a/deploy/37_deploy_method_scoped_dispute_lifecycle_stack.ts
+++ b/deploy/37_deploy_method_scoped_dispute_lifecycle_stack.ts
@@ -86,6 +86,7 @@ export const EXPECTED_LIVE: Record<
     relayerRegistry: string;
     addressGroupRegistry: string;
     protocolFeeRecipient: string;
+    allowMultipleIntents: boolean;
     stakeToken: string;
   }
 > = {
@@ -112,6 +113,7 @@ export const EXPECTED_LIVE: Record<
     relayerRegistry: "0xEbA979889a9c97382A92472fF3703786fF180083",
     addressGroupRegistry: "0x39F80118f9eB619135f116171b6Cb91D372C5AF2",
     protocolFeeRecipient: "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+    allowMultipleIntents: true,
     stakeToken: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
   },
   base_staging: {
@@ -137,6 +139,7 @@ export const EXPECTED_LIVE: Record<
     relayerRegistry: "0xB214650b424E6b5fdcB1259566eB7A512D8Bd25E",
     addressGroupRegistry: "0x54Ff7788Cb42B46FE2F016a65Fd0f654Bb9BcF3D",
     protocolFeeRecipient: "0x84e113087C97Cd80eA9D78983D4B8Ff61ECa1929",
+    allowMultipleIntents: false,
     stakeToken: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
   },
 };
@@ -658,6 +661,23 @@ async function assertLiveSharedState(
     throw new Error("Predecessor dispute registry owner or writer set drifted");
   }
 
+  await assertOrchestratorGovernanceState(orchestrator, governance, expected);
+  const orchestratorRegistry = await ethers.getContractAt(
+    "OrchestratorRegistry",
+    expected.orchestratorRegistry
+  );
+  if (!(await orchestratorRegistry.isOrchestrator(orchestrator.address))) {
+    throw new Error("OrchestratorV3 is not registered");
+  }
+
+  return assertWhitelistPolicy(hre, network, governance);
+}
+
+export async function assertOrchestratorGovernanceState(
+  orchestrator: any,
+  governance: string,
+  expected: (typeof EXPECTED_LIVE)[LiveNetwork]
+): Promise<void> {
   if (
     !sameAddress(await orchestrator.owner(), governance) ||
     (await orchestrator.paused()) ||
@@ -679,19 +699,11 @@ async function assertLiveSharedState(
       await orchestrator.protocolFeeRecipient(),
       expected.protocolFeeRecipient
     ) ||
-    (await orchestrator.allowMultipleIntents())
+    (await orchestrator.allowMultipleIntents()) !==
+      expected.allowMultipleIntents
   ) {
     throw new Error("OrchestratorV3 governance state drifted");
   }
-  const orchestratorRegistry = await ethers.getContractAt(
-    "OrchestratorRegistry",
-    expected.orchestratorRegistry
-  );
-  if (!(await orchestratorRegistry.isOrchestrator(orchestrator.address))) {
-    throw new Error("OrchestratorV3 is not registered");
-  }
-
-  return assertWhitelistPolicy(hre, network, governance);
 }
 
 async function readLiveDeployOnlyPrefix(

--- a/deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts
+++ b/deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts
@@ -216,6 +216,7 @@ async function resolveActivationContext(
     riskWindows,
     witnesses: live.attestationWitnesses.map(normalizedAddress),
     controllerChangeDelay: decimal(STAKE_VAULT_CONTROLLER_CHANGE_DELAY),
+    allowMultipleIntents: live.allowMultipleIntents,
   };
   expectedCache.set(network, expected);
   return {

--- a/deployments/activationBatchManifest.ts
+++ b/deployments/activationBatchManifest.ts
@@ -205,6 +205,7 @@ function assertTrustSurface(value: unknown): void {
     "paymentVerifierRegistry",
     "relayerRegistry",
     "protocolFeeRecipient",
+    "allowMultipleIntents",
     "freshHook",
     "whitelistPolicy",
     "groupRegistry",
@@ -221,9 +222,18 @@ function assertTrustSurface(value: unknown): void {
   ];
   assertKeys(value, keys, "trustSurface");
   for (const key of keys.filter(
-    (key) => !["witnesses", "paymentMethods", "riskWindows"].includes(key)
+    (key) =>
+      ![
+        "allowMultipleIntents",
+        "witnesses",
+        "paymentMethods",
+        "riskWindows",
+      ].includes(key)
   )) {
     assertAddress(value[key], `trustSurface.${key}`);
+  }
+  if (typeof value.allowMultipleIntents !== "boolean") {
+    throw new Error("Invalid trustSurface.allowMultipleIntents");
   }
   assertStringArray(value.witnesses, assertAddress, "trustSurface.witnesses");
   assertStringArray(

--- a/deployments/base/WhitelistPolicyMethodScoped.json
+++ b/deployments/base/WhitelistPolicyMethodScoped.json
@@ -1,0 +1,1185 @@
+{
+  "address": "0x389Cd9bA91FfFcd83d267B241E975541892759Ce",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "contract IAddressGroupRegistry",
+          "name": "_groupRegistry",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IEscrowRegistry",
+          "name": "_escrowRegistry",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IOrchestratorRegistry",
+          "name": "_orchestratorRegistry",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "escrow",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "depositId",
+          "type": "uint256"
+        }
+      ],
+      "name": "DepositNotFound",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "escrow",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "depositId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "paymentMethod",
+          "type": "bytes32"
+        }
+      ],
+      "name": "DepositPaymentMethodAlreadyBootstrapped",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "escrow",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "depositId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "paymentMethod",
+          "type": "bytes32"
+        }
+      ],
+      "name": "DepositPaymentMethodAlreadyEnabled",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "EmptyArray",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "escrow",
+          "type": "address"
+        }
+      ],
+      "name": "EscrowNotWhitelisted",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "groupId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "GroupDoesNotExist",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "dependency",
+          "type": "address"
+        }
+      ],
+      "name": "InvalidDependency",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "escrow",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "depositId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "caller",
+          "type": "address"
+        }
+      ],
+      "name": "NotDepositor",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "taker",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "escrow",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "depositId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "paymentMethod",
+          "type": "bytes32"
+        }
+      ],
+      "name": "TakerNotWhitelisted",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "attempted",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maximum",
+          "type": "uint256"
+        }
+      ],
+      "name": "TooManyGroups",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "caller",
+          "type": "address"
+        }
+      ],
+      "name": "UnauthorizedOrchestratorCaller",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ZeroAddress",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "escrow",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "depositId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "taker",
+          "type": "address"
+        }
+      ],
+      "name": "AddressRemovedFromWhitelist",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "escrow",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "depositId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "taker",
+          "type": "address"
+        }
+      ],
+      "name": "AddressWhitelisted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "escrow",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "depositId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "paymentMethod",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "groupId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "AllowedGroupAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "escrow",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "depositId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "paymentMethod",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "groupId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "AllowedGroupRemoved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "escrow",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "depositId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "paymentMethod",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "enabled",
+          "type": "bool"
+        }
+      ],
+      "name": "EnabledUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "escrowRegistry",
+          "type": "address"
+        }
+      ],
+      "name": "EscrowRegistryUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "MAX_GROUPS_PER_DEPOSIT_PAYMENT_METHOD",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_escrow",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_depositId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_paymentMethod",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32[]",
+          "name": "_groupIds",
+          "type": "bytes32[]"
+        }
+      ],
+      "name": "addAllowedGroups",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_escrow",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_depositId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "_takers",
+          "type": "address[]"
+        }
+      ],
+      "name": "addWhitelistedAddresses",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_escrow",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "_depositIds",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_paymentMethod",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32[]",
+          "name": "_groupIds",
+          "type": "bytes32[]"
+        }
+      ],
+      "name": "bootstrapDeposits",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "bootstrapped",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_escrow",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_depositId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_paymentMethod",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bool",
+          "name": "_enabled",
+          "type": "bool"
+        },
+        {
+          "internalType": "bytes32[]",
+          "name": "_groupIds",
+          "type": "bytes32[]"
+        },
+        {
+          "internalType": "address[]",
+          "name": "_takers",
+          "type": "address[]"
+        }
+      ],
+      "name": "configureDeposit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "enabled",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "escrowRegistry",
+      "outputs": [
+        {
+          "internalType": "contract IEscrowRegistry",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_escrow",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_depositId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_paymentMethod",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getAllowedGroups",
+      "outputs": [
+        {
+          "internalType": "bytes32[]",
+          "name": "",
+          "type": "bytes32[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "groupRegistry",
+      "outputs": [
+        {
+          "internalType": "contract IAddressGroupRegistry",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_escrow",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_depositId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_paymentMethod",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_groupId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "isGroupAllowed",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_escrow",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_depositId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_paymentMethod",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "_taker",
+          "type": "address"
+        }
+      ],
+      "name": "isTakerAllowed",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "isWhitelisted",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "orchestratorRegistry",
+      "outputs": [
+        {
+          "internalType": "contract IOrchestratorRegistry",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_escrow",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_depositId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_paymentMethod",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32[]",
+          "name": "_groupIds",
+          "type": "bytes32[]"
+        }
+      ],
+      "name": "removeAllowedGroups",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_escrow",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_depositId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "_takers",
+          "type": "address[]"
+        }
+      ],
+      "name": "removeWhitelistedAddresses",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_escrow",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_depositId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_paymentMethod",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bool",
+          "name": "_enabled",
+          "type": "bool"
+        }
+      ],
+      "name": "setEnabled",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IEscrowRegistry",
+          "name": "_escrowRegistry",
+          "type": "address"
+        }
+      ],
+      "name": "setEscrowRegistry",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "taker",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "escrow",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "depositId",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "to",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "fiatCurrency",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "conversionRate",
+              "type": "uint256"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "recipient",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "fee",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct IReferralFee.ReferralFee[]",
+              "name": "referralFees",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "bytes",
+              "name": "preIntentHookData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct IPreIntentHook.PreIntentContext",
+          "name": "_ctx",
+          "type": "tuple"
+        }
+      ],
+      "name": "validateSignalIntent",
+      "outputs": [],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ],
+  "transactionHash": "0x82940c1c4e0098678bfdc89e4810e94d931cdfb617a997c56404f3d545b1c58c",
+  "receipt": {
+    "to": null,
+    "from": "0x84e113087C97Cd80eA9D78983D4B8Ff61ECa1929",
+    "contractAddress": "0x389Cd9bA91FfFcd83d267B241E975541892759Ce",
+    "transactionIndex": 236,
+    "gasUsed": "1470631",
+    "logsBloom": "0x00000000000000000000000000000000000000000000004000800000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000020000200000000000000800000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000020000000000000040000000000000000000000000000000000000000000000000000",
+    "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "transactionHash": "0x82940c1c4e0098678bfdc89e4810e94d931cdfb617a997c56404f3d545b1c58c",
+    "logs": [
+      {
+        "transactionIndex": 236,
+        "blockNumber": 50528043,
+        "transactionHash": "0x82940c1c4e0098678bfdc89e4810e94d931cdfb617a997c56404f3d545b1c58c",
+        "address": "0x389Cd9bA91FfFcd83d267B241E975541892759Ce",
+        "topics": [
+          "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0",
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x00000000000000000000000084e113087c97cd80ea9d78983d4b8ff61eca1929"
+        ],
+        "data": "0x",
+        "logIndex": 629,
+        "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "blockNumber": 50528043,
+    "cumulativeGasUsed": "33982875",
+    "status": 1,
+    "byzantium": true
+  },
+  "args": [
+    "0x39F80118f9eB619135f116171b6Cb91D372C5AF2",
+    "0xeD0e847B101abc96E796260AC358e12BAa2f5B21",
+    "0xBe9fED15ED7A4B915C03EFcEcb9662739C3382A9"
+  ],
+  "numDeployments": 1,
+  "solcInputHash": "27fbb065a379a3f640c5d0396f99673a",
+  "metadata": "{\"compiler\":{\"version\":\"0.8.18+commit.87f61d96\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"contract IAddressGroupRegistry\",\"name\":\"_groupRegistry\",\"type\":\"address\"},{\"internalType\":\"contract IEscrowRegistry\",\"name\":\"_escrowRegistry\",\"type\":\"address\"},{\"internalType\":\"contract IOrchestratorRegistry\",\"name\":\"_orchestratorRegistry\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"escrow\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"depositId\",\"type\":\"uint256\"}],\"name\":\"DepositNotFound\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"escrow\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"depositId\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"paymentMethod\",\"type\":\"bytes32\"}],\"name\":\"DepositPaymentMethodAlreadyBootstrapped\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"escrow\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"depositId\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"paymentMethod\",\"type\":\"bytes32\"}],\"name\":\"DepositPaymentMethodAlreadyEnabled\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"EmptyArray\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"escrow\",\"type\":\"address\"}],\"name\":\"EscrowNotWhitelisted\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"groupId\",\"type\":\"bytes32\"}],\"name\":\"GroupDoesNotExist\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"dependency\",\"type\":\"address\"}],\"name\":\"InvalidDependency\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"escrow\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"depositId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"caller\",\"type\":\"address\"}],\"name\":\"NotDepositor\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"taker\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"escrow\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"depositId\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"paymentMethod\",\"type\":\"bytes32\"}],\"name\":\"TakerNotWhitelisted\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"attempted\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maximum\",\"type\":\"uint256\"}],\"name\":\"TooManyGroups\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"caller\",\"type\":\"address\"}],\"name\":\"UnauthorizedOrchestratorCaller\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroAddress\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"escrow\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"depositId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"taker\",\"type\":\"address\"}],\"name\":\"AddressRemovedFromWhitelist\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"escrow\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"depositId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"taker\",\"type\":\"address\"}],\"name\":\"AddressWhitelisted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"escrow\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"depositId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"paymentMethod\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"groupId\",\"type\":\"bytes32\"}],\"name\":\"AllowedGroupAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"escrow\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"depositId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"paymentMethod\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"groupId\",\"type\":\"bytes32\"}],\"name\":\"AllowedGroupRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"escrow\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"depositId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"paymentMethod\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"enabled\",\"type\":\"bool\"}],\"name\":\"EnabledUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"escrowRegistry\",\"type\":\"address\"}],\"name\":\"EscrowRegistryUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"MAX_GROUPS_PER_DEPOSIT_PAYMENT_METHOD\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_escrow\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_depositId\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"_paymentMethod\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32[]\",\"name\":\"_groupIds\",\"type\":\"bytes32[]\"}],\"name\":\"addAllowedGroups\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_escrow\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_depositId\",\"type\":\"uint256\"},{\"internalType\":\"address[]\",\"name\":\"_takers\",\"type\":\"address[]\"}],\"name\":\"addWhitelistedAddresses\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_escrow\",\"type\":\"address\"},{\"internalType\":\"uint256[]\",\"name\":\"_depositIds\",\"type\":\"uint256[]\"},{\"internalType\":\"bytes32\",\"name\":\"_paymentMethod\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32[]\",\"name\":\"_groupIds\",\"type\":\"bytes32[]\"}],\"name\":\"bootstrapDeposits\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"bootstrapped\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_escrow\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_depositId\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"_paymentMethod\",\"type\":\"bytes32\"},{\"internalType\":\"bool\",\"name\":\"_enabled\",\"type\":\"bool\"},{\"internalType\":\"bytes32[]\",\"name\":\"_groupIds\",\"type\":\"bytes32[]\"},{\"internalType\":\"address[]\",\"name\":\"_takers\",\"type\":\"address[]\"}],\"name\":\"configureDeposit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"enabled\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"escrowRegistry\",\"outputs\":[{\"internalType\":\"contract IEscrowRegistry\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_escrow\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_depositId\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"_paymentMethod\",\"type\":\"bytes32\"}],\"name\":\"getAllowedGroups\",\"outputs\":[{\"internalType\":\"bytes32[]\",\"name\":\"\",\"type\":\"bytes32[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"groupRegistry\",\"outputs\":[{\"internalType\":\"contract IAddressGroupRegistry\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_escrow\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_depositId\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"_paymentMethod\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"_groupId\",\"type\":\"bytes32\"}],\"name\":\"isGroupAllowed\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_escrow\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_depositId\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"_paymentMethod\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"_taker\",\"type\":\"address\"}],\"name\":\"isTakerAllowed\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"isWhitelisted\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"orchestratorRegistry\",\"outputs\":[{\"internalType\":\"contract IOrchestratorRegistry\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_escrow\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_depositId\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"_paymentMethod\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32[]\",\"name\":\"_groupIds\",\"type\":\"bytes32[]\"}],\"name\":\"removeAllowedGroups\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_escrow\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_depositId\",\"type\":\"uint256\"},{\"internalType\":\"address[]\",\"name\":\"_takers\",\"type\":\"address[]\"}],\"name\":\"removeWhitelistedAddresses\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_escrow\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_depositId\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"_paymentMethod\",\"type\":\"bytes32\"},{\"internalType\":\"bool\",\"name\":\"_enabled\",\"type\":\"bool\"}],\"name\":\"setEnabled\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contract IEscrowRegistry\",\"name\":\"_escrowRegistry\",\"type\":\"address\"}],\"name\":\"setEscrowRegistry\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"taker\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"escrow\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"depositId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"paymentMethod\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"fiatCurrency\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"conversionRate\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"fee\",\"type\":\"uint256\"}],\"internalType\":\"struct IReferralFee.ReferralFee[]\",\"name\":\"referralFees\",\"type\":\"tuple[]\"},{\"internalType\":\"bytes\",\"name\":\"preIntentHookData\",\"type\":\"bytes\"}],\"internalType\":\"struct IPreIntentHook.PreIntentContext\",\"name\":\"_ctx\",\"type\":\"tuple\"}],\"name\":\"validateSignalIntent\",\"outputs\":[],\"stateMutability\":\"view\",\"type\":\"function\"}],\"devdoc\":{\"details\":\"Enabling a deposit payment method with no groups and no deposit-wide whitelisted addresses is allowed and intentionally fails closed when evaluated. Writes are authorized against the escrow's recorded depositor, so the deposit must already exist. While EscrowRegistry is in accept-all mode the registry check passes for any address, so passing an EOA or a contract without `getDeposit` reverts inside the escrow call with no reason data rather than a policy error. That path is a caller mistake on a governance-gated mode, and is not worth a per-write code-length check. `escrowRegistry` is governance-settable via `setEscrowRegistry` and MUST be kept in sync with the orchestrator's escrow registry (`OrchestratorV2.setEscrowRegistry`), because if the two diverge, deposits on an escrow admitted by only one of them can be neither gated nor revoked while the orchestrator keeps admitting intents for them.\",\"kind\":\"dev\",\"methods\":{\"bootstrapDeposits(address,uint256[],bytes32,bytes32[])\":{\"details\":\"Reverts atomically unless every deposit exists on the whitelisted escrow and the selected payment method is disabled and has never been bootstrapped. Both arrays must be non-empty. Depositors retain normal control over the resulting policy, but disabling or removing groups does not clear the permanent bootstrap marker.\",\"params\":{\"depositIds\":\"Existing deposits to bootstrap.\",\"escrow\":\"Whitelisted Escrow or EscrowV2 holding the deposits.\",\"groupIds\":\"Existing curated group ids to append to every deposit payment method.\",\"paymentMethod\":\"Payment method to configure on every deposit.\"}},\"configureDeposit(address,uint256,bytes32,bool,bytes32[],address[])\":{\"details\":\"`enabled` REPLACES the payment method's current enforcement switch. `groupIds` are APPENDED to that payment method's allowed-group list, while `takers` are APPENDED to the deposit-wide direct whitelist; this call never removes or clears either list. Passing `enabled = false` disables enforcement for this payment method even while appending new groups or takers. Use `setEnabled` alone to toggle the gate without touching the lists.\",\"params\":{\"depositId\":\"Deposit to configure.\",\"enabled\":\"New value for the deposit payment method's enforcement switch; replaces the prior value.\",\"escrow\":\"Whitelisted Escrow or EscrowV2 holding the deposit.\",\"groupIds\":\"Curated group ids to append to the deposit payment method's allowed groups.\",\"paymentMethod\":\"Payment method whose enforcement and group settings are configured.\",\"takers\":\"Addresses to append to the deposit's direct whitelist.\"}},\"owner()\":{\"details\":\"Returns the address of the current owner.\"},\"renounceOwnership()\":{\"details\":\"Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.\"},\"setEscrowRegistry(address)\":{\"details\":\"Governance-only (owner). The new registry must be a non-zero address with deployed code, else this call reverts. This value MUST be kept in sync with the orchestrator's escrow registry (`OrchestratorV2.setEscrowRegistry`), because if they diverge, deposits on an escrow admitted by only one registry can be neither gated nor revoked here while the orchestrator keeps admitting intents for them.\",\"params\":{\"escrowRegistry\":\"New escrow registry used to authorize deposit configuration.\"}},\"transferOwnership(address)\":{\"details\":\"Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.\"},\"validateSignalIntent((address,address,uint256,uint256,address,bytes32,bytes32,uint256,(address,uint256)[],bytes))\":{\"details\":\"Only registered orchestrators may invoke the hook.\"}},\"title\":\"WhitelistPolicy\",\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{\"bootstrapDeposits(address,uint256[],bytes32,bytes32[])\":{\"notice\":\"One-time governance bootstrap that enables one payment method on existing deposits for supplied groups.\"},\"configureDeposit(address,uint256,bytes32,bool,bytes32[],address[])\":{\"notice\":\"Bundles enabling/disabling a deposit payment method's gate with appending groups and takers.\"},\"setEscrowRegistry(address)\":{\"notice\":\"Updates the escrow registry used to authorize deposit configuration.\"},\"validateSignalIntent((address,address,uint256,uint256,address,bytes32,bytes32,uint256,(address,uint256)[],bytes))\":{\"notice\":\"Enforces this deposit's whitelist policy during intent signaling.\"}},\"notice\":\"Persistent deposit-and-payment-method-scoped taker admission settings, independent from hook deployment. Each deposit payment method carries its own enforcement switch and bounded list of curated groups, while direct addresses remain trusted across every payment method on that deposit. The policy survives global hook replacement.\",\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/hooks/WhitelistPolicy.sol\":\"WhitelistPolicy\"},\"evmVersion\":\"paris\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\",\"useLiteralContent\":true},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[],\"viaIR\":true},\"sources\":{\"@openzeppelin/contracts/access/Ownable.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v4.9.0) (access/Ownable.sol)\\n\\npragma solidity ^0.8.0;\\n\\nimport \\\"../utils/Context.sol\\\";\\n\\n/**\\n * @dev Contract module which provides a basic access control mechanism, where\\n * there is an account (an owner) that can be granted exclusive access to\\n * specific functions.\\n *\\n * By default, the owner account will be the one that deploys the contract. This\\n * can later be changed with {transferOwnership}.\\n *\\n * This module is used through inheritance. It will make available the modifier\\n * `onlyOwner`, which can be applied to your functions to restrict their use to\\n * the owner.\\n */\\nabstract contract Ownable is Context {\\n    address private _owner;\\n\\n    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);\\n\\n    /**\\n     * @dev Initializes the contract setting the deployer as the initial owner.\\n     */\\n    constructor() {\\n        _transferOwnership(_msgSender());\\n    }\\n\\n    /**\\n     * @dev Throws if called by any account other than the owner.\\n     */\\n    modifier onlyOwner() {\\n        _checkOwner();\\n        _;\\n    }\\n\\n    /**\\n     * @dev Returns the address of the current owner.\\n     */\\n    function owner() public view virtual returns (address) {\\n        return _owner;\\n    }\\n\\n    /**\\n     * @dev Throws if the sender is not the owner.\\n     */\\n    function _checkOwner() internal view virtual {\\n        require(owner() == _msgSender(), \\\"Ownable: caller is not the owner\\\");\\n    }\\n\\n    /**\\n     * @dev Leaves the contract without owner. It will not be possible to call\\n     * `onlyOwner` functions. Can only be called by the current owner.\\n     *\\n     * NOTE: Renouncing ownership will leave the contract without an owner,\\n     * thereby disabling any functionality that is only available to the owner.\\n     */\\n    function renounceOwnership() public virtual onlyOwner {\\n        _transferOwnership(address(0));\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Can only be called by the current owner.\\n     */\\n    function transferOwnership(address newOwner) public virtual onlyOwner {\\n        require(newOwner != address(0), \\\"Ownable: new owner is the zero address\\\");\\n        _transferOwnership(newOwner);\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Internal function without access restriction.\\n     */\\n    function _transferOwnership(address newOwner) internal virtual {\\n        address oldOwner = _owner;\\n        _owner = newOwner;\\n        emit OwnershipTransferred(oldOwner, newOwner);\\n    }\\n}\\n\",\"keccak256\":\"0xba43b97fba0d32eb4254f6a5a297b39a19a247082a02d6e69349e071e2946218\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v4.9.0) (token/ERC20/IERC20.sol)\\n\\npragma solidity ^0.8.0;\\n\\n/**\\n * @dev Interface of the ERC20 standard as defined in the EIP.\\n */\\ninterface IERC20 {\\n    /**\\n     * @dev Emitted when `value` tokens are moved from one account (`from`) to\\n     * another (`to`).\\n     *\\n     * Note that `value` may be zero.\\n     */\\n    event Transfer(address indexed from, address indexed to, uint256 value);\\n\\n    /**\\n     * @dev Emitted when the allowance of a `spender` for an `owner` is set by\\n     * a call to {approve}. `value` is the new allowance.\\n     */\\n    event Approval(address indexed owner, address indexed spender, uint256 value);\\n\\n    /**\\n     * @dev Returns the amount of tokens in existence.\\n     */\\n    function totalSupply() external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the amount of tokens owned by `account`.\\n     */\\n    function balanceOf(address account) external view returns (uint256);\\n\\n    /**\\n     * @dev Moves `amount` tokens from the caller's account to `to`.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transfer(address to, uint256 amount) external returns (bool);\\n\\n    /**\\n     * @dev Returns the remaining number of tokens that `spender` will be\\n     * allowed to spend on behalf of `owner` through {transferFrom}. This is\\n     * zero by default.\\n     *\\n     * This value changes when {approve} or {transferFrom} are called.\\n     */\\n    function allowance(address owner, address spender) external view returns (uint256);\\n\\n    /**\\n     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * IMPORTANT: Beware that changing an allowance with this method brings the risk\\n     * that someone may use both the old and the new allowance by unfortunate\\n     * transaction ordering. One possible solution to mitigate this race\\n     * condition is to first reduce the spender's allowance to 0 and set the\\n     * desired value afterwards:\\n     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\\n     *\\n     * Emits an {Approval} event.\\n     */\\n    function approve(address spender, uint256 amount) external returns (bool);\\n\\n    /**\\n     * @dev Moves `amount` tokens from `from` to `to` using the\\n     * allowance mechanism. `amount` is then deducted from the caller's\\n     * allowance.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transferFrom(address from, address to, uint256 amount) external returns (bool);\\n}\\n\",\"keccak256\":\"0x287b55befed2961a7eabd7d7b1b2839cbca8a5b80ef8dcbb25ed3d4c2002c305\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Context.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.1 (utils/Context.sol)\\n\\npragma solidity ^0.8.0;\\n\\n/**\\n * @dev Provides information about the current execution context, including the\\n * sender of the transaction and its data. While these are generally available\\n * via msg.sender and msg.data, they should not be accessed in such a direct\\n * manner, since when dealing with meta-transactions the account sending and\\n * paying for execution may not be the actual sender (as far as an application\\n * is concerned).\\n *\\n * This contract is only required for intermediate, library-like contracts.\\n */\\nabstract contract Context {\\n    function _msgSender() internal view virtual returns (address) {\\n        return msg.sender;\\n    }\\n\\n    function _msgData() internal view virtual returns (bytes calldata) {\\n        return msg.data;\\n    }\\n}\\n\",\"keccak256\":\"0xe2e337e6dde9ef6b680e07338c493ebea1b5fd09b43424112868e9cc1706bca7\",\"license\":\"MIT\"},\"contracts/hooks/WhitelistPolicy.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.18;\\n\\nimport {Ownable} from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\n\\nimport {IAddressGroupRegistry} from \\\"../interfaces/IAddressGroupRegistry.sol\\\";\\nimport {IEscrow} from \\\"../interfaces/IEscrow.sol\\\";\\nimport {IEscrowRegistry} from \\\"../interfaces/IEscrowRegistry.sol\\\";\\nimport {IOrchestratorRegistry} from \\\"../interfaces/IOrchestratorRegistry.sol\\\";\\nimport {IWhitelistPolicy} from \\\"../interfaces/IWhitelistPolicy.sol\\\";\\n\\n/**\\n * @title WhitelistPolicy\\n * @notice Persistent deposit-and-payment-method-scoped taker admission settings, independent from hook deployment.\\n * Each deposit payment method carries its own enforcement switch and bounded list of curated groups, while direct\\n * addresses remain trusted across every payment method on that deposit. The policy survives global hook replacement.\\n * @dev Enabling a deposit payment method with no groups and no deposit-wide whitelisted addresses is allowed and\\n * intentionally fails closed when evaluated. Writes are authorized against the escrow's recorded depositor, so the\\n * deposit must already exist.\\n * While EscrowRegistry is in accept-all mode the registry check passes for any address, so passing an EOA or a\\n * contract without `getDeposit` reverts inside the escrow call with no reason data rather than a policy error.\\n * That path is a caller mistake on a governance-gated mode, and is not worth a per-write code-length check.\\n * `escrowRegistry` is governance-settable via `setEscrowRegistry` and MUST be kept in sync with the orchestrator's\\n * escrow registry (`OrchestratorV2.setEscrowRegistry`), because if the two diverge, deposits on an escrow admitted\\n * by only one of them can be neither gated nor revoked while the orchestrator keeps admitting intents for them.\\n */\\ncontract WhitelistPolicy is Ownable, IWhitelistPolicy {\\n    /* ============ Constants ============ */\\n\\n    uint256 public constant MAX_GROUPS_PER_DEPOSIT_PAYMENT_METHOD = 10;\\n\\n    /* ============ State Variables ============ */\\n\\n    IAddressGroupRegistry public immutable override groupRegistry;\\n    IEscrowRegistry public override escrowRegistry;\\n    IOrchestratorRegistry public immutable override orchestratorRegistry;\\n\\n    mapping(address => mapping(uint256 => mapping(bytes32 => bool))) public override enabled;\\n    mapping(address => mapping(uint256 => mapping(bytes32 => bool))) public override bootstrapped;\\n    mapping(address => mapping(uint256 => mapping(address => bool))) public override isWhitelisted;\\n    mapping(address => mapping(uint256 => mapping(bytes32 => bytes32[]))) internal allowedGroups;\\n\\n    /* ============ Events ============ */\\n\\n    event EnabledUpdated(\\n        address indexed escrow, uint256 indexed depositId, bytes32 indexed paymentMethod, bool enabled\\n    );\\n    event AddressWhitelisted(address indexed escrow, uint256 indexed depositId, address indexed taker);\\n    event AddressRemovedFromWhitelist(address indexed escrow, uint256 indexed depositId, address indexed taker);\\n    event AllowedGroupAdded(\\n        address indexed escrow, uint256 indexed depositId, bytes32 indexed paymentMethod, bytes32 groupId\\n    );\\n    event AllowedGroupRemoved(\\n        address indexed escrow, uint256 indexed depositId, bytes32 indexed paymentMethod, bytes32 groupId\\n    );\\n    event EscrowRegistryUpdated(address indexed escrowRegistry);\\n\\n    /* ============ Errors ============ */\\n\\n    error ZeroAddress();\\n    error EmptyArray();\\n    error InvalidDependency(address dependency);\\n    error GroupDoesNotExist(bytes32 groupId);\\n    error TooManyGroups(uint256 attempted, uint256 maximum);\\n    error EscrowNotWhitelisted(address escrow);\\n    error DepositNotFound(address escrow, uint256 depositId);\\n    error DepositPaymentMethodAlreadyBootstrapped(address escrow, uint256 depositId, bytes32 paymentMethod);\\n    error DepositPaymentMethodAlreadyEnabled(address escrow, uint256 depositId, bytes32 paymentMethod);\\n    error NotDepositor(address escrow, uint256 depositId, address caller);\\n    error UnauthorizedOrchestratorCaller(address caller);\\n    error TakerNotWhitelisted(address taker, address escrow, uint256 depositId, bytes32 paymentMethod);\\n\\n    /* ============ Constructor ============ */\\n\\n    constructor(\\n        IAddressGroupRegistry _groupRegistry,\\n        IEscrowRegistry _escrowRegistry,\\n        IOrchestratorRegistry _orchestratorRegistry\\n    ) Ownable() {\\n        _validateDependency(address(_groupRegistry));\\n        _validateDependency(address(_escrowRegistry));\\n        _validateDependency(address(_orchestratorRegistry));\\n\\n        groupRegistry = _groupRegistry;\\n        escrowRegistry = _escrowRegistry;\\n        orchestratorRegistry = _orchestratorRegistry;\\n    }\\n\\n    /* ============ Modifiers ============ */\\n\\n    modifier onlyDepositor(address _escrow, uint256 _depositId) {\\n        address depositor = _validateDeposit(_escrow, _depositId);\\n        if (msg.sender != depositor) revert NotDepositor(_escrow, _depositId, msg.sender);\\n        _;\\n    }\\n\\n    /* ============ Governance Functions ============ */\\n\\n    /**\\n     * @inheritdoc IWhitelistPolicy\\n     */\\n    function setEscrowRegistry(IEscrowRegistry _escrowRegistry) external override onlyOwner {\\n        _validateDependency(address(_escrowRegistry));\\n\\n        escrowRegistry = _escrowRegistry;\\n        emit EscrowRegistryUpdated(address(_escrowRegistry));\\n    }\\n\\n    /**\\n     * @inheritdoc IWhitelistPolicy\\n     */\\n    function bootstrapDeposits(\\n        address _escrow,\\n        uint256[] calldata _depositIds,\\n        bytes32 _paymentMethod,\\n        bytes32[] calldata _groupIds\\n    ) external override onlyOwner {\\n        if (_depositIds.length == 0 || _groupIds.length == 0) revert EmptyArray();\\n\\n        for (uint256 i = 0; i < _depositIds.length; ++i) {\\n            uint256 depositId = _depositIds[i];\\n            _validateDeposit(_escrow, depositId);\\n            if (bootstrapped[_escrow][depositId][_paymentMethod]) {\\n                revert DepositPaymentMethodAlreadyBootstrapped(_escrow, depositId, _paymentMethod);\\n            }\\n            if (enabled[_escrow][depositId][_paymentMethod]) {\\n                revert DepositPaymentMethodAlreadyEnabled(_escrow, depositId, _paymentMethod);\\n            }\\n\\n            bootstrapped[_escrow][depositId][_paymentMethod] = true;\\n            _setEnabled(_escrow, depositId, _paymentMethod, true);\\n            _addGroups(_escrow, depositId, _paymentMethod, _groupIds);\\n        }\\n    }\\n\\n    /* ============ Depositor Functions ============ */\\n\\n    /**\\n     * @inheritdoc IWhitelistPolicy\\n     */\\n    function configureDeposit(\\n        address _escrow,\\n        uint256 _depositId,\\n        bytes32 _paymentMethod,\\n        bool _enabled,\\n        bytes32[] calldata _groupIds,\\n        address[] calldata _takers\\n    ) external override onlyDepositor(_escrow, _depositId) {\\n        _setEnabled(_escrow, _depositId, _paymentMethod, _enabled);\\n        _addGroups(_escrow, _depositId, _paymentMethod, _groupIds);\\n        _addTakers(_escrow, _depositId, _takers);\\n    }\\n\\n    /**\\n     * @inheritdoc IWhitelistPolicy\\n     */\\n    function setEnabled(address _escrow, uint256 _depositId, bytes32 _paymentMethod, bool _enabled)\\n        external\\n        override\\n        onlyDepositor(_escrow, _depositId)\\n    {\\n        _setEnabled(_escrow, _depositId, _paymentMethod, _enabled);\\n    }\\n\\n    /**\\n     * @inheritdoc IWhitelistPolicy\\n     */\\n    function addWhitelistedAddresses(address _escrow, uint256 _depositId, address[] calldata _takers)\\n        external\\n        override\\n        onlyDepositor(_escrow, _depositId)\\n    {\\n        if (_takers.length == 0) revert EmptyArray();\\n        _addTakers(_escrow, _depositId, _takers);\\n    }\\n\\n    /**\\n     * @inheritdoc IWhitelistPolicy\\n     */\\n    function removeWhitelistedAddresses(address _escrow, uint256 _depositId, address[] calldata _takers)\\n        external\\n        override\\n        onlyDepositor(_escrow, _depositId)\\n    {\\n        if (_takers.length == 0) revert EmptyArray();\\n\\n        for (uint256 i = 0; i < _takers.length; ++i) {\\n            address taker = _takers[i];\\n            if (!isWhitelisted[_escrow][_depositId][taker]) continue;\\n\\n            isWhitelisted[_escrow][_depositId][taker] = false;\\n            emit AddressRemovedFromWhitelist(_escrow, _depositId, taker);\\n        }\\n    }\\n\\n    /**\\n     * @inheritdoc IWhitelistPolicy\\n     */\\n    function addAllowedGroups(address _escrow, uint256 _depositId, bytes32 _paymentMethod, bytes32[] calldata _groupIds)\\n        external\\n        override\\n        onlyDepositor(_escrow, _depositId)\\n    {\\n        if (_groupIds.length == 0) revert EmptyArray();\\n        _addGroups(_escrow, _depositId, _paymentMethod, _groupIds);\\n    }\\n\\n    /**\\n     * @inheritdoc IWhitelistPolicy\\n     */\\n    function removeAllowedGroups(\\n        address _escrow,\\n        uint256 _depositId,\\n        bytes32 _paymentMethod,\\n        bytes32[] calldata _groupIds\\n    ) external override onlyDepositor(_escrow, _depositId) {\\n        if (_groupIds.length == 0) revert EmptyArray();\\n\\n        bytes32[] storage depositPaymentMethodGroups = allowedGroups[_escrow][_depositId][_paymentMethod];\\n        for (uint256 i = 0; i < _groupIds.length; ++i) {\\n            bytes32 groupId = _groupIds[i];\\n            uint256 groupIndex = _findGroupIndex(depositPaymentMethodGroups, groupId);\\n            if (groupIndex == depositPaymentMethodGroups.length) continue;\\n\\n            depositPaymentMethodGroups[groupIndex] = depositPaymentMethodGroups[depositPaymentMethodGroups.length - 1];\\n            depositPaymentMethodGroups.pop();\\n            emit AllowedGroupRemoved(_escrow, _depositId, _paymentMethod, groupId);\\n        }\\n    }\\n\\n    /* ============ View Functions ============ */\\n\\n    /**\\n     * @inheritdoc IWhitelistPolicy\\n     */\\n    function getAllowedGroups(address _escrow, uint256 _depositId, bytes32 _paymentMethod)\\n        external\\n        view\\n        override\\n        returns (bytes32[] memory)\\n    {\\n        return allowedGroups[_escrow][_depositId][_paymentMethod];\\n    }\\n\\n    /**\\n     * @inheritdoc IWhitelistPolicy\\n     */\\n    function isGroupAllowed(address _escrow, uint256 _depositId, bytes32 _paymentMethod, bytes32 _groupId)\\n        external\\n        view\\n        override\\n        returns (bool)\\n    {\\n        return _containsGroup(allowedGroups[_escrow][_depositId][_paymentMethod], _groupId);\\n    }\\n\\n    /**\\n     * @inheritdoc IWhitelistPolicy\\n     */\\n    function isTakerAllowed(address _escrow, uint256 _depositId, bytes32 _paymentMethod, address _taker)\\n        external\\n        view\\n        override\\n        returns (bool)\\n    {\\n        return _isTakerAllowed(_escrow, _depositId, _paymentMethod, _taker);\\n    }\\n\\n    /**\\n     * @notice Enforces this deposit's whitelist policy during intent signaling.\\n     * @dev Only registered orchestrators may invoke the hook.\\n     */\\n    function validateSignalIntent(PreIntentContext calldata _ctx) external view override {\\n        if (!orchestratorRegistry.isOrchestrator(msg.sender)) revert UnauthorizedOrchestratorCaller(msg.sender);\\n        if (!_isTakerAllowed(_ctx.escrow, _ctx.depositId, _ctx.paymentMethod, _ctx.taker)) {\\n            revert TakerNotWhitelisted(_ctx.taker, _ctx.escrow, _ctx.depositId, _ctx.paymentMethod);\\n        }\\n    }\\n\\n    /* ============ Internal Functions ============ */\\n\\n    function _isTakerAllowed(address _escrow, uint256 _depositId, bytes32 _paymentMethod, address _taker)\\n        internal\\n        view\\n        returns (bool)\\n    {\\n        if (!enabled[_escrow][_depositId][_paymentMethod]) return true;\\n        if (isWhitelisted[_escrow][_depositId][_taker]) return true;\\n\\n        bytes32[] storage depositPaymentMethodGroups = allowedGroups[_escrow][_depositId][_paymentMethod];\\n        for (uint256 i = 0; i < depositPaymentMethodGroups.length; ++i) {\\n            if (groupRegistry.isMember(depositPaymentMethodGroups[i], _taker)) return true;\\n        }\\n        return false;\\n    }\\n\\n    function _setEnabled(address _escrow, uint256 _depositId, bytes32 _paymentMethod, bool _enabled) internal {\\n        enabled[_escrow][_depositId][_paymentMethod] = _enabled;\\n        emit EnabledUpdated(_escrow, _depositId, _paymentMethod, _enabled);\\n    }\\n\\n    function _addTakers(address _escrow, uint256 _depositId, address[] calldata _takers) internal {\\n        for (uint256 i = 0; i < _takers.length; ++i) {\\n            address taker = _takers[i];\\n            if (taker == address(0)) revert ZeroAddress();\\n            if (isWhitelisted[_escrow][_depositId][taker]) continue;\\n\\n            isWhitelisted[_escrow][_depositId][taker] = true;\\n            emit AddressWhitelisted(_escrow, _depositId, taker);\\n        }\\n    }\\n\\n    function _addGroups(address _escrow, uint256 _depositId, bytes32 _paymentMethod, bytes32[] calldata _groupIds)\\n        internal\\n    {\\n        bytes32[] storage depositPaymentMethodGroups = allowedGroups[_escrow][_depositId][_paymentMethod];\\n        for (uint256 i = 0; i < _groupIds.length; ++i) {\\n            bytes32 groupId = _groupIds[i];\\n            if (!groupRegistry.groupExists(groupId)) revert GroupDoesNotExist(groupId);\\n            if (_containsGroup(depositPaymentMethodGroups, groupId)) continue;\\n            if (depositPaymentMethodGroups.length == MAX_GROUPS_PER_DEPOSIT_PAYMENT_METHOD) {\\n                revert TooManyGroups(depositPaymentMethodGroups.length + 1, MAX_GROUPS_PER_DEPOSIT_PAYMENT_METHOD);\\n            }\\n\\n            depositPaymentMethodGroups.push(groupId);\\n            emit AllowedGroupAdded(_escrow, _depositId, _paymentMethod, groupId);\\n        }\\n    }\\n\\n    function _containsGroup(bytes32[] storage _groups, bytes32 _groupId) internal view returns (bool) {\\n        return _findGroupIndex(_groups, _groupId) != _groups.length;\\n    }\\n\\n    function _findGroupIndex(bytes32[] storage _groups, bytes32 _groupId) internal view returns (uint256) {\\n        for (uint256 i = 0; i < _groups.length; ++i) {\\n            if (_groups[i] == _groupId) return i;\\n        }\\n        return _groups.length;\\n    }\\n\\n    function _validateDeposit(address _escrow, uint256 _depositId) internal view returns (address depositor) {\\n        if (!escrowRegistry.isWhitelistedEscrow(_escrow) && !escrowRegistry.isAcceptingAllEscrows()) {\\n            revert EscrowNotWhitelisted(_escrow);\\n        }\\n\\n        depositor = IEscrow(_escrow).getDeposit(_depositId).depositor;\\n        if (depositor == address(0)) revert DepositNotFound(_escrow, _depositId);\\n    }\\n\\n    function _validateDependency(address _dependency) internal view {\\n        if (_dependency == address(0)) revert ZeroAddress();\\n        if (_dependency.code.length == 0) revert InvalidDependency(_dependency);\\n    }\\n}\\n\",\"keccak256\":\"0x8e3963508a46e1e860069ecccf47fb931a5c551ed8a5340c88ffb31db6c9ffda\",\"license\":\"MIT\"},\"contracts/interfaces/IAddressGroupRegistry.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.18;\\n\\n/**\\n * @title IAddressGroupRegistry\\n * @notice Permissionless registry of curator-managed address groups with optional resolvers.\\n */\\ninterface IAddressGroupRegistry {\\n    /**\\n     * @notice Creates a new group curated by the caller; its id is derived from the curator and global counter.\\n     */\\n    function createGroup(string calldata _name) external returns (bytes32 groupId);\\n\\n    /**\\n     * @notice Starts a two-step curator transfer; replaces any existing pending curator.\\n     */\\n    function transferGroupCurator(bytes32 _groupId, address _newCurator) external;\\n\\n    /**\\n     * @notice Cancels a pending curator transfer.\\n     */\\n    function cancelGroupCuratorTransfer(bytes32 _groupId) external;\\n\\n    /**\\n     * @notice Completes a pending curator transfer; callable only by the pending curator.\\n     */\\n    function acceptGroupCurator(bytes32 _groupId) external;\\n\\n    /**\\n     * @notice Adds members to a group (curator only; idempotent).\\n     */\\n    function addMembers(bytes32 _groupId, address[] calldata _members) external;\\n\\n    /**\\n     * @notice Removes members from a group (curator only; idempotent).\\n     */\\n    function removeMembers(bytes32 _groupId, address[] calldata _members) external;\\n\\n    /**\\n     * @notice Sets whether a group permits self-service membership (curator only).\\n     */\\n    function setGroupVisibility(bytes32 _groupId, bool _isPublic) external;\\n\\n    /**\\n     * @notice Joins a public group as the caller.\\n     */\\n    function joinGroup(bytes32 _groupId) external;\\n\\n    /**\\n     * @notice Leaves a public group's curated membership as the caller.\\n     */\\n    function leaveGroup(bytes32 _groupId) external;\\n\\n    /**\\n     * @notice Sets or clears the group's resolver (curator only; nonzero resolver must have code).\\n     */\\n    function setResolver(bytes32 _groupId, address _resolver) external;\\n\\n    /**\\n     * @notice Returns whether an account is a member (curated OR resolver; fail-closed).\\n     */\\n    function isMember(bytes32 _groupId, address _account) external view returns (bool);\\n\\n    /**\\n     * @notice Returns whether a group exists (input validation only, not a trust guarantee).\\n     */\\n    function groupExists(bytes32 _groupId) external view returns (bool);\\n\\n    /**\\n     * @notice Returns a group's governance state for atomic inspection.\\n     */\\n    function getGroup(bytes32 _groupId)\\n        external\\n        view\\n        returns (address curator, address pendingCurator, address resolver, bool isPublic, bool exists);\\n\\n    /**\\n     * @notice Returns the number of groups created (the counter used to derive group ids).\\n     */\\n    function groupCount() external view returns (uint256);\\n}\\n\",\"keccak256\":\"0x41e10d83a114968c72ceb864e9f4c43b9789fe4689c1e6734352ca33d4eb16fc\",\"license\":\"MIT\"},\"contracts/interfaces/IEscrow.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.18;\\n\\nimport { IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/IERC20.sol\\\";\\nimport { IPostIntentHook } from \\\"./IPostIntentHook.sol\\\";\\n\\ninterface IEscrow {\\n    \\n    /* ============ Structs ============ */\\n\\n    struct Intent {\\n        bytes32 intentHash;                        // Unique identifier for the intent\\n        uint256 amount;                            // Amount locked\\n        uint256 timestamp;                         // When this intent was created\\n        uint256 expiryTime;                        // When this intent expires\\n    }\\n\\n    struct Range {\\n        uint256 min;                                // Minimum value\\n        uint256 max;                                // Maximum value\\n    }\\n\\n    struct Deposit {\\n        address depositor;                          // Address of depositor\\n        address delegate;                           // Address that can manage this deposit (address(0) if no delegate)\\n        IERC20 token;                               // Address of deposit token\\n        Range intentAmountRange;                    // Range of take amount per intent\\n        // Deposit state\\n        bool acceptingIntents;                      // State: True if the deposit is accepting intents, False otherwise\\n        uint256 remainingDeposits;                  // State: Amount of liquidity immediately available to lock\\n        uint256 outstandingIntentAmount;            // State: Amount of outstanding intents (may include expired intents)\\n        // Intent guardian\\n        address intentGuardian;                     // Address that can extend intent expiry times (address(0) if no guardian)\\n        // Retention behavior\\n        bool retainOnEmpty;                         // If true, do not auto-close/sweep when empty; keep config for reuse\\n    }\\n\\n    struct Currency {\\n        bytes32 code;                               // Currency code (keccak256 hash of the currency code)\\n        uint256 minConversionRate;                  // Minimum rate of deposit token to fiat currency (in preciseUnits)\\n    }\\n\\n    struct DepositPaymentMethodData {\\n        address intentGatingService;                // Public key of gating service that will be used to verify intents\\n        bytes32 payeeDetails;                       // Payee details, has to be hash of payee details\\n        bytes data;                                 // Verification Data: Additional data used for payment verification; Can hold attester address\\n                                                    // in case of TLS proofs, domain key hash in case of zkEmail proofs, currency code etc.\\n    }\\n\\n    struct CreateDepositParams {\\n        IERC20 token;                                // The token to be deposited\\n        uint256 amount;                              // The amount of token to deposit\\n        Range intentAmountRange;                     // The max and min take amount for each intent\\n        bytes32[] paymentMethods;                    // The payment methods that deposit supports\\n        DepositPaymentMethodData[] paymentMethodData;// The payment verification data for each payment method that deposit supports\\n        Currency[][] currencies;                     // The currencies for each payment method that deposit supports\\n        address delegate;                            // Optional delegate address that can manage this deposit (address(0) for no delegate)\\n        address intentGuardian;                      // Optional intent guardian address that can extend intent expiry times (address(0) for no guardian)\\n        bool retainOnEmpty;                          // Opt-in: keep deposit and config when empty\\n    }\\n\\n    /* ============ Events ============ */\\n\\n    event DepositReceived(uint256 indexed depositId, address indexed depositor, IERC20 indexed token, uint256 amount, Range intentAmountRange, address delegate, address intentGuardian);\\n\\n    event DepositPaymentMethodAdded(uint256 indexed depositId, bytes32 indexed paymentMethod, bytes32 indexed payeeDetails, address intentGatingService);\\n    event DepositPaymentMethodActiveUpdated(uint256 indexed depositId, bytes32 indexed paymentMethod, bool active);\\n\\n    event DepositCurrencyAdded(uint256 indexed depositId, bytes32 indexed paymentMethod, bytes32 indexed currency, uint256 minConversionRate);\\n    event DepositMinConversionRateUpdated(uint256 indexed depositId, bytes32 indexed paymentMethod, bytes32 indexed currency, uint256 newMinConversionRate);\\n    \\n    event DepositFundsAdded(uint256 indexed depositId, address indexed depositor, uint256 amount);\\n    event DepositWithdrawn(uint256 indexed depositId, address indexed depositor, uint256 amount);\\n    event DepositClosed(uint256 depositId, address depositor);\\n    event DepositAcceptingIntentsUpdated(uint256 indexed depositId, bool acceptingIntents);\\n\\n    event DepositIntentAmountRangeUpdated(uint256 indexed depositId, Range intentAmountRange);\\n    event DepositRetainOnEmptyUpdated(uint256 indexed depositId, bool retainOnEmpty);\\n\\n    event DepositDelegateSet(uint256 indexed depositId, address indexed depositor, address indexed delegate);\\n    event DepositDelegateRemoved(uint256 indexed depositId, address indexed depositor);\\n\\n    event MinDepositAmountSet(uint256 minDepositAmount);\\n\\n    event OrchestratorUpdated(address indexed orchestrator);\\n    event PaymentVerifierRegistryUpdated(address indexed paymentVerifierRegistry);\\n\\n    event FundsLocked(uint256 indexed depositId, bytes32 indexed intentHash, uint256 amount, uint256 expiryTime);\\n    event FundsUnlocked(uint256 indexed depositId, bytes32 indexed intentHash, uint256 amount);\\n    event FundsUnlockedAndTransferred(\\n        uint256 indexed depositId, \\n        bytes32 indexed intentHash, \\n        uint256 unlockedAmount, \\n        uint256 transferredAmount, \\n        address to\\n    );\\n    event IntentExpiryExtended(uint256 indexed depositId, bytes32 indexed intentHash, uint256 newExpiryTime);\\n\\n    event DustRecipientUpdated(address indexed dustRecipient);\\n    event DustCollected(uint256 indexed depositId, uint256 dustAmount, address indexed dustRecipient);\\n    event DustThresholdUpdated(uint256 dustThreshold);\\n    event MaxIntentsPerDepositUpdated(uint256 maxIntentsPerDeposit);\\n    event IntentExpirationPeriodUpdated(uint256 intentExpirationPeriod);\\n\\n    /* ============ Standardized Custom Errors ============ */\\n    \\n    // Zero value errors\\n    error ZeroAddress();\\n    error ZeroValue();\\n    error ZeroMinValue();\\n    error ZeroConversionRate();\\n\\n    // Authorization errors\\n    error UnauthorizedCaller(address caller, address authorized);\\n    error UnauthorizedCallerOrDelegate(address caller, address owner, address delegate);\\n    error CannotDelegateToSelf(address depositor);\\n\\n    // Range and amount errors\\n    error InvalidRange(uint256 min, uint256 max);\\n    error AmountBelowMin(uint256 amount, uint256 min);\\n    error AmountAboveMax(uint256 amount, uint256 max);\\n    error AmountExceedsAvailable(uint256 requested, uint256 available);\\n\\n    // Not found errors\\n    error DepositNotFound(uint256 depositId);\\n    error IntentNotFound(bytes32 intentHash);\\n    error PaymentMethodNotActive(uint256 depositId, bytes32 paymentMethod);\\n    error PaymentMethodNotListed(uint256 depositId, bytes32 paymentMethod);\\n    error CurrencyNotFound(bytes32 paymentMethod, bytes32 currency);\\n    error DelegateNotFound(uint256 depositId);\\n\\n    // Already exists errors\\n    error PaymentMethodAlreadyExists(uint256 depositId, bytes32 paymentMethod);\\n    error CurrencyAlreadyExists(bytes32 paymentMethod, bytes32 currency);\\n    error IntentAlreadyExists(uint256 depositId, bytes32 intentHash);\\n\\n    // State errors\\n    error DepositNotAcceptingIntents(uint256 depositId);\\n    error DepositAlreadyInState(uint256 depositId, bool currentState);\\n    error InsufficientDepositLiquidity(uint256 depositId, uint256 available, uint256 required);\\n    error MaxIntentsExceeded(uint256 depositId, uint256 current, uint256 max);\\n\\n    // Validation errors\\n    error EmptyPayeeDetails();\\n    error ArrayLengthMismatch(uint256 length1, uint256 length2);\\n\\n    // Payment method errors\\n    error PaymentMethodNotWhitelisted(bytes32 paymentMethod);\\n    error CurrencyNotSupported(bytes32 paymentMethod, bytes32 currency);\\n\\n    \\n    /* ============ External Functions for Orchestrator ============ */\\n\\n    function lockFunds(uint256 _depositId, bytes32 _intentHash, uint256 _amount) external;\\n    function unlockFunds(uint256 _depositId, bytes32 _intentHash) external;\\n    function unlockAndTransferFunds(uint256 _depositId, bytes32 _intentHash, uint256 _transferAmount, address _to) external;\\n    function extendIntentExpiry(uint256 _depositId, bytes32 _intentHash, uint256 _additionalTime) external;\\n\\n    /* ============ View Functions ============ */\\n\\n    function getDeposit(uint256 _depositId) external view returns (Deposit memory);\\n    function getDepositIntent(uint256 _depositId, bytes32 _intentHash) external view returns (Intent memory);\\n    function getDepositPaymentMethods(uint256 _depositId) external view returns (bytes32[] memory);\\n    function getDepositCurrencies(uint256 _depositId, bytes32 _paymentMethod) external view returns (bytes32[] memory);\\n    function getDepositCurrencyMinRate(uint256 _depositId, bytes32 _paymentMethod, bytes32 _currencyCode) external view returns (uint256);\\n    function getDepositPaymentMethodData(uint256 _depositId, bytes32 _paymentMethod) external view returns (DepositPaymentMethodData memory);\\n    function getDepositPaymentMethodActive(uint256 _depositId, bytes32 _paymentMethod) external view returns (bool);\\n    function getDepositGatingService(uint256 _depositId, bytes32 _paymentMethod) external view returns (address);\\n    function getDepositIntentHashes(uint256 _depositId) external view returns (bytes32[] memory);\\n    function getExpiredIntents(uint256 _depositId) external view returns (bytes32[] memory expiredIntents, uint256 reclaimableAmount);\\n}\\n\",\"keccak256\":\"0x02077e75865a2db8887a3d4b3f4c0c398c0d2589f05506f489fb8189b223d60c\",\"license\":\"MIT\"},\"contracts/interfaces/IEscrowRegistry.sol\":{\"content\":\"//SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.18;\\n\\ninterface IEscrowRegistry {\\n    function isWhitelistedEscrow(address _escrow) external view returns (bool);\\n    function isAcceptingAllEscrows() external view returns (bool);\\n    function getWhitelistedEscrows() external view returns (address[] memory);\\n}\",\"keccak256\":\"0xb59386ede3712c6b3a67b6370a2caf5d46b5c882901f87b04de6e48f17baeddb\",\"license\":\"MIT\"},\"contracts/interfaces/IOrchestrator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.18;\\n\\nimport { IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/IERC20.sol\\\";\\nimport { IPostIntentHook } from \\\"./IPostIntentHook.sol\\\";\\n\\ninterface IOrchestrator {\\n    \\n    /* ============ Structs ============ */\\n\\n    struct Intent {\\n        address owner;                              // Address of the intent owner  \\n        address to;                                 // Address to forward funds to (can be same as owner)\\n        address escrow;                             // Address of the escrow contract holding the deposit\\n        uint256 depositId;                          // ID of the deposit the intent is associated with\\n        uint256 amount;                             // Amount of the deposit.token the owner wants to take\\n        uint256 timestamp;                          // Timestamp of the intent\\n        bytes32 paymentMethod;                      // The payment method to be used for the offchain payment\\n        bytes32 fiatCurrency;                       // Currency code that the owner is paying in offchain (keccak256 hash of the currency code)\\n        uint256 conversionRate;                     // Conversion rate of deposit token to fiat currency at the time of intent\\n        bytes32 payeeId;                            // Hashed payee identifier to whom the owner will pay offchain\\n        address referrer;                           // Address of the referrer who brought this intent (if any)\\n        uint256 referrerFee;                        // Fee to be paid to the referrer in preciseUnits (1e16 = 1%)\\n        IPostIntentHook postIntentHook;             // Address of the post-intent hook that will execute any post-intent actions\\n        bytes data;                                 // Additional data to be passed to the post-intent hook contract\\n    }\\n\\n    struct SignalIntentParams {\\n        address escrow;                             // The escrow contract where the deposit is held\\n        uint256 depositId;                          // The ID of the deposit the taker intends to use\\n        uint256 amount;                             // The amount of deposit.token the user wants to take\\n        address to;                                 // Address to forward funds to\\n        bytes32 paymentMethod;                      // The payment method to be used for the offchain payment\\n        bytes32 fiatCurrency;                       // The currency code for offchain payment\\n        uint256 conversionRate;                     // The conversion rate agreed offchain\\n        address referrer;                           // Address of the referrer (address(0) if no referrer)\\n        uint256 referrerFee;                        // Fee to be paid to the referrer\\n        bytes gatingServiceSignature;               // Signature from the deposit's gating service\\n        uint256 signatureExpiration;                // Timestamp when the gating service signature expires\\n        IPostIntentHook postIntentHook;             // Optional post-intent hook (address(0) for no hook)\\n        bytes data;                                 // Additional data for the intent\\n    }\\n\\n    struct FulfillIntentParams {\\n        bytes paymentProof;                         // Payment proof. Can be Groth16 Proof, TLSNotary proof, TLSProxy proof, attestation etc.\\n        bytes32 intentHash;                         // Identifier of intent being fulfilled\\n        bytes verificationData;                     // Additional data for payment verifier\\n        bytes postIntentHookData;                   // Additional data for post intent hook\\n    }\\n\\n    /* ============ Events ============ */\\n\\n    event IntentSignaled(\\n        bytes32 indexed intentHash, \\n        address indexed escrow,\\n        uint256 indexed depositId, \\n        bytes32 paymentMethod, \\n        address owner, \\n        address to, \\n        uint256 amount, \\n        bytes32 fiatCurrency, \\n        uint256 conversionRate, \\n        uint256 timestamp\\n    );\\n\\n    event IntentPruned(\\n        bytes32 indexed intentHash\\n    );\\n\\n    event IntentFulfilled(\\n        bytes32 indexed intentHash,\\n        address indexed fundsTransferredTo,   // Address that funds were transferred to; can be intent.to or postIntentHook address\\n        uint256 amount,\\n        bool isManualRelease\\n    );\\n\\n    event AllowMultipleIntentsUpdated(bool allowMultiple);\\n\\n    event PaymentVerifierRegistryUpdated(address indexed paymentVerifierRegistry);\\n    event PostIntentHookRegistryUpdated(address indexed postIntentHookRegistry);\\n    event RelayerRegistryUpdated(address indexed relayerRegistry);\\n    event EscrowRegistryUpdated(address indexed escrowRegistry);\\n\\n    event ProtocolFeeUpdated(uint256 protocolFee);\\n    event ProtocolFeeRecipientUpdated(address indexed protocolFeeRecipient);\\n    event PartialManualReleaseDelayUpdated(uint256 partialManualReleaseDelay);\\n\\n    /* ============ Standardized Custom Errors ============ */\\n    \\n    // Zero value errors\\n    error ZeroAddress();\\n    error ZeroValue();\\n    \\n    // Authorization errors\\n    error UnauthorizedEscrowCaller(address caller);\\n    error UnauthorizedCaller(address caller, address authorized);\\n    \\n    // Not found errors\\n    error IntentNotFound(bytes32 intentHash);\\n    error PaymentMethodDoesNotExist(bytes32 paymentMethod);\\n    error PaymentMethodNotSupported(bytes32 paymentMethod);\\n    error CurrencyNotSupported(bytes32 paymentMethod, bytes32 currency);\\n    \\n    // Whitelist errors\\n    error PaymentMethodNotWhitelisted(bytes32 paymentMethod);\\n    error PostIntentHookNotWhitelisted(address hook);\\n    error EscrowNotWhitelisted(address escrow);\\n    \\n    // Amount and fee errors\\n    error AmountBelowMin(uint256 amount, uint256 min);\\n    error AmountAboveMax(uint256 amount, uint256 max);\\n    error AmountExceedsLimit(uint256 amount, uint256 limit);\\n    error FeeExceedsMaximum(uint256 fee, uint256 maximum);\\n    error RateBelowMinimum(uint256 rate, uint256 minRate);\\n    \\n    // Validation errors\\n    error AccountHasActiveIntent(address account, bytes32 existingIntent);\\n    error InvalidReferrerFeeConfiguration();\\n    error InvalidSignature();\\n    error SignatureExpired(uint256 expiration, uint256 currentTime);\\n    error PartialReleaseNotAllowedYet(uint256 currentTime, uint256 allowedTime);\\n\\n    // Verification errors\\n    error PaymentVerificationFailed();\\n    error HashMismatch(bytes32 expected, bytes32 actual);\\n     \\n    // Transfer errors\\n    error TransferFailed(address recipient, uint256 amount);\\n    error EscrowLockFailed();\\n\\n    /* ============ View Functions ============ */\\n\\n    function getIntent(bytes32 intentHash) external view returns (Intent memory);\\n    function getAccountIntents(address account) external view returns (bytes32[] memory);\\n    \\n    /* ============ External Functions for Users ============ */\\n\\n    function signalIntent(SignalIntentParams calldata params) external;\\n\\n    function cancelIntent(bytes32 intentHash) external;\\n\\n    function fulfillIntent(FulfillIntentParams calldata params) external;\\n\\n    function releaseFundsToPayer(bytes32 intentHash) external;\\n\\n    /* ============ External Functions for Escrow ============ */\\n\\n    function pruneIntents(bytes32[] calldata intentIds) external;\\n}\",\"keccak256\":\"0xcf8db7a4c1481049dbdc2516f47cc0a4ea3a6e71093ee7c637a51294096accbf\",\"license\":\"MIT\"},\"contracts/interfaces/IOrchestratorRegistry.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.18;\\n\\n/**\\n * @title IOrchestratorRegistry\\n * @notice Interface for EscrowV2 orchestrator authorization registry.\\n */\\ninterface IOrchestratorRegistry {\\n    /**\\n     * @notice Adds an orchestrator to the allowlist.\\n     * @param _orchestrator Orchestrator address to add.\\n     */\\n    function addOrchestrator(address _orchestrator) external;\\n\\n    /**\\n     * @notice Removes an orchestrator from the allowlist.\\n     * @param _orchestrator Orchestrator address to remove.\\n     */\\n    function removeOrchestrator(address _orchestrator) external;\\n\\n    /**\\n     * @notice Returns whether an address is currently allowlisted as orchestrator.\\n     * @param _orchestrator Address to check.\\n     * @return allowed True when `_orchestrator` is authorized.\\n     */\\n    function isOrchestrator(address _orchestrator) external view returns (bool allowed);\\n}\\n\",\"keccak256\":\"0xbb2d52f475b9ebd4aadd233040b62a438cf296463fd7b269d12f28c273d0a040\",\"license\":\"MIT\"},\"contracts/interfaces/IPostIntentHook.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.18;\\n\\nimport { IOrchestrator } from \\\"./IOrchestrator.sol\\\";\\n\\n/**\\n * @title IPostIntentHook\\n * @notice Interface for post-intent hooks\\n */\\ninterface IPostIntentHook {\\n\\n    /**\\n     * @notice Post-intent hook\\n     * @param _intent The intent data structure containing all intent information\\n     * @param _fulfillIntentData The data passed to fulfillIntent\\n     */\\n    function execute(\\n        IOrchestrator.Intent memory _intent,\\n        uint256 _amountNetFees,\\n        bytes calldata _fulfillIntentData\\n    ) external;\\n}\\n\",\"keccak256\":\"0x72ae0d60c98f89eb2363f455445466c1dfaddfb338a63d65d3eb8469cbd9484d\",\"license\":\"MIT\"},\"contracts/interfaces/IPreIntentHook.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.18;\\n\\nimport { IReferralFee } from \\\"./IReferralFee.sol\\\";\\n\\n/**\\n * @title IPreIntentHook\\n * @notice Interface for pre-intent hooks that run during signalIntent.\\n */\\ninterface IPreIntentHook {\\n    struct PreIntentContext {\\n        address taker;\\n        address escrow;\\n        uint256 depositId;\\n        uint256 amount;\\n        address to;\\n        bytes32 paymentMethod;\\n        bytes32 fiatCurrency;\\n        uint256 conversionRate;\\n        IReferralFee.ReferralFee[] referralFees;\\n        bytes preIntentHookData; // Ephemeral hook-specific data from SignalIntentParams.preIntentHookData\\n    }\\n\\n    /**\\n     * @notice Called by the Orchestrator during signalIntent before state changes.\\n     * @dev Implementations should revert to reject the incoming intent.\\n     * @param _ctx Incoming intent context.\\n     */\\n    function validateSignalIntent(PreIntentContext calldata _ctx) external;\\n}\\n\",\"keccak256\":\"0x8ad7d0dde36a89a77491a59294c8d7e3e15c47c268fcce836795b1e7d282c1f7\",\"license\":\"MIT\"},\"contracts/interfaces/IReferralFee.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.18;\\n\\ninterface IReferralFee {\\n    struct ReferralFee {\\n        address recipient;\\n        uint256 fee;\\n    }\\n\\n    error ReferralFeeExceedsMaximum(uint256 totalFee, uint256 maximum);\\n    error ReferralFeeCountExceedsMaximum(uint256 count, uint256 maximum);\\n    error DuplicateReferralFeeRecipient(address recipient);\\n    error InvalidReferralFeeConfiguration();\\n}\\n\",\"keccak256\":\"0x117db0f8a3b705230a4139323f80dc534470d2c1a3a08364750ad0f9039ed1a5\",\"license\":\"MIT\"},\"contracts/interfaces/IWhitelistPolicy.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.18;\\n\\nimport {IAddressGroupRegistry} from \\\"./IAddressGroupRegistry.sol\\\";\\nimport {IEscrowRegistry} from \\\"./IEscrowRegistry.sol\\\";\\nimport {IOrchestratorRegistry} from \\\"./IOrchestratorRegistry.sol\\\";\\nimport {IPreIntentHook} from \\\"./IPreIntentHook.sol\\\";\\n\\ninterface IWhitelistPolicy is IPreIntentHook {\\n    function groupRegistry() external view returns (IAddressGroupRegistry);\\n    function escrowRegistry() external view returns (IEscrowRegistry);\\n    function orchestratorRegistry() external view returns (IOrchestratorRegistry);\\n    function enabled(address escrow, uint256 depositId, bytes32 paymentMethod) external view returns (bool);\\n    function bootstrapped(address escrow, uint256 depositId, bytes32 paymentMethod) external view returns (bool);\\n    function isWhitelisted(address escrow, uint256 depositId, address taker) external view returns (bool);\\n    function getAllowedGroups(address escrow, uint256 depositId, bytes32 paymentMethod)\\n        external\\n        view\\n        returns (bytes32[] memory);\\n    function isGroupAllowed(address escrow, uint256 depositId, bytes32 paymentMethod, bytes32 groupId)\\n        external\\n        view\\n        returns (bool);\\n    function isTakerAllowed(address escrow, uint256 depositId, bytes32 paymentMethod, address taker)\\n        external\\n        view\\n        returns (bool);\\n\\n    /**\\n     * @notice Bundles enabling/disabling a deposit payment method's gate with appending groups and takers.\\n     * @dev `enabled` REPLACES the payment method's current enforcement switch. `groupIds` are APPENDED to that\\n     * payment method's allowed-group list, while `takers` are APPENDED to the deposit-wide direct whitelist; this\\n     * call never removes or clears either list. Passing `enabled = false` disables enforcement for this payment\\n     * method even while appending new groups or takers. Use `setEnabled` alone to toggle the gate without touching\\n     * the lists.\\n     * @param escrow Whitelisted Escrow or EscrowV2 holding the deposit.\\n     * @param depositId Deposit to configure.\\n     * @param paymentMethod Payment method whose enforcement and group settings are configured.\\n     * @param enabled New value for the deposit payment method's enforcement switch; replaces the prior value.\\n     * @param groupIds Curated group ids to append to the deposit payment method's allowed groups.\\n     * @param takers Addresses to append to the deposit's direct whitelist.\\n     */\\n    function configureDeposit(\\n        address escrow,\\n        uint256 depositId,\\n        bytes32 paymentMethod,\\n        bool enabled,\\n        bytes32[] calldata groupIds,\\n        address[] calldata takers\\n    ) external;\\n\\n    /**\\n     * @notice Updates the escrow registry used to authorize deposit configuration.\\n     * @dev Governance-only (owner). The new registry must be a non-zero address with deployed code, else this call\\n     * reverts. This value MUST be kept in sync with the orchestrator's escrow registry\\n     * (`OrchestratorV2.setEscrowRegistry`), because if they diverge, deposits on an escrow admitted by only one\\n     * registry can be neither gated nor revoked here while the orchestrator keeps admitting intents for them.\\n     * @param escrowRegistry New escrow registry used to authorize deposit configuration.\\n     */\\n    function setEscrowRegistry(IEscrowRegistry escrowRegistry) external;\\n\\n    /**\\n     * @notice One-time governance bootstrap that enables one payment method on existing deposits for supplied groups.\\n     * @dev Reverts atomically unless every deposit exists on the whitelisted escrow and the selected payment method\\n     * is disabled and has never been bootstrapped. Both arrays must be non-empty. Depositors retain normal control\\n     * over the resulting policy, but disabling or removing groups does not clear the permanent bootstrap marker.\\n     * @param escrow Whitelisted Escrow or EscrowV2 holding the deposits.\\n     * @param depositIds Existing deposits to bootstrap.\\n     * @param paymentMethod Payment method to configure on every deposit.\\n     * @param groupIds Existing curated group ids to append to every deposit payment method.\\n     */\\n    function bootstrapDeposits(\\n        address escrow,\\n        uint256[] calldata depositIds,\\n        bytes32 paymentMethod,\\n        bytes32[] calldata groupIds\\n    ) external;\\n\\n    function setEnabled(address escrow, uint256 depositId, bytes32 paymentMethod, bool enabled) external;\\n    function addWhitelistedAddresses(address escrow, uint256 depositId, address[] calldata takers) external;\\n    function removeWhitelistedAddresses(address escrow, uint256 depositId, address[] calldata takers) external;\\n    function addAllowedGroups(address escrow, uint256 depositId, bytes32 paymentMethod, bytes32[] calldata groupIds)\\n        external;\\n    function removeAllowedGroups(address escrow, uint256 depositId, bytes32 paymentMethod, bytes32[] calldata groupIds)\\n        external;\\n}\\n\",\"keccak256\":\"0x38bca5927a7d984922121903e9e932b3e8074b960c0131593df08369b38064de\",\"license\":\"MIT\"}},\"version\":1}",
+  "bytecode": "0x60c0346200011b57601f62001a0938819003918201601f19168301916001600160401b0383118484101762000120578084926060946040528339810103126200011b5780516001600160a01b0380821692918381036200011b576020830151928284168094036200011b5760400151938285168086036200011b57620000c5620000d69260005460018060a01b03199633888316176000553391167f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0600080a362000136565b620000d08562000136565b62000136565b608052600154161760015560a05260405161188c90816200017d8239608051818181610e3b0152818161115101526113ac015260a051818181610b020152610d1d0152f35b600080fd5b634e487b7160e01b600052604160045260246000fd5b6001600160a01b0381169081156200016a573b15620001525750565b60249060405190631ee5274960e31b82526004820152fd5b60405163d92e233d60e01b8152600490fdfe6080604081815260048036101561001557600080fd5b600092833560e01c9081630689f72d14610e6a57508063165273ce14610e2657806316bbe4b314610cc357806321cd9fbb14610c3d578063279780bc14610bb9578063406e1d1814610b9057806349fb59e814610b315780635e78590514610aed57806367ae5b6014610a3957806367ef706f1461095b578063681548e91461074e578063715018a6146106f457806373cc7ba4146106d857806374d10d17146106955780637c9b70d9146105755780637eb288ac146104ef5780638da5cb5b146104c7578063b44b705b1461046c578063b9d2bd8a146102cb578063c03bb50f14610277578063cbcd99a3146101da5763f2fde38b1461011557600080fd5b346101d65760203660031901126101d65761012e610eab565b90610137610fbf565b6001600160a01b0391821692831561018457505082546001600160a01b0319811683178455167f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e08380a380f35b906020608492519162461bcd60e51b8352820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b6064820152fd5b8280fd5b50346101d65760203660031901126101d65780356001600160a01b038116929083900361027357610209610fbf565b821561026657823b15610251575050600180546001600160a01b031916821790557f873179742d8df742298832022224502b4c9b558e12342f5a48cf56cbb68a3acf8280a280f35b916024925191631ee5274960e31b8352820152fd5b5163d92e233d60e01b8152fd5b8380fd5b5050346102c75760803660031901126102c757610292610eab565b606435926001600160a01b03841684036102c457506020926102bb9160443590602435906110d3565b90519015158152f35b80fd5b5080fd5b5090346101d6576102db36610f21565b909491936001600160a01b0390816102f386836115b9565b16330361043957821561042957169182885260209160058352818920858a528352818920868a52835281892090895b81811061032d578a80f35b61033881838b61103c565b356103438185611567565b84549081811461041d5760001991808301908111610409576103769161036c6103959289611076565b9390549189611076565b9091600394851b1c9082549060031b91821b91600019901b1916179055565b855480156103f5577ffb0044579b42f7aa07ad6ece50cd54e05d26447c46a195b6f40229f6b1d39c55896103f09695898f968f968f96826103d891018094611076565b81939154921b1b191690558a558a51908152a4611017565b610322565b50634e487b7160e01b8e5260318d5260248efd5b50634e487b7160e01b8e5260118d5260248efd5b5050506103f090611017565b835163521299a960e01b81528890fd5b83516334633e4160e11b81526001600160a01b039091168189019081526020810186905233604082015281906060010390fd5b5050346102c75760803660031901126102c75760209181906001600160a01b03610494610eab565b168152600584528181206024358252845281812060443582528452206104bc60643582611567565b905414159051908152f35b5050346102c757816003193601126102c757905490516001600160a01b039091168152602090f35b509190346102c75761050036610f7c565b939092906001600160a01b0361051684846115b9565b163303610541578415610532575061052f94955061129b565b80f35b5163521299a960e01b81528690fd5b516334633e4160e11b81526001600160a01b0390911681870190815260208101929092523360408301529081906060010390fd5b50346101d65761058436610f7c565b9094929391926001600160a01b0392918361059f86886115b9565b16330361066357801561065557875b8181106105b9578880f35b806105d06105cb61064693858c61103c565b611062565b87878a16808d528c602089815288822084835281528a898320951694858352815260ff89832054161561064b57828252898152888220848352815284898320925252868d2060ff1981541690557f7dedaec09500c1c8dad07d733e60c59cf0d620666cf113c3254310835a2c81128d80a4611017565b6105ae565b5050505050611017565b505163521299a960e01b8152fd5b81516334633e4160e11b81526001600160a01b0387168185019081526020810187905233604082015281906060010390fd5b5050346102c75760ff816020936106ab36610ec6565b6001600160a01b039092168352600287528383209083528652828220908252855220549151911615158152f35b5050346102c757816003193601126102c75760209051600a8152f35b83346102c457806003193601126102c45761070d610fbf565b80546001600160a01b03198116825581906001600160a01b03167f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e08280a380f35b5090346101d65760803660031901126101d657610769610eab565b9167ffffffffffffffff6024358181116109575761078a9036908401610ef0565b93909460443592606435908111610953576107a89036908601610ef0565b9690946107b3610fbf565b8615801561094b575b61093d5790956001600160a01b0383169190895b8181106107db578a80f35b6107e681838b61103c565b356107f181876115b9565b50848c528b60038860209282845281812085825284528181208c8252845260ff91829120541661090a57908e918883528a60029384865281812087825286528d82822090825286522054166108d7578a8f948f93818f947fd16c24f3c1f90bb7eb0d72e5f7e6f621045333d0602d3e9d71c1e104340e6bef8f988a8f939a88966108cd9c6108d29f9e8790528452818320878452845281832088845284528183209082600194859260ff1994848682541617905589825287528181208a825287528181208b82528752209182541617905551908152a48a611376565b611017565b6107d0565b8951635aec0d2760e11b81526001600160a01b038a1681890190815260208101869052604081018d905281906060010390fd5b89516324d2541760e01b81526001600160a01b038a1681890190815260208101869052604081018d905281906060010390fd5b835163521299a960e01b8152fd5b5087156107bc565b8780fd5b8580fd5b508290346102c75760c03660031901126102c757610977610eab565b9260243560443594610987610f6d565b9567ffffffffffffffff90608435828111610953576109a99036908801610ef0565b98909260a435908111610a35576109c39036908901610ef0565b9790966001600160a01b036109d888886115b9565b163303610a0357505091816109f76109fe9461052f9a9b948888611234565b8585611376565b61129b565b516334633e4160e11b81526001600160a01b038616918101918252602082018790523360408301529081906060010390fd5b8880fd5b8284346102c45790610a4a36610ec6565b90939160018060a01b031682526020936005855283832090835284528282209082528352818120908251808584549182815201908194845286842090845b818110610ad95750505081610a9e91038261108e565b83519485948186019282875251809352850193925b828110610ac257505050500390f35b835185528695509381019392810192600101610ab3565b825484529288019260019283019201610a88565b5050346102c757816003193601126102c757517f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03168152602090f35b50346101d65760603660031901126101d657610b4b610eab565b6001600160a01b03604435818116939290849003610957579284926020969260ff95168352865282822060243583528652828220908252855220541690519015158152f35b5050346102c757816003193601126102c75760015490516001600160a01b039091168152602090f35b509190346102c75760803660031901126102c757610bd5610eab565b60243593610be1610f6d565b926001600160a01b03610bf487856115b9565b163303610c0b57505061052f929360443591611234565b516334633e4160e11b81526001600160a01b039092169082019081526020810185905233604082015281906060010390fd5b509190346102c757610c4e36610f21565b949093919291906001600160a01b03610c6784846115b9565b163303610c8f578515610c80575061052f959650611376565b5163521299a960e01b81528790fd5b516334633e4160e11b81526001600160a01b0390911681880190815260208101929092523360408301529081906060010390fd5b5090346101d657600319906020368301126102735782359067ffffffffffffffff8211610e2257610140828501938336030112610e2257805163d701dcbd60e01b815233858201526001600160a01b0391906020816024817f000000000000000000000000000000000000000000000000000000000000000087165afa908115610e18578791610ddb575b5015610dc6576024830194610d6286611062565b94610d8260a46044870135960135968787610d7c85611062565b926110d3565b15610d8b578780f35b60849750610da2610d9c8592611062565b97611062565b925163c383317760e01b815296169086015216602484015260448301526064820152fd5b51630256d21960e31b81523381860152602490fd5b90506020813d8211610e10575b81610df56020938361108e565b81010312610e0c57610e06906110c6565b38610d4e565b8680fd5b3d9150610de8565b82513d89823e3d90fd5b8480fd5b5050346102c757816003193601126102c757517f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03168152602090f35b849084346101d65760ff90602093610e8136610ec6565b6001600160a01b039092168352600387528383209083528652828220908252855220541615158152f35b600435906001600160a01b0382168203610ec157565b600080fd5b6060906003190112610ec1576004356001600160a01b0381168103610ec157906024359060443590565b9181601f84011215610ec15782359167ffffffffffffffff8311610ec1576020808501948460051b010111610ec157565b906080600319830112610ec1576004356001600160a01b0381168103610ec1579160243591604435916064359067ffffffffffffffff8211610ec157610f6991600401610ef0565b9091565b606435908115158203610ec157565b6060600319820112610ec1576004356001600160a01b0381168103610ec15791602435916044359067ffffffffffffffff8211610ec157610f6991600401610ef0565b6000546001600160a01b03163303610fd357565b606460405162461bcd60e51b815260206004820152602060248201527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e65726044820152fd5b60001981146110265760010190565b634e487b7160e01b600052601160045260246000fd5b919081101561104c5760051b0190565b634e487b7160e01b600052603260045260246000fd5b356001600160a01b0381168103610ec15790565b805482101561104c5760005260206000200190600090565b90601f8019910116810190811067ffffffffffffffff8211176110b057604052565b634e487b7160e01b600052604160045260246000fd5b51908115158203610ec157565b9160018060a01b0380931690600094828652602091600283526040948588208189528452858820828952845260ff86892054161561122757848852600494858552868920828a52855287878a20941693848a52855260ff878a2054166111d657885260058452858820908852835284872090875282528386208054957f00000000000000000000000000000000000000000000000000000000000000001690875b87811061118657505050505050505090565b6111908183611076565b90548851916310ad56b360e01b835260031b1c878201528460248201528581604481875afa90811561121d578a916111e4575b506111d6576111d190611017565b611174565b505050505050505050600190565b90508581813d8311611216575b6111fb818361108e565b810103126112125761120c906110c6565b386111c3565b8980fd5b503d6111f1565b88513d8c823e3d90fd5b5050505050505050600190565b60207fd16c24f3c1f90bb7eb0d72e5f7e6f621045333d0602d3e9d71c1e104340e6bef919492939460018060a01b031692604060008581526002845281812087825284528181208882528452209015159060ff1981541660ff8316179055604051908152a4565b929060005b8281106112ae575050505050565b6001600160a01b0390816112c66105cb83878961103c565b16801561136457836113549388168060005260046020818152604091826000208560005282528260002086600052825260ff836000205416611359578360005281528160002084600052815281600020908560005252600020600160ff198254161790557f6727748c0d923f0b5262e27f1bd0d0a4d637466ca9e32b25ff203f23c7408b07600080a4611017565b6112a0565b505050505050611017565b60405163d92e233d60e01b8152600490fd5b6001600160a01b0390811660008181526005602090815260408083208684528252808320878452825280832091989394929390927f0000000000000000000000000000000000000000000000000000000000000000169190845b8181106113e4575050505050505050505050565b6113ef81838c61103c565b35855163162da67d60e31b81528c60049183838201526024918183818b5afa90811561155d578f8b92611527575b5050156115145761142e8387611567565b91865480930361150757600a8084146114cf5750680100000000000000008310156114be57505089897f206f3c5544fdbceb4d0ae6f3f03db304e3aad145e77ca6208e5576140ad317728f858f956114b99897611495828d60016114ae950190558d611076565b90919082549060031b91821b91600019901b1916179055565b8b51908152a4611017565b6113d0565b634e487b7160e01b8a526041905288fd5b8a92600185018b8187116114f5575163d1dcbd5f60e01b81529384015282015260449150fd5b634e487b7160e01b8652601185528286fd5b505050506114b990611017565b91875191636742e58360e01b8352820152fd5b90809250813d8311611556575b61153e818361108e565b810103126112125761154f906110c6565b388f61141d565b503d611534565b89513d8c823e3d90fd5b9060005b825481101561159f578161157f8285611076565b90549060031b1c146115995761159490611017565b61156b565b91505090565b50505490565b51906001600160a01b0382168203610ec157565b600154604080516363d8a2a760e11b81526001600160a01b03938416600480830182905292969592949293602493919260209183169082818781855afa90811561178e578891849160009161181e575b501592836117af575b5050506117995787516313f3f72d60e31b8152868101869052610140919082818781885afa92831561178e57600093611671575b5050505116958615611659575050505050565b5163a6233a2960e01b81529384015282015260449150fd5b90919282823d8411611787575b611688818361108e565b8101039182126102c4578a51936101209267ffffffffffffffff9084870182811188821017611775578e526116bc866115a5565b87526116c98387016115a5565b838801528d8601518881168103610e2257878f0152605f19018d136101d6578c5192838e01918211848310176117635750906117579392918d5260608501518252608085015190820152606085015261172460a084016110c6565b608085015260c083015160a085015260e083015160c08501526101009261174c8482016115a5565b60e0860152016110c6565b90820152388080611646565b634e487b7160e01b815260418c528990fd5b634e487b7160e01b855260418d528a85fd5b503d61167e565b8a513d6000823e3d90fd5b875163f94cca3960e01b81528087018490528490fd5b8b516375abeba960e11b815293509091839182905afa908115611813576000916117de575b5015868238611612565b908282813d831161180c575b6117f4818361108e565b810103126102c45750611806906110c6565b386117d4565b503d6117ea565b89513d6000823e3d90fd5b92509082813d811161184f575b611835818361108e565b810103126102c457508261184989926110c6565b38611609565b503d61182b56fea2646970667358221220f76553bc4853eebd417455c06aec0e3d980afbc54b85055ce2021f6d94d4cc9b64736f6c63430008120033",
+  "deployedBytecode": "0x6080604081815260048036101561001557600080fd5b600092833560e01c9081630689f72d14610e6a57508063165273ce14610e2657806316bbe4b314610cc357806321cd9fbb14610c3d578063279780bc14610bb9578063406e1d1814610b9057806349fb59e814610b315780635e78590514610aed57806367ae5b6014610a3957806367ef706f1461095b578063681548e91461074e578063715018a6146106f457806373cc7ba4146106d857806374d10d17146106955780637c9b70d9146105755780637eb288ac146104ef5780638da5cb5b146104c7578063b44b705b1461046c578063b9d2bd8a146102cb578063c03bb50f14610277578063cbcd99a3146101da5763f2fde38b1461011557600080fd5b346101d65760203660031901126101d65761012e610eab565b90610137610fbf565b6001600160a01b0391821692831561018457505082546001600160a01b0319811683178455167f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e08380a380f35b906020608492519162461bcd60e51b8352820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b6064820152fd5b8280fd5b50346101d65760203660031901126101d65780356001600160a01b038116929083900361027357610209610fbf565b821561026657823b15610251575050600180546001600160a01b031916821790557f873179742d8df742298832022224502b4c9b558e12342f5a48cf56cbb68a3acf8280a280f35b916024925191631ee5274960e31b8352820152fd5b5163d92e233d60e01b8152fd5b8380fd5b5050346102c75760803660031901126102c757610292610eab565b606435926001600160a01b03841684036102c457506020926102bb9160443590602435906110d3565b90519015158152f35b80fd5b5080fd5b5090346101d6576102db36610f21565b909491936001600160a01b0390816102f386836115b9565b16330361043957821561042957169182885260209160058352818920858a528352818920868a52835281892090895b81811061032d578a80f35b61033881838b61103c565b356103438185611567565b84549081811461041d5760001991808301908111610409576103769161036c6103959289611076565b9390549189611076565b9091600394851b1c9082549060031b91821b91600019901b1916179055565b855480156103f5577ffb0044579b42f7aa07ad6ece50cd54e05d26447c46a195b6f40229f6b1d39c55896103f09695898f968f968f96826103d891018094611076565b81939154921b1b191690558a558a51908152a4611017565b610322565b50634e487b7160e01b8e5260318d5260248efd5b50634e487b7160e01b8e5260118d5260248efd5b5050506103f090611017565b835163521299a960e01b81528890fd5b83516334633e4160e11b81526001600160a01b039091168189019081526020810186905233604082015281906060010390fd5b5050346102c75760803660031901126102c75760209181906001600160a01b03610494610eab565b168152600584528181206024358252845281812060443582528452206104bc60643582611567565b905414159051908152f35b5050346102c757816003193601126102c757905490516001600160a01b039091168152602090f35b509190346102c75761050036610f7c565b939092906001600160a01b0361051684846115b9565b163303610541578415610532575061052f94955061129b565b80f35b5163521299a960e01b81528690fd5b516334633e4160e11b81526001600160a01b0390911681870190815260208101929092523360408301529081906060010390fd5b50346101d65761058436610f7c565b9094929391926001600160a01b0392918361059f86886115b9565b16330361066357801561065557875b8181106105b9578880f35b806105d06105cb61064693858c61103c565b611062565b87878a16808d528c602089815288822084835281528a898320951694858352815260ff89832054161561064b57828252898152888220848352815284898320925252868d2060ff1981541690557f7dedaec09500c1c8dad07d733e60c59cf0d620666cf113c3254310835a2c81128d80a4611017565b6105ae565b5050505050611017565b505163521299a960e01b8152fd5b81516334633e4160e11b81526001600160a01b0387168185019081526020810187905233604082015281906060010390fd5b5050346102c75760ff816020936106ab36610ec6565b6001600160a01b039092168352600287528383209083528652828220908252855220549151911615158152f35b5050346102c757816003193601126102c75760209051600a8152f35b83346102c457806003193601126102c45761070d610fbf565b80546001600160a01b03198116825581906001600160a01b03167f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e08280a380f35b5090346101d65760803660031901126101d657610769610eab565b9167ffffffffffffffff6024358181116109575761078a9036908401610ef0565b93909460443592606435908111610953576107a89036908601610ef0565b9690946107b3610fbf565b8615801561094b575b61093d5790956001600160a01b0383169190895b8181106107db578a80f35b6107e681838b61103c565b356107f181876115b9565b50848c528b60038860209282845281812085825284528181208c8252845260ff91829120541661090a57908e918883528a60029384865281812087825286528d82822090825286522054166108d7578a8f948f93818f947fd16c24f3c1f90bb7eb0d72e5f7e6f621045333d0602d3e9d71c1e104340e6bef8f988a8f939a88966108cd9c6108d29f9e8790528452818320878452845281832088845284528183209082600194859260ff1994848682541617905589825287528181208a825287528181208b82528752209182541617905551908152a48a611376565b611017565b6107d0565b8951635aec0d2760e11b81526001600160a01b038a1681890190815260208101869052604081018d905281906060010390fd5b89516324d2541760e01b81526001600160a01b038a1681890190815260208101869052604081018d905281906060010390fd5b835163521299a960e01b8152fd5b5087156107bc565b8780fd5b8580fd5b508290346102c75760c03660031901126102c757610977610eab565b9260243560443594610987610f6d565b9567ffffffffffffffff90608435828111610953576109a99036908801610ef0565b98909260a435908111610a35576109c39036908901610ef0565b9790966001600160a01b036109d888886115b9565b163303610a0357505091816109f76109fe9461052f9a9b948888611234565b8585611376565b61129b565b516334633e4160e11b81526001600160a01b038616918101918252602082018790523360408301529081906060010390fd5b8880fd5b8284346102c45790610a4a36610ec6565b90939160018060a01b031682526020936005855283832090835284528282209082528352818120908251808584549182815201908194845286842090845b818110610ad95750505081610a9e91038261108e565b83519485948186019282875251809352850193925b828110610ac257505050500390f35b835185528695509381019392810192600101610ab3565b825484529288019260019283019201610a88565b5050346102c757816003193601126102c757517f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03168152602090f35b50346101d65760603660031901126101d657610b4b610eab565b6001600160a01b03604435818116939290849003610957579284926020969260ff95168352865282822060243583528652828220908252855220541690519015158152f35b5050346102c757816003193601126102c75760015490516001600160a01b039091168152602090f35b509190346102c75760803660031901126102c757610bd5610eab565b60243593610be1610f6d565b926001600160a01b03610bf487856115b9565b163303610c0b57505061052f929360443591611234565b516334633e4160e11b81526001600160a01b039092169082019081526020810185905233604082015281906060010390fd5b509190346102c757610c4e36610f21565b949093919291906001600160a01b03610c6784846115b9565b163303610c8f578515610c80575061052f959650611376565b5163521299a960e01b81528790fd5b516334633e4160e11b81526001600160a01b0390911681880190815260208101929092523360408301529081906060010390fd5b5090346101d657600319906020368301126102735782359067ffffffffffffffff8211610e2257610140828501938336030112610e2257805163d701dcbd60e01b815233858201526001600160a01b0391906020816024817f000000000000000000000000000000000000000000000000000000000000000087165afa908115610e18578791610ddb575b5015610dc6576024830194610d6286611062565b94610d8260a46044870135960135968787610d7c85611062565b926110d3565b15610d8b578780f35b60849750610da2610d9c8592611062565b97611062565b925163c383317760e01b815296169086015216602484015260448301526064820152fd5b51630256d21960e31b81523381860152602490fd5b90506020813d8211610e10575b81610df56020938361108e565b81010312610e0c57610e06906110c6565b38610d4e565b8680fd5b3d9150610de8565b82513d89823e3d90fd5b8480fd5b5050346102c757816003193601126102c757517f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03168152602090f35b849084346101d65760ff90602093610e8136610ec6565b6001600160a01b039092168352600387528383209083528652828220908252855220541615158152f35b600435906001600160a01b0382168203610ec157565b600080fd5b6060906003190112610ec1576004356001600160a01b0381168103610ec157906024359060443590565b9181601f84011215610ec15782359167ffffffffffffffff8311610ec1576020808501948460051b010111610ec157565b906080600319830112610ec1576004356001600160a01b0381168103610ec1579160243591604435916064359067ffffffffffffffff8211610ec157610f6991600401610ef0565b9091565b606435908115158203610ec157565b6060600319820112610ec1576004356001600160a01b0381168103610ec15791602435916044359067ffffffffffffffff8211610ec157610f6991600401610ef0565b6000546001600160a01b03163303610fd357565b606460405162461bcd60e51b815260206004820152602060248201527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e65726044820152fd5b60001981146110265760010190565b634e487b7160e01b600052601160045260246000fd5b919081101561104c5760051b0190565b634e487b7160e01b600052603260045260246000fd5b356001600160a01b0381168103610ec15790565b805482101561104c5760005260206000200190600090565b90601f8019910116810190811067ffffffffffffffff8211176110b057604052565b634e487b7160e01b600052604160045260246000fd5b51908115158203610ec157565b9160018060a01b0380931690600094828652602091600283526040948588208189528452858820828952845260ff86892054161561122757848852600494858552868920828a52855287878a20941693848a52855260ff878a2054166111d657885260058452858820908852835284872090875282528386208054957f00000000000000000000000000000000000000000000000000000000000000001690875b87811061118657505050505050505090565b6111908183611076565b90548851916310ad56b360e01b835260031b1c878201528460248201528581604481875afa90811561121d578a916111e4575b506111d6576111d190611017565b611174565b505050505050505050600190565b90508581813d8311611216575b6111fb818361108e565b810103126112125761120c906110c6565b386111c3565b8980fd5b503d6111f1565b88513d8c823e3d90fd5b5050505050505050600190565b60207fd16c24f3c1f90bb7eb0d72e5f7e6f621045333d0602d3e9d71c1e104340e6bef919492939460018060a01b031692604060008581526002845281812087825284528181208882528452209015159060ff1981541660ff8316179055604051908152a4565b929060005b8281106112ae575050505050565b6001600160a01b0390816112c66105cb83878961103c565b16801561136457836113549388168060005260046020818152604091826000208560005282528260002086600052825260ff836000205416611359578360005281528160002084600052815281600020908560005252600020600160ff198254161790557f6727748c0d923f0b5262e27f1bd0d0a4d637466ca9e32b25ff203f23c7408b07600080a4611017565b6112a0565b505050505050611017565b60405163d92e233d60e01b8152600490fd5b6001600160a01b0390811660008181526005602090815260408083208684528252808320878452825280832091989394929390927f0000000000000000000000000000000000000000000000000000000000000000169190845b8181106113e4575050505050505050505050565b6113ef81838c61103c565b35855163162da67d60e31b81528c60049183838201526024918183818b5afa90811561155d578f8b92611527575b5050156115145761142e8387611567565b91865480930361150757600a8084146114cf5750680100000000000000008310156114be57505089897f206f3c5544fdbceb4d0ae6f3f03db304e3aad145e77ca6208e5576140ad317728f858f956114b99897611495828d60016114ae950190558d611076565b90919082549060031b91821b91600019901b1916179055565b8b51908152a4611017565b6113d0565b634e487b7160e01b8a526041905288fd5b8a92600185018b8187116114f5575163d1dcbd5f60e01b81529384015282015260449150fd5b634e487b7160e01b8652601185528286fd5b505050506114b990611017565b91875191636742e58360e01b8352820152fd5b90809250813d8311611556575b61153e818361108e565b810103126112125761154f906110c6565b388f61141d565b503d611534565b89513d8c823e3d90fd5b9060005b825481101561159f578161157f8285611076565b90549060031b1c146115995761159490611017565b61156b565b91505090565b50505490565b51906001600160a01b0382168203610ec157565b600154604080516363d8a2a760e11b81526001600160a01b03938416600480830182905292969592949293602493919260209183169082818781855afa90811561178e578891849160009161181e575b501592836117af575b5050506117995787516313f3f72d60e31b8152868101869052610140919082818781885afa92831561178e57600093611671575b5050505116958615611659575050505050565b5163a6233a2960e01b81529384015282015260449150fd5b90919282823d8411611787575b611688818361108e565b8101039182126102c4578a51936101209267ffffffffffffffff9084870182811188821017611775578e526116bc866115a5565b87526116c98387016115a5565b838801528d8601518881168103610e2257878f0152605f19018d136101d6578c5192838e01918211848310176117635750906117579392918d5260608501518252608085015190820152606085015261172460a084016110c6565b608085015260c083015160a085015260e083015160c08501526101009261174c8482016115a5565b60e0860152016110c6565b90820152388080611646565b634e487b7160e01b815260418c528990fd5b634e487b7160e01b855260418d528a85fd5b503d61167e565b8a513d6000823e3d90fd5b875163f94cca3960e01b81528087018490528490fd5b8b516375abeba960e11b815293509091839182905afa908115611813576000916117de575b5015868238611612565b908282813d831161180c575b6117f4818361108e565b810103126102c45750611806906110c6565b386117d4565b503d6117ea565b89513d6000823e3d90fd5b92509082813d811161184f575b611835818361108e565b810103126102c457508261184989926110c6565b38611609565b503d61182b56fea2646970667358221220f76553bc4853eebd417455c06aec0e3d980afbc54b85055ce2021f6d94d4cc9b64736f6c63430008120033",
+  "devdoc": {
+    "details": "Enabling a deposit payment method with no groups and no deposit-wide whitelisted addresses is allowed and intentionally fails closed when evaluated. Writes are authorized against the escrow's recorded depositor, so the deposit must already exist. While EscrowRegistry is in accept-all mode the registry check passes for any address, so passing an EOA or a contract without `getDeposit` reverts inside the escrow call with no reason data rather than a policy error. That path is a caller mistake on a governance-gated mode, and is not worth a per-write code-length check. `escrowRegistry` is governance-settable via `setEscrowRegistry` and MUST be kept in sync with the orchestrator's escrow registry (`OrchestratorV2.setEscrowRegistry`), because if the two diverge, deposits on an escrow admitted by only one of them can be neither gated nor revoked while the orchestrator keeps admitting intents for them.",
+    "kind": "dev",
+    "methods": {
+      "bootstrapDeposits(address,uint256[],bytes32,bytes32[])": {
+        "details": "Reverts atomically unless every deposit exists on the whitelisted escrow and the selected payment method is disabled and has never been bootstrapped. Both arrays must be non-empty. Depositors retain normal control over the resulting policy, but disabling or removing groups does not clear the permanent bootstrap marker.",
+        "params": {
+          "depositIds": "Existing deposits to bootstrap.",
+          "escrow": "Whitelisted Escrow or EscrowV2 holding the deposits.",
+          "groupIds": "Existing curated group ids to append to every deposit payment method.",
+          "paymentMethod": "Payment method to configure on every deposit."
+        }
+      },
+      "configureDeposit(address,uint256,bytes32,bool,bytes32[],address[])": {
+        "details": "`enabled` REPLACES the payment method's current enforcement switch. `groupIds` are APPENDED to that payment method's allowed-group list, while `takers` are APPENDED to the deposit-wide direct whitelist; this call never removes or clears either list. Passing `enabled = false` disables enforcement for this payment method even while appending new groups or takers. Use `setEnabled` alone to toggle the gate without touching the lists.",
+        "params": {
+          "depositId": "Deposit to configure.",
+          "enabled": "New value for the deposit payment method's enforcement switch; replaces the prior value.",
+          "escrow": "Whitelisted Escrow or EscrowV2 holding the deposit.",
+          "groupIds": "Curated group ids to append to the deposit payment method's allowed groups.",
+          "paymentMethod": "Payment method whose enforcement and group settings are configured.",
+          "takers": "Addresses to append to the deposit's direct whitelist."
+        }
+      },
+      "owner()": {
+        "details": "Returns the address of the current owner."
+      },
+      "renounceOwnership()": {
+        "details": "Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner."
+      },
+      "setEscrowRegistry(address)": {
+        "details": "Governance-only (owner). The new registry must be a non-zero address with deployed code, else this call reverts. This value MUST be kept in sync with the orchestrator's escrow registry (`OrchestratorV2.setEscrowRegistry`), because if they diverge, deposits on an escrow admitted by only one registry can be neither gated nor revoked here while the orchestrator keeps admitting intents for them.",
+        "params": {
+          "escrowRegistry": "New escrow registry used to authorize deposit configuration."
+        }
+      },
+      "transferOwnership(address)": {
+        "details": "Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner."
+      },
+      "validateSignalIntent((address,address,uint256,uint256,address,bytes32,bytes32,uint256,(address,uint256)[],bytes))": {
+        "details": "Only registered orchestrators may invoke the hook."
+      }
+    },
+    "title": "WhitelistPolicy",
+    "version": 1
+  },
+  "userdoc": {
+    "kind": "user",
+    "methods": {
+      "bootstrapDeposits(address,uint256[],bytes32,bytes32[])": {
+        "notice": "One-time governance bootstrap that enables one payment method on existing deposits for supplied groups."
+      },
+      "configureDeposit(address,uint256,bytes32,bool,bytes32[],address[])": {
+        "notice": "Bundles enabling/disabling a deposit payment method's gate with appending groups and takers."
+      },
+      "setEscrowRegistry(address)": {
+        "notice": "Updates the escrow registry used to authorize deposit configuration."
+      },
+      "validateSignalIntent((address,address,uint256,uint256,address,bytes32,bytes32,uint256,(address,uint256)[],bytes))": {
+        "notice": "Enforces this deposit's whitelist policy during intent signaling."
+      }
+    },
+    "notice": "Persistent deposit-and-payment-method-scoped taker admission settings, independent from hook deployment. Each deposit payment method carries its own enforcement switch and bounded list of curated groups, while direct addresses remain trusted across every payment method on that deposit. The policy survives global hook replacement.",
+    "version": 1
+  },
+  "storageLayout": {
+    "storage": [
+      {
+        "astId": 7,
+        "contract": "contracts/hooks/WhitelistPolicy.sol:WhitelistPolicy",
+        "label": "_owner",
+        "offset": 0,
+        "slot": "0",
+        "type": "t_address"
+      },
+      {
+        "astId": 24457,
+        "contract": "contracts/hooks/WhitelistPolicy.sol:WhitelistPolicy",
+        "label": "escrowRegistry",
+        "offset": 0,
+        "slot": "1",
+        "type": "t_contract(IEscrowRegistry)27016"
+      },
+      {
+        "astId": 24470,
+        "contract": "contracts/hooks/WhitelistPolicy.sol:WhitelistPolicy",
+        "label": "enabled",
+        "offset": 0,
+        "slot": "2",
+        "type": "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_bytes32,t_bool)))"
+      },
+      {
+        "astId": 24479,
+        "contract": "contracts/hooks/WhitelistPolicy.sol:WhitelistPolicy",
+        "label": "bootstrapped",
+        "offset": 0,
+        "slot": "3",
+        "type": "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_bytes32,t_bool)))"
+      },
+      {
+        "astId": 24488,
+        "contract": "contracts/hooks/WhitelistPolicy.sol:WhitelistPolicy",
+        "label": "isWhitelisted",
+        "offset": 0,
+        "slot": "4",
+        "type": "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_address,t_bool)))"
+      },
+      {
+        "astId": 24497,
+        "contract": "contracts/hooks/WhitelistPolicy.sol:WhitelistPolicy",
+        "label": "allowedGroups",
+        "offset": 0,
+        "slot": "5",
+        "type": "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_bytes32)dyn_storage)))"
+      }
+    ],
+    "types": {
+      "t_address": {
+        "encoding": "inplace",
+        "label": "address",
+        "numberOfBytes": "20"
+      },
+      "t_array(t_bytes32)dyn_storage": {
+        "base": "t_bytes32",
+        "encoding": "dynamic_array",
+        "label": "bytes32[]",
+        "numberOfBytes": "32"
+      },
+      "t_bool": {
+        "encoding": "inplace",
+        "label": "bool",
+        "numberOfBytes": "1"
+      },
+      "t_bytes32": {
+        "encoding": "inplace",
+        "label": "bytes32",
+        "numberOfBytes": "32"
+      },
+      "t_contract(IEscrowRegistry)27016": {
+        "encoding": "inplace",
+        "label": "contract IEscrowRegistry",
+        "numberOfBytes": "20"
+      },
+      "t_mapping(t_address,t_bool)": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => bool)",
+        "numberOfBytes": "32",
+        "value": "t_bool"
+      },
+      "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_address,t_bool)))": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => mapping(uint256 => mapping(address => bool)))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_uint256,t_mapping(t_address,t_bool))"
+      },
+      "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_bytes32)dyn_storage)))": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => mapping(uint256 => mapping(bytes32 => bytes32[])))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_bytes32)dyn_storage))"
+      },
+      "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_bytes32,t_bool)))": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => mapping(uint256 => mapping(bytes32 => bool)))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_uint256,t_mapping(t_bytes32,t_bool))"
+      },
+      "t_mapping(t_bytes32,t_array(t_bytes32)dyn_storage)": {
+        "encoding": "mapping",
+        "key": "t_bytes32",
+        "label": "mapping(bytes32 => bytes32[])",
+        "numberOfBytes": "32",
+        "value": "t_array(t_bytes32)dyn_storage"
+      },
+      "t_mapping(t_bytes32,t_bool)": {
+        "encoding": "mapping",
+        "key": "t_bytes32",
+        "label": "mapping(bytes32 => bool)",
+        "numberOfBytes": "32",
+        "value": "t_bool"
+      },
+      "t_mapping(t_uint256,t_mapping(t_address,t_bool))": {
+        "encoding": "mapping",
+        "key": "t_uint256",
+        "label": "mapping(uint256 => mapping(address => bool))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_address,t_bool)"
+      },
+      "t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_bytes32)dyn_storage))": {
+        "encoding": "mapping",
+        "key": "t_uint256",
+        "label": "mapping(uint256 => mapping(bytes32 => bytes32[]))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_bytes32,t_array(t_bytes32)dyn_storage)"
+      },
+      "t_mapping(t_uint256,t_mapping(t_bytes32,t_bool))": {
+        "encoding": "mapping",
+        "key": "t_uint256",
+        "label": "mapping(uint256 => mapping(bytes32 => bool))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_bytes32,t_bool)"
+      },
+      "t_uint256": {
+        "encoding": "inplace",
+        "label": "uint256",
+        "numberOfBytes": "32"
+      }
+    }
+  }
+}

--- a/deployments/methodScopedActivation.ts
+++ b/deployments/methodScopedActivation.ts
@@ -329,6 +329,7 @@ export type ExpectedActivationState = {
   riskWindows: Record<string, string>;
   witnesses: string[];
   controllerChangeDelay: string;
+  allowMultipleIntents: boolean;
 };
 export type ActivationAddresses = {
   safe: string;
@@ -547,7 +548,8 @@ function commonInvariants(
     ],
     [
       "orchestrator.allowMultipleIntents",
-      !snapshot.orchestrator.allowMultipleIntents,
+      snapshot.orchestrator.allowMultipleIntents ===
+        expected.allowMultipleIntents,
     ],
     ["orchestrator.registered", snapshot.orchestrator.registered],
     [
@@ -1071,6 +1073,7 @@ export type TrustSurfaceInput = {
   paymentVerifierRegistry: string;
   relayerRegistry: string;
   protocolFeeRecipient: string;
+  allowMultipleIntents: boolean;
   freshHook: string;
   whitelistPolicy: string;
   groupRegistry: string;
@@ -1100,6 +1103,7 @@ export function buildTrustSurface(
     paymentVerifierRegistry: addresses.paymentVerifierRegistry,
     relayerRegistry: addresses.relayerRegistry,
     protocolFeeRecipient: addresses.protocolFeeRecipient,
+    allowMultipleIntents: expected.allowMultipleIntents,
     freshHook: addresses.freshHook,
     whitelistPolicy: addresses.whitelistPolicy,
     groupRegistry: addresses.groupRegistry,

--- a/docs/superpowers/specs/2026-08-27-method-scoped-dispute-activation-lane-design.md
+++ b/docs/superpowers/specs/2026-08-27-method-scoped-dispute-activation-lane-design.md
@@ -237,7 +237,10 @@ recorded in the sidecar; they hold no funds and no privileges):
   in both guards): registry `owner == Safe`; orchestrator `owner == Safe`,
   `escrowRegistry` / `paymentVerifierRegistry` / `relayerRegistry` ==
   pinned, `protocolFee == 0`, `protocolFeeRecipient == pinned`,
-  `allowMultipleIntents == false`, `OrchestratorRegistry.isOrchestrator(orchestrator)`;
+  `allowMultipleIntents == EXPECTED_LIVE[network].allowMultipleIntents` (pinned per
+  network: Base `true` since governance enabled it on 2026-08-21, Base staging
+  `false`; the guard's `TrustSurface` carries the pinned value),
+  `OrchestratorRegistry.isOrchestrator(orchestrator)`;
   fresh hook `orchestratorRegistry` / `whitelistPolicy` /
   `disputeProtectionPolicy` == pinned; `WhitelistPolicyMethodScoped` `owner
   == Safe` and `escrowRegistry` / `groupRegistry` / `orchestratorRegistry`

--- a/scripts/test-method-scoped-activation-rehearsal.cjs
+++ b/scripts/test-method-scoped-activation-rehearsal.cjs
@@ -422,6 +422,7 @@ async function fixture(network) {
     network,
     governance: governance.address.toLowerCase(),
     deployer: deployer.address.toLowerCase(),
+    allowMultipleIntents: await orchestrator.allowMultipleIntents(),
     addresses,
     riskWindows: { [METHOD.toLowerCase()]: RISK_WINDOW.toString() },
     witnesses: [witness.address.toLowerCase()],

--- a/scripts/test-method-scoped-activation.cjs
+++ b/scripts/test-method-scoped-activation.cjs
@@ -97,6 +97,7 @@ function expected(network = "base") {
     network,
     governance: network === "base" ? addresses.safe : addresses.deployer,
     deployer: addresses.deployer,
+    allowMultipleIntents: network === "base",
     addresses,
     riskWindows: { [METHOD_A]: "86400", [METHOD_B]: "172800" },
     witnesses: [address(31), address(32)],
@@ -179,7 +180,7 @@ function snapshot(network = "base") {
       relayerRegistry: addresses.relayerRegistry,
       protocolFee: "0",
       protocolFeeRecipient: addresses.protocolFeeRecipient,
-      allowMultipleIntents: false,
+      allowMultipleIntents: wanted.allowMultipleIntents,
       registered: true,
     },
     freshHook: {
@@ -707,6 +708,7 @@ test("buildTrustSurface maps addresses and preserves payment method and witness 
     paymentVerifierRegistry: addresses.paymentVerifierRegistry,
     relayerRegistry: addresses.relayerRegistry,
     protocolFeeRecipient: addresses.protocolFeeRecipient,
+    allowMultipleIntents: true,
     freshHook: addresses.freshHook,
     whitelistPolicy: addresses.whitelistPolicy,
     groupRegistry: addresses.groupRegistry,
@@ -947,6 +949,60 @@ test("manifest validation covers exact schema, transaction digest, full snapshot
   assert.throws(
     () => validateActivationBatchManifest(extra),
     /Invalid activation Safe batch manifest/
+  );
+  const missingAllowMultipleIntents = /** @type {any} */ (
+    structuredClone(manifest)
+  );
+  delete missingAllowMultipleIntents.trustSurface.allowMultipleIntents;
+  assert.throws(
+    () => validateActivationBatchManifest(missingAllowMultipleIntents),
+    /Invalid activation Safe batch manifest/
+  );
+});
+
+test("guard constructor tuple pins allowMultipleIntents in the compiled ABI order", () => {
+  const {
+    deriveActivationConstructorArgs,
+  } = require("./verify-method-scoped-safe-batch.ts");
+  const manifest = manifestFixture();
+  const artifact = require("../artifacts/contracts/mocks/DisputeMethodScopedRotationGuard.sol/DisputeMethodScopedRotationGuard.json");
+  const constructor = /** @type {any} */ (
+    artifact.abi.find((entry) => entry.type === "constructor")
+  );
+  assert.ok(constructor);
+  assert.deepEqual(
+    constructor.inputs[0].components.map(
+      (/** @type {{ name: string }} */ component) => component.name
+    ),
+    [
+      "safe",
+      "disputeRegistry",
+      "orchestrator",
+      "orchestratorRegistry",
+      "escrowRegistry",
+      "paymentVerifierRegistry",
+      "relayerRegistry",
+      "protocolFeeRecipient",
+      "allowMultipleIntents",
+      "freshHook",
+      "whitelistPolicy",
+      "groupRegistry",
+      "attestationVerifier",
+      "witnesses",
+      "disputeVerifier",
+      "nullifierRegistryV2",
+      "predecessorPolicy",
+      "freshPolicy",
+      "vault",
+      "predecessorHook",
+      "paymentMethods",
+      "riskWindows",
+    ]
+  );
+  assert.doesNotThrow(() =>
+    new utils.Interface(artifact.abi).encodeDeploy(
+      deriveActivationConstructorArgs(manifest, "guard")
+    )
   );
 });
 
@@ -1519,7 +1575,7 @@ test("readActivationSnapshot pins every read and decodes both policy event signa
       relayerRegistry: live.relayerRegistry,
       protocolFee: BigNumber.from(0),
       protocolFeeRecipient: live.protocolFeeRecipient,
-      allowMultipleIntents: false,
+      allowMultipleIntents: live.allowMultipleIntents,
     })
   );
   contracts.set(

--- a/scripts/test-method-scoped-deployment.cjs
+++ b/scripts/test-method-scoped-deployment.cjs
@@ -36,6 +36,7 @@ const lane37Module = require("../deploy/37_deploy_method_scoped_dispute_lifecycl
 const {
   ACTIVE_PAYMENT_METHODS,
   BASE_STAGING_ACTIVE_PAYMENT_METHODS,
+  MULTI_SIG,
 } = require("../deployments/parameters.ts");
 const {
   assertCanonicalDeployment,
@@ -647,6 +648,56 @@ test("lane 36 and lane 37 share every common live dependency pin", () => {
   }
 });
 
+/** @param {"base" | "base_staging"} network @param {boolean} allowMultipleIntents */
+function orchestratorGovernanceFixture(network, allowMultipleIntents) {
+  const expected = lane37Module.EXPECTED_LIVE[network];
+  const governance = MULTI_SIG[network] || expected.deployer;
+  return {
+    governance,
+    expected,
+    orchestrator: {
+      owner: async () => governance,
+      paused: async () => false,
+      chainId: async () => ethers.BigNumber.from(8453),
+      escrowRegistry: async () => expected.escrowRegistry,
+      paymentVerifierRegistry: async () => expected.paymentVerifierRegistry,
+      relayerRegistry: async () => expected.relayerRegistry,
+      protocolFee: async () => ethers.constants.Zero,
+      protocolFeeRecipient: async () => expected.protocolFeeRecipient,
+      allowMultipleIntents: async () => allowMultipleIntents,
+    },
+  };
+}
+
+test("lane 37 accepts Base with allowMultipleIntents enabled", async () => {
+  const { orchestrator, governance, expected } = orchestratorGovernanceFixture(
+    "base",
+    true
+  );
+  await assert.doesNotReject(
+    lane37Module.assertOrchestratorGovernanceState(
+      orchestrator,
+      governance,
+      expected
+    )
+  );
+});
+
+test("lane 37 rejects enabled allowMultipleIntents on Base staging", async () => {
+  const { orchestrator, governance, expected } = orchestratorGovernanceFixture(
+    "base_staging",
+    true
+  );
+  await assert.rejects(
+    lane37Module.assertOrchestratorGovernanceState(
+      orchestrator,
+      governance,
+      expected
+    ),
+    /OrchestratorV3 governance state drifted/
+  );
+});
+
 test("lane 37 exports the method-scoped dispute stack identity", () => {
   assert.deepEqual(lane37Module.LOCAL_DISPUTE_DEPLOYMENT_NAMES, [
     "DisputeNullifierRegistry",
@@ -961,6 +1012,7 @@ test("lane 37 reuses every shared lane 34 live pin without a whitelist pin", () 
     for (const [field, value] of Object.entries(
       lane37Module.EXPECTED_LIVE[network]
     )) {
+      if (field === "allowMultipleIntents") continue;
       assert.deepEqual(
         value,
         /** @type {Record<string, unknown>} */ (
@@ -969,6 +1021,10 @@ test("lane 37 reuses every shared lane 34 live pin without a whitelist pin", () 
         `${network}.${field}`
       );
     }
+    assert.equal(
+      lane37Module.EXPECTED_LIVE[network].allowMultipleIntents,
+      network === "base"
+    );
   }
 });
 

--- a/scripts/verify-method-scoped-safe-batch.ts
+++ b/scripts/verify-method-scoped-safe-batch.ts
@@ -103,6 +103,7 @@ function trustSurfaceTuple(surface: TrustSurfaceInput): unknown[] {
     surface.paymentVerifierRegistry,
     surface.relayerRegistry,
     surface.protocolFeeRecipient,
+    surface.allowMultipleIntents,
     surface.freshHook,
     surface.whitelistPolicy,
     surface.groupRegistry,

--- a/test-foundry/deterministic/mocks/DisputeMethodScopedActivation.t.sol
+++ b/test-foundry/deterministic/mocks/DisputeMethodScopedActivation.t.sol
@@ -148,6 +148,12 @@ contract DisputeMethodScopedActivationTest is OrchestratorV3Fixture {
         new DisputeMethodScopedRotationGuard(_surface(), false, address(this)).assertReady();
     }
 
+    function test_RotationGuardPassesWhenAllowMultipleIntentsIsPinnedTrue() public {
+        vm.prank(safe);
+        orchestrator.setAllowMultipleIntents(true);
+        new DisputeMethodScopedRotationGuard(_surface(), true, address(this)).assertReady();
+    }
+
     function test_RotationGuardRejectsRegistryOwner() public {
         vm.prank(safe);
         disputeRegistry.transferOwnership(other);
@@ -223,10 +229,11 @@ contract DisputeMethodScopedActivationTest is OrchestratorV3Fixture {
     }
 
     function test_RotationGuardRejectsOrchestratorAllowMultipleIntents() public {
+        TrustSurface memory surface = _surface();
         vm.prank(safe);
-        orchestrator.setAllowMultipleIntents(true);
+        orchestrator.setAllowMultipleIntents(!surface.allowMultipleIntents);
         _expectRotationError(
-            _surface(), DisputeMethodScopedTrustSurfaceChecks.OrchestratorAllowMultipleIntentsMismatch.selector, true
+            surface, DisputeMethodScopedTrustSurfaceChecks.OrchestratorAllowMultipleIntentsMismatch.selector, true
         );
     }
 
@@ -637,14 +644,14 @@ contract DisputeMethodScopedActivationTest is OrchestratorV3Fixture {
 
     function test_CutoverGuardRejectsTrustSurfaceDrift() public {
         _prepareCutover(true);
+        TrustSurface memory surface = _surface();
         vm.prank(safe);
-        orchestrator.setAllowMultipleIntents(true);
-        _expectCutoverError(
-            _intentHashes(INTENT_HASH),
-            _inventory(),
-            escrow.depositCounter(),
-            DisputeMethodScopedTrustSurfaceChecks.OrchestratorAllowMultipleIntentsMismatch.selector
+        orchestrator.setAllowMultipleIntents(!surface.allowMultipleIntents);
+        DisputeMethodScopedCutoverGuard guard = new DisputeMethodScopedCutoverGuard(
+            surface, _intentHashes(INTENT_HASH), _inventory(), address(escrow), escrow.depositCounter()
         );
+        vm.expectPartialRevert(DisputeMethodScopedTrustSurfaceChecks.OrchestratorAllowMultipleIntentsMismatch.selector);
+        guard.assertReady();
     }
 
     function test_RotationPostconditionPassesWithoutWarpBetweenCalls() public {
@@ -748,9 +755,10 @@ contract DisputeMethodScopedActivationTest is OrchestratorV3Fixture {
     function test_CutoverPostconditionRejectsTrustSurfaceDrift() public {
         _prepareCutover(true);
         _executeCutover();
-        vm.prank(safe);
-        orchestrator.setAllowMultipleIntents(true);
         DisputeMethodScopedCutoverPostcondition postcondition = new DisputeMethodScopedCutoverPostcondition(_surface());
+        TrustSurface memory surface = _surface();
+        vm.prank(safe);
+        orchestrator.setAllowMultipleIntents(!surface.allowMultipleIntents);
         vm.expectPartialRevert(DisputeMethodScopedTrustSurfaceChecks.OrchestratorAllowMultipleIntentsMismatch.selector);
         postcondition.assertPostconditions();
     }
@@ -764,6 +772,7 @@ contract DisputeMethodScopedActivationTest is OrchestratorV3Fixture {
         surface.paymentVerifierRegistry = address(paymentVerifierRegistry);
         surface.relayerRegistry = address(relayerRegistry);
         surface.protocolFeeRecipient = protocolFeeRecipient;
+        surface.allowMultipleIntents = orchestrator.allowMultipleIntents();
         surface.freshHook = address(freshHook);
         surface.whitelistPolicy = address(whitelistPolicy);
         surface.groupRegistry = address(groupRegistry);


### PR DESCRIPTION
## Summary
- Records lane 36's deploy-only execution on **Base** from `7316a5e`: `WhitelistPolicyMethodScoped` `0x389Cd9bA91FfFcd83d267B241E975541892759Ce` (tx `0x82940c1c4e0098678bfdc89e4810e94d931cdfb617a997c56404f3d545b1c58c`, Safe-owned, Basescan-verified).
- Fixes the next fail-closed stop on Base: governance enabled `OrchestratorV3.allowMultipleIntents` on 2026-08-21 (tx `0xdd319c7b2a7a94bbfd3da6f5596bb8ce6b2d679abff6771f101c4749de4e8c5c`; the package's dispute-readiness metadata already documents `true`), while lanes 37/38 and the activation guard hard-coded `false` from the lane-32 era. Lane 37 therefore aborted on Base with `OrchestratorV3 governance state drifted` before sending anything. Base staging still has `false`.
- The expectation is now pinned **per network** (Base `true`, Base staging `false`) in lane 37's `EXPECTED_LIVE` and threaded through lane 38's expected state, `TrustSurface` (new `bool allowMultipleIntents` after `protocolFeeRecipient`), manifest schema, verifier tuple encoding, and the on-chain guard — fail-closed semantics unchanged. Neither lane has executed on Base, so both remain editable under the immutability rule.

## Changes
- `deployments/base/WhitelistPolicyMethodScoped.json` — new record (`7839873`).
- `deploy/37…`, `deploy/38…`, `deployments/methodScopedActivation.ts`, `deployments/activationBatchManifest.ts`, `scripts/verify-method-scoped-safe-batch.ts`, `contracts/mocks/DisputeMethodScopedActivationTypes.sol` + tests (`a3cfd27`).
- Spec amended (`bd5bddd`).

## Test Plan
- [x] Foundry activation guard tests 69/69; `yarn test:method-scoped-activation` 36+2+3; `yarn test:method-scoped-deployment` 41/41 (Base `true` passes, staging `true` fails closed); dispute-lifecycle 45/45; typecheck
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tzc4JYcsy2feiByPEeQXrc
