### PR TITLE
fix(deploy): lane 38 staging preflight encoding and snapshot concurrency

### DIFF
--- a/deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts
+++ b/deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts
@@ -101,6 +101,55 @@ type ActivationContext = {
 
 const expectedCache = new Map<ActivationNetwork, ExpectedActivationState>();
 const PAGE_SIZE = 10_000;
+const DEFAULT_READ_CONCURRENCY = 16;
+const MAX_READ_CONCURRENCY = 64;
+
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  if (
+    !Number.isSafeInteger(limit) ||
+    limit < 1 ||
+    limit > MAX_READ_CONCURRENCY
+  ) {
+    throw new Error(
+      `Concurrency limit must be an integer from 1 to ${MAX_READ_CONCURRENCY}`
+    );
+  }
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        results[index] = await fn(items[index], index);
+      }
+    }
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+function readConcurrency(): number {
+  const raw = process.env.METHOD_SCOPED_READ_CONCURRENCY;
+  if (raw === undefined) return DEFAULT_READ_CONCURRENCY;
+  if (!/^[1-9][0-9]*$/.test(raw)) {
+    throw new Error(
+      `METHOD_SCOPED_READ_CONCURRENCY must be an integer from 1 to ${MAX_READ_CONCURRENCY}`
+    );
+  }
+  const limit = Number(raw);
+  if (!Number.isSafeInteger(limit) || limit > MAX_READ_CONCURRENCY) {
+    throw new Error(
+      `METHOD_SCOPED_READ_CONCURRENCY must be an integer from 1 to ${MAX_READ_CONCURRENCY}`
+    );
+  }
+  return limit;
+}
 
 function sameAddress(left: string, right: string): boolean {
   return left.toLowerCase() === right.toLowerCase();
@@ -352,30 +401,39 @@ async function enumeratePredecessorIntents(
     "StakeVault",
     context.expected.addresses.vault
   );
-  const intents: IntentLockState[] = [];
-  for (const intentHash of intentHashes) {
-    const [intent, lock] = await Promise.all([
-      taggedRead(policy, "getDisputeProtectionIntent", [intentHash], blockTag),
-      taggedRead(vault, "locks", [intentHash], blockTag),
-    ]);
-    const status = Number(
-      intent.status ?? intent[4]
-    ) as IntentLockState["status"];
-    const lockAmount = decimal(lock.amount ?? lock[1]);
-    const maturesAt = decimal(lock.maturesAt ?? lock[2]);
-    intents.push({
-      intentHash,
-      status,
-      lockAmount,
-      maturesAt,
-      classification: classifyIntentLock(
+  const concurrency = readConcurrency();
+  const intents = await mapWithConcurrency(
+    intentHashes,
+    concurrency,
+    async (intentHash): Promise<IntentLockState> => {
+      const [intent, lock] = await Promise.all([
+        taggedRead(
+          policy,
+          "getDisputeProtectionIntent",
+          [intentHash],
+          blockTag
+        ),
+        taggedRead(vault, "locks", [intentHash], blockTag),
+      ]);
+      const status = Number(
+        intent.status ?? intent[4]
+      ) as IntentLockState["status"];
+      const lockAmount = decimal(lock.amount ?? lock[1]);
+      const maturesAt = decimal(lock.maturesAt ?? lock[2]);
+      return {
+        intentHash,
         status,
         lockAmount,
         maturesAt,
-        blockTimestamp
-      ),
-    });
-  }
+        classification: classifyIntentLock(
+          status,
+          lockAmount,
+          maturesAt,
+          blockTimestamp
+        ),
+      };
+    }
+  );
   return proveNoLivePredecessorLocks(intents, fromBlock, blockNumber);
 }
 
@@ -432,37 +490,55 @@ async function readInventoryInputs(
     await taggedRead(escrow, "depositCounter", [], blockTag)
   );
   const depositCounter = decimal(depositCounterValue);
