### PR TITLE
fix(deploy): treat the pinned deposit counter as a floor in the vault cutover guard

### DIFF
--- a/contracts/mocks/DisputeMethodScopedVaultActivationTypes.sol
+++ b/contracts/mocks/DisputeMethodScopedVaultActivationTypes.sol
@@ -118,7 +118,7 @@ abstract contract DisputeMethodScopedVaultTrustSurfaceChecks {
     error LifecycleHookMismatch(address actual);
     error PredecessorIntentStatusMismatch(bytes32 intentHash, uint8 actual);
     error PredecessorIntentLockAmountMismatch(bytes32 intentHash, uint256 actual);
-    error DepositCounterMismatch(uint256 actual);
+    error DepositCounterBelowProof(uint256 actual, uint256 pinned);
     error InventoryTupleProtectionMismatch(address escrow, uint256 depositId, bytes32 paymentMethod, bool actual);
 
     VaultTrustSurface internal expected;

--- a/contracts/mocks/DisputeMethodScopedVaultCutoverGuard.sol
+++ b/contracts/mocks/DisputeMethodScopedVaultCutoverGuard.sol
@@ -9,6 +9,12 @@ import {
     VaultTrustSurface
 } from "./DisputeMethodScopedVaultActivationTypes.sol";
 
+/**
+ * @title DisputeMethodScopedVaultCutoverGuard
+ * @notice Binds the dedicated-vault cutover to its proof-time trust surface and depositor inventory.
+ * @dev The proof-time deposit counter is a floor because later deposits cannot carry predecessor opt-outs that the
+ *      fresh default-on policy would honor. A depositor who needs an opt-out re-applies it on the fresh policy.
+ */
 contract DisputeMethodScopedVaultCutoverGuard is DisputeMethodScopedVaultTrustSurfaceChecks {
     bool private immutable expectVaultAcceptOwnership;
     bool private immutable expectPolicyAcceptOwnership;
@@ -43,7 +49,9 @@ contract DisputeMethodScopedVaultCutoverGuard is DisputeMethodScopedVaultTrustSu
         _assertFreshPolicyConfiguration();
 
         uint256 actualCounter = IActivationEscrow(escrow).depositCounter();
-        if (actualCounter != expectedDepositCounter) revert DepositCounterMismatch(actualCounter);
+        if (actualCounter < expectedDepositCounter) {
+            revert DepositCounterBelowProof(actualCounter, expectedDepositCounter);
+        }
         IActivationPolicy fresh = IActivationPolicy(expected.freshPolicy);
         for (uint256 tupleIndex = 0; tupleIndex < inventoryTuples.length; tupleIndex++) {
             InventoryTuple memory tuple = inventoryTuples[tupleIndex];

--- a/deployments/vaultMethodScopedActivation.ts
+++ b/deployments/vaultMethodScopedActivation.ts
@@ -723,7 +723,6 @@ export const VAULT_GUARD_BOUND_FIELDS: Record<
     "registry.writers",
     "orchestrator.lifecycleHook",
     "inventory.escrow",
-    "inventory.depositCounter",
     "inventory.tuples.escrow",
     "inventory.tuples.depositId",
     "inventory.tuples.paymentMethod",
@@ -765,6 +764,13 @@ export function assertVaultGuardExpectationsUnchanged(
   proof: VaultActivationSnapshot,
   simulation: VaultActivationSnapshot
 ): void {
+  if (
+    kind === "vault-cutover" &&
+    BigInt(simulation.inventory.depositCounter) <
+      BigInt(proof.inventory.depositCounter)
+  ) {
+    throw new Error("inventory.depositCounter regressed");
+  }
   const changed = VAULT_GUARD_BOUND_FIELDS[kind].filter(
     (path) =>
       comparable(getPath(proof, path)) !== comparable(getPath(simulation, path))

--- a/docs/superpowers/specs/2026-08-28-method-scoped-dedicated-vault-lanes-design.md
+++ b/docs/superpowers/specs/2026-08-28-method-scoped-dedicated-vault-lanes-design.md
@@ -67,3 +67,12 @@ Lane 38 without the rotation. Reuses lane 38's exported machinery by import wher
 ## Non-goals
 
 No changes to `StakeVault`, `DisputeProtectionPolicy`, `IntentLifecycleHookV1`, or `WhitelistPolicy` source; no migration of stake or depositor opt-outs from the old stacks; no rollback path to lane 37/38 artifacts.
+
+## Amendment 2026-08-28: cutover deposit-counter floor
+
+The lane-40 vault-cutover guard and fresh-block verifier treat the proof-time `inventory.depositCounter` as a floor:
+the live counter must be greater than or equal to the pinned value. `EscrowV2` continues minting deposits between
+proof generation and Safe execution, so exact equality made an otherwise valid batch expire immediately. Every
+pinned inventory tuple remains equality-bound and is re-checked on-chain against the fresh policy. Deposits created
+after the proof cannot carry predecessor opt-outs that the fresh default-on policy would honor; a depositor who needs
+an opt-out re-applies it on the fresh policy.

--- a/scripts/test-method-scoped-activation.cjs
+++ b/scripts/test-method-scoped-activation.cjs
@@ -2959,7 +2959,7 @@ test("vault transaction builders encode conditional acceptances and exact call o
   );
 });
 
-test("vault guard comparison binds cutover inventory and writer-removal intent proof", () => {
+test("vault guard comparison floors the cutover counter and binds tuple and writer-removal proofs", () => {
   const {
     assertVaultGuardExpectationsUnchanged,
   } = require("../deployments/vaultMethodScopedActivation.ts");
@@ -2969,11 +2969,33 @@ test("vault guard comparison binds cutover inventory and writer-removal intent p
   assert.doesNotThrow(() =>
     assertVaultGuardExpectationsUnchanged("vault-cutover", proof, current)
   );
-  current.inventory.depositCounter = "2";
+  current.inventory.depositCounter = "5";
+  assert.doesNotThrow(() =>
+    assertVaultGuardExpectationsUnchanged("vault-cutover", proof, current)
+  );
+  current.inventory.depositCounter = "3";
   assert.throws(
     () =>
       assertVaultGuardExpectationsUnchanged("vault-cutover", proof, current),
-    /inventory.depositCounter/
+    /inventory.depositCounter regressed/
+  );
+  const proofWithTuple = structuredClone(proof);
+  proofWithTuple.inventory.tuples.push({
+    escrow: vaultAddresses.escrow,
+    depositId: "1",
+    paymentMethod: METHOD_A,
+    sources: ["predecessor-opt-out"],
+  });
+  const tupleDrift = structuredClone(proofWithTuple);
+  tupleDrift.inventory.tuples[0].depositId = "999";
+  assert.throws(
+    () =>
+      assertVaultGuardExpectationsUnchanged(
+        "vault-cutover",
+        proofWithTuple,
+        tupleDrift
+      ),
+    /inventory.tuples.depositId/
   );
   const lockDrift = structuredClone(proof);
   lockDrift.lockProof.intents[0].status = 5;
@@ -3109,12 +3131,16 @@ test("vault constructor derivation independently binds both ownership acceptance
   );
 });
 
-test("vault verifier branch uses injected lane-40 readers before artifact identity checks", async () => {
+/**
+ * @param {string} liveDepositCounter
+ */
+function vaultVerificationFixture(liveDepositCounter) {
   const {
     computeVaultManifestSha256,
     vaultSafeBatchJson,
   } = require("../deployments/vaultActivationBatchManifest.ts");
   const {
+    deriveVaultActivationConstructorArgs,
     verifyVaultActivationCandidate,
   } = require("./verify-method-scoped-safe-batch.ts");
   const { BASE_SAFE } = require("./simulate-dispute-opt-in-safe-batch.ts");
@@ -3122,6 +3148,17 @@ test("vault verifier branch uses injected lane-40 readers before artifact identi
   const manifest = vaultManifestFixture();
   manifest.safe = BASE_SAFE.toLowerCase();
   manifest.sourceSha = repository.sourceSha;
+  manifest.guard.constructorArgs = deriveVaultActivationConstructorArgs(
+    manifest,
+    "guard"
+  );
+  manifest.postcondition.constructorArgs = deriveVaultActivationConstructorArgs(
+    manifest,
+    "postcondition"
+  );
+  const runtime = "0x6001";
+  manifest.guard.runtimeCodeHash = utils.keccak256(runtime);
+  manifest.postcondition.runtimeCodeHash = utils.keccak256(runtime);
   const { manifestSha256: _digest, ...unsigned } = manifest;
   manifest.manifestSha256 = computeVaultManifestSha256(unsigned);
   const batch = vaultSafeBatchJson(
@@ -3129,6 +3166,39 @@ test("vault verifier branch uses injected lane-40 readers before artifact identi
     manifest.transactions,
     1234
   );
+  /** @type {Record<string, any>} */
+  const artifacts = {};
+  for (const identity of [manifest.guard, manifest.postcondition]) {
+    const hardhatArtifact = require(`../artifacts/contracts/mocks/${identity.artifactName}.sol/${identity.artifactName}.json`);
+    artifacts[identity.artifactName] = {
+      abi: hardhatArtifact.abi,
+      bytecode: "0x6000",
+      deployedBytecode: runtime,
+      evm: { deployedBytecode: { immutableReferences: {} } },
+    };
+  }
+  /** @type {Record<string, {data: string}>} */
+  const deploymentTransactions = {};
+  /** @type {Record<string, {status: number, contractAddress: string}>} */
+  const receipts = {};
+  const identities =
+    /** @type {Array<["guard" | "postcondition", import("../deployments/vaultActivationBatchManifest").ContractIdentity]>} */ ([
+      ["guard", manifest.guard],
+      ["postcondition", manifest.postcondition],
+    ]);
+  for (const [role, identity] of identities) {
+    const artifact = artifacts[identity.artifactName];
+    const encoded = new utils.Interface(artifact.abi).encodeDeploy(
+      deriveVaultActivationConstructorArgs(manifest, role)
+    );
+    deploymentTransactions[identity.deployTransactionHash] = {
+      data: `${artifact.bytecode}${encoded.slice(2)}`,
+    };
+    receipts[identity.deployTransactionHash] = {
+      status: 1,
+      contractAddress: identity.address,
+    };
+  }
   const provider = {
     _isProvider: true,
     getNetwork: async () => ({ chainId: 8453, name: "base" }),
@@ -3141,29 +3211,33 @@ test("vault verifier branch uses injected lane-40 readers before artifact identi
     resolveName: async (name) => name,
     call: async () =>
       utils.defaultAbiCoder.encode(["uint256"], [manifest.safeNonce]),
+    /** @param {string} transactionHash */
+    getTransactionReceipt: async (transactionHash) =>
+      receipts[transactionHash] || null,
+    /** @param {string} transactionHash */
+    getTransaction: async (transactionHash) =>
+      deploymentTransactions[transactionHash] || null,
+    getCode: async () => runtime,
   };
   const hre = {
     __methodScopedVerificationProvider: provider,
     deployments: {
-      getExtendedArtifact: async () => {
-        throw new Error("vault guard identity boundary reached");
-      },
-      getArtifact: async () => {
-        throw new Error("unexpected artifact lookup");
-      },
+      /** @param {string} name */
+      getExtendedArtifact: async (name) => artifacts[name],
+      /** @param {string} name */
+      getArtifact: async (name) => artifacts[name],
     },
     ethers: ethersPackage,
   };
-  let loaded = false;
+  const liveSnapshot = vaultSnapshot();
+  liveSnapshot.inventory.depositCounter = liveDepositCounter;
   const lane = {
-    loadVaultActivationContext: async () => {
-      loaded = true;
-    },
+    loadVaultActivationContext: async () => {},
     expectedVaultActivationState: () => vaultExpected(),
-    readVaultActivationSnapshot: async () => vaultSnapshot(),
+    readVaultActivationSnapshot: async () => liveSnapshot,
     runPinnedSimulation: async () => {},
   };
-  await assert.rejects(
+  const run = () =>
     verifyVaultActivationCandidate(/** @type {any} */ (hre), {
       kind: "vault-cutover",
       batch,
@@ -3173,8 +3247,14 @@ test("vault verifier branch uses injected lane-40 readers before artifact identi
       forkRpcUrl: "fake-rpc",
       artifactPaths: { batch: "unused", sidecar: "unused" },
       lane,
-    }),
-    /vault guard identity boundary reached/
+    });
+  return { run };
+}
+
+test("vault verifier fresh-block drift check accepts a higher counter and rejects a lower counter", async () => {
+  await assert.doesNotReject(vaultVerificationFixture("5").run());
+  await assert.rejects(
+    vaultVerificationFixture("3").run(),
+    /inventory.depositCounter regressed/
   );
-  assert.equal(loaded, true);
 });

--- a/test-foundry/deterministic/mocks/DisputeMethodScopedVaultActivation.t.sol
+++ b/test-foundry/deterministic/mocks/DisputeMethodScopedVaultActivation.t.sol
@@ -115,6 +115,24 @@ contract DisputeMethodScopedVaultActivationTest is OrchestratorV3Fixture {
         }
     }
 
+    function test_CutoverGuardPassesWhenDepositCounterAdvancesAboveProof() public {
+        _cutover(true, true, escrow.depositCounter() - 1).assertReady();
+    }
+
+    function test_CutoverGuardRejectsDepositCounterBelowProof() public {
+        uint256 actualCounter = escrow.depositCounter();
+        uint256 pinnedCounter = actualCounter + 1;
+        DisputeMethodScopedVaultCutoverGuard guard = _cutover(true, true, pinnedCounter);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                DisputeMethodScopedVaultTrustSurfaceChecks.DepositCounterBelowProof.selector,
+                actualCounter,
+                pinnedCounter
+            )
+        );
+        guard.assertReady();
+    }
+
     function test_CutoverGuardRejectsOwnershipPredicates() public {
         _expectCutover(
             _surface(),
@@ -206,13 +224,6 @@ contract DisputeMethodScopedVaultActivationTest is OrchestratorV3Fixture {
         );
         vm.prank(depositor);
         freshPolicy.setDisputeProtectionEnabled(address(escrow), depositId, METHOD, false);
-        _expectCutover(
-            _surface(),
-            true,
-            true,
-            escrow.depositCounter() + 1,
-            DisputeMethodScopedVaultTrustSurfaceChecks.DepositCounterMismatch.selector
-        );
     }
 
     function test_CutoverGuardRejectsFreshPolicyAndSharedSurfaceDrift() public {


### PR DESCRIPTION
## Summary
The Base vault-cutover batch generated from `8094d53` reverted in its guard with `DepositCounterMismatch(4319)` minutes after generation: `EscrowV2` mints deposits continuously (4,306 → 4,319 today), so an exact `depositCounter` binding cannot survive a 2-of-2 signing window. Earlier proposals only estimated cleanly by luck.

- `DisputeMethodScopedVaultCutoverGuard` now requires `escrow.depositCounter() >= pinned` (`DepositCounterBelowProof(actual, pinned)` otherwise) — proves the same escrow and no reset — while every pinned inventory tuple is still re-checked on-chain (`isDisputeProtectionEnabled == false` on the fresh policy). Constructor signature/arg order unchanged, so manifest/verifier derivation is compatible.
- P→S drift (`assertVaultGuardExpectationsUnchanged`) and the standalone verifier's fresh-block drift use the same floor for `vault-cutover`; tuple drift still fails. Writer-removal kind and all lane-38 files untouched.
- Rationale (spec amendment 2026-08-28): deposits created after the proof cannot carry predecessor opt-outs that the default-on fresh policy would honor; a depositor re-opts-out on the fresh policy if needed.

## Test Plan
- [x] Foundry vault guard suite 11/11 (counter above pin passes, below reverts, tuple drift reverts); `yarn test:method-scoped-activation` 68 across five files; typecheck; forge fmt; prettier
- [ ] CI green; then regenerate the Base cutover batch and re-propose at nonce 77

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tzc4JYcsy2feiByPEeQXrc