### PR TITLE
fix(ci): assign the deterministic mocks tests to a coverage partition

### DIFF
--- a/scripts/run-foundry-coverage.cjs
+++ b/scripts/run-foundry-coverage.cjs
@@ -81,6 +81,11 @@ const deterministicCoverageRuns = [
         test: "test-foundry/deterministic/libs",
     },
     {
+        name: "deterministic-mocks",
+        irMinimum: true,
+        test: "test-foundry/deterministic/mocks",
+    },
+    {
         name: "deterministic-oracles",
         irMinimum: true,
         test: "test-foundry/deterministic/oracles",
@@ -165,6 +170,7 @@ const coverageLanes = new Map([
             "deterministic-deployment",
             "deterministic-guardian",
             "deterministic-hooks",
+            "deterministic-mocks",
             "deterministic-oracles",
             "deterministic-periphery",
             "deterministic-registries",


### PR DESCRIPTION
Every push-only Foundry coverage shard on `main` has failed since the activation-guard lanes added `test-foundry/deterministic/mocks/` without a `deterministicCoverageRuns` entry (`deterministic coverage partition mismatch`). Adds the `deterministic-mocks` run (alphabetized, `irMinimum: true`) on the `remaining` lane; `contracts/mocks` stays excluded from production coverage; floors unchanged. `yarn coverage --lane=remaining` passes locally (186 s). Note: shards skip on PR runs — the proof is `main`'s run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tzc4JYcsy2feiByPEeQXrc