### PR TITLE
chore(deploy): pin lane 36 and retire lane 37

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,11 @@
   every supported run, and rejects both of its tags. Its Safe simulation and verification scripts remain as tooling
   for that executed history. The Base `*OptIn` trio is the live dispute stack until a later activation lane replaces
   it; the Base-staging `*OptIn` trio is deployed but was never activated.
-- Lanes `36` and `37` are the current, deploy-only successors for the payment-method-scoped policies. Lane `36`
+- Lanes `36` and `37` executed deploy-only on Base staging and Base on 2026-08-27 and are immutable (pinned in
+  `deployments/immutableDeploymentLanes.ts`). Lane `36` stays mounted behind its canonical-record skip; lane `37` is
+  retired for live networks (its preflight requires the predecessor hook, which lane 38 replaces) and is mounted through
+  `deployments/activeDeploymentLanes/37_…ts`, a wrapper that delegates to the pinned source only on `localhost`/`hardhat`
+  so local deployments keep the method-scoped stack; its tags are refused by the runner. Lane `36`
   deploys `WhitelistPolicyMethodScoped`; lane `37` deploys `DisputeProtectionPolicyMethodScoped` and
   `IntentLifecycleHookV1MethodScoped` against the lane-36 policy, the network's pinned verifier and dispute
   registry, and the pinned predecessor `StakeVault`, which is reused (controller rotation happens in the activation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,8 +139,11 @@ Current numbered lanes include:
 - `33`: IntentGuardian fee update;
 - `34`: opt-in dispute stack (immutable, retired; its Base trio is live);
 - `35`: Mercury payment method (Base staging only);
-- `36`: `WhitelistPolicyMethodScoped` (deploy-only);
-- `37`: method-scoped dispute lifecycle stack (deploy-only);
+- `36`: `WhitelistPolicyMethodScoped` (immutable, executed on both networks,
+  still mounted behind its canonical-record skip);
+- `37`: method-scoped dispute lifecycle stack (immutable, executed on both
+  networks; retired on live networks, mounted through a localhost-only
+  wrapper);
 - `38`: method-scoped dispute activation (tag-only; staging EOA steps, two
   guarded Base Safe batches).
 

--- a/README.md
+++ b/README.md
@@ -712,9 +712,11 @@ and `IntentLifecycleHookV1MethodScoped`, wiring the hook to the lane-36 policy a
 while reusing the network's pinned `DisputeVerifier`, `DisputeNullifierRegistry`, and — because `StakeVault`
 is unchanged and holds live taker stake — the predecessor `StakeVault` itself (`StakeVaultOptIn` on Base, the
 lane-32 vault on Base staging). The fresh policy becomes that vault's controller only through the vault's
-delayed two-step handover in the activation lane; a `StakeVaultMethodScoped` record exists on localhost only. Use `yarn deploy:dispute-method-scoped:base_staging` or
-`yarn deploy:dispute-method-scoped:base` with `ENABLE_STAGING_V3_DISPUTE_METHOD_SCOPED_DEPLOYMENT=true` or
-`ENABLE_BASE_V3_DISPUTE_METHOD_SCOPED_DEPLOYMENT=true`. The deploy-only run authorizes only the
+delayed two-step handover in the activation lane; a `StakeVaultMethodScoped` record exists on localhost only. The lane
+executed deploy-only on Base staging and Base on 2026-08-27 and is immutable and retired for live networks: the runner
+refuses its tags, and `deployments/activeDeploymentLanes/37_deploy_method_scoped_dispute_lifecycle_stack.ts` mounts it
+only for `localhost`/`hardhat`, where it still deploys the local method-scoped stack. The historical deploy-only run
+authorized only the
 fresh hook, applies non-zero risk windows only to PayPal, Venmo, and Cash App, and on Base initiates the
 policy's two-step ownership transfer for the Safe to accept later. It is
 transaction-by-transaction resumable and leaves the active O3 hook and the dispute-registry writer set
@@ -761,7 +763,7 @@ pinned after its first live transition, and the `active-dispute-stack.json`,
 `PREDECESSOR_DISPUTE_STACKS`, evidence, and `WhitelistPolicy` package-alias flips land in recording PRs
 after each execution. Before lane 38 can run:
 
-- [ ] Lanes 36 and 37 have executed deploy-only on Base staging and Base and their records are committed,
+- [x] Lanes 36 and 37 have executed deploy-only on Base staging and Base and their records are committed,
       and lane 37 is retired in `deployments/immutableDeploymentLanes.ts`.
 - [ ] `yarn whitelist:bootstrap` has populated `WhitelistPolicyMethodScoped` on each network.
 - [ ] `zkp2p-indexer` indexes the fresh addresses and the tuple-scoped `EnabledUpdated` /

--- a/deployments/activeDeploymentLanes/37_deploy_method_scoped_dispute_lifecycle_stack.ts
+++ b/deployments/activeDeploymentLanes/37_deploy_method_scoped_dispute_lifecycle_stack.ts
@@ -1,0 +1,30 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+const historicalLane =
+  require("../../deploy/37_deploy_method_scoped_dispute_lifecycle_stack")
+    .default as DeployFunction;
+
+const LOCAL_NETWORKS = new Set(["localhost", "hardhat"]);
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const network = hre.deployments.getNetworkName();
+  if (!LOCAL_NETWORKS.has(network)) {
+    throw new Error("Lane 37 is retired on live networks; local networks only");
+  }
+  await historicalLane(hre);
+};
+
+func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> => {
+  const network = hre.deployments.getNetworkName();
+  if (!LOCAL_NETWORKS.has(network)) return true;
+  return (await historicalLane.skip?.(hre)) ?? false;
+};
+
+func.tags = [
+  "37_deploy_method_scoped_dispute_lifecycle_stack",
+  "V3DisputeMethodScopedStack",
+];
+func.dependencies = [];
+
+export default func;

