### PR TITLE
chore: record UPI staging activation

### DIFF
--- a/deployments/outputs/platforms/base_staging.json
+++ b/deployments/outputs/platforms/base_staging.json
@@ -156,6 +156,13 @@
         "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
       ],
       "updatedAt": "2026-08-20T08:12:22.843Z"
+    },
+    "upi": {
+      "paymentMethodHash": "0xe99a5081226cbbff9440a63da5caa04fa30f210c12c4dd9976132ac075054cd9",
+      "currencies": [
+        "0xaad766fbc07fb357bed9fd8b03b935f2f71fe29fc48f08274bc2a01d7f642afc"
+      ],
+      "updatedAt": "2026-09-01T08:18:01.000Z"
     }
   }
 }

--- a/deployments/outputs/platforms/snapshots/base_staging/upi_2026-09-01T08-18-01.json
+++ b/deployments/outputs/platforms/snapshots/base_staging/upi_2026-09-01T08-18-01.json
@@ -1,0 +1,7 @@
+{
+  "paymentMethodHash": "0xe99a5081226cbbff9440a63da5caa04fa30f210c12c4dd9976132ac075054cd9",
+  "currencies": [
+    "0xaad766fbc07fb357bed9fd8b03b935f2f71fe29fc48f08274bc2a01d7f642afc"
+  ],
+  "updatedAt": "2026-09-01T08:18:01.000Z"
+}


### PR DESCRIPTION
## Summary
- record the generated Base staging UPI/INR platform snapshot
- preserve the timestamped activation evidence

## Onchain evidence
- UPV3 add: `0xb86ebeb7d863e1d620f6b1092b0cde14537c3daadc79caf93b7edfd5bbf765b9`
- Registry bind: `0xc580340d22df0591026976ff0c04df6864373a7538832618bb089d6f82a6cb1d`
- both receipts succeeded; exact 13-method order/set, INR-only binding, owners, and nullifier invariants independently verified

## Validation
- semantic equality with deployment-generated artifacts
- JSON parse
- `git diff --check`