### PR TITLE
chore(deploy): record Base method-scoped rotation Safe batch

### DIFF
--- a/deployments/outputs/safe-batches/base_method_scoped_rotation.json
+++ b/deployments/outputs/safe-batches/base_method_scoped_rotation.json
@@ -1,0 +1,46 @@
+{
+  "version": "1.0",
+  "chainId": "8453",
+  "createdAt": 1787854537000,
+  "meta": {
+    "name": "ZKP2P method-scoped dispute rotation - base",
+    "description": "assertReady(); optionally acceptOwnership(); setAdmissionsPaused(true); proposeController(freshPolicy)",
+    "txBuilderVersion": "1.16.5",
+    "createdFromSafeAddress": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0x4fe80b802a1899e8999cb57e3fb1ffb13017857b",
+      "value": "0",
+      "data": "0xbf9a61ac",
+      "operation": 0,
+      "contractMethod": null,
+      "contractInputsValues": null
+    },
+    {
+      "to": "0x46b6d18e641c14dfb15a01f767fd33cc0a6e3488",
+      "value": "0",
+      "data": "0x79ba5097",
+      "operation": 0,
+      "contractMethod": null,
+      "contractInputsValues": null
+    },
+    {
+      "to": "0xcec48f7242edbf02875bb4629115bd927e1287aa",
+      "value": "0",
+      "data": "0x150025660000000000000000000000000000000000000000000000000000000000000001",
+      "operation": 0,
+      "contractMethod": null,
+      "contractInputsValues": null
+    },
+    {
+      "to": "0x4d16f4a9946cfc76b1c1a4b63aa9d94cda2dbceb",
+      "value": "0",
+      "data": "0xc8f6ec5500000000000000000000000046b6d18e641c14dfb15a01f767fd33cc0a6e3488",
+      "operation": 0,
+      "contractMethod": null,
+      "contractInputsValues": null
+    }
+  ]
+}

