### PR TITLE
chore(deploy): record Base whitelist policy ownership transfer Safe transaction

### DIFF
--- a/deployments/outputs/safe-batches/base_whitelist_policy_transfer_to_deployer.json
+++ b/deployments/outputs/safe-batches/base_whitelist_policy_transfer_to_deployer.json
@@ -1,10 +1,10 @@
 {
   "version": "1.0",
   "chainId": "8453",
-  "createdAt": 1787906773386,
+  "createdAt": 1787906999950,
   "meta": {
-    "name": "Base WhitelistPolicyMethodScoped ownership to deployer",
-    "description": "WhitelistPolicy (single-step Ownable) transferOwnership to the operations deployer so the Peer Pay bootstrap can be executed directly (Safe bootstrap batches 78-83 kept reverting as deposits changed between generation and signing)",
+    "name": "Base WhitelistPolicyMethodScoped ownership to the lane deployer",
+    "description": "WhitelistPolicy (single-step Ownable) transferOwnership to the pinned lane deployer 0x84e1…1929 so the Peer Pay bootstrap runs directly (Safe bootstrap batches 78-83 reverted as deposits changed before signatures landed)",
     "txBuilderVersion": "1.16.0",
     "createdFromSafeAddress": "0x0bC26FF515411396DD588Abd6Ef6846E04470227"
   },
@@ -12,7 +12,7 @@
     {
       "to": "0x389Cd9bA91FfFcd83d267B241E975541892759Ce",
       "value": "0",
-      "data": "0xf2fde38b000000000000000000000000e29a5bd4d0ceba6c125a0361e7d20ab4ea275c2f",
+      "data": "0xf2fde38b00000000000000000000000084e113087c97cd80ea9d78983d4b8ff61eca1929",
       "operation": 0,
       "contractMethod": {
         "name": "transferOwnership",
@@ -24,7 +24,7 @@
         ]
       },
       "contractInputsValues": {
-        "newOwner": "0xe29a5BD4D0CEbA6C125A0361E7D20ab4eA275C2f"
+        "newOwner": "0x84e113087C97Cd80eA9D78983D4B8Ff61ECa1929"
       }
     }
   ]

--- a/deployments/outputs/safe-batches/base_whitelist_policy_transfer_to_deployer.json
+++ b/deployments/outputs/safe-batches/base_whitelist_policy_transfer_to_deployer.json
@@ -1,0 +1,31 @@
+{
+  "version": "1.0",
+  "chainId": "8453",
+  "createdAt": 1787906773386,
+  "meta": {
+    "name": "Base WhitelistPolicyMethodScoped ownership to deployer",
+    "description": "WhitelistPolicy (single-step Ownable) transferOwnership to the operations deployer so the Peer Pay bootstrap can be executed directly (Safe bootstrap batches 78-83 kept reverting as deposits changed between generation and signing)",
+    "txBuilderVersion": "1.16.0",
+    "createdFromSafeAddress": "0x0bC26FF515411396DD588Abd6Ef6846E04470227"
+  },
+  "transactions": [
+    {
+      "to": "0x389Cd9bA91FfFcd83d267B241E975541892759Ce",
+      "value": "0",
+      "data": "0xf2fde38b000000000000000000000000e29a5bd4d0ceba6c125a0361e7d20ab4ea275c2f",
+      "operation": 0,
+      "contractMethod": {
+        "name": "transferOwnership",
+        "inputs": [
+          {
+            "name": "newOwner",
+            "type": "address"
+          }
+        ]
+      },
+      "contractInputsValues": {
+        "newOwner": "0xe29a5BD4D0CEbA6C125A0361E7D20ab4eA275C2f"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Records the Transaction Builder JSON for `WhitelistPolicyMethodScoped.transferOwnership(0x84e113087C97Cd80eA9D78983D4B8Ff61ECa1929)` — the pinned lane deployer — at Safe nonce 78 (`0xb6711900…9f74`), so the Peer Pay whitelist bootstrap runs directly from the deployer (the six Safe bootstrap batches reverted as deposits changed before both signatures landed). OptIn writer removal re-proposed at nonce 79 (`0x35a4979c…06f7`). An earlier proposal to a wrong address was withdrawn from the transaction service before any signature. Not executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tzc4JYcsy2feiByPEeQXrc