### PR TITLE
feat(scripts): verify Safe batches against protected paths, not the whole tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,9 @@
   remove predecessor writer, `setLifecycleHook`. A postcondition contract is appended in the pinned fork
   simulation only. Artifacts live at `deployments/outputs/safe-batches/base_method_scoped_{rotation,cutover}.json`
   with `.sha256.json` sidecars; `yarn verify:method-scoped-safe-batch --batch rotation|cutover` must pass
-  immediately before the Safe executes, and no script ever signs. Retire lane 37 before activation (its skip
+  immediately before the Safe executes, and no script ever signs. Artifact-child verification permits unrelated
+  commits after the recorded source SHA only while every path in `ACTIVATION_PROTECTED_PATHS` remains unchanged.
+  Retire lane 37 before activation (its skip
   asserts the predecessor hook is still live), pin lane 38 after its first live transition, and keep the
   `active-dispute-stack.json` / `PREDECESSOR_DISPUTE_STACKS` / evidence flip and the `WhitelistPolicy`
   package alias in recording PRs after each execution — the lane itself flips nothing repo-side.
@@ -97,6 +99,8 @@
   predecessor vault holds no locks. Snapshots carry `freshVault` and `predecessorVault` separately; guards, manifest
   (v3), verifier kinds (`vault-cutover`, `vault-writer-removal`) and artifacts
   (`deployments/outputs/safe-batches/base_method_scoped_vault_*`) are additive to lane 38's, which stay byte-identical.
+  The same artifact-child protected-path rule applies to both lane-40 batch kinds; unrelated repository changes do not
+  require regeneration when the batch producers and verifiers are unchanged.
   Recording checkpoints: commit live records before any artifact generation, pin lanes 39/40 after their first live
   execution, propose the Base cutover at the live Safe nonce, and flip manifests/package only after execution.
 - `deployments/predecessorDisputeStack.ts` keeps two pinned maps: `PREDECESSOR_DISPUTE_STACKS` describes the

--- a/README.md
+++ b/README.md
@@ -757,7 +757,9 @@ Each batch is simulated on a pinned Base fork with a postcondition contract appe
 sidecar that pins the proof snapshot, guard identity, and source SHA. Run
 `yarn verify:method-scoped-safe-batch --batch rotation|cutover` immediately before the Safe executes;
 it re-derives the guard constructor arguments from the manifest, re-proves the guard and postcondition
-deployments, re-reads the chain at a fresh block, and re-runs the simulation. No script signs. Lane 37
+deployments, re-reads the chain at a fresh block, and re-runs the simulation. Artifact-child verification allows
+unrelated commits after the recorded source SHA only when every producer and verifier path in
+`ACTIVATION_PROTECTED_PATHS` is unchanged. No script signs. Lane 37
 must be retired before activation (its skip asserts the predecessor hook is still live), lane 38 is
 pinned after its first live transition, and the `active-dispute-stack.json`,
 `PREDECESSOR_DISPUTE_STACKS`, evidence, and `WhitelistPolicy` package-alias flips land in recording PRs
@@ -782,6 +784,8 @@ Base prepares one guarded cutover batch (guard → conditional `acceptOwnership`
 terminal and `StakeVaultOptIn` holds no locks. Artifacts live at
 `deployments/outputs/safe-batches/base_method_scoped_vault_{cutover,writer_removal}.json`; run
 `yarn verify:method-scoped-safe-batch --batch vault-cutover|vault-writer-removal` immediately before the Safe executes.
+The same protected-path rule keeps these batches valid across unrelated merges without weakening their source,
+artifact-pair, or live-chain checks.
 Stake in the old vaults is abandoned: stakers withdraw once their locks release and takers re-stake in the new vault
 before the cutover; that readiness is part of `CONFIRM_BASE_V3_DISPUTE_METHOD_SCOPED_VAULT_DOWNSTREAM_READY`.
 

--- a/docs/superpowers/specs/2026-08-28-method-scoped-dedicated-vault-lanes-design.md
+++ b/docs/superpowers/specs/2026-08-28-method-scoped-dedicated-vault-lanes-design.md
@@ -60,7 +60,7 @@ Lane 38 without the rotation. Reuses lane 38's exported machinery by import wher
 ## Sequencing after merge (with recording checkpoints)
 
 1. Staging: lane 39 (deploy-only) → **recording PR #1** (staging records; pin lanes 39 and 40 at their executed digests — a lane is immutable after any live execution) → lane 40 steps (add writer → set hook → remove lane-32 writer; staging lane-32 has zero intents) — all deployer EOA; Basescan verify; on-chain reads; Slack.
-2. Base: lane 39 (deploy-only; vault + policy ownership transfers initiated) → **recording PR #2** (Base records; artifact generation requires a clean worktree at `HEAD == sourceSha`) → lane 40 cutover preparation → standalone verifier → propose at nonce 77 → owners execute on Kartik's go (then 78–83) → **recording PR #3** (execution evidence, `active-dispute-stack.json` / `PREDECESSOR_DISPUTE_STACKS` / evidence flips, package alias, RC).
+2. Base: lane 39 (deploy-only; vault + policy ownership transfers initiated) → **recording PR #2** (Base records; artifact generation requires a clean worktree at `HEAD == sourceSha`) → lane 40 cutover preparation → standalone verifier (artifact-child protected-path rule below) → propose at nonce 77 → owners execute on Kartik's go (then 78–83) → **recording PR #3** (execution evidence, `active-dispute-stack.json` / `PREDECESSOR_DISPUTE_STACKS` / evidence flips, package alias, RC).
 3. Fresh-vault readiness is a precondition of the Base cutover and is attested by `CONFIRM_BASE_…_DOWNSTREAM_READY`: indexer/curator on the new addresses, affected takers re-staked in `StakeVaultMethodScoped` (the fresh policy calls `lockStake` on admission; `stakeOwnerOf` falls back to the taker when no delegation exists), delegations/selections recreated, and any predecessor opt-outs that must persist recreated on the fresh policy (none exist today).
 4. Writer-removal batch once every predecessor intent is terminal and the predecessor vault holds no locks (earliest possible: after both OptIn locks are released, i.e. no sooner than 2026-09-10 11:30 UTC unless disputed/released earlier).
 
@@ -76,3 +76,11 @@ proof generation and Safe execution, so exact equality made an otherwise valid b
 pinned inventory tuple remains equality-bound and is re-checked on-chain against the fresh policy. Deposits created
 after the proof cannot carry predecessor opt-outs that the fresh default-on policy would honor; a depositor who needs
 an opt-out re-applies it on the fresh policy.
+
+## Amendment 2026-08-28: protected artifact paths
+
+Generation mode remains clean-worktree-only with `HEAD == sourceSha`. Artifact-child verification instead requires
+`sourceSha` to be an ancestor of `HEAD` and rejects changes only under `ACTIVATION_PROTECTED_PATHS`, which covers the
+lanes, activation and manifest modules, verifier and simulators, contracts, deployment records and pins, and toolchain
+configuration that produce or verify all four method-scoped batches. Unrelated CI, documentation, and other
+non-protected repository changes no longer force artifact regeneration or a replacement Safe proposal.

--- a/scripts/test-method-scoped-activation.cjs
+++ b/scripts/test-method-scoped-activation.cjs
@@ -21,7 +21,7 @@ const {
   writeFileSync,
 } = require("node:fs");
 const { tmpdir } = require("node:os");
-const { basename, join } = require("node:path");
+const { basename, dirname, join } = require("node:path");
 const { test } = require("node:test");
 const { BigNumber, utils } = require("ethers");
 const ethersPackage = require("ethers");
@@ -2256,6 +2256,28 @@ function temporaryGitRepository(prefix) {
   };
 }
 
+/** @param {{ root: string }} repository @param {string[]} paths */
+function commitRepositoryPaths(repository, paths) {
+  for (const path of paths) {
+    mkdirSync(dirname(join(repository.root, path)), { recursive: true });
+    writeFileSync(join(repository.root, path), `${path}\n`);
+  }
+  execFileSync("git", ["add", "."], { cwd: repository.root });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=Task Four",
+      "-c",
+      "user.email=task4@example.invalid",
+      "commit",
+      "-qm",
+      "fixture",
+    ],
+    { cwd: repository.root }
+  );
+}
+
 test("generation Git mode requires a clean worktree and exact source HEAD", () => {
   const {
     assertActivationArtifactGitState,
@@ -2265,8 +2287,7 @@ test("generation Git mode requires a clean worktree and exact source HEAD", () =
     assertActivationArtifactGitState(
       repository.root,
       repository.sourceSha,
-      "generation",
-      []
+      "generation"
     )
   );
   assert.throws(
@@ -2274,8 +2295,7 @@ test("generation Git mode requires a clean worktree and exact source HEAD", () =
       assertActivationArtifactGitState(
         repository.root,
         "f".repeat(40),
-        "generation",
-        []
+        "generation"
       ),
     /HEAD does not equal/
   );
@@ -2285,83 +2305,106 @@ test("generation Git mode requires a clean worktree and exact source HEAD", () =
       assertActivationArtifactGitState(
         repository.root,
         repository.sourceSha,
-        "generation",
-        []
+        "generation"
       ),
     /clean worktree/
   );
 });
 
-test("artifact-child Git mode allows only the selected lane-38 pair and its superseded copies", () => {
+test("artifact-child Git mode permits unrelated paths", () => {
   const {
     assertActivationArtifactGitState,
   } = require("./verify-method-scoped-safe-batch.ts");
   const repository = temporaryGitRepository("method-scoped-child-");
-  const allowed = ACTIVATION_BATCH_PATHS.rotation;
-  mkdirSync(join(repository.root, "deployments/outputs/safe-batches"), {
-    recursive: true,
-  });
-  writeFileSync(join(repository.root, allowed.batch), "{}\n");
-  writeFileSync(join(repository.root, allowed.sidecar), "{}\n");
-  execFileSync("git", ["add", "."], { cwd: repository.root });
-  execFileSync(
-    "git",
-    [
-      "-c",
-      "user.name=Task Four",
-      "-c",
-      "user.email=task4@example.invalid",
-      "commit",
-      "-qm",
-      "artifacts",
-    ],
-    { cwd: repository.root }
-  );
-  const allowlist = [
-    allowed.batch,
-    allowed.sidecar,
-    `${allowed.supersededDir}/base_method_scoped_rotation_*`,
-  ];
+  commitRepositoryPaths(repository, [
+    "README.md",
+    "deployments/outputs/safe-batches/base_optin_writer_removal.json",
+    ".github/workflows/x.yml",
+  ]);
   assert.doesNotThrow(() =>
     assertActivationArtifactGitState(
       repository.root,
       repository.sourceSha,
-      "artifact-child",
-      allowlist
+      "artifact-child"
     )
   );
-  mkdirSync(
-    join(repository.root, "deployments/outputs/safe-batches/superseded"),
-    {
-      recursive: true,
-    }
+});
+
+test("artifact-child Git mode rejects and names every protected path", () => {
+  const {
+    ACTIVATION_PROTECTED_PATHS,
+    assertActivationArtifactGitState,
+  } = require("./verify-method-scoped-safe-batch.ts");
+  assert.deepEqual(ACTIVATION_PROTECTED_PATHS, [
+    "deploy/37_deploy_method_scoped_dispute_lifecycle_stack.ts",
+    "deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts",
+    "deploy/39_deploy_method_scoped_vault_stack.ts",
+    "deploy/40_activate_method_scoped_vault_stack.ts",
+    "deployments/methodScopedActivation.ts",
+    "deployments/vaultMethodScopedActivation.ts",
+    "deployments/activationBatchManifest.ts",
+    "deployments/vaultActivationBatchManifest.ts",
+    "deployments/safeArtifacts.ts",
+    "deployments/safeBatchManifest.ts",
+    "deployments/predecessorDisputeStack.ts",
+    "deployments/canonicalDeployment.ts",
+    "deployments/parameters.ts",
+    "deployments/immutableDeploymentLanes.ts",
+    "deployments/base/",
+    "deployments/base_staging/",
+    "scripts/verify-method-scoped-safe-batch.ts",
+    "scripts/simulate-method-scoped-safe-batch.ts",
+    "scripts/simulate-dispute-opt-in-safe-batch.ts",
+    "contracts/",
+    "hardhat.config.ts",
+    "foundry.toml",
+    "package.json",
+    "yarn.lock",
+    "tsconfig*.json",
+  ]);
+  for (const protectedPath of [
+    "deploy/40_activate_method_scoped_vault_stack.ts",
+    "contracts/mocks/Protected.sol",
+    "scripts/verify-method-scoped-safe-batch.ts",
+    "deployments/base/StakeVaultMethodScoped.json",
+  ]) {
+    const repository = temporaryGitRepository("method-scoped-protected-");
+    commitRepositoryPaths(repository, [protectedPath]);
+    assert.throws(
+      () =>
+        assertActivationArtifactGitState(
+          repository.root,
+          repository.sourceSha,
+          "artifact-child"
+        ),
+      new RegExp(protectedPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    );
+  }
+});
+
+test("artifact-child Git mode requires ancestry and a clean worktree", () => {
+  const {
+    assertActivationArtifactGitState,
+  } = require("./verify-method-scoped-safe-batch.ts");
+  const repository = temporaryGitRepository("method-scoped-child-state-");
+  assert.throws(
+    () =>
+      assertActivationArtifactGitState(
+        repository.root,
+        "f".repeat(40),
+        "artifact-child"
+      ),
+    /not an ancestor/
   );
-  const lane34Path =
-    "deployments/outputs/safe-batches/superseded/base_opt_in_dispute_lifecycle.json";
-  writeFileSync(join(repository.root, lane34Path), "{}\n");
-  execFileSync("git", ["add", "."], { cwd: repository.root });
-  execFileSync(
-    "git",
-    [
-      "-c",
-      "user.name=Task Four",
-      "-c",
-      "user.email=task4@example.invalid",
-      "commit",
-      "-qm",
-      "unrelated",
-    ],
-    { cwd: repository.root }
-  );
+  writeFileSync(join(repository.root, "tracked"), "dirty\n");
   assert.throws(
     () =>
       assertActivationArtifactGitState(
         repository.root,
         repository.sourceSha,
-        "artifact-child",
-        allowlist
+        "artifact-child"
       ),
-    /base_opt_in_dispute_lifecycle/
+    /clean worktree/
   );
 });
 

--- a/scripts/test-method-scoped-vault-activation.cjs
+++ b/scripts/test-method-scoped-vault-activation.cjs
@@ -13,6 +13,10 @@ moduleAlias.reset();
 moduleAlias.addAlias("@utils", process.cwd() + "/utils");
 
 const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const { mkdtempSync, mkdirSync, writeFileSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const { dirname, join } = require("node:path");
 const { test } = require("node:test");
 const { utils } = require("ethers");
 
@@ -21,6 +25,99 @@ const address = (value) => `0x${value.toString(16).padStart(40, "0")}`;
 /** @param {number} value */
 const hash = (value) => `0x${value.toString(16).padStart(64, "0")}`;
 const ZERO = address(0);
+
+/** @param {string} prefix */
+function temporaryGitRepository(prefix) {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  execFileSync("git", ["init", "-q"], { cwd: root });
+  writeFileSync(join(root, "tracked"), "base\n");
+  execFileSync("git", ["add", "tracked"], { cwd: root });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=Vault Activation",
+      "-c",
+      "user.email=vault-activation@example.invalid",
+      "commit",
+      "-qm",
+      "base",
+    ],
+    { cwd: root }
+  );
+  return {
+    root,
+    sourceSha: execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+    }).trim(),
+  };
+}
+
+/** @param {{ root: string }} repository @param {string[]} paths */
+function commitRepositoryPaths(repository, paths) {
+  for (const path of paths) {
+    mkdirSync(dirname(join(repository.root, path)), { recursive: true });
+    writeFileSync(join(repository.root, path), `${path}\n`);
+  }
+  execFileSync("git", ["add", "."], { cwd: repository.root });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=Vault Activation",
+      "-c",
+      "user.email=vault-activation@example.invalid",
+      "commit",
+      "-qm",
+      "fixture",
+    ],
+    { cwd: repository.root }
+  );
+}
+
+test("vault artifact-child verification permits unrelated changes", () => {
+  const {
+    assertActivationArtifactGitState,
+  } = require("./verify-method-scoped-safe-batch.ts");
+  const repository = temporaryGitRepository("vault-activation-unrelated-");
+  commitRepositoryPaths(repository, [
+    "README.md",
+    "deployments/outputs/safe-batches/base_optin_writer_removal.json",
+    ".github/workflows/x.yml",
+  ]);
+  assert.doesNotThrow(() =>
+    assertActivationArtifactGitState(
+      repository.root,
+      repository.sourceSha,
+      "artifact-child"
+    )
+  );
+});
+
+test("vault artifact-child verification rejects protected changes", () => {
+  const {
+    assertActivationArtifactGitState,
+  } = require("./verify-method-scoped-safe-batch.ts");
+  for (const protectedPath of [
+    "deploy/40_activate_method_scoped_vault_stack.ts",
+    "contracts/mocks/VaultProtected.sol",
+    "scripts/verify-method-scoped-safe-batch.ts",
+    "deployments/base/StakeVaultMethodScoped.json",
+  ]) {
+    const repository = temporaryGitRepository("vault-activation-protected-");
+    commitRepositoryPaths(repository, [protectedPath]);
+    assert.throws(
+      () =>
+        assertActivationArtifactGitState(
+          repository.root,
+          repository.sourceSha,
+          "artifact-child"
+        ),
+      new RegExp(protectedPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    );
+  }
+});
 
 const vaultAddresses = {
   safe: address(1),

--- a/scripts/verify-method-scoped-safe-batch.ts
+++ b/scripts/verify-method-scoped-safe-batch.ts
@@ -43,6 +43,33 @@ import { EXPECTED_LIVE } from "../deploy/37_deploy_method_scoped_dispute_lifecyc
 import { BASE_SAFE } from "./simulate-dispute-opt-in-safe-batch";
 
 export type ActivationGitMode = "generation" | "artifact-child";
+export const ACTIVATION_PROTECTED_PATHS: readonly string[] = [
+  "deploy/37_deploy_method_scoped_dispute_lifecycle_stack.ts",
+  "deploy/38_activate_method_scoped_dispute_lifecycle_stack.ts",
+  "deploy/39_deploy_method_scoped_vault_stack.ts",
+  "deploy/40_activate_method_scoped_vault_stack.ts",
+  "deployments/methodScopedActivation.ts",
+  "deployments/vaultMethodScopedActivation.ts",
+  "deployments/activationBatchManifest.ts",
+  "deployments/vaultActivationBatchManifest.ts",
+  "deployments/safeArtifacts.ts",
+  "deployments/safeBatchManifest.ts",
+  "deployments/predecessorDisputeStack.ts",
+  "deployments/canonicalDeployment.ts",
+  "deployments/parameters.ts",
+  "deployments/immutableDeploymentLanes.ts",
+  "deployments/base/",
+  "deployments/base_staging/",
+  "scripts/verify-method-scoped-safe-batch.ts",
+  "scripts/simulate-method-scoped-safe-batch.ts",
+  "scripts/simulate-dispute-opt-in-safe-batch.ts",
+  "contracts/",
+  "hardhat.config.ts",
+  "foundry.toml",
+  "package.json",
+  "yarn.lock",
+  "tsconfig*.json",
+];
 type VerificationRuntimeEnvironment = HardhatRuntimeEnvironment & {
   __methodScopedVerificationProvider?: ethers.providers.Provider;
 };
@@ -83,11 +110,12 @@ function git(repositoryRoot: string, args: string[]): string {
   }).trim();
 }
 
+/** The optional legacy paths preserve immutable generation-lane call sites; they do not define artifact-child policy. */
 export function assertActivationArtifactGitState(
   repositoryRoot: string,
   sourceSha: string,
   mode: ActivationGitMode,
-  allowedPaths: readonly string[]
+  _legacyArtifactPaths?: readonly string[]
 ): void {
   if (git(repositoryRoot, ["status", "--porcelain"]) !== "") {
     throw new Error("Safe artifact verification requires a clean worktree");
@@ -112,20 +140,25 @@ export function assertActivationArtifactGitState(
   const changed = git(repositoryRoot, [
     "diff",
     "--name-only",
+    "--no-renames",
     `${sourceSha}..${head}`,
   ])
     .split("\n")
     .filter(Boolean);
-  const allowed = (path: string): boolean =>
-    allowedPaths.some((candidate) =>
-      candidate.endsWith("*")
-        ? path.startsWith(candidate.slice(0, -1))
-        : path === candidate
-    );
-  const unexpected = changed.filter((path) => !allowed(path));
-  if (unexpected.length > 0) {
+  const isProtected = (path: string): boolean =>
+    ACTIVATION_PROTECTED_PATHS.some((candidate) => {
+      if (candidate.endsWith("/")) return path.startsWith(candidate);
+      const wildcard = candidate.indexOf("*");
+      if (wildcard === -1) return path === candidate;
+      return (
+        path.startsWith(candidate.slice(0, wildcard)) &&
+        path.endsWith(candidate.slice(wildcard + 1))
+      );
+    });
+  const protectedChanges = changed.filter(isProtected);
+  if (protectedChanges.length > 0) {
     throw new Error(
-      `Artifact child contains unrelated paths: ${unexpected.join(", ")}`
+      `Artifact child changes protected paths: ${protectedChanges.join(", ")}`
     );
   }
 }
@@ -498,16 +531,10 @@ export async function verifyActivationCandidate(
     throw new Error("Safe manifest does not target the pinned ZKP2P Base Safe");
   }
   assertBatchMatchesActivationManifest(batch, manifest);
-  const pathConfig = ACTIVATION_BATCH_PATHS[input.kind];
   assertActivationArtifactGitState(
     input.repositoryRoot,
     manifest.sourceSha,
-    input.mode,
-    [
-      pathConfig.batch,
-      pathConfig.sidecar,
-      `${pathConfig.supersededDir}/base_method_scoped_${input.kind}_*`,
-    ]
+    input.mode
   );
   if (!input.forkRpcUrl) {
     throw new Error(
@@ -625,19 +652,10 @@ export async function verifyVaultActivationCandidate(
     throw new Error("Safe manifest does not target the pinned ZKP2P Base Safe");
   }
   assertBatchMatchesVaultActivationManifest(batch, manifest);
-  const pathConfig = VAULT_ACTIVATION_BATCH_PATHS[input.kind];
   assertActivationArtifactGitState(
     input.repositoryRoot,
     manifest.sourceSha,
-    input.mode,
-    [
-      pathConfig.batch,
-      pathConfig.sidecar,
-      `${pathConfig.supersededDir}/base_method_scoped_${input.kind.replace(
-        /-/g,
-        "_"
-      )}_*`,
-    ]
+    input.mode
   );
   if (!input.forkRpcUrl) {
     throw new Error(


### PR DESCRIPTION
## Summary
Artifact-child verification (`yarn verify:method-scoped-safe-batch`, all four kinds) previously required that **only** the batch's artifact pair changed between its recorded source SHA and `HEAD`. Every unrelated merge (package bumps, records, CI fixes) therefore forced a regeneration and a new Safe proposal — seven superseded nonce-77 proposals on 2026-08-28.

It now requires that none of the **protected paths** changed since the source SHA: lanes 37–40, the activation/manifest/artifact modules, the verifier and simulators, `contracts/`, the Base/Base-staging deployment records and pins, and the toolchain config (`hardhat.config.ts`, `foundry.toml`, `package.json`, `yarn.lock`, `tsconfig*.json`). Unrelated paths may change. Clean-tree, ancestry, and generation-mode (`HEAD == sourceSha`) rules are unchanged; errors list the offending protected paths. Lane 34's verifier and the pinned lane-38 source are untouched.

## Note on the queued batch
This change edits the verifier (a protected path), so the live nonce-77 batch (`0xf20c9517…`, recorded at `b503781`) is **not** regenerated (decision: skip); its pre-signing verification runs from a detached checkout of `b503781`, which passed today.

## Test Plan
- [x] `yarn test:method-scoped-activation` 53+2+11+3+3 (unrelated paths pass; protected paths fail and are named; ancestry/clean-tree cases), typecheck
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tzc4JYcsy2feiByPEeQXrc