-  const deposits = [];
-  const enabledByTuple = new Map<string, boolean>();
+  const depositIds = [];
   for (
     let depositId = hre.ethers.BigNumber.from(0);
     depositId.lt(depositCounterValue);
     depositId = depositId.add(1)
   ) {
-    const depositIdString = depositId.toString();
-    const [deposit, listedPaymentMethods] = await Promise.all([
-      taggedRead(escrow, "getDeposit", [depositId], blockTag),
-      taggedRead(escrow, "getDepositPaymentMethods", [depositId], blockTag),
-    ]);
-    const normalizedMethods = (listedPaymentMethods as string[]).map(
-      normalizedHash
-    );
-    deposits.push({
-      depositId: depositIdString,
-      depositor: normalizedAddress(deposit.depositor ?? deposit[0]),
-      token: normalizedAddress((deposit.token ?? deposit[2]).toString()),
-      listedPaymentMethods: normalizedMethods,
-    });
-    for (const method of normalizedMethods) {
-      if ((successorRiskWindows[method] ?? "0") === "0") continue;
+    depositIds.push(depositId);
+  }
+  const concurrency = readConcurrency();
+  const deposits = await mapWithConcurrency(
+    depositIds,
+    concurrency,
+    async (depositId) => {
+      const [deposit, listedPaymentMethods] = await Promise.all([
+        taggedRead(escrow, "getDeposit", [depositId], blockTag),
+        taggedRead(escrow, "getDepositPaymentMethods", [depositId], blockTag),
+      ]);
+      return {
+        depositId: depositId.toString(),
+        depositor: normalizedAddress(deposit.depositor ?? deposit[0]),
+        token: normalizedAddress((deposit.token ?? deposit[2]).toString()),
+        listedPaymentMethods: (listedPaymentMethods as string[]).map(
+          normalizedHash
+        ),
+      };
+    }
+  );
+  const enabledByTuple = new Map<string, boolean>();
+  const successorTuples = deposits.flatMap((deposit) =>
+    deposit.listedPaymentMethods
+      .filter((method) => (successorRiskWindows[method] ?? "0") !== "0")
+      .map((method) => ({ depositId: deposit.depositId, method }))
+  );
+  const successorEnabled = await mapWithConcurrency(
+    successorTuples,
+    concurrency,
+    async ({ depositId, method }) => {
       const enabled = await taggedRead(
         successor,
         "isDisputeProtectionEnabled",
         [addresses.escrow, depositId, method],
         blockTag
       );
-      enabledByTuple.set(`${depositIdString}:${method}`, Boolean(enabled));
+      return Boolean(enabled);
     }
+  );
+  for (let index = 0; index < successorTuples.length; index += 1) {
+    const { depositId, method } = successorTuples[index];
+    enabledByTuple.set(`${depositId}:${method}`, successorEnabled[index]);
   }
 
   const predecessorInterface = new hre.ethers.utils.Interface(
@@ -534,6 +610,7 @@ export async function readActivationSnapshot(
   network: ActivationNetwork,
   blockTag: string | number
 ): Promise<ActivationSnapshot> {
+  const startedAt = Date.now();
   const context = await resolveActivationContext(hre, network);
   const block = await hre.ethers.provider.getBlock(blockTag);
   if (!block) throw new Error(`Activation block ${blockTag} is unavailable`);
@@ -684,7 +761,7 @@ export async function readActivationSnapshot(
     read(attestationVerifier, "witnesses"),
   ]);
   const addressValue = (value: string) => normalizedAddress(value);
-  return {
+  const snapshot: ActivationSnapshot = {
     network,
     blockNumber,
     blockHash: normalizedHash(block.hash),
@@ -756,6 +833,14 @@ export async function readActivationSnapshot(
     lockProof,
     inventory,
   };
+  console.log(
+    `snapshot ${network}@${blockNumber}: ${
+      inventory.depositCounter
+    } deposits, ${lockProof.intents.length} predecessor intents, ${
+      Date.now() - startedAt
+    } ms`
+  );
+  return snapshot;
 }
 
 export async function assertActivationSharedState(

--- a/deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts
+++ b/deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts
@@ -994,7 +994,7 @@ export function assertStagingAdvance(
   }
 }
 
-async function preflightStagingTransaction(
+export async function preflightStagingTransaction(
   hre: HardhatRuntimeEnvironment,
   transaction: NormalizedSafeBatchTransaction,
   deployer: string,
@@ -1024,7 +1024,9 @@ async function preflightStagingTransaction(
       {
         from: deployer,
         to: transaction.to,
-        value: hre.ethers.utils.hexValue(transaction.value),
+        value: hre.ethers.utils.hexValue(
+          hre.ethers.BigNumber.from(transaction.value)
+        ),
         data: transaction.data,
         nonce: hre.ethers.utils.hexValue(nonce),
       },

--- a/scripts/test-method-scoped-activation.cjs
+++ b/scripts/test-method-scoped-activation.cjs
@@ -88,6 +88,34 @@ const addresses = {
   stakeToken: address(21),
 };
 
+test("bounded concurrency preserves input order", async () => {
+  const {
+    mapWithConcurrency,
+  } = require("../deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts");
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const provider = {
+    /** @param {number} value */
+    read: async (value) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setImmediate(resolve));
+      inFlight -= 1;
+      return value * 2;
+    },
+  };
+  const items = [5, 4, 3, 2, 1];
+
+  const concurrent = await mapWithConcurrency(items, 3, provider.read);
+  assert.equal(maxInFlight, 3);
+  assert.deepEqual(concurrent, [10, 8, 6, 4, 2]);
+
+  maxInFlight = 0;
+  const sequential = await mapWithConcurrency(items, 1, provider.read);
+  assert.equal(maxInFlight, 1);
+  assert.deepEqual(concurrent, sequential);
+});
+
 /**
  * @param {import("../deployments/methodScopedActivation").ActivationNetwork} network
  * @returns {import("../deployments/methodScopedActivation").ExpectedActivationState}
@@ -1392,7 +1420,7 @@ test("readActivationSnapshot pins every read and decodes both policy event signa
   const unlistedMethod = hash(705);
   /** @type {string[]} */
   const successorEnabledReads = [];
-  const intentHash = hash(700);
+  const intentHashes = [hash(700), hash(706), hash(707)];
   const predecessorInterface = new utils.Interface(predecessorRecord.abi);
   const successorInterface = new utils.Interface(compiledPolicy.abi);
 
@@ -1424,7 +1452,7 @@ test("readActivationSnapshot pins every read and decodes both policy event signa
       predecessorInterface,
       "DisputeProtectionIntentOpened",
       [
-        intentHash,
+        intentHashes[0],
         address(701),
         address(702),
         address(703),
@@ -1435,6 +1463,38 @@ test("readActivationSnapshot pins every read and decodes both policy event signa
       predecessor.contracts.DisputeProtectionPolicy.address,
       120,
       1
+    ),
+    rawLog(
+      predecessorInterface,
+      "DisputeProtectionIntentOpened",
+      [
+        intentHashes[1],
+        address(701),
+        address(702),
+        address(703),
+        listedMethod,
+        "5",
+        "100",
+      ],
+      predecessor.contracts.DisputeProtectionPolicy.address,
+      121,
+      7
+    ),
+    rawLog(
+      predecessorInterface,
+      "DisputeProtectionIntentOpened",
+      [
+        intentHashes[2],
+        address(701),
+        address(702),
+        address(703),
+        listedMethod,
+        "5",
+        "100",
+      ],
+      predecessor.contracts.DisputeProtectionPolicy.address,
+      122,
+      8
     ),
     rawLog(
       successorInterface,
@@ -1482,6 +1542,10 @@ test("readActivationSnapshot pins every read and decodes both policy event signa
     successorInterface.getEventTopic("DisputeProtectionEnabledUpdated")
   );
 
+  const trackedMethods = new Set(["getDeposit", "getDisputeProtectionIntent"]);
+  /** @type {any} */
+  let provider;
+
   /** @param {Record<string, unknown>} methods */
   const taggedContract = (methods) =>
     new Proxy(
@@ -1495,9 +1559,11 @@ test("readActivationSnapshot pins every read and decodes both policy event signa
             const override = args.at(-1);
             assert.deepEqual(override, { blockTag });
             const value = methods[property];
-            return typeof value === "function"
-              ? value(...args.slice(0, -1))
-              : value;
+            const readArgs = args.slice(0, -1);
+            if (trackedMethods.has(property)) {
+              await provider.recordTargetRead(property, String(readArgs[0]));
+            }
+            return typeof value === "function" ? value(...readArgs) : value;
           };
         },
       }
@@ -1532,7 +1598,7 @@ test("readActivationSnapshot pins every read and decodes both policy event signa
       disputeVerifier: predecessor.contracts.DisputeVerifier.address,
       disputeNullifierRegistry:
         predecessor.contracts.DisputeNullifierRegistry.address,
-      getDisputeProtectionIntent: { status: 4 },
+      getDisputeProtectionIntent: () => ({ status: 4 }),
     })
   );
   contracts.set(
@@ -1554,7 +1620,7 @@ test("readActivationSnapshot pins every read and decodes both policy event signa
       pendingControllerValidAt: BigNumber.from(0),
       controllerChangeDelay: BigNumber.from(172800),
       stakeToken: live.stakeToken,
-      locks: [address(701), BigNumber.from(0), BigNumber.from(0)],
+      locks: () => [address(701), BigNumber.from(0), BigNumber.from(0)],
     })
   );
   contracts.set(
@@ -1610,12 +1676,13 @@ test("readActivationSnapshot pins every read and decodes both policy event signa
   contracts.set(
     escrow.toLowerCase(),
     taggedContract({
-      depositCounter: BigNumber.from(1),
-      getDeposit: {
-        depositor: address(900),
+      depositCounter: BigNumber.from(4),
+      /** @param {BigNumber} depositId */
+      getDeposit: (depositId) => ({
+        depositor: address(900 + depositId.toNumber()),
         token: live.stakeToken,
-      },
-      getDepositPaymentMethods: [listedMethod, unlistedMethod],
+      }),
+      getDepositPaymentMethods: () => [listedMethod, unlistedMethod],
     })
   );
 
@@ -1644,7 +1711,26 @@ test("readActivationSnapshot pins every read and decodes both policy event signa
   };
   /** @type {any[]} */
   const logQueries = [];
-  const provider = {
+  provider = {
+    targetReadsInFlight: 0,
+    maxTargetReadsInFlight: 0,
+    targetReadStarts: [],
+    resetTargetReads() {
+      this.targetReadsInFlight = 0;
+      this.maxTargetReadsInFlight = 0;
+      this.targetReadStarts = [];
+    },
+    /** @param {string} method @param {string} id */
+    async recordTargetRead(method, id) {
+      this.targetReadsInFlight += 1;
+      this.maxTargetReadsInFlight = Math.max(
+        this.maxTargetReadsInFlight,
+        this.targetReadsInFlight
+      );
+      this.targetReadStarts.push({ method, id });
+      await new Promise((resolve) => setImmediate(resolve));
+      this.targetReadsInFlight -= 1;
+    },
     /** @param {string | number} requestedTag */
     getBlock: async (requestedTag) => {
       assert.equal(requestedTag, blockTag);
@@ -1694,13 +1780,55 @@ test("readActivationSnapshot pins every read and decodes both policy event signa
       },
     },
   });
-  const result = await lane.readActivationSnapshot(
-    hre,
-    "base_staging",
-    blockTag
+  const savedConcurrency = process.env.METHOD_SCOPED_READ_CONCURRENCY;
+  let sequential;
+  let result;
+  try {
+    process.env.METHOD_SCOPED_READ_CONCURRENCY = "1";
+    provider.resetTargetReads();
+    sequential = await lane.readActivationSnapshot(
+      hre,
+      "base_staging",
+      blockTag
+    );
+    assert.equal(provider.maxTargetReadsInFlight, 1);
+
+    process.env.METHOD_SCOPED_READ_CONCURRENCY = "3";
+    successorEnabledReads.length = 0;
+    provider.resetTargetReads();
+    result = await lane.readActivationSnapshot(hre, "base_staging", blockTag);
+  } finally {
+    if (savedConcurrency === undefined) {
+      delete process.env.METHOD_SCOPED_READ_CONCURRENCY;
+    } else {
+      process.env.METHOD_SCOPED_READ_CONCURRENCY = savedConcurrency;
+    }
+  }
+  assert.deepEqual(result, sequential);
+  assert.equal(provider.maxTargetReadsInFlight, 3);
+  assert.deepEqual(
+    provider.targetReadStarts
+      .filter(
+        /** @param {{method: string}} read */ (read) =>
+          read.method === "getDisputeProtectionIntent"
+      )
+      .map(/** @param {{id: string}} read */ (read) => read.id),
+    intentHashes
+  );
+  assert.deepEqual(
+    provider.targetReadStarts
+      .filter(
+        /** @param {{method: string}} read */ (read) =>
+          read.method === "getDeposit"
+      )
+      .map(/** @param {{id: string}} read */ (read) => read.id),
+    ["0", "1", "2", "3"]
   );
   assert.equal(result.blockNumber, blockTag);
-  assert.equal(result.lockProof.intents[0].intentHash, intentHash);
+  assert.deepEqual(
+    result.lockProof.intents.map(({ intentHash }) => intentHash),
+    intentHashes
+  );
   assert.equal(result.lockProof.intents[0].classification, "terminal");
   assert.deepEqual(result.freshPolicy.authorizedHooks, [freshHook]);
   assert.deepEqual(result.inventory.tuples, [
@@ -1712,7 +1840,7 @@ test("readActivationSnapshot pins every read and decodes both policy event signa
     },
   ]);
   assert.equal(result.inventory.ok, true);
-  assert.deepEqual(successorEnabledReads, [listedMethod]);
+  assert.deepEqual(successorEnabledReads, Array(4).fill(listedMethod));
   assert.ok(logQueries.some((query) => query.fromBlock >= 10000));
   assert.equal(
     lane.expectedActivationState("base_staging").addresses.freshPolicy,

--- a/scripts/test-method-scoped-activation.cjs
+++ b/scripts/test-method-scoped-activation.cjs
@@ -1751,6 +1751,76 @@ test("staging advance accepts the controller wait but rejects a two-step jump", 
   );
 });
 
+test("staging PREPARE preflight hex-encodes normalized transaction quantities", async () => {
+  const lane = require("../deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts");
+  const state = snapshot("base_staging");
+  const wanted = expected("base_staging");
+  const reduction = reduceActivation(state, wanted);
+  assert.equal(reduction.phase, "deployed");
+  assert.equal(reduction.nextStagingAction, "pause-predecessor-admissions");
+  const transaction = buildStagingTransaction(
+    reduction.nextStagingAction,
+    wanted.addresses,
+    state.lockProof
+  );
+  assert.equal(transaction.value, "0");
+
+  const quantity = /^0x([1-9a-f][0-9a-f]*|0)$/;
+  /** @param {unknown} value @param {string} argument */
+  const assertQuantity = (value, argument) => {
+    if (typeof value === "string" && quantity.test(value)) return;
+    throw Object.assign(
+      new Error(
+        `invalid hexlify value (argument="${argument}", value=${JSON.stringify(
+          value
+        )}, code=INVALID_ARGUMENT, version=bytes/5.7.0)`
+      ),
+      { code: "INVALID_ARGUMENT", argument, value }
+    );
+  };
+  /** @param {string} method @param {any[]} params */
+  const validateRpcQuantities = (method, params) => {
+    if (method !== "eth_estimateGas" && method !== "eth_call") return;
+    const request = params[0];
+    for (const field of ["value", "nonce", "gas"]) {
+      if (request[field] !== undefined) assertQuantity(request[field], field);
+    }
+    assertQuantity(params[1], "blockTag");
+  };
+  /** @type {any} */
+  const provider = {
+    getTransactionCount: async () => 0,
+    getBalance: async () => BigNumber.from(1_000_000),
+    getFeeData: async () => ({ gasPrice: BigNumber.from(1) }),
+    /** @param {any} request @param {string | number} blockTag */
+    call: async (request, blockTag) =>
+      provider.send("eth_call", [
+        {
+          ...request,
+          value: utils.hexValue(BigNumber.from(request.value)),
+          nonce: utils.hexValue(BigNumber.from(request.nonce)),
+        },
+        utils.hexValue(BigNumber.from(blockTag)),
+      ]),
+    /** @param {string} method @param {any[]} params */
+    send: async (method, params) => {
+      validateRpcQuantities(method, params);
+      return method === "eth_estimateGas" ? "0x5208" : "0x";
+    },
+  };
+  const hre = /** @type {any} */ ({
+    ethers: { provider, BigNumber, utils },
+  });
+
+  const result = await lane.preflightStagingTransaction(
+    hre,
+    transaction,
+    wanted.deployer,
+    state.blockNumber
+  );
+  assert.equal(result.gasLimit.toString(), "21000");
+});
+
 test("staging flags are mutually exclusive and confirmations fail in order", async () => {
   const lane = require("../deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts");
   const names = [


### PR DESCRIPTION
## Summary
Two fixes surfaced by the first real lane-38 runs (no transaction was sent by either failing run):
- **`hexValue` on a decimal-string `value`** — the normalized Safe transaction carries `value` as a decimal string, so `preflightStagingTransaction` threw `invalid hexlify value` after a successful preflight/reducer pass on Base staging. Fixed by parsing through `BigNumber.from`; the fake RPC provider in the tests now validates hex quantities so this class of bug is caught (`e8092dc`).
- **Sequential snapshot reads** — Base has 4,306 escrow deposits, so one pinned snapshot took >10 minutes (the read-only run timed out). Deposit, successor-method, and predecessor-intent reads now use ordered bounded concurrency (default 16, `METHOD_SCOPED_READ_CONCURRENCY`, 1–64) with identical outputs; a real Base snapshot now takes ~100 s (`4d53b38`).

## Evidence
- Staging read-only reduction: phase `deployed`, next `pause-predecessor-admissions`, lock proof and inventory clean.
- Base read-only snapshot @50531648: 4,306 deposits, 5 predecessor intents (lock proof `false` as expected pre-maturity), inventory 0 tuples, 99.9 s.

## Test Plan
- [x] `yarn test:method-scoped-activation` 38+2+3 (new: hex-quantity validating provider, deployed-phase PREPARE regression, concurrency limit/order/equivalence), typecheck
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tzc4JYcsy2feiByPEeQXrc