### PR TITLE
chore(release): contracts-v2 0.4.1-rc.7

### DIFF
--- a/.github/workflows/publish-contracts-v2.yml
+++ b/.github/workflows/publish-contracts-v2.yml
@@ -33,7 +33,7 @@ env:
   RELEASE_VERSION: ${{ inputs.release }}
   RELEASE_TAG: contracts-v2-v${{ inputs.release }}
   LATEST_BASELINE: 0.4.0
-  RC_BASELINE: 0.4.1-rc.5
+  RC_BASELINE: 0.4.1-rc.6
   NPM_CONFIG_PROVENANCE: "true"
   REQUIRE_PROVENANCE: "true"
   RECOVERY_MODE: ${{ inputs.recovery }}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/contracts-v2",
-  "version": "0.4.1-rc.6",
+  "version": "0.4.1-rc.7",
   "description": "ZKP2P V2 smart contract interfaces and utilities",
   "main": "./_cjs/index.js",
   "module": "./_esm/index.js",

--- a/scripts/npm-release.spec.mjs
+++ b/scripts/npm-release.spec.mjs
@@ -358,7 +358,7 @@ test('derives a future RC release line from the package version', () => {
 
 test('commits the next RC candidate while preserving stable release support', () => {
   const packageManifest = JSON.parse(fs.readFileSync(packageManifestPath, 'utf8'));
-  assert.equal(packageManifest.version, '0.4.1-rc.6');
+  assert.equal(packageManifest.version, '0.4.1-rc.7');
   assert.deepEqual(
     resolveReleasePolicy({
       release: '0.4.1',
@@ -388,7 +388,7 @@ test('publish workflow consumes the version-derived channel without RC-only path
   const workflow = fs.readFileSync(releaseWorkflowPath, 'utf8');
 
   assert.match(workflow, /^  LATEST_BASELINE: 0\.4\.0$/m);
-  assert.match(workflow, /^  RC_BASELINE: 0\.4\.1-rc\.5$/m);
+  assert.match(workflow, /^  RC_BASELINE: 0\.4\.1-rc\.6$/m);
   assert.match(workflow, /^\s{2}policy:\s*$/m);
   assert.match(workflow, /node scripts\/npm-release\.mjs resolve "\$PACKAGE_JSON" "\$RELEASE_VERSION"/);
   assert.match(workflow, /DIST_TAG:\s*\$\{\{ needs\.policy\.outputs\.dist_tag \}\}/);


### PR DESCRIPTION
## Summary
- Bumps `@zkp2p/contracts-v2` to `0.4.1-rc.7` (first unused RC after the published `0.4.1-rc.6`).
- Moves the publish workflow's `RC_BASELINE` from `0.4.1-rc.5` to the published `0.4.1-rc.6` so the registry guard matches npm (`latest` = `0.4.0` unchanged); release-policy tests updated to the new literals.
- Package content: today's method-scoped deployment records remain stripped from published output until activation (`yarn pkg:extract` is a no-op); source ABIs from #278/#280/#281 are the consumer-visible change.

## Local preflight (publish skill)
- `yarn install --immutable`, `yarn compile`, `yarn pkg:build` (33 Base / 33 Base Staging / 12 canonical), `yarn pkg:test` 5/5, `yarn workspace @zkp2p/contracts-v2 verify:release` (66 deployment-backed entries + 12 canonical ABIs), `yarn test:release-policy` 112/112
- `npm pack --dry-run`: `zkp2p-contracts-v2-0.4.1-rc.7.tgz`, 722 files, repository `https://github.com/zkp2p/zkp2p-contracts.git`
- Local Foundry 1.5.1 ≠ workflow pin v1.7.1 → CI's pinned full suite is the Foundry gate

## After merge
Create annotated tag `contracts-v2-v0.4.1-rc.7` at the merge commit and dispatch **Publish contracts-v2** with `release=0.4.1-rc.7`, `recovery=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tzc4JYcsy2feiByPEeQXrc