--- a/deployments/immutableDeploymentLanes.ts
+++ b/deployments/immutableDeploymentLanes.ts
@@ -45,6 +45,29 @@ export const IMMUTABLE_DEPLOYMENT_LANES = {
     retired: true,
     tags: ["34_deploy_opt_in_dispute_lifecycle_stack", "V3DisputeOptInStack"],
   },
+  // PR #282 commit executed on Base; lane stays mounted, its skip canonical-checks the record.
+  "36_deploy_method_scoped_whitelist_policy.ts": {
+    deployedSourceSha: "7316a5ece51d56419d0b02c9cd3c29c8ff5ba4be",
+    sha256: "3bc01ba3e308a2d9cbaa58a95a7094c5ed2116df103ff6fbb997962cc9240fde",
+    activeSource: undefined,
+    retired: false,
+    tags: [
+      "36_deploy_method_scoped_whitelist_policy",
+      "MethodScopedWhitelistPolicy",
+    ],
+  },
+  // Executed on Base staging and Base 2026-08-27 (PRs #282/#284); retired for live networks; local networks deploy through the wrapper.
+  "37_deploy_method_scoped_dispute_lifecycle_stack.ts": {
+    deployedSourceSha: "de4a96a1039246a8eefdaeb6d7b643504f605fe6",
+    sha256: "fb19ffe1724d34d95097bddc28d0068218e06346ff1e5ea5c4a6aedd7d8a40c6",
+    activeSource:
+      "deployments/activeDeploymentLanes/37_deploy_method_scoped_dispute_lifecycle_stack.ts",
+    retired: true,
+    tags: [
+      "37_deploy_method_scoped_dispute_lifecycle_stack",
+      "V3DisputeMethodScopedStack",
+    ],
+  },
 } as const;
 
 export type DeploymentLanes = Readonly<

--- a/package.json
+++ b/package.json
@@ -28,8 +28,6 @@
     "deploy:mercury:base_staging": "EXECUTE_STAGING_MERCURY_PAYMENT_METHOD=true ts-node --transpile-only scripts/deployActive.ts base_staging 35_add_mercury_payment_method && hardhat export --network base_staging --export ./deployments/outputs/baseStagingContracts.ts && ts-node --transpile-only scripts/canonicalizeDeploymentOutput.ts base_staging ./deployments/outputs/baseStagingContracts.ts && yarn workspace @zkp2p/contracts-v2 extract",
     "deploy:method-scoped-policy:base_staging": "ts-node --transpile-only scripts/deployActive.ts base_staging 36_deploy_method_scoped_whitelist_policy",
     "deploy:method-scoped-policy:base": "ts-node --transpile-only scripts/deployActive.ts base 36_deploy_method_scoped_whitelist_policy",
