### PR TITLE
chore(release): drop the dispute-stack activation status, contracts-v2 0.4.1-rc.9

### DIFF
--- a/.github/workflows/publish-contracts-v2.yml
+++ b/.github/workflows/publish-contracts-v2.yml
@@ -33,7 +33,7 @@ env:
   RELEASE_VERSION: ${{ inputs.release }}
   RELEASE_TAG: contracts-v2-v${{ inputs.release }}
   LATEST_BASELINE: 0.4.0
-  RC_BASELINE: 0.4.1-rc.7
+  RC_BASELINE: 0.4.1-rc.8
   NPM_CONFIG_PROVENANCE: "true"
   REQUIRE_PROVENANCE: "true"
   RECOVERY_MODE: ${{ inputs.recovery }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,15 +180,11 @@ yarn workspace @zkp2p/contracts-v2 verify:release
 ```
 
 Source ABI exports and network address/runtime exports are different contracts.
-The package intentionally exports V3 source ABIs and current Base-staging
-lifecycle addresses while Base production may have no corresponding active V3
-address. Never invent a zero address, copy a staging address into Base, publish
-an inactive address as active, or remove an ABI merely because the contract is
-not deployed on every network. One explicit exception (decided 2026-08-28): a
-release candidate may front-run an approved, already-queued governance cutover
-so clients can sync before it executes, provided the package's dispute-stack
-readiness metadata and README state that the cutover is pending and name the
-Safe transaction.
+The package exports the currently selected (latest) addresses for each network,
+and consumers treat them as the addresses to use. It does not export activation
+status or rollout timing; operators complete rollout only after every multisig
+executes. Never invent a zero address, copy a staging address into Base, or
+remove an ABI merely because the contract is not deployed on every network.
 
 Any publication must use
 `.agents/skills/zkp2p-contracts-publish/SKILL.md`; never publish locally or

--- a/README.md
+++ b/README.md
@@ -785,15 +785,8 @@ terminal and `StakeVaultOptIn` holds no locks. Artifacts live at
 Stake in the old vaults is abandoned: stakers withdraw once their locks release and takers re-stake in the new vault
 before the cutover; that readiness is part of `CONFIRM_BASE_V3_DISPUTE_METHOD_SCOPED_VAULT_DOWNSTREAM_READY`.
 
-The `0.4.1-rc.8` package front-runs the approved Base cutover so downstream clients can sync first. On both Base and
-Base staging its canonical `StakeVault`, `DisputeProtectionPolicy`, `IntentLifecycleHookV1`, and `WhitelistPolicy`
-keys select `StakeVaultMethodScoped`, `DisputeProtectionPolicyMethodScopedStaked`,
-`IntentLifecycleHookV1MethodScopedStaked`, and `WhitelistPolicyMethodScoped`, respectively. The package dispute-stack
-manifest exposes `activation.status`: Base staging is `activated`; Base is `pending` at Safe
-`0x0bC26FF515411396DD588Abd6Ef6846E04470227`, nonce 77, Safe transaction hash
-`0x6dd4de20ac21ac2961653dd3ea07c3ab79281ce472dd5a74ec791f659620f3c9`. Until that transaction executes, Base O3
-still uses `IntentLifecycleHookV1OptIn` at `0x71467dCac3B50eeED5A485aC6a70f27B1EAC1970`, and the registry writer remains
-`DisputeProtectionPolicyOptIn` at `0xcEc48F7242eDBf02875BB4629115Bd927e1287aA`.
+The package exports the currently selected (latest) addresses for each network, and consumers should treat them as
+the addresses to use.
 
 Dispute-evidence issuance in `attestation-service` remains a separate follow-up and is intentionally not implemented
 by these contract lanes. Only PayPal, Venmo, and Cash App receive non-zero onchain risk windows, matching the

--- a/deployments/dispute-stack-evidence.json
+++ b/deployments/dispute-stack-evidence.json
@@ -46,12 +46,6 @@
           "0xE078D93bFdd87A8c5C5cCA5905DCbA0Dd7A1F0BD"
         ]
       },
-      "activation": {
-        "status": "pending",
-        "safe": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
-        "nonce": 77,
-        "safeTxHash": "0x6dd4de20ac21ac2961653dd3ea07c3ab79281ce472dd5a74ec791f659620f3c9"
-      },
       "prerequisites": {
         "orchestratorPaused": false,
         "admissionsPaused": false,
@@ -189,9 +183,6 @@
           "0x66649F896521b0fb487fE2077b4FBDA283d7f19a",
           "0x4ab950AE1e3326578Bf7e643a2031E858aBa2927"
         ]
-      },
-      "activation": {
-        "status": "activated"
       },
       "prerequisites": {
         "orchestratorPaused": false,

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -8,16 +8,9 @@ Official npm package for ZKP2P V2 smart contract interfaces, ABIs, addresses, an
   `DisputeVerifier`, `IntentLifecycleHookV1`, and `StakeVault`.
 - Hard-cuts unused chargeback deployment aliases and exposes only the canonical `Dispute*` API.
 - Requires a complete fresh Base staging dispute stack before the release can be published.
-- Keeps `OrchestratorV3` hook activation as a separate governance operation after downstream
-  consumers have upgraded.
 - Exports deterministic dispute-stack manifests for Base production and staging,
   including runtime identities, governance ownership, attestation trust, and exact authorization sets.
-- Hard-cuts the retired `disputeReadiness` subpath in favor of `disputeStack`; runtime readiness
-  remains a consumer decision based on fresh on-chain reads.
-- Front-runs the approved Base dedicated-vault cutover so clients can sync the selected addresses
-  before governance executes it. Base staging is activated; Base is pending at Safe nonce 77,
-  Safe transaction hash
-  `0x6dd4de20ac21ac2961653dd3ea07c3ab79281ce472dd5a74ec791f659620f3c9`.
+- Hard-cuts the retired `disputeReadiness` subpath in favor of `disputeStack`.
 
 ## Installation
 
@@ -58,7 +51,7 @@ import {
   WhitelistPolicy,
 } from "@zkp2p/contracts-v2/abis/contracts"
 
-// Import the trusted dispute-stack manifest used before accepting a V3 successor
+// Import the selected per-network dispute-stack manifest
 import { base as baseDisputeStack } from "@zkp2p/contracts-v2/disputeStack"
 
 // Example: Create contract instance with ethers
@@ -173,8 +166,6 @@ console.log('Decimals:', usdInfo.decimals);
 manifest pins:
 
 - The selected dispute-stack version and selection hash.
-- The network activation status. Read `activation.status`; a `pending` value also includes the
-  governing `safe`, `nonce`, and `safeTxHash`.
 - The exact successor and recognized predecessor addresses and runtime code hashes.
 - The complete approved orchestrator membership, its runtime identities, and the registry deployment
   block from which consumers reconstruct additions/removals and reject extras; plus verifier, whitelist,
@@ -184,21 +175,8 @@ manifest pins:
 - The approved risk window for every active payment-method bytes32 hash: 1,209,600 seconds for
   PayPal, Venmo, and Cash App, and zero for all other active methods.
 
-This RC exports the dedicated-vault stack on both networks regardless of activation status:
-`StakeVault` selects `StakeVaultMethodScoped`, `DisputeProtectionPolicy` selects
-`DisputeProtectionPolicyMethodScopedStaked`, `IntentLifecycleHookV1` selects
-`IntentLifecycleHookV1MethodScopedStaked`, and `WhitelistPolicy` selects
-`WhitelistPolicyMethodScoped`. Base staging reports `activation.status === "activated"`. Base
-reports `activation.status === "pending"` for Safe
-`0x0bC26FF515411396DD588Abd6Ef6846E04470227`, nonce 77, and the Safe transaction hash above.
-Until that transaction executes, the live Base lifecycle hook remains `IntentLifecycleHookV1OptIn`
-at `0x71467dCac3B50eeED5A485aC6a70f27B1EAC1970` and the live writer remains
-`DisputeProtectionPolicyOptIn` at `0xcEc48F7242eDBf02875BB4629115Bd927e1287aA`.
-
-These are trusted package expectations, not a statement that governance has already activated the
-successor. A consumer must read current on-chain code and state, compare it with the manifest, and
-fail closed on any missing or mismatched identity, dependency, authorization, prerequisite, or
-sentinel result.
+The package exports the currently selected (latest) addresses for each network, and consumers should
+treat them as the addresses to use.
 
 
 ## API Reference

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/contracts-v2",
-  "version": "0.4.1-rc.8",
+  "version": "0.4.1-rc.9",
   "description": "ZKP2P V2 smart contract interfaces and utilities",
   "main": "./_cjs/index.js",
   "module": "./_esm/index.js",

--- a/packages/contracts/scripts/extractors/disputeStack.ts
+++ b/packages/contracts/scripts/extractors/disputeStack.ts
@@ -11,9 +11,6 @@ import {
 } from "../../../../deployments/parameters";
 
 type ActiveDisputeStack = { version: number; selectionHash: string };
-type DisputeStackActivation =
-  | { status: "activated" }
-  | { status: "pending"; safe: string; nonce: number; safeTxHash: string };
 type DisputeStackPrerequisites = {
   orchestratorPaused: false;
   admissionsPaused: false;
@@ -69,7 +66,6 @@ type DisputeStackEvidence = {
     {
       governance: { owner: string; pendingOwner: string };
       attestationTrust: { requiredSignatures: string; witnesses: string[] };
-      activation: DisputeStackActivation;
       prerequisites: DisputeStackPrerequisites;
       activeDisputeStack: ActiveDisputeStack;
       recognizedPredecessorHook: RuntimeIdentity;
@@ -230,7 +226,6 @@ function validateEvidence(network: (typeof NETWORKS)[number], output: Deployment
     [
       "governance",
       "attestationTrust",
-      "activation",
       "prerequisites",
       "activeDisputeStack",
       "recognizedPredecessorHook",
@@ -248,20 +243,6 @@ function validateEvidence(network: (typeof NETWORKS)[number], output: Deployment
   }
   if (!sameJson(output.activeDisputeStack, expectedSelection)) {
     throw new Error(`${network.manifestName} deployment output selection stamp mismatch`);
-  }
-  if (
-    (evidence.activation.status === "activated" &&
-      Object.keys(evidence.activation).length !== 1) ||
-    (evidence.activation.status === "pending" &&
-      (!ADDRESS_PATTERN.test(evidence.activation.safe) ||
-        !Number.isSafeInteger(evidence.activation.nonce) ||
-        evidence.activation.nonce < 0 ||
-        !HASH_PATTERN.test(evidence.activation.safeTxHash) ||
-        Object.keys(evidence.activation).length !== 4)) ||
-    (evidence.activation.status !== "activated" &&
-      evidence.activation.status !== "pending")
-  ) {
-    throw new Error(`${network.manifestName} activation evidence is malformed`);
   }
   if ([evidence.recognizedPredecessorHook, evidence.recognizedPredecessorPolicy].some(
     (identity) =>
@@ -490,7 +471,6 @@ export function buildDisputeStackManifest(packageName: "base" | "baseStaging") {
     network: network.manifestName,
     chainId: Number(output.chainId),
     activeDisputeStack: networkEvidence.activeDisputeStack,
-    activation: networkEvidence.activation,
     runtimeIdentities,
     addressExpectations,
     expectedRelations: {
@@ -589,9 +569,6 @@ export type BasePaymentMethodHash = ${basePaymentMethodHashType};
 export type BaseStagingPaymentMethodHash = ${baseStagingPaymentMethodHashType};
 export type PaymentMethodHash<Network extends DisputeStackNetwork = DisputeStackNetwork> = Network extends 'base_staging' ? BaseStagingPaymentMethodHash : BasePaymentMethodHash;
 export type RiskWindowSeconds = ${riskWindowSecondsType};
-export type DisputeStackActivation =
-  | { status: 'activated' }
-  | { status: 'pending'; safe: Address; nonce: number; safeTxHash: Hash };
 export interface RuntimeIdentity { address: Address; runtimeCodeHash: RuntimeCodeHash; }
 export type RuntimeIdentityName = 'Orchestrator' | 'OrchestratorV2' | 'OrchestratorV3' | 'StakeVault' | 'DisputeProtectionPolicy' | 'IntentLifecycleHookV1' | 'RecognizedPredecessorHook' | 'RecognizedPredecessorPolicy' | 'OrchestratorRegistry' | 'WhitelistPolicy' | 'DisputeVerifier' | 'DisputeNullifierRegistry' | 'MultiAttestationVerifier';
 export type GovernedRuntimeIdentityName = 'OrchestratorRegistry' | 'OrchestratorV3' | 'StakeVault' | 'DisputeProtectionPolicy' | 'WhitelistPolicy' | 'DisputeVerifier' | 'DisputeNullifierRegistry' | 'MultiAttestationVerifier';
@@ -601,7 +578,6 @@ export interface DisputeStackManifest<Network extends DisputeStackNetwork = Disp
   network: Network;
   chainId: 8453;
   activeDisputeStack: { version: 2; selectionHash: string };
-  activation: DisputeStackActivation;
   runtimeIdentities: Record<RuntimeIdentityName, RuntimeIdentity>;
   addressExpectations: {
     AddressGroupRegistry: Address;
@@ -672,7 +648,7 @@ export interface DisputeStackManifest<Network extends DisputeStackNetwork = Disp
 import baseData from './base.json';
 import baseStagingData from './baseStaging.json';
 import type { DisputeStackManifest } from './types';
-export type { Address, DisputeStackActivation, DisputeStackManifest, DisputeStackNetwork, GovernedRuntimeIdentityName, Hash, PaymentMethodHash, RiskWindowSeconds, RuntimeCodeHash, RuntimeIdentity, RuntimeIdentityName, TwoStepGovernedRuntimeIdentityName } from './types';
+export type { Address, DisputeStackManifest, DisputeStackNetwork, GovernedRuntimeIdentityName, Hash, PaymentMethodHash, RiskWindowSeconds, RuntimeCodeHash, RuntimeIdentity, RuntimeIdentityName, TwoStepGovernedRuntimeIdentityName } from './types';
 export { default as base } from './base.json';
 export { default as baseStaging } from './baseStaging.json';
 export const disputeStackByNetwork = {
@@ -683,7 +659,7 @@ export const disputeStackByNetwork = {
   );
   fs.writeFileSync(
     path.join(OUTPUT_DIRECTORY, "index.d.ts"),
-    `export type { Address, DisputeStackActivation, DisputeStackManifest, DisputeStackNetwork, GovernedRuntimeIdentityName, Hash, PaymentMethodHash, RiskWindowSeconds, RuntimeCodeHash, RuntimeIdentity, RuntimeIdentityName, TwoStepGovernedRuntimeIdentityName } from './types';\nexport { default as base } from './base';\nexport { default as baseStaging } from './baseStaging';\nexport declare const disputeStackByNetwork: { base: import('./types').DisputeStackManifest<'base'>; baseStaging: import('./types').DisputeStackManifest<'base_staging'> };\n`,
+    `export type { Address, DisputeStackManifest, DisputeStackNetwork, GovernedRuntimeIdentityName, Hash, PaymentMethodHash, RiskWindowSeconds, RuntimeCodeHash, RuntimeIdentity, RuntimeIdentityName, TwoStepGovernedRuntimeIdentityName } from './types';\nexport { default as base } from './base';\nexport { default as baseStaging } from './baseStaging';\nexport declare const disputeStackByNetwork: { base: import('./types').DisputeStackManifest<'base'>; baseStaging: import('./types').DisputeStackManifest<'base_staging'> };\n`,
   );
   console.log(`✅ Dispute stack metadata written to ${OUTPUT_DIRECTORY}`);
 }

--- a/packages/contracts/scripts/verify-release.mjs
+++ b/packages/contracts/scripts/verify-release.mjs
@@ -240,8 +240,6 @@ for (const {
     fail(`${name} dispute stack selection differs from deployment output`);
   if (!sameJson(disputeStack.activeDisputeStack, networkEvidence.activeDisputeStack))
     fail(`${name} dispute stack selection differs from trusted evidence`);
-  if (!sameJson(disputeStack.activation, networkEvidence.activation))
-    fail(`${name} activation status differs from trusted evidence`);
   const expectedRuntimeIdentities = Object.fromEntries(
     [
       "Orchestrator",

--- a/scripts/active-dispute-stack.spec.cjs
+++ b/scripts/active-dispute-stack.spec.cjs
@@ -345,13 +345,6 @@ const DISPUTE_STACK_BY_NETWORK = {
     orchestratorAuthorizationFromBlock: "42878566",
     policyDeploymentBlock: "50537204",
     allowMultipleIntents: true,
-    activation: {
-      status: "pending",
-      safe: "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
-      nonce: 77,
-      safeTxHash:
-        "0x6dd4de20ac21ac2961653dd3ea07c3ab79281ce472dd5a74ec791f659620f3c9",
-    },
     attestationWitnesses: [
       "0xDB4Ed7FAF170F0f6493E3adaaCaaFaF47092c754",
       "0xE078D93bFdd87A8c5C5cCA5905DCbA0Dd7A1F0BD",
@@ -440,7 +433,6 @@ const DISPUTE_STACK_BY_NETWORK = {
     orchestratorAuthorizationFromBlock: "42614859",
     policyDeploymentBlock: "50536390",
     allowMultipleIntents: false,
-    activation: { status: "activated" },
     attestationWitnesses: [
       "0x66649F896521b0fb487fE2077b4FBDA283d7f19a",
       "0x4ab950AE1e3326578Bf7e643a2031E858aBa2927",
@@ -610,7 +602,7 @@ test("package extraction publishes the exact dispute stack manifest without inte
       requiredSignatures: "1",
       witnesses: expected.attestationWitnesses,
     });
-    assert.deepEqual(manifest.activation, expected.activation);
+    assert.equal("activation" in manifest, false);
     assert.deepEqual(manifest.exactAuthorizationSets, {
       orchestratorAuthorizationFromBlock:
         expected.orchestratorAuthorizationFromBlock,
@@ -667,7 +659,7 @@ test("package extraction publishes the exact dispute stack manifest without inte
     assert.equal(declarations.includes(`'${seconds}'`), true);
   }
   assert.match(declarations, /chainId: 8453;/);
-  assert.match(declarations, /activation: DisputeStackActivation;/);
+  assert.doesNotMatch(declarations, /DisputeStackActivation|activation:/);
   for (const paymentMethodHash of Object.keys(
     RISK_WINDOWS_BY_NETWORK.baseStaging
   )) {
@@ -688,6 +680,7 @@ test("package extraction publishes the exact dispute stack manifest without inte
   );
   assert.match(indexDeclarations, /from ['"]\.\/base['"]/);
   assert.match(indexDeclarations, /from ['"]\.\/baseStaging['"]/);
+  assert.doesNotMatch(indexDeclarations, /DisputeStackActivation/);
   assert.doesNotMatch(indexDeclarations, /\.json['"]/);
 });
 

--- a/scripts/npm-release.spec.mjs
+++ b/scripts/npm-release.spec.mjs
@@ -358,7 +358,7 @@ test('derives a future RC release line from the package version', () => {
 
 test('commits the next RC candidate while preserving stable release support', () => {
   const packageManifest = JSON.parse(fs.readFileSync(packageManifestPath, 'utf8'));
-  assert.equal(packageManifest.version, '0.4.1-rc.8');
+  assert.equal(packageManifest.version, '0.4.1-rc.9');
   assert.deepEqual(
     resolveReleasePolicy({
       release: '0.4.1',
@@ -388,7 +388,7 @@ test('publish workflow consumes the version-derived channel without RC-only path
   const workflow = fs.readFileSync(releaseWorkflowPath, 'utf8');
 
   assert.match(workflow, /^  LATEST_BASELINE: 0\.4\.0$/m);
-  assert.match(workflow, /^  RC_BASELINE: 0\.4\.1-rc\.7$/m);
+  assert.match(workflow, /^  RC_BASELINE: 0\.4\.1-rc\.8$/m);
   assert.match(workflow, /^\s{2}policy:\s*$/m);
   assert.match(workflow, /node scripts\/npm-release\.mjs resolve "\$PACKAGE_JSON" "\$RELEASE_VERSION"/);
   assert.match(workflow, /DIST_TAG:\s*\$\{\{ needs\.policy\.outputs\.dist_tag \}\}/);


### PR DESCRIPTION
## Summary
- Removes the per-network `activation` status introduced in #297 from the dispute-stack evidence, extractor/types/exports, release verifier, READMEs, and tests. Decision (2026-08-28): the package never carries activation state — consumers treat the exported (latest) addresses as live; rollout happens only after every multisig executes.
- Address selection is unchanged from rc.8 (both networks on the dedicated-vault records; `yarn pkg:extract` is a no-op; eight exported addresses byte-identical).
- Bumps `@zkp2p/contracts-v2` to `0.4.1-rc.9`; `RC_BASELINE` → `0.4.1-rc.8`.

## Test Plan
- [x] `pkg:build` / `pkg:test` 5/5 / `verify:release` (66 + 12) / `test:release-policy` 112/112 / `npm pack --dry-run` (722 entries, no `activation` in CJS/ESM/JSON/d.ts)
- [x] dispute-lifecycle 13+32, method-scoped 47, vault-deployment 8, activation 68, v3-groups 7/7, typecheck
- [ ] CI green

## After merge
Tag `contracts-v2-v0.4.1-rc.9` at the merge commit, dispatch **Publish contracts-v2**; regenerate the Base cutover batch (source SHA moves again) and re-propose at nonce 77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tzc4JYcsy2feiByPEeQXrc