### PR TITLE
fix: keep Cash App outside dispute protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,13 +794,13 @@ The package exports the currently selected (latest) addresses for each network, 
 the addresses to use.
 
 Dispute-evidence issuance in `attestation-service` remains a separate follow-up and is intentionally not implemented
-by these contract lanes. Only PayPal, Venmo, and Cash App receive non-zero onchain risk windows, matching the
-explicitly ratified chargebackable-platform set.
+by these contract lanes. Only PayPal and Venmo receive non-zero onchain risk windows; Cash App and every other
+active payment method have a zero window and do not require stake.
 
 ### Whitelist Bootstrap
 
 `yarn whitelist:bootstrap` discovers active deposits from a configurable raw GraphQL endpoint and
-selects only deposits with an active Venmo, Cash App, or PayPal payment method. It deduplicates the
+selects only deposits with an active Venmo or PayPal payment method. It deduplicates the
 matching rows by deposit and payment method and simulates canonical `bootstrapDeposits` batches against the
 lane-36 `WhitelistPolicyMethodScoped` record for the ordered, non-empty, distinct group list supplied through
 `WHITELIST_GROUP_IDS`. It refuses the lane-29 deposit-scoped policy address and fails closed on a network whose

--- a/deployments/dispute-stack-evidence.json
+++ b/deployments/dispute-stack-evidence.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "riskWindowSecondsByPaymentMethod": {
     "base": {
-      "0x10940ee67cfb3c6c064569ec92c0ee934cd7afa18dd2ca2d6a2254fcb009c17d": "1209600",
+      "0x10940ee67cfb3c6c064569ec92c0ee934cd7afa18dd2ca2d6a2254fcb009c17d": "0",
       "0x3ccc3d4d5e769b1f82dc4988485551dc0cd3c7a3926d7d8a4dde91507199490f": "1209600",
       "0x554a007c2217df766b977723b276671aee5ebb4adaea0edb6433c88b3e61dac5": "0",
       "0x5908bb0c9b87763ac6171d4104847667e7f02b4c47b574fe890c1f439ed128bb": "0",

--- a/deployments/parameters.ts
+++ b/deployments/parameters.ts
@@ -165,7 +165,6 @@ export function getActivePaymentMethods(network: string): string[] {
 export const DISPUTABLE_PAYMENT_METHODS: string[] = [
   "paypal",
   "venmo",
-  "cashapp",
 ];
 
 export const ORCHESTRATOR_V3_PROTOCOL_FEE: any = {

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -173,7 +173,7 @@ manifest pins:
 - A fail-closed sentinel probe and the active-successor prerequisites, including unpaused
   admission, an unpaused orchestrator, and `allowMultipleIntents = true`.
 - The approved risk window for every active payment-method bytes32 hash: 1,209,600 seconds for
-  PayPal, Venmo, and Cash App, and zero for all other active methods.
+  PayPal and Venmo, and zero for all other active methods, including Cash App.
 
 The package exports the currently selected (latest) addresses for each network, and consumers should
 treat them as the addresses to use.

--- a/packages/contracts/scripts/extractors/disputeStack.ts
+++ b/packages/contracts/scripts/extractors/disputeStack.ts
@@ -114,6 +114,19 @@ const NETWORKS = [
   },
 ] as const;
 
+/**
+ * The risk windows currently active on-chain. Staging still carries the legacy
+ * Cash App window until its governed policy update is executed; deployment
+ * parameters intentionally omit it from every future configuration.
+ */
+const LIVE_DISPUTABLE_PAYMENT_METHODS: Record<
+  (typeof NETWORKS)[number]["manifestName"],
+  readonly string[]
+> = {
+  base: DISPUTABLE_PAYMENT_METHODS,
+  base_staging: [...DISPUTABLE_PAYMENT_METHODS, "cashapp"],
+};
+
 const RUNTIME_IDENTITY_NAMES: RuntimeIdentityName[] = [
   "Orchestrator",
   "OrchestratorV2",
@@ -412,10 +425,16 @@ function deploymentBlockNumber(
   return blockNumber.toString();
 }
 
-function configuredRiskWindows(network: string): Record<string, string> {
+function configuredRiskWindows(
+  network: keyof typeof LIVE_DISPUTABLE_PAYMENT_METHODS,
+): Record<string, string> {
   const activePaymentMethods = getActivePaymentMethods(network);
-  const configured = new Set(DISPUTABLE_PAYMENT_METHODS);
-  if (DISPUTABLE_PAYMENT_METHODS.some((method) => !activePaymentMethods.includes(method))) {
+  const liveDisputablePaymentMethods = LIVE_DISPUTABLE_PAYMENT_METHODS[network];
+  if (!liveDisputablePaymentMethods) {
+    throw new Error(`Unsupported dispute stack network ${network}`);
+  }
+  const configured = new Set(liveDisputablePaymentMethods);
+  if (liveDisputablePaymentMethods.some((method) => !activePaymentMethods.includes(method))) {
     throw new Error("Disputable payment methods must be active");
   }
   const entries = activePaymentMethods.map((method) => [

--- a/scripts/active-dispute-stack.spec.cjs
+++ b/scripts/active-dispute-stack.spec.cjs
@@ -316,7 +316,7 @@ test("address extraction preserves the exact active dispute selection stamp", as
 
 const BASE_RISK_WINDOWS = {
   "0x10940ee67cfb3c6c064569ec92c0ee934cd7afa18dd2ca2d6a2254fcb009c17d":
-    "1209600",
+    "0",
   "0x3ccc3d4d5e769b1f82dc4988485551dc0cd3c7a3926d7d8a4dde91507199490f":
     "1209600",
   "0x554a007c2217df766b977723b276671aee5ebb4adaea0edb6433c88b3e61dac5": "0",
@@ -333,6 +333,8 @@ const RISK_WINDOWS_BY_NETWORK = {
   base: BASE_RISK_WINDOWS,
   baseStaging: {
     ...BASE_RISK_WINDOWS,
+    "0x10940ee67cfb3c6c064569ec92c0ee934cd7afa18dd2ca2d6a2254fcb009c17d":
+      "1209600",
     "0x1d966dbd6aeb8674d7c05174bd0ded7b56a798672bfb862ef20bbe8c2bbfce18": "0",
     "0xf81480907d808d639ad3230869e4b05a3b01b2d34e323af40f2efab807effd32": "0",
   },

--- a/scripts/bootstrapWhitelistPolicy.ts
+++ b/scripts/bootstrapWhitelistPolicy.ts
@@ -100,10 +100,6 @@ const TARGET_PAYMENT_METHODS = [
     hash: "0x90262a3db0edd0be2369c6b28f9e8511ec0bac7136cefbada0880602f87e7268",
   },
   {
-    name: "cashapp",
-    hash: "0x10940ee67cfb3c6c064569ec92c0ee934cd7afa18dd2ca2d6a2254fcb009c17d",
-  },
-  {
     name: "paypal",
     hash: "0x3ccc3d4d5e769b1f82dc4988485551dc0cd3c7a3926d7d8a4dde91507199490f",
   },
@@ -900,7 +896,7 @@ async function runSelfTest(): Promise<void> {
     {
       escrowAddress,
       depositId: BigNumber.from(42),
-      paymentMethodHashes: [TARGET_PAYMENT_METHODS[1].hash, TARGET_PAYMENT_METHODS[2].hash],
+      paymentMethodHashes: [TARGET_PAYMENT_METHODS[1].hash],
     },
   ];
   const selectionDigest = buildSelectionDigest(selectionDeposits, groupIds);

--- a/scripts/test-method-scoped-deployment.cjs
+++ b/scripts/test-method-scoped-deployment.cjs
@@ -938,7 +938,6 @@ test("lane 37 deploy-only steps are ordered contiguous prefixes", () => {
     "authorize-hook",
     "set-risk-window:paypal",
     "set-risk-window:venmo",
-    "set-risk-window:cashapp",
   ];
   assert.deepEqual(lane37Module.DEPLOY_ONLY_STEP_KINDS.base_staging, common);
   assert.deepEqual(lane37Module.DEPLOY_ONLY_STEP_KINDS.base, [

--- a/scripts/test-method-scoped-vault-deployment.cjs
+++ b/scripts/test-method-scoped-vault-deployment.cjs
@@ -64,7 +64,6 @@ test("lane 39 orders every live operation as a resumable prefix", () => {
     "authorize-hook",
     "set-risk-window:paypal",
     "set-risk-window:venmo",
-    "set-risk-window:cashapp",
   ];
   assert.deepEqual(lane39.DEPLOY_ONLY_STEP_KINDS.base_staging, common);
   assert.deepEqual(lane39.DEPLOY_ONLY_STEP_KINDS.base, [
@@ -159,8 +158,8 @@ test("lane 39 pins the exact predecessor-vault state left by lane 38", () => {
   );
 });
 
-test("lane 39 configures only paypal, venmo, and cashapp risk windows", () => {
-  assert.deepEqual(DISPUTABLE_PAYMENT_METHODS, ["paypal", "venmo", "cashapp"]);
+test("lane 39 configures only paypal and venmo risk windows", () => {
+  assert.deepEqual(DISPUTABLE_PAYMENT_METHODS, ["paypal", "venmo"]);
   assert.deepEqual(
     lane39.getRiskWindowPaymentMethods("base"),
     ACTIVE_PAYMENT_METHODS


### PR DESCRIPTION
## Summary\n\n- remove Cash App from the canonical disputable payment-method set\n- keep the production Cash App risk window at zero so signaling never requires stake\n- preserve the verified legacy Base staging window as live evidence until its governed update executes\n- exclude Cash App from chargeback-oriented whitelist bootstrap discovery\n- update current contract and package documentation\n\nLive Base verification showed Cash App already has a zero production risk window, so this PR requires no production transaction. Future deployment parameters configure risk windows only for PayPal and Venmo.\n\n## Validation\n\n- yarn hardhat compile\n- yarn pkg:build\n- yarn pkg:test\n- yarn test:method-scoped-vault-deployment (8 passed)\n- yarn test:method-scoped-deployment (49 passed)\n- yarn whitelist:bootstrap --self-test\n- yarn typecheck:dispute-deployment