### PR TITLE
chore: prepare contracts-v2 0.4.1-rc.10

### DIFF
--- a/.github/workflows/publish-contracts-v2.yml
+++ b/.github/workflows/publish-contracts-v2.yml
@@ -33,7 +33,7 @@ env:
   RELEASE_VERSION: ${{ inputs.release }}
   RELEASE_TAG: contracts-v2-v${{ inputs.release }}
   LATEST_BASELINE: 0.4.0
-  RC_BASELINE: 0.4.1-rc.8
+  RC_BASELINE: 0.4.1-rc.9
   NPM_CONFIG_PROVENANCE: "true"
   REQUIRE_PROVENANCE: "true"
   RECOVERY_MODE: ${{ inputs.recovery }}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/contracts-v2",
-  "version": "0.4.1-rc.9",
+  "version": "0.4.1-rc.10",
   "description": "ZKP2P V2 smart contract interfaces and utilities",
   "main": "./_cjs/index.js",
   "module": "./_esm/index.js",

--- a/scripts/npm-release.spec.mjs
+++ b/scripts/npm-release.spec.mjs
@@ -358,7 +358,7 @@ test('derives a future RC release line from the package version', () => {
 
 test('commits the next RC candidate while preserving stable release support', () => {
   const packageManifest = JSON.parse(fs.readFileSync(packageManifestPath, 'utf8'));
-  assert.equal(packageManifest.version, '0.4.1-rc.9');
+  assert.equal(packageManifest.version, '0.4.1-rc.10');
   assert.deepEqual(
     resolveReleasePolicy({
       release: '0.4.1',
@@ -388,7 +388,7 @@ test('publish workflow consumes the version-derived channel without RC-only path
   const workflow = fs.readFileSync(releaseWorkflowPath, 'utf8');
 
   assert.match(workflow, /^  LATEST_BASELINE: 0\.4\.0$/m);
-  assert.match(workflow, /^  RC_BASELINE: 0\.4\.1-rc\.8$/m);
+  assert.match(workflow, /^  RC_BASELINE: 0\.4\.1-rc\.9$/m);
   assert.match(workflow, /^\s{2}policy:\s*$/m);
   assert.match(workflow, /node scripts\/npm-release\.mjs resolve "\$PACKAGE_JSON" "\$RELEASE_VERSION"/);
   assert.match(workflow, /DIST_TAG:\s*\$\{\{ needs\.policy\.outputs\.dist_tag \}\}/);


### PR DESCRIPTION
## Summary

- prepare `@zkp2p/contracts-v2@0.4.1-rc.10` from the canonical Cash App dispute-protection fix in #311
- advance the protected publisher's observed `rc` baseline from `0.4.1-rc.8` to the current `0.4.1-rc.9`
- keep the release-policy fixture pinned to the committed candidate and registry baseline

No contracts or deployment outputs change in this PR.

## Validation

- focused release-policy tests: 3 passed
- release policy resolves `rc`, `npm-publish`, guard `0.4.1-rc.9`, verify `0.4.1-rc.10`
- exact source commit `99961c9` is green in Foundry CI and Release readiness
- local immutable install was inconclusive on this host: the git dependency pack hit `tsc: Permission denied`; CI uses the pinned release toolchain and remains authoritative