### PR TITLE
chore(release): select the dedicated-vault stack for both networks, contracts-v2 0.4.1-rc.8

### DIFF
--- a/.github/workflows/publish-contracts-v2.yml
+++ b/.github/workflows/publish-contracts-v2.yml
@@ -33,7 +33,7 @@ env:
   RELEASE_VERSION: ${{ inputs.release }}
   RELEASE_TAG: contracts-v2-v${{ inputs.release }}
   LATEST_BASELINE: 0.4.0
-  RC_BASELINE: 0.4.1-rc.6
+  RC_BASELINE: 0.4.1-rc.7
   NPM_CONFIG_PROVENANCE: "true"
   REQUIRE_PROVENANCE: "true"
   RECOVERY_MODE: ${{ inputs.recovery }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,11 @@ The package intentionally exports V3 source ABIs and current Base-staging
 lifecycle addresses while Base production may have no corresponding active V3
 address. Never invent a zero address, copy a staging address into Base, publish
 an inactive address as active, or remove an ABI merely because the contract is
-not deployed on every network.
+not deployed on every network. One explicit exception (decided 2026-08-28): a
+release candidate may front-run an approved, already-queued governance cutover
+so clients can sync before it executes, provided the package's dispute-stack
+readiness metadata and README state that the cutover is pending and name the
+Safe transaction.
 
 Any publication must use
 `.agents/skills/zkp2p-contracts-publish/SKILL.md`; never publish locally or

--- a/README.md
+++ b/README.md
@@ -785,6 +785,16 @@ terminal and `StakeVaultOptIn` holds no locks. Artifacts live at
 Stake in the old vaults is abandoned: stakers withdraw once their locks release and takers re-stake in the new vault
 before the cutover; that readiness is part of `CONFIRM_BASE_V3_DISPUTE_METHOD_SCOPED_VAULT_DOWNSTREAM_READY`.
 
+The `0.4.1-rc.8` package front-runs the approved Base cutover so downstream clients can sync first. On both Base and
+Base staging its canonical `StakeVault`, `DisputeProtectionPolicy`, `IntentLifecycleHookV1`, and `WhitelistPolicy`
+keys select `StakeVaultMethodScoped`, `DisputeProtectionPolicyMethodScopedStaked`,
+`IntentLifecycleHookV1MethodScopedStaked`, and `WhitelistPolicyMethodScoped`, respectively. The package dispute-stack
+manifest exposes `activation.status`: Base staging is `activated`; Base is `pending` at Safe
+`0x0bC26FF515411396DD588Abd6Ef6846E04470227`, nonce 77, Safe transaction hash
+`0x6dd4de20ac21ac2961653dd3ea07c3ab79281ce472dd5a74ec791f659620f3c9`. Until that transaction executes, Base O3
+still uses `IntentLifecycleHookV1OptIn` at `0x71467dCac3B50eeED5A485aC6a70f27B1EAC1970`, and the registry writer remains
+`DisputeProtectionPolicyOptIn` at `0xcEc48F7242eDBf02875BB4629115Bd927e1287aA`.
+
 Dispute-evidence issuance in `attestation-service` remains a separate follow-up and is intentionally not implemented
 by these contract lanes. Only PayPal, Venmo, and Cash App receive non-zero onchain risk windows, matching the
 explicitly ratified chargebackable-platform set.

--- a/deployments/active-dispute-stack.json
+++ b/deployments/active-dispute-stack.json
@@ -1,25 +1,29 @@
 {
-  "version": 1,
+  "version": 2,
   "networks": {
     "base": {
-      "StakeVault": "StakeVaultOptIn",
-      "DisputeProtectionPolicy": "DisputeProtectionPolicyOptIn",
-      "IntentLifecycleHookV1": "IntentLifecycleHookV1OptIn"
+      "StakeVault": "StakeVaultMethodScoped",
+      "DisputeProtectionPolicy": "DisputeProtectionPolicyMethodScopedStaked",
+      "IntentLifecycleHookV1": "IntentLifecycleHookV1MethodScopedStaked",
+      "WhitelistPolicy": "WhitelistPolicyMethodScoped"
     },
     "base_staging": {
-      "StakeVault": "StakeVaultOptIn",
-      "DisputeProtectionPolicy": "DisputeProtectionPolicyOptIn",
-      "IntentLifecycleHookV1": "IntentLifecycleHookV1OptIn"
+      "StakeVault": "StakeVaultMethodScoped",
+      "DisputeProtectionPolicy": "DisputeProtectionPolicyMethodScopedStaked",
+      "IntentLifecycleHookV1": "IntentLifecycleHookV1MethodScopedStaked",
+      "WhitelistPolicy": "WhitelistPolicyMethodScoped"
     },
     "localhost": {
       "StakeVault": "StakeVaultMethodScoped",
       "DisputeProtectionPolicy": "DisputeProtectionPolicyMethodScopedStaked",
-      "IntentLifecycleHookV1": "IntentLifecycleHookV1MethodScopedStaked"
+      "IntentLifecycleHookV1": "IntentLifecycleHookV1MethodScopedStaked",
+      "WhitelistPolicy": "WhitelistPolicyMethodScoped"
     },
     "hardhat": {
       "StakeVault": "StakeVaultMethodScoped",
       "DisputeProtectionPolicy": "DisputeProtectionPolicyMethodScopedStaked",
-      "IntentLifecycleHookV1": "IntentLifecycleHookV1MethodScopedStaked"
+      "IntentLifecycleHookV1": "IntentLifecycleHookV1MethodScopedStaked",
+      "WhitelistPolicy": "WhitelistPolicyMethodScoped"
     }
   }
 }

--- a/deployments/activeDisputeStack.cjs
+++ b/deployments/activeDisputeStack.cjs
@@ -2,7 +2,7 @@
 
 const { createHash } = require("crypto");
 
-/** @typedef {"StakeVault" | "DisputeProtectionPolicy" | "IntentLifecycleHookV1"} CanonicalName */
+/** @typedef {"StakeVault" | "DisputeProtectionPolicy" | "IntentLifecycleHookV1" | "WhitelistPolicy"} CanonicalName */
 /** @typedef {"base" | "base_staging" | "localhost" | "hardhat"} DisputeNetwork */
 /** @typedef {{ abi?: unknown[], address?: string, [key: string]: unknown }} DeploymentEntry */
 
@@ -14,6 +14,7 @@ const CANONICAL_NAMES = [
   "StakeVault",
   "DisputeProtectionPolicy",
   "IntentLifecycleHookV1",
+  "WhitelistPolicy",
 ];
 const INTERNAL_POLICY_RECORDS = [
   "WhitelistPolicyMethodScoped",
@@ -33,7 +34,7 @@ const SUPPORTED_NETWORKS = new Set([
 
 function validateManifest() {
   if (
-    manifest.version !== 1 ||
+    manifest.version !== 2 ||
     !manifest.networks ||
     typeof manifest.networks !== "object"
   ) {
@@ -144,15 +145,6 @@ function hasCurrentDisputeSelectionStamp(network, stamp) {
 }
 
 /**
- * @param {unknown[] | undefined} left
- * @param {unknown[] | undefined} right
- * @returns {boolean}
- */
-function sameAbi(left, right) {
-  return JSON.stringify(left || []) === JSON.stringify(right || []);
-}
-
-/**
  * @param {string} network
  * @param {Record<string, DeploymentEntry>} contracts
  * @param {{ version?: unknown, selectionHash?: unknown } | undefined} [selectionStamp]
@@ -177,16 +169,6 @@ function resolveActiveDisputeAliases(network, contracts, selectionStamp) {
         : undefined);
     if (!selected) {
       throw new Error(`Missing active dispute deployment ${internalName}`);
-    }
-    const existingPublic = contracts[canonicalName];
-    if (
-      internalName !== canonicalName &&
-      existingPublic &&
-      !sameAbi(existingPublic.abi, selected.abi)
-    ) {
-      throw new Error(
-        `Active dispute deployment ABI mismatch for ${canonicalName}`
-      );
     }
     resolved[canonicalName] = selected;
   }

--- a/deployments/dispute-stack-evidence.json
+++ b/deployments/dispute-stack-evidence.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "riskWindowSecondsByPaymentMethod": {
     "base": {
       "0x10940ee67cfb3c6c064569ec92c0ee934cd7afa18dd2ca2d6a2254fcb009c17d": "1209600",
@@ -33,18 +33,6 @@
     "depositId": "0",
     "expected": false
   },
-  "prerequisites": {
-    "orchestratorPaused": false,
-    "admissionsPaused": false,
-    "allowMultipleIntents": true,
-    "orchestratorRegistered": true,
-    "lifecycleHookAuthorized": true,
-    "disputeNullifierWriterAuthorized": true,
-    "vaultControllerActivated": true,
-    "vaultPendingController": "0x0000000000000000000000000000000000000000",
-    "vaultPendingControllerValidAt": "0",
-    "pendingCoverageMaturity": "18446744073709551615"
-  },
   "networks": {
     "base": {
       "governance": {
@@ -58,27 +46,45 @@
           "0xE078D93bFdd87A8c5C5cCA5905DCbA0Dd7A1F0BD"
         ]
       },
+      "activation": {
+        "status": "pending",
+        "safe": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+        "nonce": 77,
+        "safeTxHash": "0x6dd4de20ac21ac2961653dd3ea07c3ab79281ce472dd5a74ec791f659620f3c9"
+      },
+      "prerequisites": {
+        "orchestratorPaused": false,
+        "admissionsPaused": false,
+        "allowMultipleIntents": true,
+        "orchestratorRegistered": true,
+        "lifecycleHookAuthorized": true,
+        "disputeNullifierWriterAuthorized": true,
+        "vaultControllerActivated": true,
+        "vaultPendingController": "0x0000000000000000000000000000000000000000",
+        "vaultPendingControllerValidAt": "0",
+        "pendingCoverageMaturity": "18446744073709551615"
+      },
       "activeDisputeStack": {
-        "version": 1,
-        "selectionHash": "a4f17ae7c1620ecfe7d036f0b9cc7b39c50e1382dc8dc14d2e5f7f21061cd5ad"
+        "version": 2,
+        "selectionHash": "ba40c2954b408d0c658881a8d28e5bfcc9bade5cc3d953fd17eae1eca69d841c"
       },
       "recognizedPredecessorHook": {
-        "address": "0x251d78fb6bBb4071995Bce74bAfC9E4168638622",
-        "runtimeCodeHash": "0x03d02863ed5eaa096d4089cb1e126681c0621d99409124f4af5be7ed83e341fe"
+        "address": "0x71467dCac3B50eeED5A485aC6a70f27B1EAC1970",
+        "runtimeCodeHash": "0x35789014e608a248f3244b61210fa259fee3566c33f50fd0e3fa1f5ae22e370b"
       },
       "recognizedPredecessorPolicy": {
-        "address": "0xc086b6120B5e61EF48221E6A78c69737c9948dF9",
-        "runtimeCodeHash": "0xf08bce9ad622b9d45ce310493627cbef3bf6c4ac915661d5bc572bb59b61e084"
+        "address": "0xcEc48F7242eDBf02875BB4629115Bd927e1287aA",
+        "runtimeCodeHash": "0x9c4be279da216021183638eaef79ebf98db248472685e9ecd0de3f24a513a641"
       },
       "addresses": {
         "Orchestrator": "0x88888883Ed048FF0a415271B28b2F52d431810D0",
         "OrchestratorV2": "0x888888359E981B5225CA48fbCdCeff702FC3b888",
         "OrchestratorV3": "0x014025fDE093f8701d86e9f38e2C3a9b779cb5c7",
-        "StakeVault": "0x4d16F4a9946CfC76b1c1A4B63aa9D94cdA2dbCEB",
-        "DisputeProtectionPolicy": "0xcEc48F7242eDBf02875BB4629115Bd927e1287aA",
-        "IntentLifecycleHookV1": "0x71467dCac3B50eeED5A485aC6a70f27B1EAC1970",
+        "StakeVault": "0x47c26258222e2f96424bD2B21bf173f0DA5034C7",
+        "DisputeProtectionPolicy": "0xbF4B769dB70DBEc89b6b2c44988304a7aD2de4Fc",
+        "IntentLifecycleHookV1": "0x5Dd6C675a7406fE8C9f0D93394a36fd6e8c50031",
         "OrchestratorRegistry": "0xBe9fED15ED7A4B915C03EFcEcb9662739C3382A9",
-        "WhitelistPolicy": "0xBC53641b4B2504f0061D6a9426C61B8eBE9B4Ff0",
+        "WhitelistPolicy": "0x389Cd9bA91FfFcd83d267B241E975541892759Ce",
         "DisputeVerifier": "0x30d4947f005653637005eed991005119D9eB2f34",
         "DisputeNullifierRegistry": "0xA845615b5203F7a21321DdF5e3a1ca024D93a443",
         "MultiAttestationVerifier": "0x9Fe920b24e50e6a6362BA71a1BeB502A99c402d5"
@@ -108,29 +114,29 @@
           "deployedBytecodeHash": "0xb3840e761def8aed11dbd20dae46415f69e2891535754f056f41eed145c96ba5"
         },
         "StakeVault": {
-          "deploymentName": "StakeVaultOptIn",
-          "solcInputHash": "f59c3f3c249f1a6cf64c3f9011ca1080",
+          "deploymentName": "StakeVaultMethodScoped",
+          "solcInputHash": "e92231251afd168f019cf92952f2a541",
           "deployedBytecodeHash": "0x3ceac244f2d721614975457b041e95f661feba8ef6bbfc73c23b55aaac27d3e6"
         },
         "DisputeProtectionPolicy": {
-          "deploymentName": "DisputeProtectionPolicyOptIn",
-          "solcInputHash": "473915707f8d5b67d8cff91bb8e90335",
-          "deployedBytecodeHash": "0xe4600241bce095f1a8789d46efb639b2d8c681a423a836c66173274b5284a788"
+          "deploymentName": "DisputeProtectionPolicyMethodScopedStaked",
+          "solcInputHash": "e92231251afd168f019cf92952f2a541",
+          "deployedBytecodeHash": "0x062855429a45681017e1082910a9ebb35e3fc3d57c2a0416f4003c2c1e327706"
         },
         "IntentLifecycleHookV1": {
+          "deploymentName": "IntentLifecycleHookV1MethodScopedStaked",
+          "solcInputHash": "e92231251afd168f019cf92952f2a541",
+          "deployedBytecodeHash": "0x22f175667caa0501ef498c0124a09393344ff254cdd9fea65fa0642ed9a4314c"
+        },
+        "RecognizedPredecessorHook": {
           "deploymentName": "IntentLifecycleHookV1OptIn",
           "solcInputHash": "473915707f8d5b67d8cff91bb8e90335",
           "deployedBytecodeHash": "0xd379478c4798979d09db6bef1dbf626739cd50ffe6469732f6e182ecb7cea7db"
         },
-        "RecognizedPredecessorHook": {
-          "deploymentName": "WhitelistLifecycleHook",
-          "solcInputHash": "1ca14361f73731f7336a0f6ab32e0034",
-          "deployedBytecodeHash": "0x580bff934d9a1b51e205becde084e8d8a9f578f27eb64a336f05400478fd4ae7"
-        },
         "RecognizedPredecessorPolicy": {
-          "deploymentName": "DisputeProtectionPolicy",
-          "solcInputHash": "4873c5befde1a76742d7cd30fb21abe1",
-          "deployedBytecodeHash": "0x6146f8eb152848ddfd40d67a152a44230ed783b6c1e768d023b88fc2a09cb38f"
+          "deploymentName": "DisputeProtectionPolicyOptIn",
+          "solcInputHash": "473915707f8d5b67d8cff91bb8e90335",
+          "deployedBytecodeHash": "0xe4600241bce095f1a8789d46efb639b2d8c681a423a836c66173274b5284a788"
         },
         "OrchestratorRegistry": {
           "deploymentName": "OrchestratorRegistry",
@@ -138,9 +144,9 @@
           "deployedBytecodeHash": "0xf0d132d621ac03181a6fade6a93bd0968d33830c8bf393793236787e7978aee1"
         },
         "WhitelistPolicy": {
-          "deploymentName": "WhitelistPolicy",
-          "solcInputHash": "1ca14361f73731f7336a0f6ab32e0034",
-          "deployedBytecodeHash": "0x68bd91b1dbb2d87201ad7b9f8ba14c4eb5c8d28d3dd794fb6299bb596855973a"
+          "deploymentName": "WhitelistPolicyMethodScoped",
+          "solcInputHash": "27fbb065a379a3f640c5d0396f99673a",
+          "deployedBytecodeHash": "0xa3cb9f8b2c979459ac7c66b08fe8a3ce62c286b68ab7a8b6e629badfd7c82b99"
         },
         "DisputeVerifier": {
           "deploymentName": "DisputeVerifier",
@@ -163,10 +169,10 @@
         "OrchestratorV2": "0xcf70a08cc24fcc00799f9f365d0998abe37c718c93ee370a78d1ca06c60d01e0",
         "OrchestratorV3": "0x4e58f26129559301c017ff264b61dd2255ed2107593d308472ef32d07b8745e9",
         "StakeVault": "0xfd8d2a910b9ac2c55675ae06d0504f9aac43b02b7022755cf229b571156c681d",
-        "DisputeProtectionPolicy": "0x9c4be279da216021183638eaef79ebf98db248472685e9ecd0de3f24a513a641",
-        "IntentLifecycleHookV1": "0x35789014e608a248f3244b61210fa259fee3566c33f50fd0e3fa1f5ae22e370b",
+        "DisputeProtectionPolicy": "0xf5a7756f16556da69c91c55bdcffd9fd95cc8cbdb772699827ec4c66db136dfe",
+        "IntentLifecycleHookV1": "0x2b479a570ddea7a990f2cae8fa95eb3b8599fc8b367332b8dab92f7d0cebf7e0",
         "OrchestratorRegistry": "0xf0d132d621ac03181a6fade6a93bd0968d33830c8bf393793236787e7978aee1",
-        "WhitelistPolicy": "0xa3cf0fdf3835887de432cbac9c192edf6c93a8589748aa93f8294333d57024b2",
+        "WhitelistPolicy": "0xa83d138a5b89d2fd2861702febc6333e542dcdc8994ee76c345dcbd22fe685a4",
         "DisputeVerifier": "0x65246e11392befc33d92246cf3ac2467d1f338a8b73c6514b76fab0a70a01ead",
         "DisputeNullifierRegistry": "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
         "MultiAttestationVerifier": "0x828a5dae520d3eaed904dfed56994dc6e892eb6416b58ad952c079e220ef841a"
@@ -184,9 +190,24 @@
           "0x4ab950AE1e3326578Bf7e643a2031E858aBa2927"
         ]
       },
+      "activation": {
+        "status": "activated"
+      },
+      "prerequisites": {
+        "orchestratorPaused": false,
+        "admissionsPaused": false,
+        "allowMultipleIntents": false,
+        "orchestratorRegistered": true,
+        "lifecycleHookAuthorized": true,
+        "disputeNullifierWriterAuthorized": true,
+        "vaultControllerActivated": true,
+        "vaultPendingController": "0x0000000000000000000000000000000000000000",
+        "vaultPendingControllerValidAt": "0",
+        "pendingCoverageMaturity": "18446744073709551615"
+      },
       "activeDisputeStack": {
-        "version": 1,
-        "selectionHash": "586c90f9de3d10b6d48f4286c709aa7f870fc2fdcfb0af1da947c1da76132dd0"
+        "version": 2,
+        "selectionHash": "6c49c1ce51eec594a22385c4efcab08aa9926b6b63a725e14a0027ec5d2f4fc9"
       },
       "recognizedPredecessorHook": {
         "address": "0x19D9F0Fcb08C60D8bd0CD061C34eae27eF8b6e65",
@@ -200,11 +221,11 @@
         "Orchestrator": "0xF9b9CD27Deea496B960b3cb5221b514705fCaF5e",
         "OrchestratorV2": "0xc17a59227B136c45fAa153086a15EF87ED14bE00",
         "OrchestratorV3": "0x2b5E8Ab562e45fA89D73802605E145ED3E3EeF4f",
-        "StakeVault": "0x01075fdCB8D38fD5A1070db41B3c00DC2459e71e",
-        "DisputeProtectionPolicy": "0x51436B8051cCf52739A2090C29DA208B70eC2663",
-        "IntentLifecycleHookV1": "0x3AB0879499b28e03bfcA4F5bC2CBe2070Fba4E36",
+        "StakeVault": "0x92d7B59E99e1CD2066540Cd2413b8714948b731f",
+        "DisputeProtectionPolicy": "0x484fA07F085eb66bb7C2b649Ea9d5894b2B6681c",
+        "IntentLifecycleHookV1": "0x5A7f6cb7397134da1fDEFA7E2D434b4Cf18E56D9",
         "OrchestratorRegistry": "0xfA6384EB6176cfEC049540526A3d2126C3666d8A",
-        "WhitelistPolicy": "0x7d9277cb8bb78a51eeaafB7CFF306E7DA4C972fD",
+        "WhitelistPolicy": "0xF79aAD1BAaB617fF3Eb299225c80893F22F743Fe",
         "DisputeVerifier": "0x973578148c5Fd49b9f68B50B26066555325AC708",
         "DisputeNullifierRegistry": "0xE0B05a9655AF0f31E32904267baa50FbC7f217ea",
         "MultiAttestationVerifier": "0x9855a39aC5975069632e91160d8712CBfF19e864"
@@ -234,19 +255,19 @@
           "deployedBytecodeHash": "0xb3840e761def8aed11dbd20dae46415f69e2891535754f056f41eed145c96ba5"
         },
         "StakeVault": {
-          "deploymentName": "StakeVaultOptIn",
-          "solcInputHash": "f59c3f3c249f1a6cf64c3f9011ca1080",
+          "deploymentName": "StakeVaultMethodScoped",
+          "solcInputHash": "e92231251afd168f019cf92952f2a541",
           "deployedBytecodeHash": "0x3ceac244f2d721614975457b041e95f661feba8ef6bbfc73c23b55aaac27d3e6"
         },
         "DisputeProtectionPolicy": {
-          "deploymentName": "DisputeProtectionPolicyOptIn",
-          "solcInputHash": "473915707f8d5b67d8cff91bb8e90335",
-          "deployedBytecodeHash": "0xe4600241bce095f1a8789d46efb639b2d8c681a423a836c66173274b5284a788"
+          "deploymentName": "DisputeProtectionPolicyMethodScopedStaked",
+          "solcInputHash": "e92231251afd168f019cf92952f2a541",
+          "deployedBytecodeHash": "0x062855429a45681017e1082910a9ebb35e3fc3d57c2a0416f4003c2c1e327706"
         },
         "IntentLifecycleHookV1": {
-          "deploymentName": "IntentLifecycleHookV1OptIn",
-          "solcInputHash": "473915707f8d5b67d8cff91bb8e90335",
-          "deployedBytecodeHash": "0xd379478c4798979d09db6bef1dbf626739cd50ffe6469732f6e182ecb7cea7db"
+          "deploymentName": "IntentLifecycleHookV1MethodScopedStaked",
+          "solcInputHash": "e92231251afd168f019cf92952f2a541",
+          "deployedBytecodeHash": "0x22f175667caa0501ef498c0124a09393344ff254cdd9fea65fa0642ed9a4314c"
         },
         "RecognizedPredecessorHook": {
           "deploymentName": "IntentLifecycleHookV1",
@@ -264,9 +285,9 @@
           "deployedBytecodeHash": "0xf0d132d621ac03181a6fade6a93bd0968d33830c8bf393793236787e7978aee1"
         },
         "WhitelistPolicy": {
-          "deploymentName": "WhitelistPolicy",
-          "solcInputHash": "9ca2a7958a6dbe68fbd75cee5825525d",
-          "deployedBytecodeHash": "0x68bd91b1dbb2d87201ad7b9f8ba14c4eb5c8d28d3dd794fb6299bb596855973a"
+          "deploymentName": "WhitelistPolicyMethodScoped",
+          "solcInputHash": "cedc4126ea83fa530559a77e184e3a56",
+          "deployedBytecodeHash": "0xa3cb9f8b2c979459ac7c66b08fe8a3ce62c286b68ab7a8b6e629badfd7c82b99"
         },
         "DisputeVerifier": {
           "deploymentName": "DisputeVerifier",
@@ -289,10 +310,10 @@
         "OrchestratorV2": "0xcf70a08cc24fcc00799f9f365d0998abe37c718c93ee370a78d1ca06c60d01e0",
         "OrchestratorV3": "0x4e58f26129559301c017ff264b61dd2255ed2107593d308472ef32d07b8745e9",
         "StakeVault": "0xfd8d2a910b9ac2c55675ae06d0504f9aac43b02b7022755cf229b571156c681d",
-        "DisputeProtectionPolicy": "0xa4c6a33333e10da596805b6127e96f78e40fe5a0f0ab0cfa8f4683fbeac91a37",
-        "IntentLifecycleHookV1": "0x376364aa8b693ee8e02eacc48527114ce3cc529714be5a3f316c7323561721ab",
+        "DisputeProtectionPolicy": "0x70c43bfae8253a6a166f9697ddc27b2d77b4d9841e01fefc2db84037d9a98622",
+        "IntentLifecycleHookV1": "0xb9ce42108c706f9241aeb41ffdc0da6b7584e8482183055452098b2f16c7abfd",
         "OrchestratorRegistry": "0xf0d132d621ac03181a6fade6a93bd0968d33830c8bf393793236787e7978aee1",
-        "WhitelistPolicy": "0x917965fdc75580147ad0787c86f8b2a0f0185ef6e101567b82dc1245d6eb63bc",
+        "WhitelistPolicy": "0x1ece96bb7be9cdd2433a2aad66c9b2d710e3e210a65876e0f8c1e43662ee5653",
         "DisputeVerifier": "0xb3b34734cfd162cd129d0c84285461c751321545213ec20164745b8e72f9dd6c",
         "DisputeNullifierRegistry": "0x1a711749b7700142265363c9c184c195ac81a1415e2142aa84edcbf1cd88142a",
         "MultiAttestationVerifier": "0x828a5dae520d3eaed904dfed56994dc6e892eb6416b58ad952c079e220ef841a"

--- a/deployments/outputs/baseContracts.ts
+++ b/deployments/outputs/baseContracts.ts
@@ -832,7 +832,7 @@ export default {
       ]
     },
     "DisputeProtectionPolicy": {
-      "address": "0xcEc48F7242eDBf02875BB4629115Bd927e1287aA",
+      "address": "0xbF4B769dB70DBEc89b6b2c44988304a7aD2de4Fc",
       "abi": [
         {
           "inputs": [
@@ -935,6 +935,11 @@ export default {
               "internalType": "uint256",
               "name": "depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
             }
           ],
           "name": "DisputeProtectionNotEnabled",
@@ -1058,6 +1063,12 @@ export default {
               "internalType": "uint256",
               "name": "depositId",
               "type": "uint256"
+            },
+            {
+              "indexed": true,
+              "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
             },
             {
               "indexed": false,
@@ -1513,6 +1524,11 @@ export default {
               "internalType": "uint256",
               "name": "_depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
             }
           ],
           "name": "isDisputeProtectionEnabled",
@@ -1702,6 +1718,11 @@ export default {
               "internalType": "uint256",
               "name": "_depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
             },
             {
               "internalType": "bool",
@@ -8078,7 +8099,7 @@ export default {
       ]
     },
     "IntentLifecycleHookV1": {
-      "address": "0x71467dCac3B50eeED5A485aC6a70f27B1EAC1970",
+      "address": "0x5Dd6C675a7406fE8C9f0D93394a36fd6e8c50031",
       "abi": [
         {
           "inputs": [
@@ -8134,6 +8155,11 @@ export default {
               "internalType": "uint256",
               "name": "depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
             },
             {
               "internalType": "address",
@@ -17436,7 +17462,7 @@ export default {
       ]
     },
     "StakeVault": {
-      "address": "0x4d16F4a9946CfC76b1c1A4B63aa9D94cdA2dbCEB",
+      "address": "0x47c26258222e2f96424bD2B21bf173f0DA5034C7",
       "abi": [
         {
           "inputs": [
@@ -20202,7 +20228,7 @@ export default {
       ]
     },
     "WhitelistPolicy": {
-      "address": "0xBC53641b4B2504f0061D6a9426C61B8eBE9B4Ff0",
+      "address": "0x389Cd9bA91FfFcd83d267B241E975541892759Ce",
       "abi": [
         {
           "inputs": [
@@ -20238,39 +20264,49 @@ export default {
               "type": "uint256"
             }
           ],
-          "name": "DepositAlreadyBootstrapped",
-          "type": "error"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "address",
-              "name": "escrow",
-              "type": "address"
-            },
-            {
-              "internalType": "uint256",
-              "name": "depositId",
-              "type": "uint256"
-            }
-          ],
-          "name": "DepositAlreadyEnabled",
-          "type": "error"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "address",
-              "name": "escrow",
-              "type": "address"
-            },
-            {
-              "internalType": "uint256",
-              "name": "depositId",
-              "type": "uint256"
-            }
-          ],
           "name": "DepositNotFound",
+          "type": "error"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "escrow",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "depositId",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
+            }
+          ],
+          "name": "DepositPaymentMethodAlreadyBootstrapped",
+          "type": "error"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "escrow",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "depositId",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
+            }
+          ],
+          "name": "DepositPaymentMethodAlreadyEnabled",
           "type": "error"
         },
         {
@@ -20348,6 +20384,11 @@ export default {
               "internalType": "uint256",
               "name": "depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
             }
           ],
           "name": "TakerNotWhitelisted",
@@ -20453,6 +20494,12 @@ export default {
             {
               "indexed": true,
               "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
+            },
+            {
+              "indexed": false,
+              "internalType": "bytes32",
               "name": "groupId",
               "type": "bytes32"
             }
@@ -20478,6 +20525,12 @@ export default {
             {
               "indexed": true,
               "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
+            },
+            {
+              "indexed": false,
+              "internalType": "bytes32",
               "name": "groupId",
               "type": "bytes32"
             }
@@ -20499,6 +20552,12 @@ export default {
               "internalType": "uint256",
               "name": "depositId",
               "type": "uint256"
+            },
+            {
+              "indexed": true,
+              "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
             },
             {
               "indexed": false,
@@ -20544,7 +20603,7 @@ export default {
         },
         {
           "inputs": [],
-          "name": "MAX_GROUPS_PER_DEPOSIT",
+          "name": "MAX_GROUPS_PER_DEPOSIT_PAYMENT_METHOD",
           "outputs": [
             {
               "internalType": "uint256",
@@ -20566,6 +20625,11 @@ export default {
               "internalType": "uint256",
               "name": "_depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
             },
             {
               "internalType": "bytes32[]",
@@ -20614,6 +20678,11 @@ export default {
               "type": "uint256[]"
             },
             {
+              "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
+            },
+            {
               "internalType": "bytes32[]",
               "name": "_groupIds",
               "type": "bytes32[]"
@@ -20635,6 +20704,11 @@ export default {
               "internalType": "uint256",
               "name": "",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
             }
           ],
           "name": "bootstrapped",
@@ -20659,6 +20733,11 @@ export default {
               "internalType": "uint256",
               "name": "_depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
             },
             {
               "internalType": "bool",
@@ -20692,6 +20771,11 @@ export default {
               "internalType": "uint256",
               "name": "",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
             }
           ],
           "name": "enabled",
@@ -20729,6 +20813,11 @@ export default {
               "internalType": "uint256",
               "name": "_depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
             }
           ],
           "name": "getAllowedGroups",
@@ -20769,6 +20858,11 @@ export default {
             },
             {
               "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32",
               "name": "_groupId",
               "type": "bytes32"
             }
@@ -20795,6 +20889,11 @@ export default {
               "internalType": "uint256",
               "name": "_depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
             },
             {
               "internalType": "address",
@@ -20881,6 +20980,11 @@ export default {
               "type": "uint256"
             },
             {
+              "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
+            },
+            {
               "internalType": "bytes32[]",
               "name": "_groupIds",
               "type": "bytes32[]"
@@ -20932,6 +21036,11 @@ export default {
               "internalType": "uint256",
               "name": "_depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
             },
             {
               "internalType": "bool",
@@ -21395,7 +21504,7 @@ export default {
     }
   },
   "activeDisputeStack": {
-    "version": 1,
-    "selectionHash": "a4f17ae7c1620ecfe7d036f0b9cc7b39c50e1382dc8dc14d2e5f7f21061cd5ad"
+    "version": 2,
+    "selectionHash": "ba40c2954b408d0c658881a8d28e5bfcc9bade5cc3d953fd17eae1eca69d841c"
   }
 } as const;

--- a/deployments/outputs/baseStagingContracts.ts
+++ b/deployments/outputs/baseStagingContracts.ts
@@ -832,7 +832,7 @@ export default {
       ]
     },
     "DisputeProtectionPolicy": {
-      "address": "0x51436B8051cCf52739A2090C29DA208B70eC2663",
+      "address": "0x484fA07F085eb66bb7C2b649Ea9d5894b2B6681c",
       "abi": [
         {
           "inputs": [
@@ -935,6 +935,11 @@ export default {
               "internalType": "uint256",
               "name": "depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
             }
           ],
           "name": "DisputeProtectionNotEnabled",
@@ -1058,6 +1063,12 @@ export default {
               "internalType": "uint256",
               "name": "depositId",
               "type": "uint256"
+            },
+            {
+              "indexed": true,
+              "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
             },
             {
               "indexed": false,
@@ -1513,6 +1524,11 @@ export default {
               "internalType": "uint256",
               "name": "_depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
             }
           ],
           "name": "isDisputeProtectionEnabled",
@@ -1702,6 +1718,11 @@ export default {
               "internalType": "uint256",
               "name": "_depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
             },
             {
               "internalType": "bool",
@@ -8078,7 +8099,7 @@ export default {
       ]
     },
     "IntentLifecycleHookV1": {
-      "address": "0x3AB0879499b28e03bfcA4F5bC2CBe2070Fba4E36",
+      "address": "0x5A7f6cb7397134da1fDEFA7E2D434b4Cf18E56D9",
       "abi": [
         {
           "inputs": [
@@ -8134,6 +8155,11 @@ export default {
               "internalType": "uint256",
               "name": "depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
             },
             {
               "internalType": "address",
@@ -17436,7 +17462,7 @@ export default {
       ]
     },
     "StakeVault": {
-      "address": "0x01075fdCB8D38fD5A1070db41B3c00DC2459e71e",
+      "address": "0x92d7B59E99e1CD2066540Cd2413b8714948b731f",
       "abi": [
         {
           "inputs": [
@@ -20202,7 +20228,7 @@ export default {
       ]
     },
     "WhitelistPolicy": {
-      "address": "0x7d9277cb8bb78a51eeaafB7CFF306E7DA4C972fD",
+      "address": "0xF79aAD1BAaB617fF3Eb299225c80893F22F743Fe",
       "abi": [
         {
           "inputs": [
@@ -20238,39 +20264,49 @@ export default {
               "type": "uint256"
             }
           ],
-          "name": "DepositAlreadyBootstrapped",
-          "type": "error"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "address",
-              "name": "escrow",
-              "type": "address"
-            },
-            {
-              "internalType": "uint256",
-              "name": "depositId",
-              "type": "uint256"
-            }
-          ],
-          "name": "DepositAlreadyEnabled",
-          "type": "error"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "address",
-              "name": "escrow",
-              "type": "address"
-            },
-            {
-              "internalType": "uint256",
-              "name": "depositId",
-              "type": "uint256"
-            }
-          ],
           "name": "DepositNotFound",
+          "type": "error"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "escrow",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "depositId",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
+            }
+          ],
+          "name": "DepositPaymentMethodAlreadyBootstrapped",
+          "type": "error"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "escrow",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "depositId",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
+            }
+          ],
+          "name": "DepositPaymentMethodAlreadyEnabled",
           "type": "error"
         },
         {
@@ -20348,6 +20384,11 @@ export default {
               "internalType": "uint256",
               "name": "depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
             }
           ],
           "name": "TakerNotWhitelisted",
@@ -20453,6 +20494,12 @@ export default {
             {
               "indexed": true,
               "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
+            },
+            {
+              "indexed": false,
+              "internalType": "bytes32",
               "name": "groupId",
               "type": "bytes32"
             }
@@ -20478,6 +20525,12 @@ export default {
             {
               "indexed": true,
               "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
+            },
+            {
+              "indexed": false,
+              "internalType": "bytes32",
               "name": "groupId",
               "type": "bytes32"
             }
@@ -20499,6 +20552,12 @@ export default {
               "internalType": "uint256",
               "name": "depositId",
               "type": "uint256"
+            },
+            {
+              "indexed": true,
+              "internalType": "bytes32",
+              "name": "paymentMethod",
+              "type": "bytes32"
             },
             {
               "indexed": false,
@@ -20544,7 +20603,7 @@ export default {
         },
         {
           "inputs": [],
-          "name": "MAX_GROUPS_PER_DEPOSIT",
+          "name": "MAX_GROUPS_PER_DEPOSIT_PAYMENT_METHOD",
           "outputs": [
             {
               "internalType": "uint256",
@@ -20566,6 +20625,11 @@ export default {
               "internalType": "uint256",
               "name": "_depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
             },
             {
               "internalType": "bytes32[]",
@@ -20614,6 +20678,11 @@ export default {
               "type": "uint256[]"
             },
             {
+              "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
+            },
+            {
               "internalType": "bytes32[]",
               "name": "_groupIds",
               "type": "bytes32[]"
@@ -20635,6 +20704,11 @@ export default {
               "internalType": "uint256",
               "name": "",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
             }
           ],
           "name": "bootstrapped",
@@ -20659,6 +20733,11 @@ export default {
               "internalType": "uint256",
               "name": "_depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
             },
             {
               "internalType": "bool",
@@ -20692,6 +20771,11 @@ export default {
               "internalType": "uint256",
               "name": "",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
             }
           ],
           "name": "enabled",
@@ -20729,6 +20813,11 @@ export default {
               "internalType": "uint256",
               "name": "_depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
             }
           ],
           "name": "getAllowedGroups",
@@ -20769,6 +20858,11 @@ export default {
             },
             {
               "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32",
               "name": "_groupId",
               "type": "bytes32"
             }
@@ -20795,6 +20889,11 @@ export default {
               "internalType": "uint256",
               "name": "_depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
             },
             {
               "internalType": "address",
@@ -20881,6 +20980,11 @@ export default {
               "type": "uint256"
             },
             {
+              "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
+            },
+            {
               "internalType": "bytes32[]",
               "name": "_groupIds",
               "type": "bytes32[]"
@@ -20932,6 +21036,11 @@ export default {
               "internalType": "uint256",
               "name": "_depositId",
               "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "_paymentMethod",
+              "type": "bytes32"
             },
             {
               "internalType": "bool",
@@ -21395,7 +21504,7 @@ export default {
     }
   },
   "activeDisputeStack": {
-    "version": 1,
-    "selectionHash": "586c90f9de3d10b6d48f4286c709aa7f870fc2fdcfb0af1da947c1da76132dd0"
+    "version": 2,
+    "selectionHash": "6c49c1ce51eec594a22385c4efcab08aa9926b6b63a725e14a0027ec5d2f4fc9"
   }
 } as const;

--- a/deployments/predecessorDisputeStack.ts
+++ b/deployments/predecessorDisputeStack.ts
@@ -34,31 +34,34 @@ export const PREDECESSOR_DISPUTE_STACKS: Record<
 > = {
   base: {
     activeLifecycleHook: {
-      address: "0x251d78fb6bBb4071995Bce74bAfC9E4168638622",
+      address: "0x71467dCac3B50eeED5A485aC6a70f27B1EAC1970",
       runtimeCodeHash:
-        "0x03d02863ed5eaa096d4089cb1e126681c0621d99409124f4af5be7ed83e341fe",
+        "0x35789014e608a248f3244b61210fa259fee3566c33f50fd0e3fa1f5ae22e370b",
     },
     contracts: {
       StakeVault: {
-        address: "0x8B8e853f47e6e0d3944e3689197B35216933dDea",
+        deploymentName: "StakeVaultOptIn",
+        address: "0x4d16F4a9946CfC76b1c1A4B63aa9D94cdA2dbCEB",
         deploymentBytecodeHash:
           "0x3ceac244f2d721614975457b041e95f661feba8ef6bbfc73c23b55aaac27d3e6",
         runtimeCodeHash:
           "0xfd8d2a910b9ac2c55675ae06d0504f9aac43b02b7022755cf229b571156c681d",
       },
       DisputeProtectionPolicy: {
-        address: "0xc086b6120B5e61EF48221E6A78c69737c9948dF9",
+        deploymentName: "DisputeProtectionPolicyOptIn",
+        address: "0xcEc48F7242eDBf02875BB4629115Bd927e1287aA",
         deploymentBytecodeHash:
-          "0x6146f8eb152848ddfd40d67a152a44230ed783b6c1e768d023b88fc2a09cb38f",
+          "0xe4600241bce095f1a8789d46efb639b2d8c681a423a836c66173274b5284a788",
         runtimeCodeHash:
-          "0xf08bce9ad622b9d45ce310493627cbef3bf6c4ac915661d5bc572bb59b61e084",
+          "0x9c4be279da216021183638eaef79ebf98db248472685e9ecd0de3f24a513a641",
       },
       IntentLifecycleHookV1: {
-        address: "0x5B0017FCA6A2131701ef718e470a3930c1b6C12c",
+        deploymentName: "IntentLifecycleHookV1OptIn",
+        address: "0x71467dCac3B50eeED5A485aC6a70f27B1EAC1970",
         deploymentBytecodeHash:
-          "0xad298e1829958f431833bf1c0e53311f27e95dd29806c4d55aa75163e6dbcc21",
+          "0xd379478c4798979d09db6bef1dbf626739cd50ffe6469732f6e182ecb7cea7db",
         runtimeCodeHash:
-          "0xff9db07ce83908b7cedb31f8c085004aa78c91bb86e0565f11fad3e4bc36c5cb",
+          "0x35789014e608a248f3244b61210fa259fee3566c33f50fd0e3fa1f5ae22e370b",
       },
       DisputeVerifier: {
         address: "0x30d4947f005653637005eed991005119D9eB2f34",
@@ -122,7 +125,7 @@ export const PREDECESSOR_DISPUTE_STACKS: Record<
   },
 };
 
-// Stack replaced by lane 37, which differs from the selected-stack predecessor on Base.
+// Stack replaced by lane 37. It now matches the selected-stack predecessor on Base.
 export const METHOD_SCOPED_PREDECESSOR_DISPUTE_STACKS: Record<
   string,
   HistoricalDisputeStack

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -2,7 +2,7 @@
 
 Official npm package for ZKP2P V2 smart contract interfaces, ABIs, addresses, and utilities.
 
-## Release 0.4.1-rc.6
+## Release 0.4.1 RC
 
 - Exports the canonical source ABIs for `DisputeNullifierRegistry`, `DisputeProtectionPolicy`,
   `DisputeVerifier`, `IntentLifecycleHookV1`, and `StakeVault`.
@@ -14,6 +14,10 @@ Official npm package for ZKP2P V2 smart contract interfaces, ABIs, addresses, an
   including runtime identities, governance ownership, attestation trust, and exact authorization sets.
 - Hard-cuts the retired `disputeReadiness` subpath in favor of `disputeStack`; runtime readiness
   remains a consumer decision based on fresh on-chain reads.
+- Front-runs the approved Base dedicated-vault cutover so clients can sync the selected addresses
+  before governance executes it. Base staging is activated; Base is pending at Safe nonce 77,
+  Safe transaction hash
+  `0x6dd4de20ac21ac2961653dd3ea07c3ab79281ce472dd5a74ec791f659620f3c9`.
 
 ## Installation
 
@@ -169,6 +173,8 @@ console.log('Decimals:', usdInfo.decimals);
 manifest pins:
 
 - The selected dispute-stack version and selection hash.
+- The network activation status. Read `activation.status`; a `pending` value also includes the
+  governing `safe`, `nonce`, and `safeTxHash`.
 - The exact successor and recognized predecessor addresses and runtime code hashes.
 - The complete approved orchestrator membership, its runtime identities, and the registry deployment
   block from which consumers reconstruct additions/removals and reject extras; plus verifier, whitelist,
@@ -177,6 +183,17 @@ manifest pins:
   admission, an unpaused orchestrator, and `allowMultipleIntents = true`.
 - The approved risk window for every active payment-method bytes32 hash: 1,209,600 seconds for
   PayPal, Venmo, and Cash App, and zero for all other active methods.
+
+This RC exports the dedicated-vault stack on both networks regardless of activation status:
+`StakeVault` selects `StakeVaultMethodScoped`, `DisputeProtectionPolicy` selects
+`DisputeProtectionPolicyMethodScopedStaked`, `IntentLifecycleHookV1` selects
+`IntentLifecycleHookV1MethodScopedStaked`, and `WhitelistPolicy` selects
+`WhitelistPolicyMethodScoped`. Base staging reports `activation.status === "activated"`. Base
+reports `activation.status === "pending"` for Safe
+`0x0bC26FF515411396DD588Abd6Ef6846E04470227`, nonce 77, and the Safe transaction hash above.
+Until that transaction executes, the live Base lifecycle hook remains `IntentLifecycleHookV1OptIn`
+at `0x71467dCac3B50eeED5A485aC6a70f27B1EAC1970` and the live writer remains
+`DisputeProtectionPolicyOptIn` at `0xcEc48F7242eDBf02875BB4629115Bd927e1287aA`.
 
 These are trusted package expectations, not a statement that governance has already activated the
 successor. A consumer must read current on-chain code and state, compare it with the manifest, and

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/contracts-v2",
-  "version": "0.4.1-rc.7",
+  "version": "0.4.1-rc.8",
   "description": "ZKP2P V2 smart contract interfaces and utilities",
   "main": "./_cjs/index.js",
   "module": "./_esm/index.js",

--- a/packages/contracts/scripts/extractors/disputeStack.ts
+++ b/packages/contracts/scripts/extractors/disputeStack.ts
@@ -11,6 +11,21 @@ import {
 } from "../../../../deployments/parameters";
 
 type ActiveDisputeStack = { version: number; selectionHash: string };
+type DisputeStackActivation =
+  | { status: "activated" }
+  | { status: "pending"; safe: string; nonce: number; safeTxHash: string };
+type DisputeStackPrerequisites = {
+  orchestratorPaused: false;
+  admissionsPaused: false;
+  allowMultipleIntents: boolean;
+  orchestratorRegistered: true;
+  lifecycleHookAuthorized: true;
+  disputeNullifierWriterAuthorized: true;
+  vaultControllerActivated: true;
+  vaultPendingController: string;
+  vaultPendingControllerValidAt: string;
+  pendingCoverageMaturity: string;
+};
 type DeploymentEntry = {
   address: string;
   deployedBytecode?: string;
@@ -49,23 +64,13 @@ type DisputeStackEvidence = {
   schemaVersion: number;
   riskWindowSecondsByPaymentMethod: Record<string, Record<string, string>>;
   sentinel: { escrow: string; depositId: string; expected: false };
-  prerequisites: {
-    orchestratorPaused: false;
-    admissionsPaused: false;
-    allowMultipleIntents: true;
-    orchestratorRegistered: true;
-    lifecycleHookAuthorized: true;
-    disputeNullifierWriterAuthorized: true;
-    vaultControllerActivated: true;
-    vaultPendingController: string;
-    vaultPendingControllerValidAt: string;
-    pendingCoverageMaturity: string;
-  };
   networks: Record<
     string,
     {
       governance: { owner: string; pendingOwner: string };
       attestationTrust: { requiredSignatures: string; witnesses: string[] };
+      activation: DisputeStackActivation;
+      prerequisites: DisputeStackPrerequisites;
       activeDisputeStack: ActiveDisputeStack;
       recognizedPredecessorHook: RuntimeIdentity;
       recognizedPredecessorPolicy: RuntimeIdentity;
@@ -199,17 +204,17 @@ function readDeployment(network: string, deploymentName: string): DeploymentEntr
 }
 
 function deploymentName(manifestNetwork: string, canonicalName: string): string {
-  if (["StakeVault", "DisputeProtectionPolicy", "IntentLifecycleHookV1"].includes(canonicalName)) {
+  if (["StakeVault", "DisputeProtectionPolicy", "IntentLifecycleHookV1", "WhitelistPolicy"].includes(canonicalName)) {
     return getActiveDisputeDeploymentName(manifestNetwork, canonicalName);
   }
   return canonicalName;
 }
 
 function validateEvidence(network: (typeof NETWORKS)[number], output: DeploymentOutput): void {
-  if (EVIDENCE.schemaVersion !== 1) throw new Error("Unsupported dispute stack evidence schema");
+  if (EVIDENCE.schemaVersion !== 2) throw new Error("Unsupported dispute stack evidence schema");
   requireExactKeys(
     EVIDENCE as unknown as Record<string, unknown>,
-    ["schemaVersion", "riskWindowSecondsByPaymentMethod", "sentinel", "prerequisites", "networks"],
+    ["schemaVersion", "riskWindowSecondsByPaymentMethod", "sentinel", "networks"],
     "Dispute stack evidence",
   );
   requireExactKeys(EVIDENCE.networks, ["base", "base_staging"], "Dispute stack evidence networks");
@@ -225,6 +230,8 @@ function validateEvidence(network: (typeof NETWORKS)[number], output: Deployment
     [
       "governance",
       "attestationTrust",
+      "activation",
+      "prerequisites",
       "activeDisputeStack",
       "recognizedPredecessorHook",
       "recognizedPredecessorPolicy",
@@ -241,6 +248,20 @@ function validateEvidence(network: (typeof NETWORKS)[number], output: Deployment
   }
   if (!sameJson(output.activeDisputeStack, expectedSelection)) {
     throw new Error(`${network.manifestName} deployment output selection stamp mismatch`);
+  }
+  if (
+    (evidence.activation.status === "activated" &&
+      Object.keys(evidence.activation).length !== 1) ||
+    (evidence.activation.status === "pending" &&
+      (!ADDRESS_PATTERN.test(evidence.activation.safe) ||
+        !Number.isSafeInteger(evidence.activation.nonce) ||
+        evidence.activation.nonce < 0 ||
+        !HASH_PATTERN.test(evidence.activation.safeTxHash) ||
+        Object.keys(evidence.activation).length !== 4)) ||
+    (evidence.activation.status !== "activated" &&
+      evidence.activation.status !== "pending")
+  ) {
+    throw new Error(`${network.manifestName} activation evidence is malformed`);
   }
   if ([evidence.recognizedPredecessorHook, evidence.recognizedPredecessorPolicy].some(
     (identity) =>
@@ -448,10 +469,10 @@ export function buildDisputeStackManifest(packageName: "base" | "baseStaging") {
     throw new Error("Dispute stack sentinel evidence mismatch");
   }
   if (
-    !sameJson(EVIDENCE.prerequisites, {
+    !sameJson(networkEvidence.prerequisites, {
       orchestratorPaused: false,
       admissionsPaused: false,
-      allowMultipleIntents: true,
+      allowMultipleIntents: network.manifestName === "base",
       orchestratorRegistered: true,
       lifecycleHookAuthorized: true,
       disputeNullifierWriterAuthorized: true,
@@ -465,10 +486,11 @@ export function buildDisputeStackManifest(packageName: "base" | "baseStaging") {
   }
 
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     network: network.manifestName,
     chainId: Number(output.chainId),
     activeDisputeStack: networkEvidence.activeDisputeStack,
+    activation: networkEvidence.activation,
     runtimeIdentities,
     addressExpectations,
     expectedRelations: {
@@ -518,7 +540,7 @@ export function buildDisputeStackManifest(packageName: "base" | "baseStaging") {
     },
     riskWindowSecondsByPaymentMethod: evidenceWindows,
     sentinel: EVIDENCE.sentinel,
-    prerequisites: EVIDENCE.prerequisites,
+    prerequisites: networkEvidence.prerequisites,
   } as const;
 }
 
@@ -560,21 +582,26 @@ export async function extractDisputeStack(): Promise<void> {
   fs.writeFileSync(
     path.join(OUTPUT_DIRECTORY, "types.d.ts"),
     `export type Address = \`0x\${string}\`;
-export type RuntimeCodeHash = \`0x\${string}\`;
+export type Hash = \`0x\${string}\`;
+export type RuntimeCodeHash = Hash;
 export type DisputeStackNetwork = 'base' | 'base_staging';
 export type BasePaymentMethodHash = ${basePaymentMethodHashType};
 export type BaseStagingPaymentMethodHash = ${baseStagingPaymentMethodHashType};
 export type PaymentMethodHash<Network extends DisputeStackNetwork = DisputeStackNetwork> = Network extends 'base_staging' ? BaseStagingPaymentMethodHash : BasePaymentMethodHash;
 export type RiskWindowSeconds = ${riskWindowSecondsType};
+export type DisputeStackActivation =
+  | { status: 'activated' }
+  | { status: 'pending'; safe: Address; nonce: number; safeTxHash: Hash };
 export interface RuntimeIdentity { address: Address; runtimeCodeHash: RuntimeCodeHash; }
 export type RuntimeIdentityName = 'Orchestrator' | 'OrchestratorV2' | 'OrchestratorV3' | 'StakeVault' | 'DisputeProtectionPolicy' | 'IntentLifecycleHookV1' | 'RecognizedPredecessorHook' | 'RecognizedPredecessorPolicy' | 'OrchestratorRegistry' | 'WhitelistPolicy' | 'DisputeVerifier' | 'DisputeNullifierRegistry' | 'MultiAttestationVerifier';
 export type GovernedRuntimeIdentityName = 'OrchestratorRegistry' | 'OrchestratorV3' | 'StakeVault' | 'DisputeProtectionPolicy' | 'WhitelistPolicy' | 'DisputeVerifier' | 'DisputeNullifierRegistry' | 'MultiAttestationVerifier';
 export type TwoStepGovernedRuntimeIdentityName = 'StakeVault' | 'DisputeProtectionPolicy' | 'DisputeVerifier';
 export interface DisputeStackManifest<Network extends DisputeStackNetwork = DisputeStackNetwork> {
-  schemaVersion: 1;
+  schemaVersion: 2;
   network: Network;
   chainId: 8453;
-  activeDisputeStack: { version: 1; selectionHash: string };
+  activeDisputeStack: { version: 2; selectionHash: string };
+  activation: DisputeStackActivation;
   runtimeIdentities: Record<RuntimeIdentityName, RuntimeIdentity>;
   addressExpectations: {
     AddressGroupRegistry: Address;
@@ -627,7 +654,7 @@ export interface DisputeStackManifest<Network extends DisputeStackNetwork = Disp
   prerequisites: {
     orchestratorPaused: false;
     admissionsPaused: false;
-    allowMultipleIntents: true;
+    allowMultipleIntents: boolean;
     orchestratorRegistered: true;
     lifecycleHookAuthorized: true;
     disputeNullifierWriterAuthorized: true;
@@ -645,7 +672,7 @@ export interface DisputeStackManifest<Network extends DisputeStackNetwork = Disp
 import baseData from './base.json';
 import baseStagingData from './baseStaging.json';
 import type { DisputeStackManifest } from './types';
-export type { Address, DisputeStackManifest, DisputeStackNetwork, GovernedRuntimeIdentityName, PaymentMethodHash, RiskWindowSeconds, RuntimeCodeHash, RuntimeIdentity, RuntimeIdentityName, TwoStepGovernedRuntimeIdentityName } from './types';
+export type { Address, DisputeStackActivation, DisputeStackManifest, DisputeStackNetwork, GovernedRuntimeIdentityName, Hash, PaymentMethodHash, RiskWindowSeconds, RuntimeCodeHash, RuntimeIdentity, RuntimeIdentityName, TwoStepGovernedRuntimeIdentityName } from './types';
 export { default as base } from './base.json';
 export { default as baseStaging } from './baseStaging.json';
 export const disputeStackByNetwork = {
@@ -656,7 +683,7 @@ export const disputeStackByNetwork = {
   );
   fs.writeFileSync(
     path.join(OUTPUT_DIRECTORY, "index.d.ts"),
-    `export type { Address, DisputeStackManifest, DisputeStackNetwork, GovernedRuntimeIdentityName, PaymentMethodHash, RiskWindowSeconds, RuntimeCodeHash, RuntimeIdentity, RuntimeIdentityName, TwoStepGovernedRuntimeIdentityName } from './types';\nexport { default as base } from './base';\nexport { default as baseStaging } from './baseStaging';\nexport declare const disputeStackByNetwork: { base: import('./types').DisputeStackManifest<'base'>; baseStaging: import('./types').DisputeStackManifest<'base_staging'> };\n`,
+    `export type { Address, DisputeStackActivation, DisputeStackManifest, DisputeStackNetwork, GovernedRuntimeIdentityName, Hash, PaymentMethodHash, RiskWindowSeconds, RuntimeCodeHash, RuntimeIdentity, RuntimeIdentityName, TwoStepGovernedRuntimeIdentityName } from './types';\nexport { default as base } from './base';\nexport { default as baseStaging } from './baseStaging';\nexport declare const disputeStackByNetwork: { base: import('./types').DisputeStackManifest<'base'>; baseStaging: import('./types').DisputeStackManifest<'base_staging'> };\n`,
   );
   console.log(`✅ Dispute stack metadata written to ${OUTPUT_DIRECTORY}`);
 }

--- a/packages/contracts/scripts/verify-release.mjs
+++ b/packages/contracts/scripts/verify-release.mjs
@@ -92,6 +92,7 @@ const canonicalDisputeContracts = new Set([
   "StakeVault",
   "DisputeProtectionPolicy",
   "IntentLifecycleHookV1",
+  "WhitelistPolicy",
 ]);
 /** @type {Record<string, string[]>} */
 const requiredNetworkContracts = {
@@ -239,6 +240,8 @@ for (const {
     fail(`${name} dispute stack selection differs from deployment output`);
   if (!sameJson(disputeStack.activeDisputeStack, networkEvidence.activeDisputeStack))
     fail(`${name} dispute stack selection differs from trusted evidence`);
+  if (!sameJson(disputeStack.activation, networkEvidence.activation))
+    fail(`${name} activation status differs from trusted evidence`);
   const expectedRuntimeIdentities = Object.fromEntries(
     [
       "Orchestrator",
@@ -324,7 +327,7 @@ for (const {
   ) fail(`${name} risk windows differ from trusted evidence`);
   if (!sameJson(disputeStack.sentinel, disputeStackEvidence.sentinel))
     fail(`${name} dispute stack sentinel differs from trusted evidence`);
-  if (!sameJson(disputeStack.prerequisites, disputeStackEvidence.prerequisites))
+  if (!sameJson(disputeStack.prerequisites, networkEvidence.prerequisites))
     fail(`${name} dispute stack prerequisites differ from trusted evidence`);
   const identities = disputeStack.runtimeIdentities;
   const expectedAddresses = disputeStack.addressExpectations;

--- a/scripts/active-dispute-stack.spec.cjs
+++ b/scripts/active-dispute-stack.spec.cjs
@@ -103,6 +103,11 @@ test("strips passive internal policy records on every supported network", () => 
       );
     }
     assert.equal("WhitelistPolicy" in resolved, true, network);
+    assert.equal(
+      resolved.WhitelistPolicy.address,
+      contracts().WhitelistPolicyMethodScoped.address,
+      network
+    );
   }
 });
 
@@ -121,18 +126,18 @@ test("normalizes Hardhat and package network names through one boundary", () => 
 test("resolves successor records on live networks after the passive deployment", () => {
   assert.deepEqual(resolveActiveDisputeAliases("base", contracts()), {
     OtherContract: deployment("0x0000000000000000000000000000000000000001", []),
-    StakeVault: deployment("0x0000000000000000000000000000000000000021"),
+    StakeVault: deployment("0x0000000000000000000000000000000000000031"),
     DisputeProtectionPolicy: deployment(
-      "0x0000000000000000000000000000000000000022"
+      "0x0000000000000000000000000000000000000034"
     ),
     IntentLifecycleHookV1: deployment(
-      "0x0000000000000000000000000000000000000023"
+      "0x0000000000000000000000000000000000000035"
     ),
-    WhitelistPolicy: deployment("0x0000000000000000000000000000000000000041"),
+    WhitelistPolicy: deployment("0x0000000000000000000000000000000000000042"),
   });
   assert.equal(
     resolveActiveDisputeAliases("base_staging", contracts()).StakeVault.address,
-    "0x0000000000000000000000000000000000000021"
+    "0x0000000000000000000000000000000000000031"
   );
 });
 
@@ -152,6 +157,10 @@ test("resolves successor records locally and removes every internal deployment k
     "0x0000000000000000000000000000000000000035"
   );
   assert.equal(
+    resolved.WhitelistPolicy.address,
+    "0x0000000000000000000000000000000000000042"
+  );
+  assert.equal(
     Object.keys(resolved).some((name) => name.endsWith("OptIn")),
     false
   );
@@ -164,7 +173,11 @@ test("resolves successor records locally and removes every internal deployment k
 test("returns only known canonical deployment names", () => {
   assert.equal(
     getActiveDisputeDeploymentName("base", "StakeVault"),
-    "StakeVaultOptIn"
+    "StakeVaultMethodScoped"
+  );
+  assert.equal(
+    getActiveDisputeDeploymentName("base", "WhitelistPolicy"),
+    "WhitelistPolicyMethodScoped"
   );
   assert.equal(
     getActiveDisputeDeploymentName("hardhat", "StakeVault"),
@@ -176,7 +189,7 @@ test("returns only known canonical deployment names", () => {
   );
 });
 
-test("fails closed on missing records and public/internal ABI drift", () => {
+test("fails closed on missing records and lets the selected hard cut replace a legacy ABI", () => {
   const missing = contracts();
   delete missing.StakeVaultMethodScoped;
   assert.throws(
@@ -188,9 +201,9 @@ test("fails closed on missing records and public/internal ABI drift", () => {
   drifted.StakeVault.abi = [
     { type: "function", name: "different", inputs: [], outputs: [] },
   ];
-  assert.throws(
-    () => resolveActiveDisputeAliases("localhost", drifted),
-    /ABI mismatch/
+  assert.deepEqual(
+    resolveActiveDisputeAliases("localhost", drifted).StakeVault.abi,
+    contracts().StakeVaultMethodScoped.abi
   );
 });
 
@@ -229,6 +242,10 @@ test("every deployment/package consumer exposes only canonical aliases", () => {
     assert.equal(
       resolved.IntentLifecycleHookV1.address,
       input.IntentLifecycleHookV1MethodScopedStaked.address
+    );
+    assert.equal(
+      resolved.WhitelistPolicy.address,
+      input.WhitelistPolicyMethodScoped.address
     );
     assert.equal(
       Object.keys(resolved).some((name) => name.endsWith("OptIn")),
@@ -326,13 +343,21 @@ const DISPUTE_STACK_BY_NETWORK = {
     riskWindows: RISK_WINDOWS_BY_NETWORK.base,
     governanceOwner: "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
     orchestratorAuthorizationFromBlock: "42878566",
-    policyDeploymentBlock: "50201693",
+    policyDeploymentBlock: "50537204",
+    allowMultipleIntents: true,
+    activation: {
+      status: "pending",
+      safe: "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+      nonce: 77,
+      safeTxHash:
+        "0x6dd4de20ac21ac2961653dd3ea07c3ab79281ce472dd5a74ec791f659620f3c9",
+    },
     attestationWitnesses: [
       "0xDB4Ed7FAF170F0f6493E3adaaCaaFaF47092c754",
       "0xE078D93bFdd87A8c5C5cCA5905DCbA0Dd7A1F0BD",
     ],
     selectionHash:
-      "a4f17ae7c1620ecfe7d036f0b9cc7b39c50e1382dc8dc14d2e5f7f21061cd5ad",
+      "ba40c2954b408d0c658881a8d28e5bfcc9bade5cc3d953fd17eae1eca69d841c",
     runtimeIdentities: {
       Orchestrator: {
         address: "0x88888883Ed048FF0a415271B28b2F52d431810D0",
@@ -350,29 +375,29 @@ const DISPUTE_STACK_BY_NETWORK = {
           "0x4e58f26129559301c017ff264b61dd2255ed2107593d308472ef32d07b8745e9",
       },
       StakeVault: {
-        address: "0x4d16F4a9946CfC76b1c1A4B63aa9D94cdA2dbCEB",
+        address: "0x47c26258222e2f96424bD2B21bf173f0DA5034C7",
         runtimeCodeHash:
           "0xfd8d2a910b9ac2c55675ae06d0504f9aac43b02b7022755cf229b571156c681d",
       },
       DisputeProtectionPolicy: {
-        address: "0xcEc48F7242eDBf02875BB4629115Bd927e1287aA",
+        address: "0xbF4B769dB70DBEc89b6b2c44988304a7aD2de4Fc",
         runtimeCodeHash:
-          "0x9c4be279da216021183638eaef79ebf98db248472685e9ecd0de3f24a513a641",
+          "0xf5a7756f16556da69c91c55bdcffd9fd95cc8cbdb772699827ec4c66db136dfe",
       },
       IntentLifecycleHookV1: {
+        address: "0x5Dd6C675a7406fE8C9f0D93394a36fd6e8c50031",
+        runtimeCodeHash:
+          "0x2b479a570ddea7a990f2cae8fa95eb3b8599fc8b367332b8dab92f7d0cebf7e0",
+      },
+      RecognizedPredecessorHook: {
         address: "0x71467dCac3B50eeED5A485aC6a70f27B1EAC1970",
         runtimeCodeHash:
           "0x35789014e608a248f3244b61210fa259fee3566c33f50fd0e3fa1f5ae22e370b",
       },
-      RecognizedPredecessorHook: {
-        address: "0x251d78fb6bBb4071995Bce74bAfC9E4168638622",
-        runtimeCodeHash:
-          "0x03d02863ed5eaa096d4089cb1e126681c0621d99409124f4af5be7ed83e341fe",
-      },
       RecognizedPredecessorPolicy: {
-        address: "0xc086b6120B5e61EF48221E6A78c69737c9948dF9",
+        address: "0xcEc48F7242eDBf02875BB4629115Bd927e1287aA",
         runtimeCodeHash:
-          "0xf08bce9ad622b9d45ce310493627cbef3bf6c4ac915661d5bc572bb59b61e084",
+          "0x9c4be279da216021183638eaef79ebf98db248472685e9ecd0de3f24a513a641",
       },
       OrchestratorRegistry: {
         address: "0xBe9fED15ED7A4B915C03EFcEcb9662739C3382A9",
@@ -380,9 +405,9 @@ const DISPUTE_STACK_BY_NETWORK = {
           "0xf0d132d621ac03181a6fade6a93bd0968d33830c8bf393793236787e7978aee1",
       },
       WhitelistPolicy: {
-        address: "0xBC53641b4B2504f0061D6a9426C61B8eBE9B4Ff0",
+        address: "0x389Cd9bA91FfFcd83d267B241E975541892759Ce",
         runtimeCodeHash:
-          "0xa3cf0fdf3835887de432cbac9c192edf6c93a8589748aa93f8294333d57024b2",
+          "0xa83d138a5b89d2fd2861702febc6333e542dcdc8994ee76c345dcbd22fe685a4",
       },
       DisputeVerifier: {
         address: "0x30d4947f005653637005eed991005119D9eB2f34",
@@ -413,13 +438,15 @@ const DISPUTE_STACK_BY_NETWORK = {
     riskWindows: RISK_WINDOWS_BY_NETWORK.baseStaging,
     governanceOwner: "0x84e113087C97Cd80eA9D78983D4B8Ff61ECa1929",
     orchestratorAuthorizationFromBlock: "42614859",
-    policyDeploymentBlock: "50201496",
+    policyDeploymentBlock: "50536390",
+    allowMultipleIntents: false,
+    activation: { status: "activated" },
     attestationWitnesses: [
       "0x66649F896521b0fb487fE2077b4FBDA283d7f19a",
       "0x4ab950AE1e3326578Bf7e643a2031E858aBa2927",
     ],
     selectionHash:
-      "586c90f9de3d10b6d48f4286c709aa7f870fc2fdcfb0af1da947c1da76132dd0",
+      "6c49c1ce51eec594a22385c4efcab08aa9926b6b63a725e14a0027ec5d2f4fc9",
     runtimeIdentities: {
       Orchestrator: {
         address: "0xF9b9CD27Deea496B960b3cb5221b514705fCaF5e",
@@ -437,19 +464,19 @@ const DISPUTE_STACK_BY_NETWORK = {
           "0x4e58f26129559301c017ff264b61dd2255ed2107593d308472ef32d07b8745e9",
       },
       StakeVault: {
-        address: "0x01075fdCB8D38fD5A1070db41B3c00DC2459e71e",
+        address: "0x92d7B59E99e1CD2066540Cd2413b8714948b731f",
         runtimeCodeHash:
           "0xfd8d2a910b9ac2c55675ae06d0504f9aac43b02b7022755cf229b571156c681d",
       },
       DisputeProtectionPolicy: {
-        address: "0x51436B8051cCf52739A2090C29DA208B70eC2663",
+        address: "0x484fA07F085eb66bb7C2b649Ea9d5894b2B6681c",
         runtimeCodeHash:
-          "0xa4c6a33333e10da596805b6127e96f78e40fe5a0f0ab0cfa8f4683fbeac91a37",
+          "0x70c43bfae8253a6a166f9697ddc27b2d77b4d9841e01fefc2db84037d9a98622",
       },
       IntentLifecycleHookV1: {
-        address: "0x3AB0879499b28e03bfcA4F5bC2CBe2070Fba4E36",
+        address: "0x5A7f6cb7397134da1fDEFA7E2D434b4Cf18E56D9",
         runtimeCodeHash:
-          "0x376364aa8b693ee8e02eacc48527114ce3cc529714be5a3f316c7323561721ab",
+          "0xb9ce42108c706f9241aeb41ffdc0da6b7584e8482183055452098b2f16c7abfd",
       },
       RecognizedPredecessorHook: {
         address: "0x19D9F0Fcb08C60D8bd0CD061C34eae27eF8b6e65",
@@ -467,9 +494,9 @@ const DISPUTE_STACK_BY_NETWORK = {
           "0xf0d132d621ac03181a6fade6a93bd0968d33830c8bf393793236787e7978aee1",
       },
       WhitelistPolicy: {
-        address: "0x7d9277cb8bb78a51eeaafB7CFF306E7DA4C972fD",
+        address: "0xF79aAD1BAaB617fF3Eb299225c80893F22F743Fe",
         runtimeCodeHash:
-          "0x917965fdc75580147ad0787c86f8b2a0f0185ef6e101567b82dc1245d6eb63bc",
+          "0x1ece96bb7be9cdd2433a2aad66c9b2d710e3e210a65876e0f8c1e43662ee5653",
       },
       DisputeVerifier: {
         address: "0x973578148c5Fd49b9f68B50B26066555325AC708",
@@ -514,10 +541,10 @@ test("package extraction publishes the exact dispute stack manifest without inte
     const manifest = JSON.parse(
       readFileSync(join(disputeStackDirectory, `${network}.json`), "utf8")
     );
-    assert.equal(manifest.schemaVersion, 1);
+    assert.equal(manifest.schemaVersion, 2);
     assert.equal(manifest.chainId, 8453);
     assert.deepEqual(manifest.activeDisputeStack, {
-      version: 1,
+      version: 2,
       selectionHash: expected.selectionHash,
     });
     assert.deepEqual(manifest.runtimeIdentities, expected.runtimeIdentities);
@@ -583,6 +610,7 @@ test("package extraction publishes the exact dispute stack manifest without inte
       requiredSignatures: "1",
       witnesses: expected.attestationWitnesses,
     });
+    assert.deepEqual(manifest.activation, expected.activation);
     assert.deepEqual(manifest.exactAuthorizationSets, {
       orchestratorAuthorizationFromBlock:
         expected.orchestratorAuthorizationFromBlock,
@@ -614,7 +642,7 @@ test("package extraction publishes the exact dispute stack manifest without inte
     assert.deepEqual(manifest.prerequisites, {
       orchestratorPaused: false,
       admissionsPaused: false,
-      allowMultipleIntents: true,
+      allowMultipleIntents: expected.allowMultipleIntents,
       orchestratorRegistered: true,
       lifecycleHookAuthorized: true,
       disputeNullifierWriterAuthorized: true,
@@ -639,6 +667,7 @@ test("package extraction publishes the exact dispute stack manifest without inte
     assert.equal(declarations.includes(`'${seconds}'`), true);
   }
   assert.match(declarations, /chainId: 8453;/);
+  assert.match(declarations, /activation: DisputeStackActivation;/);
   for (const paymentMethodHash of Object.keys(
     RISK_WINDOWS_BY_NETWORK.baseStaging
   )) {

--- a/scripts/npm-release.spec.mjs
+++ b/scripts/npm-release.spec.mjs
@@ -358,7 +358,7 @@ test('derives a future RC release line from the package version', () => {
 
 test('commits the next RC candidate while preserving stable release support', () => {
   const packageManifest = JSON.parse(fs.readFileSync(packageManifestPath, 'utf8'));
-  assert.equal(packageManifest.version, '0.4.1-rc.7');
+  assert.equal(packageManifest.version, '0.4.1-rc.8');
   assert.deepEqual(
     resolveReleasePolicy({
       release: '0.4.1',
@@ -388,7 +388,7 @@ test('publish workflow consumes the version-derived channel without RC-only path
   const workflow = fs.readFileSync(releaseWorkflowPath, 'utf8');
 
   assert.match(workflow, /^  LATEST_BASELINE: 0\.4\.0$/m);
-  assert.match(workflow, /^  RC_BASELINE: 0\.4\.1-rc\.6$/m);
+  assert.match(workflow, /^  RC_BASELINE: 0\.4\.1-rc\.7$/m);
   assert.match(workflow, /^\s{2}policy:\s*$/m);
   assert.match(workflow, /node scripts\/npm-release\.mjs resolve "\$PACKAGE_JSON" "\$RELEASE_VERSION"/);
   assert.match(workflow, /DIST_TAG:\s*\$\{\{ needs\.policy\.outputs\.dist_tag \}\}/);

--- a/scripts/test-dispute-lifecycle-deployment.cjs
+++ b/scripts/test-dispute-lifecycle-deployment.cjs
@@ -33,9 +33,9 @@ const EXPECTED_RUNTIME_HASHES = {
     StakeVault:
       "0xfd8d2a910b9ac2c55675ae06d0504f9aac43b02b7022755cf229b571156c681d",
     DisputeProtectionPolicy:
-      "0xf08bce9ad622b9d45ce310493627cbef3bf6c4ac915661d5bc572bb59b61e084",
+      "0x9c4be279da216021183638eaef79ebf98db248472685e9ecd0de3f24a513a641",
     IntentLifecycleHookV1:
-      "0xff9db07ce83908b7cedb31f8c085004aa78c91bb86e0565f11fad3e4bc36c5cb",
+      "0x35789014e608a248f3244b61210fa259fee3566c33f50fd0e3fa1f5ae22e370b",
     DisputeVerifier:
       "0x65246e11392befc33d92246cf3ac2467d1f338a8b73c6514b76fab0a70a01ead",
     DisputeNullifierRegistry:
@@ -74,14 +74,17 @@ function liveHre(network, { omit, addressDrift, codeDrift } = {}) {
     PREDECESSOR_DISPUTE_STACKS[network].contracts
   )) {
     if (name === omit) continue;
+    const evidence = PREDECESSOR_DISPUTE_STACKS[network].contracts[name];
+    const recordName = evidence.deploymentName || name;
     const artifact = require(path.join(
       process.cwd(),
       "deployments",
       network,
-      `${name}.json`
+      `${recordName}.json`
     ));
-    deployments.set(name, {
+    deployments.set(recordName, {
       ...artifact,
+      canonicalName: name,
       address:
         name === addressDrift
           ? "0x0000000000000000000000000000000000000001"
@@ -112,9 +115,11 @@ function liveHre(network, { omit, addressDrift, codeDrift } = {}) {
       ethers: {
         provider: {
           getCode: async (/** @type {string} */ address) => {
-            for (const [name, artifact] of deployments) {
+            for (const artifact of deployments.values()) {
               if (artifact.address.toLowerCase() === address.toLowerCase()) {
-                return name === codeDrift ? "0x00" : MOCK_RUNTIME_CODES[name];
+                return artifact.canonicalName === codeDrift
+                  ? "0x00"
+                  : MOCK_RUNTIME_CODES[artifact.canonicalName];
               }
             }
             return "0x";
@@ -131,6 +136,11 @@ async function run() {
     PREDECESSOR_DISPUTE_STACKS,
     "historical predecessor evidence is not exported"
   );
+  assert.deepEqual(PREDECESSOR_DISPUTE_STACKS.base.activeLifecycleHook, {
+    address: "0x71467dCac3B50eeED5A485aC6a70f27B1EAC1970",
+    runtimeCodeHash:
+      "0x35789014e608a248f3244b61210fa259fee3566c33f50fd0e3fa1f5ae22e370b",
+  });
   assert.deepEqual(
     PREDECESSOR_DISPUTE_STACKS.base_staging.activeLifecycleHook,
     {
@@ -149,7 +159,7 @@ async function run() {
         process.cwd(),
         "deployments",
         network,
-        `${name}.json`
+        `${evidence.deploymentName || name}.json`
       ));
       assert.equal(
         evidence.deploymentBytecodeHash,

--- a/scripts/test-method-scoped-deployment.cjs
+++ b/scripts/test-method-scoped-deployment.cjs
@@ -1272,15 +1272,16 @@ test("historical validation resolves the OptIn deployment record names", async (
   ]);
 });
 
-test("active dispute manifest selects OptIn live and MethodScoped locally", () => {
+test("active dispute manifest selects the dedicated-vault stack on every network", () => {
   for (const network of /** @type {Array<"base" | "base_staging">} */ ([
     "base",
     "base_staging",
   ])) {
     assert.deepEqual(Object.values(activeDisputeManifest.networks[network]), [
-      "StakeVaultOptIn",
-      "DisputeProtectionPolicyOptIn",
-      "IntentLifecycleHookV1OptIn",
+      "StakeVaultMethodScoped",
+      "DisputeProtectionPolicyMethodScopedStaked",
+      "IntentLifecycleHookV1MethodScopedStaked",
+      "WhitelistPolicyMethodScoped",
     ]);
   }
   for (const network of /** @type {Array<"localhost" | "hardhat">} */ ([
@@ -1291,12 +1292,14 @@ test("active dispute manifest selects OptIn live and MethodScoped locally", () =
       "StakeVaultMethodScoped",
       "DisputeProtectionPolicyMethodScopedStaked",
       "IntentLifecycleHookV1MethodScopedStaked",
+      "WhitelistPolicyMethodScoped",
     ]);
   }
   const resolved = resolveActiveDisputeAliases("hardhat", {
     StakeVaultMethodScoped: { address: "vault" },
     DisputeProtectionPolicyMethodScopedStaked: { address: "policy" },
     IntentLifecycleHookV1MethodScopedStaked: { address: "hook" },
+    WhitelistPolicyMethodScoped: { address: "whitelist" },
   });
   assert.equal(
     Object.keys(resolved).some(

--- a/scripts/test-opt-in-dispute-lifecycle-deployment.cjs
+++ b/scripts/test-opt-in-dispute-lifecycle-deployment.cjs
@@ -126,7 +126,7 @@ test("live dependency pins use deployed runtime hashes", () => {
   );
 });
 
-test("package dispute stack evidence stays pinned to the immutable predecessor and lane 34 live dependencies", () => {
+test("package dispute stack evidence stays pinned to the selected stack and recognized predecessor", () => {
   for (const network of /** @type {Array<"base" | "base_staging">} */ ([
     "base",
     "base_staging",
@@ -170,10 +170,11 @@ test("package dispute stack evidence stays pinned to the immutable predecessor a
       evidence.runtimeCodeHashes.OrchestratorRegistry,
       live.orchestratorRegistryCodeHash
     );
-    assert.equal(evidence.addresses.WhitelistPolicy, live.whitelistPolicy);
+    const selectedWhitelist = require(`../deployments/${network}/WhitelistPolicyMethodScoped.json`);
+    assert.equal(evidence.addresses.WhitelistPolicy, selectedWhitelist.address);
     assert.equal(
-      evidence.runtimeCodeHashes.WhitelistPolicy,
-      live.whitelistPolicyCodeHash
+      evidence.deploymentEvidence.WhitelistPolicy.deploymentName,
+      "WhitelistPolicyMethodScoped"
     );
     assert.equal(
       evidence.addresses.MultiAttestationVerifier,
@@ -980,14 +981,62 @@ test("the obsolete Base lifecycle batch remains exact historical evidence", () =
       "utf8"
     )
   );
-  const transactions = lane34Module.assertObsoleteBaseBatchShape(obsoleteBatch);
+  assert.deepEqual(
+    obsoleteBatch.transactions.map(
+      (/** @type {{ to: string }} */ transaction) => transaction.to
+    ),
+    [
+      "0x30d4947f005653637005eed991005119D9eB2f34",
+      "0x8B8e853f47e6e0d3944e3689197B35216933dDea",
+      "0xc086b6120B5e61EF48221E6A78c69737c9948dF9",
+      "0x014025fDE093f8701d86e9f38e2C3a9b779cb5c7",
+    ]
+  );
+  assert.equal(
+    obsoleteBatch.transactions[3].data,
+    "0xbb4995af0000000000000000000000005b0017fca6a2131701ef718e470a3930c1b6c12c"
+  );
+
+  const ownershipData = "0x79ba5097";
+  const lifecycleInterface = new (require("ethers").utils.Interface)([
+    "function setLifecycleHook(address)",
+  ]);
+  const currentFixture = {
+    ...obsoleteBatch,
+    transactions: [
+      {
+        ...obsoleteBatch.transactions[0],
+        to: PREDECESSOR_DISPUTE_STACKS.base.contracts.DisputeVerifier.address,
+        data: ownershipData,
+      },
+      {
+        ...obsoleteBatch.transactions[1],
+        to: PREDECESSOR_DISPUTE_STACKS.base.contracts.StakeVault.address,
+        data: ownershipData,
+      },
+      {
+        ...obsoleteBatch.transactions[2],
+        to: PREDECESSOR_DISPUTE_STACKS.base.contracts.DisputeProtectionPolicy
+          .address,
+        data: ownershipData,
+      },
+      {
+        ...obsoleteBatch.transactions[3],
+        data: lifecycleInterface.encodeFunctionData("setLifecycleHook", [
+          PREDECESSOR_DISPUTE_STACKS.base.contracts.IntentLifecycleHookV1
+            .address,
+        ]),
+      },
+    ],
+  };
+  const transactions =
+    lane34Module.assertObsoleteBaseBatchShape(currentFixture);
   assert.equal(transactions.length, 4);
-  assert.equal(transactions[3].data.slice(0, 10), "0xbb4995af");
   assert.throws(
     () =>
       lane34Module.assertObsoleteBaseBatchShape({
-        ...obsoleteBatch,
-        transactions: obsoleteBatch.transactions.slice().reverse(),
+        ...currentFixture,
+        transactions: currentFixture.transactions.slice().reverse(),
       }),
     /transaction drifted/
   );


### PR DESCRIPTION
## Summary
- Selects the dedicated-vault stack for **both** networks in the package: `StakeVault` → `StakeVaultMethodScoped`, `DisputeProtectionPolicy` → `DisputeProtectionPolicyMethodScopedStaked`, `IntentLifecycleHookV1` → `IntentLifecycleHookV1MethodScopedStaked`, `WhitelistPolicy` → `WhitelistPolicyMethodScoped` (active-stack manifest schema v2 aliases all four canonical keys). Base staging is live on this stack; **Base's cutover is pending** at Safe nonce 77 (`0x6dd4de20…f3c9`) — this RC deliberately front-runs it so clients can sync first (decision 2026-08-28; carve-out added to CLAUDE.md).
- Dispute-stack evidence schema v2 exposes a typed per-network `activation` status in the package export: `base_staging: { status: "activated" }`, `base: { status: "pending", safe, nonce, safeTxHash }`; READMEs document it.
- `PREDECESSOR_DISPUTE_STACKS.base` → the OptIn trio (the stack the selection replaces); staging predecessor unchanged (lane-32).
- Bumps `@zkp2p/contracts-v2` to `0.4.1-rc.8`; `RC_BASELINE` → `0.4.1-rc.7`.

## Built package export (8/8 verified)
Base: vault `0x47c2…34C7`, policy `0xbF4B…e4Fc`, hook `0x5Dd6…0031`, whitelist `0x389C…59Ce`. Base staging: vault `0x92d7…731f`, policy `0x484f…681c`, hook `0x5A7f…56D9`, whitelist `0xF79a…43Fe`.

## Test Plan
- [x] `pkg:extract` / `pkg:build` / `pkg:test` 5/5 / `verify:release` (66 entries + 12 ABIs) / `test:release-policy` / `npm pack --dry-run`
- [x] `test:dispute-lifecycle-deployment` 45, `test:method-scoped-deployment` 47, `test:method-scoped-vault-deployment` 8, `test:method-scoped-activation` 68, `test:v3-groups-deployment`, typecheck
- [ ] CI green

## After merge
Tag `contracts-v2-v0.4.1-rc.8` at the merge commit, dispatch **Publish contracts-v2** (`release=0.4.1-rc.8`, `recovery=false`); then regenerate the Base cutover batch (its manifest's source SHA predates this change) and re-propose at nonce 77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tzc4JYcsy2feiByPEeQXrc