--- a/deployments/outputs/safe-batches/base_method_scoped_rotation.sha256.json
+++ b/deployments/outputs/safe-batches/base_method_scoped_rotation.sha256.json
@@ -1,0 +1,353 @@
+{
+  "version": 2,
+  "kind": "rotation",
+  "chainId": 8453,
+  "safe": "0x0bc26ff515411396dd588abd6ef6846e04470227",
+  "safeNonce": "77",
+  "sourceSha": "11b405f8a8f0fd98c20d350135f22adce703ea3f",
+  "proofBlock": {
+    "number": 50532492,
+    "hash": "0x5f8032268c330337dd7bb536acf16a50b40054abe8dcc673377e591b0de2ae2f"
+  },
+  "simulationBlockNumber": 50532595,
+  "simulationBlockHash": "0x53003db7063a3578cf08f9f3e950ce1e5a7164c2eea58c6a7d2241b2f88fc7bd",
+  "simulationResult": "success",
+  "transactions": [
+    {
+      "to": "0x4fe80b802a1899e8999cb57e3fb1ffb13017857b",
+      "value": "0",
+      "data": "0xbf9a61ac",
+      "operation": 0
+    },
+    {
+      "to": "0x46b6d18e641c14dfb15a01f767fd33cc0a6e3488",
+      "value": "0",
+      "data": "0x79ba5097",
+      "operation": 0
+    },
+    {
+      "to": "0xcec48f7242edbf02875bb4629115bd927e1287aa",
+      "value": "0",
+      "data": "0x150025660000000000000000000000000000000000000000000000000000000000000001",
+      "operation": 0
+    },
+    {
+      "to": "0x4d16f4a9946cfc76b1c1a4b63aa9d94cda2dbceb",
+      "value": "0",
+      "data": "0xc8f6ec5500000000000000000000000046b6d18e641c14dfb15a01f767fd33cc0a6e3488",
+      "operation": 0
+    }
+  ],
+  "transactionsSha256": "0f9682f2f54d3da7d5e876c843be9aee93d686ff0a9ad6811f4326f0e8166ab1",
+  "guard": {
+    "address": "0x4fe80b802a1899e8999cb57e3fb1ffb13017857b",
+    "artifactName": "DisputeMethodScopedRotationGuard",
+    "constructorArgs": [
+      {
+        "safe": "0x0bc26ff515411396dd588abd6ef6846e04470227",
+        "disputeRegistry": "0xa845615b5203f7a21321ddf5e3a1ca024d93a443",
+        "orchestrator": "0x014025fde093f8701d86e9f38e2c3a9b779cb5c7",
+        "orchestratorRegistry": "0xbe9fed15ed7a4b915c03efcecb9662739c3382a9",
+        "escrowRegistry": "0xed0e847b101abc96e796260ac358e12baa2f5b21",
+        "paymentVerifierRegistry": "0x2b82d24437ff66fb173eabdfd67ee2aceb8beb1e",
+        "relayerRegistry": "0xeba979889a9c97382a92472ff3703786ff180083",
+        "protocolFeeRecipient": "0x0bc26ff515411396dd588abd6ef6846e04470227",
+        "allowMultipleIntents": true,
+        "freshHook": "0x8dee00081bd075f804f4589440c331bcedeece59",
+        "whitelistPolicy": "0x389cd9ba91fffcd83d267b241e975541892759ce",
+        "groupRegistry": "0x39f80118f9eb619135f116171b6cb91d372c5af2",
+        "attestationVerifier": "0x9fe920b24e50e6a6362ba71a1beb502a99c402d5",
+        "witnesses": [
+          "0xdb4ed7faf170f0f6493e3adaacaafaf47092c754",
+          "0xe078d93bfdd87a8c5c5cca5905dcba0dd7a1f0bd"
+        ],
+        "disputeVerifier": "0x30d4947f005653637005eed991005119d9eb2f34",
+        "nullifierRegistryV2": "0x5455e761b866dfa6a2f5dc6d6525825bf9c09aeb",
+        "predecessorPolicy": "0xcec48f7242edbf02875bb4629115bd927e1287aa",
+        "freshPolicy": "0x46b6d18e641c14dfb15a01f767fd33cc0a6e3488",
+        "vault": "0x4d16f4a9946cfc76b1c1a4b63aa9d94cda2dbceb",
+        "predecessorHook": "0x71467dcac3b50eeed5a485ac6a70f27b1eac1970",
+        "paymentMethods": [
+          "0xcac9daea62d7b89d75ac73af4ee14dcf25721012ae82b568c2ea5c808eaa04ff",
+          "0x5908bb0c9b87763ac6171d4104847667e7f02b4c47b574fe890c1f439ed128bb",
+          "0x90262a3db0edd0be2369c6b28f9e8511ec0bac7136cefbada0880602f87e7268",
+          "0x617f88ab82b5c1b014c539f7e75121427f0bb50a4c58b187a238531e7d58605d",
+          "0x10940ee67cfb3c6c064569ec92c0ee934cd7afa18dd2ca2d6a2254fcb009c17d",
+          "0x554a007c2217df766b977723b276671aee5ebb4adaea0edb6433c88b3e61dac5",
+          "0xa5418819c024239299ea32e09defae8ec412c03e58f5c75f1b2fe84c857f5483",
+          "0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3",
+          "0x62c7ed738ad3e7618111348af32691b5767777fbaf46a2d8943237625552645c",
+          "0x3ccc3d4d5e769b1f82dc4988485551dc0cd3c7a3926d7d8a4dde91507199490f"
+        ],
+        "riskWindows": [
+          "0",
+          "0",
+          "1209600",
+          "0",
+          "1209600",
+          "0",
+          "0",
+          "0",
+          "0",
+          "1209600"
+        ]
+      },
+      true,
+      "0x84e113087c97cd80ea9d78983d4b8ff61eca1929"
+    ],
+    "deployTransactionHash": "0xccc9e1f15aeb4ef7b9e538132911be5ad27c376fac95d47c87ec35b898640e99",
+    "runtimeCodeHash": "0x19dc01a6a58ae5ef8f9c13995f91b8f1222f61df77b23e8d6cd0d7ce99a30c01"
+  },
+  "postcondition": {
+    "address": "0xee876b0751559db03aa2d18d72ce6cff6af9966d",
+    "artifactName": "DisputeMethodScopedRotationPostcondition",
+    "constructorArgs": [
+      {
+        "safe": "0x0bc26ff515411396dd588abd6ef6846e04470227",
+        "disputeRegistry": "0xa845615b5203f7a21321ddf5e3a1ca024d93a443",
+        "orchestrator": "0x014025fde093f8701d86e9f38e2c3a9b779cb5c7",
+        "orchestratorRegistry": "0xbe9fed15ed7a4b915c03efcecb9662739c3382a9",
+        "escrowRegistry": "0xed0e847b101abc96e796260ac358e12baa2f5b21",
+        "paymentVerifierRegistry": "0x2b82d24437ff66fb173eabdfd67ee2aceb8beb1e",
+        "relayerRegistry": "0xeba979889a9c97382a92472ff3703786ff180083",
+        "protocolFeeRecipient": "0x0bc26ff515411396dd588abd6ef6846e04470227",
+        "allowMultipleIntents": true,
+        "freshHook": "0x8dee00081bd075f804f4589440c331bcedeece59",
+        "whitelistPolicy": "0x389cd9ba91fffcd83d267b241e975541892759ce",
+        "groupRegistry": "0x39f80118f9eb619135f116171b6cb91d372c5af2",
+        "attestationVerifier": "0x9fe920b24e50e6a6362ba71a1beb502a99c402d5",
+        "witnesses": [
+          "0xdb4ed7faf170f0f6493e3adaacaafaf47092c754",
+          "0xe078d93bfdd87a8c5c5cca5905dcba0dd7a1f0bd"
+        ],
+        "disputeVerifier": "0x30d4947f005653637005eed991005119d9eb2f34",
+        "nullifierRegistryV2": "0x5455e761b866dfa6a2f5dc6d6525825bf9c09aeb",
+        "predecessorPolicy": "0xcec48f7242edbf02875bb4629115bd927e1287aa",
+        "freshPolicy": "0x46b6d18e641c14dfb15a01f767fd33cc0a6e3488",
+        "vault": "0x4d16f4a9946cfc76b1c1a4b63aa9d94cda2dbceb",
+        "predecessorHook": "0x71467dcac3b50eeed5a485ac6a70f27b1eac1970",
+        "paymentMethods": [
+          "0xcac9daea62d7b89d75ac73af4ee14dcf25721012ae82b568c2ea5c808eaa04ff",
+          "0x5908bb0c9b87763ac6171d4104847667e7f02b4c47b574fe890c1f439ed128bb",
+          "0x90262a3db0edd0be2369c6b28f9e8511ec0bac7136cefbada0880602f87e7268",
+          "0x617f88ab82b5c1b014c539f7e75121427f0bb50a4c58b187a238531e7d58605d",
+          "0x10940ee67cfb3c6c064569ec92c0ee934cd7afa18dd2ca2d6a2254fcb009c17d",
+          "0x554a007c2217df766b977723b276671aee5ebb4adaea0edb6433c88b3e61dac5",
+          "0xa5418819c024239299ea32e09defae8ec412c03e58f5c75f1b2fe84c857f5483",
+          "0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3",
+          "0x62c7ed738ad3e7618111348af32691b5767777fbaf46a2d8943237625552645c",
+          "0x3ccc3d4d5e769b1f82dc4988485551dc0cd3c7a3926d7d8a4dde91507199490f"
+        ],
+        "riskWindows": [
+          "0",
+          "0",
+          "1209600",
+          "0",
+          "1209600",
+          "0",
+          "0",
+          "0",
+          "0",
+          "1209600"
+        ]
+      },
+      "172800"
+    ],
+    "deployTransactionHash": "0x3be6d0a990ca4725ea0308cd0e460d1aae2f71ef5e539f0feed22c24cfb51622",
+    "runtimeCodeHash": "0xa1ee37893f7c74ef996547c7d5f6a2baeb12597f6191cf5cb65606d080e2ff73"
+  },
+  "trustSurface": {
+    "safe": "0x0bc26ff515411396dd588abd6ef6846e04470227",
+    "disputeRegistry": "0xa845615b5203f7a21321ddf5e3a1ca024d93a443",
+    "orchestrator": "0x014025fde093f8701d86e9f38e2c3a9b779cb5c7",
+    "orchestratorRegistry": "0xbe9fed15ed7a4b915c03efcecb9662739c3382a9",
+    "escrowRegistry": "0xed0e847b101abc96e796260ac358e12baa2f5b21",
+    "paymentVerifierRegistry": "0x2b82d24437ff66fb173eabdfd67ee2aceb8beb1e",
+    "relayerRegistry": "0xeba979889a9c97382a92472ff3703786ff180083",
+    "protocolFeeRecipient": "0x0bc26ff515411396dd588abd6ef6846e04470227",
+    "allowMultipleIntents": true,
+    "freshHook": "0x8dee00081bd075f804f4589440c331bcedeece59",
+    "whitelistPolicy": "0x389cd9ba91fffcd83d267b241e975541892759ce",
+    "groupRegistry": "0x39f80118f9eb619135f116171b6cb91d372c5af2",
+    "attestationVerifier": "0x9fe920b24e50e6a6362ba71a1beb502a99c402d5",
+    "witnesses": [
+      "0xdb4ed7faf170f0f6493e3adaacaafaf47092c754",
+      "0xe078d93bfdd87a8c5c5cca5905dcba0dd7a1f0bd"
+    ],
+    "disputeVerifier": "0x30d4947f005653637005eed991005119d9eb2f34",
+    "nullifierRegistryV2": "0x5455e761b866dfa6a2f5dc6d6525825bf9c09aeb",
+    "predecessorPolicy": "0xcec48f7242edbf02875bb4629115bd927e1287aa",
+    "freshPolicy": "0x46b6d18e641c14dfb15a01f767fd33cc0a6e3488",
+    "vault": "0x4d16f4a9946cfc76b1c1a4b63aa9d94cda2dbceb",
+    "predecessorHook": "0x71467dcac3b50eeed5a485ac6a70f27b1eac1970",
+    "paymentMethods": [
+      "0xcac9daea62d7b89d75ac73af4ee14dcf25721012ae82b568c2ea5c808eaa04ff",
+      "0x5908bb0c9b87763ac6171d4104847667e7f02b4c47b574fe890c1f439ed128bb",
+      "0x90262a3db0edd0be2369c6b28f9e8511ec0bac7136cefbada0880602f87e7268",
+      "0x617f88ab82b5c1b014c539f7e75121427f0bb50a4c58b187a238531e7d58605d",
+      "0x10940ee67cfb3c6c064569ec92c0ee934cd7afa18dd2ca2d6a2254fcb009c17d",
+      "0x554a007c2217df766b977723b276671aee5ebb4adaea0edb6433c88b3e61dac5",
+      "0xa5418819c024239299ea32e09defae8ec412c03e58f5c75f1b2fe84c857f5483",
+      "0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3",
+      "0x62c7ed738ad3e7618111348af32691b5767777fbaf46a2d8943237625552645c",
+      "0x3ccc3d4d5e769b1f82dc4988485551dc0cd3c7a3926d7d8a4dde91507199490f"
+    ],
+    "riskWindows": [
+      "0",
+      "0",
+      "1209600",
+      "0",
+      "1209600",
+      "0",
+      "0",
+      "0",
+      "0",
+      "1209600"
+    ]
+  },
+  "proofSnapshot": {
+    "network": "base",
+    "blockNumber": 50532492,
+    "blockHash": "0x5f8032268c330337dd7bb536acf16a50b40054abe8dcc673377e591b0de2ae2f",
+    "blockTimestamp": "1787854331",
+    "freshPolicy": {
+      "owner": "0x84e113087c97cd80ea9d78983d4b8ff61eca1929",
+      "pendingOwner": "0x0bc26ff515411396dd588abd6ef6846e04470227",
+      "admissionsPaused": false,
+      "disputeVerifier": "0x30d4947f005653637005eed991005119d9eb2f34",
+      "disputeNullifierRegistry": "0xa845615b5203f7a21321ddf5e3a1ca024d93a443",
+      "stakeVault": "0x4d16f4a9946cfc76b1c1a4b63aa9d94cda2dbceb",
+      "authorizedHooks": [
+        "0x8dee00081bd075f804f4589440c331bcedeece59"
+      ],
+      "riskWindows": {
+        "0xcac9daea62d7b89d75ac73af4ee14dcf25721012ae82b568c2ea5c808eaa04ff": "0",
+        "0x5908bb0c9b87763ac6171d4104847667e7f02b4c47b574fe890c1f439ed128bb": "0",
+        "0x90262a3db0edd0be2369c6b28f9e8511ec0bac7136cefbada0880602f87e7268": "1209600",
+        "0x617f88ab82b5c1b014c539f7e75121427f0bb50a4c58b187a238531e7d58605d": "0",
+        "0x10940ee67cfb3c6c064569ec92c0ee934cd7afa18dd2ca2d6a2254fcb009c17d": "1209600",
+        "0x554a007c2217df766b977723b276671aee5ebb4adaea0edb6433c88b3e61dac5": "0",
+        "0xa5418819c024239299ea32e09defae8ec412c03e58f5c75f1b2fe84c857f5483": "0",
+        "0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3": "0",
+        "0x62c7ed738ad3e7618111348af32691b5767777fbaf46a2d8943237625552645c": "0",
+        "0x3ccc3d4d5e769b1f82dc4988485551dc0cd3c7a3926d7d8a4dde91507199490f": "1209600"
+      }
+    },
+    "predecessorPolicy": {
+      "owner": "0x0bc26ff515411396dd588abd6ef6846e04470227",
+      "pendingOwner": "0x0000000000000000000000000000000000000000",
+      "admissionsPaused": false,
+      "disputeVerifier": "0x30d4947f005653637005eed991005119d9eb2f34",
+      "disputeNullifierRegistry": "0xa845615b5203f7a21321ddf5e3a1ca024d93a443"
+    },
+    "disputeVerifier": {
+      "owner": "0x0bc26ff515411396dd588abd6ef6846e04470227",
+      "pendingOwner": "0x0000000000000000000000000000000000000000",
+      "attestationVerifier": "0x9fe920b24e50e6a6362ba71a1beb502a99c402d5",
+      "nullifierRegistry": "0x5455e761b866dfa6a2f5dc6d6525825bf9c09aeb"
+    },
+    "vault": {
+      "owner": "0x0bc26ff515411396dd588abd6ef6846e04470227",
+      "pendingOwner": "0x0000000000000000000000000000000000000000",
+      "controller": "0xcec48f7242edbf02875bb4629115bd927e1287aa",
+      "pendingController": "0x0000000000000000000000000000000000000000",
+      "pendingControllerValidAt": "0",
+      "controllerChangeDelay": "172800",
+      "stakeToken": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+    },
+    "registry": {
+      "owner": "0x0bc26ff515411396dd588abd6ef6846e04470227",
+      "writers": [
+        "0xcec48f7242edbf02875bb4629115bd927e1287aa"
+      ]
+    },
+    "orchestrator": {
+      "owner": "0x0bc26ff515411396dd588abd6ef6846e04470227",
+      "paused": false,
+      "lifecycleHook": "0x71467dcac3b50eeed5a485ac6a70f27b1eac1970",
+      "escrowRegistry": "0xed0e847b101abc96e796260ac358e12baa2f5b21",
+      "paymentVerifierRegistry": "0x2b82d24437ff66fb173eabdfd67ee2aceb8beb1e",
+      "relayerRegistry": "0xeba979889a9c97382a92472ff3703786ff180083",
+      "protocolFee": "0",
+      "protocolFeeRecipient": "0x0bc26ff515411396dd588abd6ef6846e04470227",
+      "allowMultipleIntents": true,
+      "registered": true
+    },
+    "freshHook": {
+      "orchestratorRegistry": "0xbe9fed15ed7a4b915c03efcecb9662739c3382a9",
+      "whitelistPolicy": "0x389cd9ba91fffcd83d267b241e975541892759ce",
+      "disputeProtectionPolicy": "0x46b6d18e641c14dfb15a01f767fd33cc0a6e3488"
+    },
+    "whitelistPolicy": {
+      "owner": "0x0bc26ff515411396dd588abd6ef6846e04470227",
+      "escrowRegistry": "0xed0e847b101abc96e796260ac358e12baa2f5b21",
+      "groupRegistry": "0x39f80118f9eb619135f116171b6cb91d372c5af2",
+      "orchestratorRegistry": "0xbe9fed15ed7a4b915c03efcecb9662739c3382a9"
+    },
+    "attestationVerifier": {
+      "owner": "0x0bc26ff515411396dd588abd6ef6846e04470227",
+      "requiredSignatures": "1",
+      "witnesses": [
+        "0xdb4ed7faf170f0f6493e3adaacaafaf47092c754",
+        "0xe078d93bfdd87a8c5c5cca5905dcba0dd7a1f0bd"
+      ]
+    },
+    "lockProof": {
+      "fromBlock": 50201693,
+      "toBlock": 50532492,
+      "intents": [
+        {
+          "intentHash": "0x00f53cecf2ea9c6ac3af4876d3fc1abf4c9f2355efe032d8ce333ee3a6bd6f6b",
+          "status": 2,
+          "lockAmount": "0",
+          "maturesAt": "0",
+          "classification": "terminal"
+        },
+        {
+          "intentHash": "0x133ab131e279bcda3e1cfad95780409aaf22ac32058effbdbb8373ad90f44d72",
+          "status": 2,
+          "lockAmount": "0",
+          "maturesAt": "0",
+          "classification": "terminal"
+        },
+        {
+          "intentHash": "0x2c5695a501b1566d8cd4fbd82dfad8496894cda6dc5c1255dcd00858e8e8b469",
+          "status": 3,
+          "lockAmount": "105263",
+          "maturesAt": "1788819021",
+          "classification": "settled-unmatured"
+        },
+        {
+          "intentHash": "0x027182217e9e0a1aebb196d4f635d5eabbee18161502f4a98eb9e50e9b40ba37",
+          "status": 2,
+          "lockAmount": "0",
+          "maturesAt": "0",
+          "classification": "terminal"
+        },
+        {
+          "intentHash": "0x1db13804a43460e863760372e1324662bd5375a424273396c3915ab18a7fe72d",
+          "status": 3,
+          "lockAmount": "1000000",
+          "maturesAt": "1789039859",
+          "classification": "settled-unmatured"
+        }
+      ],
+      "ok": false,
+      "releasable": [],
+      "blocking": [
+        "0x2c5695a501b1566d8cd4fbd82dfad8496894cda6dc5c1255dcd00858e8e8b469",
+        "0x1db13804a43460e863760372e1324662bd5375a424273396c3915ab18a7fe72d"
+      ],
+      "earliestMaturity": "1788819021"
+    },
+    "inventory": {
+      "escrow": "0x777777779d229cdf3110e9de47943791c26300ef",
+      "depositCounter": "4309",
+      "block": 50532492,
+      "tuples": [],
+      "violations": [],
+      "ok": true
+    }
+  },
+  "manifestSha256": "34ee21e4e0eba334d1dc326c96060a1b29006381cecbacac371bc0fc723a8d7c"
+}


### PR DESCRIPTION
## Summary
Records the lane-38 **rotation** Safe batch for Base, prepared from canonical main `11b405f`:
- Guard `0x4fe80b802a1899e8999cb57e3fb1ffb13017857b`, postcondition `0xee876b0751559db03aa2d18d72ce6cff6af9966d` (deployer-deployed; the earlier orphaned guard `0x281e…D56C` from the aborted first run is not referenced).
- Proof block 50532492 → simulation block 50532595, pinned-fork simulation `success`, Safe nonce 77, 4 transactions: guard `assertReady`, fresh policy `acceptOwnership`, OptIn policy `setAdmissionsPaused(true)`, `StakeVaultOptIn.proposeController(freshPolicy)`.
- Queued in the Safe as safeTxHash `0x4929bba2…9266` (supersedes the standalone `acceptOwnership` at nonce 77). **Not executed.** `yarn verify:method-scoped-safe-batch --batch rotation` (artifact-child mode) is the pre-signing gate.

Only the artifact pair changes (required by the verifier's artifact-child allowlist). Lane 38 pinning happens after its first live transition, in a later recording PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tzc4JYcsy2feiByPEeQXrc