### PR TITLE
fix(deploy): retry lane 38 pinned reads on block lag

### DIFF
--- a/deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts
+++ b/deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts
@@ -103,6 +103,67 @@ const expectedCache = new Map<ActivationNetwork, ExpectedActivationState>();
 const PAGE_SIZE = 10_000;
 const DEFAULT_READ_CONCURRENCY = 16;
 const MAX_READ_CONCURRENCY = 64;
+const DEFAULT_BLOCK_LAG_ATTEMPTS = 15;
+const DEFAULT_BLOCK_LAG_DELAY_MS = 2_000;
+const BLOCK_LAG_ERROR =
+  /unknown block|header not found|block not found|missing trie node/i;
+
+function blockLagSetting(
+  name: "METHOD_SCOPED_BLOCK_LAG_RETRIES" | "METHOD_SCOPED_BLOCK_LAG_DELAY_MS",
+  fallback: number,
+  allowZero: boolean
+): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  if (!/^(0|[1-9][0-9]*)$/.test(raw)) {
+    throw new Error(`${name} must be a non-negative safe integer`);
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || (!allowZero && value === 0)) {
+    throw new Error(
+      `${name} must be ${
+        allowZero ? "a non-negative" : "a positive"
+      } safe integer`
+    );
+  }
+  return value;
+}
+
+export async function withBlockLagRetry<T>(
+  label: string,
+  fn: () => Promise<T>,
+  retryResult: (result: T) => boolean = () => false
+): Promise<T> {
+  const attempts = blockLagSetting(
+    "METHOD_SCOPED_BLOCK_LAG_RETRIES",
+    DEFAULT_BLOCK_LAG_ATTEMPTS,
+    false
+  );
+  const delayMs = blockLagSetting(
+    "METHOD_SCOPED_BLOCK_LAG_DELAY_MS",
+    DEFAULT_BLOCK_LAG_DELAY_MS,
+    true
+  );
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const result = await fn();
+      if (!retryResult(result) || attempt === attempts) return result;
+      console.log(
+        `Retrying ${label} after block lag (${attempt}/${attempts}): empty result`
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!BLOCK_LAG_ERROR.test(message) || attempt === attempts) throw error;
+      console.log(
+        `Retrying ${label} after block lag (${attempt}/${attempts}): ${message}`
+      );
+    }
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw new Error("Block lag retry attempts exhausted");
+}
 
 export async function mapWithConcurrency<T, R>(
   items: readonly T[],
@@ -1283,9 +1344,14 @@ export async function deployActivationContract(
   if (receipt.status !== 1 || !receipt.contractAddress) {
     throw new Error(`${artifactName} deployment did not succeed`);
   }
-  const runtimeCode = await hre.ethers.provider.getCode(
-    receipt.contractAddress,
-    receipt.blockNumber
+  const runtimeCode = await withBlockLagRetry(
+    `${artifactName} runtime code at block ${receipt.blockNumber}`,
+    () =>
+      hre.ethers.provider.getCode(
+        receipt.contractAddress as string,
+        receipt.blockNumber
+      ),
+    (code) => code === "0x"
   );
   if (runtimeCode === "0x") {
     throw new Error(`${artifactName} deployment has no runtime bytecode`);
@@ -1442,16 +1508,16 @@ async function prepareBaseBatch(
   if (simulationBlockNumber <= proofBlockNumber) {
     throw new Error("Simulation block must follow the proof block");
   }
-  const simulationBlock = await hre.ethers.provider.getBlock(
-    simulationBlockNumber
+  const simulationBlock = await withBlockLagRetry(
+    `Base simulation block ${simulationBlockNumber}`,
+    () => hre.ethers.provider.getBlock(simulationBlockNumber)
   );
   if (!simulationBlock?.hash) {
     throw new Error("Could not pin the simulation block");
   }
-  const simulationSnapshot = await readActivationSnapshot(
-    hre,
-    "base",
-    simulationBlockNumber
+  const simulationSnapshot = await withBlockLagRetry(
+    `Base simulation snapshot at block ${simulationBlockNumber}`,
+    () => readActivationSnapshot(hre, "base", simulationBlockNumber)
   );
   assertGuardExpectationsUnchanged(kind, proofSnapshot, simulationSnapshot);
   const transactions =

--- a/scripts/test-method-scoped-activation.cjs
+++ b/scripts/test-method-scoped-activation.cjs
@@ -1179,6 +1179,159 @@ test("lane 38 exports its identity, Base helpers, and no dependencies", () => {
   assert.equal(typeof lane.runPinnedSimulation, "function");
 });
 
+test("deployActivationContract retries transient block lag and records the identity", async () => {
+  const lane = require("../deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts");
+  const runtimeCode = "0x6001";
+  const receipt = {
+    status: 1,
+    contractAddress: address(980),
+    blockNumber: 123,
+    transactionHash: hash(981),
+  };
+  let getCodeCalls = 0;
+  const hre = /** @type {any} */ ({
+    getUnnamedAccounts: async () => [addresses.deployer],
+    ethers: {
+      getSigner: async () => ({}),
+      getContractFactory: async () => ({
+        deploy: async () => ({
+          deployTransaction: { wait: async () => receipt },
+        }),
+      }),
+      provider: {
+        getCode: async () => {
+          getCodeCalls += 1;
+          if (getCodeCalls <= 2)
+            throw new Error("ProviderError: Unknown block");
+          return runtimeCode;
+        },
+      },
+      utils,
+    },
+  });
+  const savedRetries = process.env.METHOD_SCOPED_BLOCK_LAG_RETRIES;
+  const savedDelay = process.env.METHOD_SCOPED_BLOCK_LAG_DELAY_MS;
+  try {
+    process.env.METHOD_SCOPED_BLOCK_LAG_RETRIES = "3";
+    process.env.METHOD_SCOPED_BLOCK_LAG_DELAY_MS = "0";
+    const identity = await lane.deployActivationContract(hre, "Example", []);
+    assert.equal(getCodeCalls, 3);
+    assert.deepEqual(identity, {
+      address: receipt.contractAddress,
+      artifactName: "Example",
+      constructorArgs: [],
+      deployTransactionHash: receipt.transactionHash,
+      runtimeCodeHash: utils.keccak256(runtimeCode),
+    });
+  } finally {
+    if (savedRetries === undefined)
+      delete process.env.METHOD_SCOPED_BLOCK_LAG_RETRIES;
+    else process.env.METHOD_SCOPED_BLOCK_LAG_RETRIES = savedRetries;
+    if (savedDelay === undefined)
+      delete process.env.METHOD_SCOPED_BLOCK_LAG_DELAY_MS;
+    else process.env.METHOD_SCOPED_BLOCK_LAG_DELAY_MS = savedDelay;
+  }
+});
+
+test("deployActivationContract fails with the provider error after configured attempts", async () => {
+  const lane = require("../deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts");
+  const providerError = new Error("header not found");
+  let getCodeCalls = 0;
+  const hre = /** @type {any} */ ({
+    getUnnamedAccounts: async () => [addresses.deployer],
+    ethers: {
+      getSigner: async () => ({}),
+      getContractFactory: async () => ({
+        deploy: async () => ({
+          deployTransaction: {
+            wait: async () => ({
+              status: 1,
+              contractAddress: address(982),
+              blockNumber: 124,
+              transactionHash: hash(983),
+            }),
+          },
+        }),
+      }),
+      provider: {
+        getCode: async () => {
+          getCodeCalls += 1;
+          throw providerError;
+        },
+      },
+      utils,
+    },
+  });
+  const savedRetries = process.env.METHOD_SCOPED_BLOCK_LAG_RETRIES;
+  const savedDelay = process.env.METHOD_SCOPED_BLOCK_LAG_DELAY_MS;
+  try {
+    process.env.METHOD_SCOPED_BLOCK_LAG_RETRIES = "3";
+    process.env.METHOD_SCOPED_BLOCK_LAG_DELAY_MS = "0";
+    await assert.rejects(
+      lane.deployActivationContract(hre, "Example", []),
+      (error) => error === providerError
+    );
+    assert.equal(getCodeCalls, 3);
+  } finally {
+    if (savedRetries === undefined)
+      delete process.env.METHOD_SCOPED_BLOCK_LAG_RETRIES;
+    else process.env.METHOD_SCOPED_BLOCK_LAG_RETRIES = savedRetries;
+    if (savedDelay === undefined)
+      delete process.env.METHOD_SCOPED_BLOCK_LAG_DELAY_MS;
+    else process.env.METHOD_SCOPED_BLOCK_LAG_DELAY_MS = savedDelay;
+  }
+});
+
+test("withBlockLagRetry retries a lagging simulation block and empty deployment code", async () => {
+  const lane = require("../deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts");
+  const savedRetries = process.env.METHOD_SCOPED_BLOCK_LAG_RETRIES;
+  const savedDelay = process.env.METHOD_SCOPED_BLOCK_LAG_DELAY_MS;
+  let blockCalls = 0;
+  let codeCalls = 0;
+  try {
+    process.env.METHOD_SCOPED_BLOCK_LAG_RETRIES = "3";
+    process.env.METHOD_SCOPED_BLOCK_LAG_DELAY_MS = "0";
+    const block = await lane.withBlockLagRetry("simulation block", async () => {
+      blockCalls += 1;
+      if (blockCalls === 1) throw new Error("block not found");
+      return { number: 201, hash: hash(201) };
+    });
+    const code = await lane.withBlockLagRetry(
+      "deployment runtime code",
+      async () => {
+        codeCalls += 1;
+        return codeCalls === 1 ? "0x" : "0x6001";
+      },
+      (value) => value === "0x"
+    );
+    assert.equal(blockCalls, 2);
+    assert.equal(block.number, 201);
+    assert.equal(codeCalls, 2);
+    assert.equal(code, "0x6001");
+  } finally {
+    if (savedRetries === undefined)
+      delete process.env.METHOD_SCOPED_BLOCK_LAG_RETRIES;
+    else process.env.METHOD_SCOPED_BLOCK_LAG_RETRIES = savedRetries;
+    if (savedDelay === undefined)
+      delete process.env.METHOD_SCOPED_BLOCK_LAG_DELAY_MS;
+    else process.env.METHOD_SCOPED_BLOCK_LAG_DELAY_MS = savedDelay;
+  }
+});
+
+test("withBlockLagRetry does not retry unrelated provider errors", async () => {
+  const lane = require("../deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts");
+  const providerError = new Error("execution reverted");
+  let calls = 0;
+  await assert.rejects(
+    lane.withBlockLagRetry("simulation snapshot", async () => {
+      calls += 1;
+      throw providerError;
+    }),
+    (error) => error === providerError
+  );
+  assert.equal(calls, 1);
+});
+
 test("deploy summary includes both lane 38 tags without a dependency chain", () => {
   const summary = readTextFileSync("deploy/deploy_summary.ts", "utf8");
   assert.match(summary, /38_activate_method_scoped_dispute_lifecycle_stack/);


### PR DESCRIPTION
## Summary
The first real Base rotation preparation deployed its guard (nonce 13084, `0x281e43e24Ef76b6Da26f4262caE5DE3428B9D56C`, now orphaned) and then aborted: the load-balanced RPC served the deploy receipt from one node and the follow-up pinned `getCode(address, receipt.blockNumber)` from another that had not imported the block yet (`ProviderError: Unknown block`).

Pinned reads that immediately follow a fresh receipt or block number in the Base path (post-receipt `getCode`, `getBlock(simulationBlockNumber)`, the simulation snapshot) now retry on transient unknown-block errors and on empty code right after a create receipt (`METHOD_SCOPED_BLOCK_LAG_RETRIES` / `METHOD_SCOPED_BLOCK_LAG_DELAY_MS`, default 15 × 2 s). Sends are never retried; other errors propagate immediately.

## Test Plan
- [x] `yarn test:method-scoped-activation` 42+2+3 (recovery, exhaustion, empty-code, block-lag, unrelated-error cases), typecheck
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tzc4JYcsy2feiByPEeQXrc