### PR TITLE
fix(scripts): load activation records before verifying a Safe batch

### DIFF
--- a/deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts
+++ b/deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts
@@ -341,6 +341,14 @@ async function resolveActivationContext(
   };
 }
 
+export async function loadActivationContext(
+  hre: HardhatRuntimeEnvironment,
+  network: ActivationNetwork
+): Promise<void> {
+  if (expectedCache.has(network)) return;
+  await resolveActivationContext(hre, network);
+}
+
 export function expectedActivationState(
   network: ActivationNetwork
 ): ExpectedActivationState {

--- a/scripts/test-method-scoped-activation.cjs
+++ b/scripts/test-method-scoped-activation.cjs
@@ -2338,6 +2338,94 @@ test("artifact-child Git mode allows only the selected lane-38 pair and its supe
   );
 });
 
+test("artifact-child verifier loads Base activation records from a cold lane module", async () => {
+  const {
+    verifyActivationCandidate,
+  } = require("./verify-method-scoped-safe-batch.ts");
+  const { BASE_SAFE } = require("./simulate-dispute-opt-in-safe-batch.ts");
+  const lanePath = require.resolve(
+    "../deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts"
+  );
+  delete require.cache[lanePath];
+
+  const repository = temporaryGitRepository("method-scoped-cold-child-");
+  const paths = ACTIVATION_BATCH_PATHS.rotation;
+  const manifest = manifestFixture();
+  manifest.safe = BASE_SAFE.toLowerCase();
+  manifest.sourceSha = repository.sourceSha;
+  manifest.proofSnapshot.inventory.escrow =
+    require("../deployments/base/EscrowV2.json").address.toLowerCase();
+  const { manifestSha256: _oldDigest, ...unsigned } = manifest;
+  manifest.manifestSha256 = computeManifestSha256(unsigned);
+  const batch = safeBatchJson("rotation", manifest.transactions, 1234);
+  const batchPath = join(repository.root, paths.batch);
+  const sidecarPath = join(repository.root, paths.sidecar);
+  mkdirSync(join(repository.root, "deployments/outputs/safe-batches"), {
+    recursive: true,
+  });
+  writeFileSync(batchPath, JSON.stringify(batch));
+  writeFileSync(sidecarPath, JSON.stringify(manifest));
+  execFileSync("git", ["add", "."], { cwd: repository.root });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=Task Four",
+      "-c",
+      "user.email=task4@example.invalid",
+      "commit",
+      "-qm",
+      "artifacts",
+    ],
+    { cwd: repository.root }
+  );
+
+  const provider = {
+    _isProvider: true,
+    getNetwork: async () => ({ chainId: 8453, name: "base" }),
+    /** @param {string | number} blockTag */
+    getBlock: async (blockTag) =>
+      blockTag === manifest.proofBlock.number
+        ? {
+            number: manifest.proofBlock.number,
+            hash: manifest.proofBlock.hash,
+            timestamp: manifest.proofBlock.number,
+          }
+        : { number: 300, hash: hash(300), timestamp: 300 },
+    /** @param {string} name */
+    resolveName: async (name) => name,
+    call: async () =>
+      utils.defaultAbiCoder.encode(["uint256"], [manifest.safeNonce]),
+  };
+  const hre = /** @type {any} */ ({
+    __methodScopedVerificationProvider: provider,
+    deployments: {
+      /** @param {string} name */
+      get: async (name) => require(`../deployments/base/${name}.json`),
+      getExtendedArtifact: async () => {
+        throw new Error("guard identity boundary reached");
+      },
+      getArtifact: async () => {
+        throw new Error("unexpected artifact lookup");
+      },
+    },
+    ethers: ethersPackage,
+  });
+
+  await assert.rejects(
+    verifyActivationCandidate(hre, {
+      kind: "rotation",
+      batch: undefined,
+      manifest: undefined,
+      mode: "artifact-child",
+      repositoryRoot: repository.root,
+      forkRpcUrl: "fake-rpc",
+      artifactPaths: { batch: batchPath, sidecar: sidecarPath },
+    }),
+    /guard identity boundary reached/
+  );
+});
+
 /**
  * @param {"rotation" | "cutover"} kind
  * @param {{ nonce?: string, proofBlockHash?: string, snapshotAtF?: import("../deployments/methodScopedActivation").ActivationSnapshot, simulationError?: Error }} [overrides]

--- a/scripts/verify-method-scoped-safe-batch.ts
+++ b/scripts/verify-method-scoped-safe-batch.ts
@@ -363,6 +363,7 @@ export async function verifyActivationCandidate(
     throw new Error("Safe nonce drifted from the manifest");
   }
   const lane = require("../deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts");
+  await lane.loadActivationContext(verificationHre, "base");
   const expected = lane.expectedActivationState("base");
   if (
     manifest.proofSnapshot.inventory.escrow.toLowerCase() !==


### PR DESCRIPTION
## Summary
The standalone artifact-child verifier (`yarn verify:method-scoped-safe-batch --batch rotation`, the mandatory pre-signing gate) ran in a cold process and called lane 38's `expectedActivationState("base")` before anything had loaded the Base deployment records, throwing `Activation deployment records for base have not been loaded`. It worked in generation mode only because the lane had already loaded them.

- Lane 38 exports an idempotent activation-context loader; the verifier awaits it before reading expected state or snapshots.
- Regression: artifact-child verification against a fresh require of the lane module.

Consequence (by design, not changed here): because this commit touches non-artifact paths after the recorded source SHA `11b405f`, the currently queued rotation batch must be regenerated from the new main before the verifier can pass; that regeneration follows this merge.

## Test Plan
- [x] `yarn test:method-scoped-activation` 43+2+3, typecheck
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tzc4JYcsy2feiByPEeQXrc