-    "deploy:dispute-method-scoped:base_staging": "ts-node --transpile-only scripts/deployActive.ts base_staging 37_deploy_method_scoped_dispute_lifecycle_stack",
-    "deploy:dispute-method-scoped:base": "ts-node --transpile-only scripts/deployActive.ts base 37_deploy_method_scoped_dispute_lifecycle_stack",
     "deploy:dispute-method-scoped-activation:base_staging": "ts-node --transpile-only scripts/deployActive.ts base_staging 38_activate_method_scoped_dispute_lifecycle_stack",
     "deploy:dispute-method-scoped-activation:base": "ts-node --transpile-only scripts/deployActive.ts base 38_activate_method_scoped_dispute_lifecycle_stack",
     "whitelist:bootstrap": "ts-node --transpile-only scripts/bootstrapWhitelistPolicy.ts",

--- a/scripts/test-method-scoped-deployment.cjs
+++ b/scripts/test-method-scoped-deployment.cjs
@@ -15,6 +15,7 @@ moduleAlias.addAlias("@utils", process.cwd() + "/utils");
 const assert = require("node:assert/strict");
 const { createHash } = require("node:crypto");
 const {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -327,10 +328,16 @@ function emptyDeploymentHre(network) {
   });
 }
 
-test("immutable lanes 29 and 34 match their exact pinned source digests", () => {
+test("immutable deployment lanes match their exact pinned source digests", () => {
   const lane29 = IMMUTABLE_DEPLOYMENT_LANES["29_deploy_whitelist_policy.ts"];
   const lane34 =
     IMMUTABLE_DEPLOYMENT_LANES["34_deploy_opt_in_dispute_lifecycle_stack.ts"];
+  const lane36 =
+    IMMUTABLE_DEPLOYMENT_LANES["36_deploy_method_scoped_whitelist_policy.ts"];
+  const lane37 =
+    IMMUTABLE_DEPLOYMENT_LANES[
+      "37_deploy_method_scoped_dispute_lifecycle_stack.ts"
+    ];
   assert.deepEqual(
     {
       sha256: lane29.sha256,
@@ -369,13 +376,55 @@ test("immutable lanes 29 and 34 match their exact pinned source digests", () => 
       retired: true,
     }
   );
+  assert.deepEqual(
+    {
+      sha256: lane36.sha256,
+      actual: sha256(
+        join(
+          repositoryRoot,
+          "deploy",
+          "36_deploy_method_scoped_whitelist_policy.ts"
+        )
+      ),
+      activeSource: lane36.activeSource,
+      retired: lane36.retired,
+    },
+    {
+      sha256:
+        "3bc01ba3e308a2d9cbaa58a95a7094c5ed2116df103ff6fbb997962cc9240fde",
+      actual:
+        "3bc01ba3e308a2d9cbaa58a95a7094c5ed2116df103ff6fbb997962cc9240fde",
+      activeSource: undefined,
+      retired: false,
+    }
+  );
+  assert.deepEqual(
+    {
+      sha256: lane37.sha256,
+      actual: sha256(
+        join(
+          repositoryRoot,
+          "deploy",
+          "37_deploy_method_scoped_dispute_lifecycle_stack.ts"
+        )
+      ),
+      activeSource: lane37.activeSource,
+      retired: lane37.retired,
+    },
+    {
+      sha256:
+        "fb19ffe1724d34d95097bddc28d0068218e06346ff1e5ea5c4a6aedd7d8a40c6",
+      actual:
+        "fb19ffe1724d34d95097bddc28d0068218e06346ff1e5ea5c4a6aedd7d8a40c6",
+      activeSource:
+        "deployments/activeDeploymentLanes/37_deploy_method_scoped_dispute_lifecycle_stack.ts",
+      retired: true,
+    }
+  );
   assertImmutableDeploymentLanes(repositoryRoot);
 });
 
-for (const filename of [
-  "29_deploy_whitelist_policy.ts",
-  "34_deploy_opt_in_dispute_lifecycle_stack.ts",
-]) {
+for (const filename of Object.keys(IMMUTABLE_DEPLOYMENT_LANES)) {
   test(`immutable lane validation names a mutated ${filename}`, () => {
     const fixtureRoot = immutableFixture(filename);
     try {
@@ -408,7 +457,6 @@ test("active selection mounts successor lanes and excludes retired history", () 
   );
   for (const filename of [
     "36_deploy_method_scoped_whitelist_policy.ts",
-    "37_deploy_method_scoped_dispute_lifecycle_stack.ts",
     "32_deploy_deposit_creation_guard.ts",
   ]) {
     assert.equal(
@@ -416,6 +464,13 @@ test("active selection mounts successor lanes and excludes retired history", () 
       join(repositoryRoot, "deploy", filename)
     );
   }
+  assert.equal(
+    byName.get("37_deploy_method_scoped_dispute_lifecycle_stack.ts"),
+    join(
+      repositoryRoot,
+      "deployments/activeDeploymentLanes/37_deploy_method_scoped_dispute_lifecycle_stack.ts"
+    )
+  );
   assert.equal(
     byName.has("32_deploy_and_activate_dispute_lifecycle_stack.ts"),
     false
@@ -426,12 +481,14 @@ test("active selection mounts successor lanes and excludes retired history", () 
   );
 });
 
-test("deployment tags reject retired history and accept lanes 36 and 37", () => {
+test("deployment tags reject retired history and lane 37 but accept lane 36", () => {
   for (const tag of [
     "32_deploy_and_activate_dispute_lifecycle_stack",
     "V3DisputeLifecycleStack",
     "34_deploy_opt_in_dispute_lifecycle_stack",
     "V3DisputeOptInStack",
+    "37_deploy_method_scoped_dispute_lifecycle_stack",
+    "V3DisputeMethodScopedStack",
   ]) {
     assert.throws(() => assertSupportedDeploymentTag(tag), /Refusing retired/);
   }
@@ -446,10 +503,44 @@ test("deployment tags reject retired history and accept lanes 36 and 37", () => 
     assertSupportedDeploymentTag("36_deploy_method_scoped_whitelist_policy")
   );
   assert.doesNotThrow(() =>
-    assertSupportedDeploymentTag(
-      "37_deploy_method_scoped_dispute_lifecycle_stack"
-    )
+    assertSupportedDeploymentTag("MethodScopedWhitelistPolicy")
   );
+});
+
+test("lane 37 wrapper delegates only on local networks", async () => {
+  const wrapperPath = join(
+    repositoryRoot,
+    "deployments/activeDeploymentLanes/37_deploy_method_scoped_dispute_lifecycle_stack.ts"
+  );
+  assert.equal(existsSync(wrapperPath), true, "lane 37 wrapper must exist");
+  const historicalSkip = lane37Module.default.skip;
+  let historicalSkipCalls = 0;
+  lane37Module.default.skip = async () => {
+    historicalSkipCalls += 1;
+    return false;
+  };
+  try {
+    const lane37Wrapper = require(wrapperPath).default;
+    for (const network of ["base", "base_staging", "unknown"]) {
+      assert.equal(await lane37Wrapper.skip(emptyDeploymentHre(network)), true);
+    }
+    assert.equal(historicalSkipCalls, 0);
+    for (const network of ["localhost", "hardhat"]) {
+      assert.equal(
+        await lane37Wrapper.skip(emptyDeploymentHre(network)),
+        false
+      );
+    }
+    assert.equal(historicalSkipCalls, 2);
+    await assert.rejects(
+      lane37Wrapper(emptyDeploymentHre("base")),
+      /Lane 37 is retired on live networks; local networks only/
+    );
+    assert.deepEqual(lane37Wrapper.tags, lane37Module.default.tags);
+    assert.deepEqual(lane37Wrapper.dependencies, []);
+  } finally {
+    lane37Module.default.skip = historicalSkip;
+  }
 });
 
 test("lane 36 exports the method-scoped whitelist identity", () => {
@@ -1230,8 +1321,6 @@ test("summary and package wiring expose only the current deployment lanes", () =
   for (const script of [
     "deploy:method-scoped-policy:base_staging",
     "deploy:method-scoped-policy:base",
-    "deploy:dispute-method-scoped:base_staging",
-    "deploy:dispute-method-scoped:base",
     "verify:method-scoped:base_staging",
     "verify:method-scoped:base",
   ]) {
@@ -1241,6 +1330,16 @@ test("summary and package wiring expose only the current deployment lanes", () =
       ),
       "string",
       script
+    );
+  }
+  for (const script of [
+    "deploy:dispute-method-scoped:base_staging",
+    "deploy:dispute-method-scoped:base",
+  ]) {
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(packageJson.scripts, script),
+      false,
+      `${script} must be removed`
     );
   }
   assert.equal(

--- a/scripts/test-opt-in-dispute-lifecycle-deployment.cjs
+++ b/scripts/test-opt-in-dispute-lifecycle-deployment.cjs
@@ -452,6 +452,29 @@ test("immutable lane manifest pins the exact deployed sources", () => {
       retired: true,
       tags: ["34_deploy_opt_in_dispute_lifecycle_stack", "V3DisputeOptInStack"],
     },
+    "36_deploy_method_scoped_whitelist_policy.ts": {
+      deployedSourceSha: "7316a5ece51d56419d0b02c9cd3c29c8ff5ba4be",
+      sha256:
+        "3bc01ba3e308a2d9cbaa58a95a7094c5ed2116df103ff6fbb997962cc9240fde",
+      activeSource: undefined,
+      retired: false,
+      tags: [
+        "36_deploy_method_scoped_whitelist_policy",
+        "MethodScopedWhitelistPolicy",
+      ],
+    },
+    "37_deploy_method_scoped_dispute_lifecycle_stack.ts": {
+      deployedSourceSha: "de4a96a1039246a8eefdaeb6d7b643504f605fe6",
+      sha256:
+        "fb19ffe1724d34d95097bddc28d0068218e06346ff1e5ea5c4a6aedd7d8a40c6",
+      activeSource:
+        "deployments/activeDeploymentLanes/37_deploy_method_scoped_dispute_lifecycle_stack.ts",
+      retired: true,
+      tags: [
+        "37_deploy_method_scoped_dispute_lifecycle_stack",
+        "V3DisputeMethodScopedStack",
+      ],
+    },
   });
 });
 

--- a/tsconfig.dispute-deployment.json
+++ b/tsconfig.dispute-deployment.json
@@ -12,6 +12,7 @@
     "hardhat.config.ts",
     "deployments/activeDisputeStack.cjs",
     "deployments/activeDeploymentLanes/30_deploy_v3_lifecycle_stack.ts",
+    "deployments/activeDeploymentLanes/37_deploy_method_scoped_dispute_lifecycle_stack.ts",
     "deployments/canonicalDeployment.ts",
     "deployments/immutableDeploymentLanes.ts",
     "deployments/managedDisputeLifecycleHook.ts",


### PR DESCRIPTION
## Summary
- Lanes 36 and 37 executed deploy-only on Base staging and Base on 2026-08-27 (#282/#283/#284), so both are now immutable and pinned in `deployments/immutableDeploymentLanes.ts` (lane 36 at `7316a5e` digest `3bc01ba3…40fde`, lane 37 at `de4a96a` digest `fb19ffe1…a40c6`).
- Lane 36 stays mounted behind its canonical-record skip (like lane 29).
- Lane 37 is **retired for live networks** — its preflight requires the predecessor hook and writer set, which lane 38 replaces, so every untagged `deploy:base*` would abort after activation. Its tags are refused by the runner and the `deploy:dispute-method-scoped:*` package scripts are removed.
- Because lane 37 is also the only lane that deploys the method-scoped stack on local networks (lane 38 refuses them), it is mounted through `deployments/activeDeploymentLanes/37_…ts`, a lane-30-style wrapper that delegates to the pinned source only on `localhost`/`hardhat` and skips/throws elsewhere. Docs updated (AGENTS/README/CLAUDE).

## Test Plan
- [x] `yarn test:method-scoped-deployment` 46/46 (digest checks for both entries, selection mounts 36 from `deploy/` and 37 from the wrapper, lane-37 tags refused, wrapper skip/throw matrix), activation 36+2+3, dispute-lifecycle 45/45, v3-groups 7/7, typecheck
- [x] Localhost gate: fresh `yarn deploy:localhost` exit 0 with `DisputeProtectionPolicyMethodScoped` / `IntentLifecycleHookV1MethodScoped` / `StakeVaultMethodScoped` records created via the wrapper; lane 38 skipped
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tzc4JYcsy2feiByPEeQXrc