### PR TITLE
Pay L1 referrals to buyers’ stake backers

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -80,6 +80,8 @@ jobs:
         run: cp .env.default .env
       - name: Test release environment policy
         run: corepack yarn test:release-policy
+      - name: Test sponsor fee economics
+        run: node --test scripts/model-sponsor-fees.spec.mjs
       - name: Compile deployment contracts and package
         run: |
           corepack yarn compile

--- a/contracts/OrchestratorV3.sol
+++ b/contracts/OrchestratorV3.sol
@@ -23,6 +23,8 @@ import { IPaymentVerifier } from "./interfaces/IPaymentVerifier.sol";
 import { IPaymentVerifierRegistry } from "./interfaces/IPaymentVerifierRegistry.sol";
 import { IRelayerRegistry } from "./interfaces/IRelayerRegistry.sol";
 import { ReferralFeeLib } from "./lib/ReferralFeeLib.sol";
+import { IStakeReferralLifecycleHook } from "./interfaces/IStakeReferralLifecycleHook.sol";
+import { IDisputeProtectionPolicy } from "./interfaces/IDisputeProtectionPolicy.sol";
 
 /**
  * @title OrchestratorV3
@@ -62,6 +64,15 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
     // Governance-selected lifecycle hook; snapshotted per intent at signal.
     IIntentLifecycleHook public lifecycleHook;
     mapping(bytes32 => IIntentLifecycleHook) internal intentLifecycleHooks;
+
+    struct StakeReferralConfig {
+        IStakeReferralLifecycleHook hook;
+        IDisputeProtectionPolicy policy;
+        address feeSource;
+        uint256 l1ReferralFee;
+    }
+    StakeReferralConfig public stakeReferralConfig;
+    mapping(bytes32 => StakeReferral) internal intentStakeReferrals;
 
     // Contract references
     IEscrowRegistry public escrowRegistry;                              // Registry of escrow contracts
@@ -180,6 +191,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
 
         if (address(snapshottedLifecycleHook) != address(0)) {
             snapshottedLifecycleHook.onIntentSignaled(intentHash);
+            _snapshotStakeReferral(intentHash, snapshottedLifecycleHook);
         }
         emit IntentLifecycleHookSnapshotted(intentHash, address(snapshottedLifecycleHook));
 
@@ -244,6 +256,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         // Snapshot manager fee terms before pruning (pruning deletes the mappings).
         address managerFeeRecipient = intentManagerFeeRecipient[_params.intentHash];
         uint256 managerFee = intentManagerFee[_params.intentHash];
+        StakeReferral memory stakeReferral = intentStakeReferrals[_params.intentHash];
         
         address verifier = paymentVerifierRegistry.getVerifier(intent.paymentMethod);
         if (verifier == address(0)) revert PaymentMethodDoesNotExist(intent.paymentMethod);
@@ -272,6 +285,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
             _params.postIntentHookData,
             managerFeeRecipient,
             managerFee,
+            stakeReferral,
             false
         );
     }
@@ -296,6 +310,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         // Snapshot manager fee terms before pruning (pruning deletes the mappings).
         address managerFeeRecipient = intentManagerFeeRecipient[_intentHash];
         uint256 managerFee = intentManagerFee[_intentHash];
+        StakeReferral memory stakeReferral = intentStakeReferrals[_intentHash];
         
         // Effects
         _pruneIntent(_intentHash);
@@ -311,6 +326,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
             "",
             managerFeeRecipient,
             managerFee,
+            stakeReferral,
             true
         );
     }
@@ -370,6 +386,27 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
     }
 
     /* ============ Governance Functions ============ */
+
+    /**
+     * @notice Sets the existing L1 referral rate for buyers backed by an external stake owner.
+     * @dev The fee comes from the specified Peer referral entry, never from additional buyer charges or other
+     * referrals. Configuration applies only to the exact hook and future signals. Governance must keep this rate
+     * aligned with the referral program's L1 rate. The dispute policy is derived from the hook, not supplied separately.
+     * @param _hook Canonical lifecycle hook that locks collateral through its dispute policy.
+     * @param _feeSource Peer service-fee recipient whose allocation funds the stake referral.
+     * @param _l1ReferralFee L1 rate in 1e18 precise units (40 bps = 4e15); zero disables future stake referrals.
+     */
+    function setStakeReferralConfig(IStakeReferralLifecycleHook _hook, address _feeSource, uint256 _l1ReferralFee)
+        external
+        onlyOwner
+    {
+        if (address(_hook).code.length == 0) revert InvalidLifecycleHook(address(_hook));
+        if (_feeSource == address(0)) revert ZeroAddress();
+        if (_l1ReferralFee > ReferralFeeLib.MAX_REFERRER_FEE) revert InvalidStakeReferralFee(_l1ReferralFee);
+        IDisputeProtectionPolicy policy = _hook.disputeProtectionPolicy();
+        stakeReferralConfig = StakeReferralConfig(_hook, policy, _feeSource, _l1ReferralFee);
+        emit StakeReferralConfigured(address(_hook), _feeSource, _l1ReferralFee);
+    }
 
     /**
      * @notice GOVERNANCE ONLY: Updates the global lifecycle hook used by future intents.
@@ -495,7 +532,46 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         return intentLifecycleHooks[_intentHash];
     }
 
+    /**
+     * @inheritdoc IOrchestratorV3
+     */
+    function getIntentStakeReferral(bytes32 _intentHash) external view returns (StakeReferral memory) {
+        return intentStakeReferrals[_intentHash];
+    }
+
     /* ============ Internal Functions ============ */
+
+    function _snapshotStakeReferral(bytes32 _intentHash, IIntentLifecycleHook _hook) internal {
+        StakeReferralConfig memory config = stakeReferralConfig;
+        if (address(config.hook) != address(_hook) || config.l1ReferralFee == 0) return;
+        IDisputeProtectionPolicy.DisputeProtectionIntent memory protection =
+            config.policy.getDisputeProtectionIntent(_intentHash);
+        if (
+            protection.status == IDisputeProtectionPolicy.DisputeProtectionIntentStatus.NONE
+                || protection.stakeOwner == protection.taker
+        ) return;
+
+        IReferralFee.ReferralFee[] storage fees = intents[_intentHash].referralFees;
+        uint256 availableFee;
+        bool recipientExists;
+        for (uint256 feeIndex = 0; feeIndex < fees.length; ++feeIndex) {
+            if (fees[feeIndex].recipient == config.feeSource) availableFee = fees[feeIndex].fee;
+            if (fees[feeIndex].recipient == protection.stakeOwner) recipientExists = true;
+        }
+        if (availableFee < config.l1ReferralFee) {
+            revert InsufficientStakeReferralBudget(config.feeSource, availableFee, config.l1ReferralFee);
+        }
+        if (
+            !recipientExists && availableFee > config.l1ReferralFee
+                && fees.length == ReferralFeeLib.MAX_REFERRAL_FEE_RECIPIENTS
+        ) {
+            revert IReferralFee.ReferralFeeCountExceedsMaximum(
+                fees.length + 1, ReferralFeeLib.MAX_REFERRAL_FEE_RECIPIENTS
+            );
+        }
+        intentStakeReferrals[_intentHash] = StakeReferral(protection.stakeOwner, config.feeSource, config.l1ReferralFee);
+        emit IntentStakeReferralSnapshotted(_intentHash, protection.stakeOwner, config.feeSource, config.l1ReferralFee);
+    }
 
     /**
      * @notice Prunes a cancelled (cancel / escrow prune / orphan cleanup) intent, then executes the fail-closed
@@ -636,6 +712,7 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         delete intents[_intentHash];
         delete intentManagerFeeRecipient[_intentHash];
         delete intentManagerFee[_intentHash];
+        delete intentStakeReferrals[_intentHash];
 
         emit IntentPruned(_intentHash);
     }
@@ -649,7 +726,8 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         Intent memory _intent,
         uint256 _releaseAmount,
         address _managerFeeRecipient,
-        uint256 _managerFee
+        uint256 _managerFee,
+        StakeReferral memory _stakeReferral
     ) internal returns (uint256 netFees) {
         uint256 protocolFeeAmount;
         uint256 referralFeeAmount;
@@ -661,13 +739,28 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
             _token.safeTransfer(protocolFeeRecipient, protocolFeeAmount);
         }
 
+        uint256 stakeReferralAmount = (_releaseAmount * _stakeReferral.fee) / PRECISE_UNIT;
+        bool stakeReferralPaid;
+
         // Calculate referral fees (taken from taker) - based on release amount
         for (uint256 i = 0; i < _intent.referralFees.length; ++i) {
             IReferralFee.ReferralFee memory referralFee = _intent.referralFees[i];
             uint256 feeAmount = (_releaseAmount * referralFee.fee) / PRECISE_UNIT;
             referralFeeAmount += feeAmount;
+            // Split the already-rounded donor amount so the buyer's exact net payout is unchanged.
+            if (referralFee.recipient == _stakeReferral.feeSource) feeAmount -= stakeReferralAmount;
+            if (referralFee.recipient == _stakeReferral.recipient) {
+                feeAmount += stakeReferralAmount;
+                stakeReferralPaid = true;
+            }
+            // A fully allocated donor has no payout. Preserve the ordinary fee path's zero-rounding behavior.
+            if (feeAmount == 0 && referralFee.recipient == _stakeReferral.feeSource) continue;
             _token.safeTransfer(referralFee.recipient, feeAmount);
             emit IntentReferralFeeDistributed(_intentHash, referralFee.recipient, feeAmount);
+        }
+        if (!stakeReferralPaid && stakeReferralAmount > 0) {
+            _token.safeTransfer(_stakeReferral.recipient, stakeReferralAmount);
+            emit IntentReferralFeeDistributed(_intentHash, _stakeReferral.recipient, stakeReferralAmount);
         }
 
         // Calculate manager fee (taken from taker) - based on release amount
@@ -694,12 +787,15 @@ contract OrchestratorV3 is Ownable, Pausable, ReentrancyGuard, IOrchestratorV3 {
         bytes memory _postIntentHookData,
         address _managerFeeRecipient,
         uint256 _managerFee,
+        StakeReferral memory _stakeReferral,
         bool _isManualRelease
     ) internal {
         IIntentLifecycleHook snapshottedLifecycleHook = intentLifecycleHooks[_intentHash];
         delete intentLifecycleHooks[_intentHash];
 
-        uint256 netFees = _calculateAndTransferFees(_token, _intentHash, _intent, _releaseAmount, _managerFeeRecipient, _managerFee);
+        uint256 netFees = _calculateAndTransferFees(
+            _token, _intentHash, _intent, _releaseAmount, _managerFeeRecipient, _managerFee, _stakeReferral
+        );
         uint256 netAmount = _releaseAmount - netFees;
 
         if (address(snapshottedLifecycleHook) != address(0)) {

--- a/contracts/hooks/DisputeProtectionPolicy.sol
+++ b/contracts/hooks/DisputeProtectionPolicy.sol
@@ -343,7 +343,7 @@ contract DisputeProtectionPolicy is IDisputeProtectionPolicy, Ownable2Step, Reen
      * @notice Returns the stored dispute protection state for an intent.
      * @param _intentHash Intent whose dispute protection state is queried.
      */
-    function getDisputeProtectionIntent(bytes32 _intentHash) external view returns (DisputeProtectionIntent memory) {
+    function getDisputeProtectionIntent(bytes32 _intentHash) external view override returns (DisputeProtectionIntent memory) {
         return disputeProtectionIntentByIntentHash[_intentHash];
     }
 

--- a/contracts/interfaces/IDisputeProtectionPolicy.sol
+++ b/contracts/interfaces/IDisputeProtectionPolicy.sol
@@ -6,9 +6,13 @@ pragma solidity ^0.8.18;
  * @title IDisputeProtectionPolicy
  * @notice Lifecycle-hook integration surface for stake-backed dispute coverage.
  * @dev The concrete policy exposes depositor, governance, dispute, and release functions directly.
- *      This interface intentionally contains only the functions consumed by IntentLifecycleHookV1.
+ *      This interface contains lifecycle calls consumed by IntentLifecycleHookV1 and the stake-referral snapshot
+ *      read consumed by OrchestratorV3.
  */
 interface IDisputeProtectionPolicy {
+    /** @notice Returns the snapshotted collateral owner and lifecycle state for an intent. */
+    function getDisputeProtectionIntent(bytes32 _intentHash) external view returns (DisputeProtectionIntent memory);
+
     /**
      * @notice Lifecycle state of a dispute-protected intent.
      * @dev `NONE` is the required zero-value sentinel for an uninitialized mapping entry; it is not a live state.

--- a/contracts/interfaces/IOrchestratorV3.sol
+++ b/contracts/interfaces/IOrchestratorV3.sol
@@ -7,6 +7,7 @@ import { IPostIntentHookV2 } from "./IPostIntentHookV2.sol";
 import { IIntentLifecycleHook } from "./IIntentLifecycleHook.sol";
 import { IPreIntentHook } from "./IPreIntentHook.sol";
 import { IReferralFee } from "./IReferralFee.sol";
+import { IStakeReferralLifecycleHook } from "./IStakeReferralLifecycleHook.sol";
 
 /**
  * @title IOrchestratorV3
@@ -16,6 +17,23 @@ import { IReferralFee } from "./IReferralFee.sol";
 interface IOrchestratorV3 {
 
     /* ============ Structs ============ */
+
+    struct StakeReferral {
+        address recipient;
+        address feeSource;
+        uint256 fee;
+    }
+
+    event StakeReferralConfigured(address indexed lifecycleHook, address indexed feeSource, uint256 l1ReferralFee);
+    event IntentStakeReferralSnapshotted(bytes32 indexed intentHash, address indexed recipient, address feeSource, uint256 fee);
+    error InvalidStakeReferralFee(uint256 fee);
+    error InsufficientStakeReferralBudget(address feeSource, uint256 availableFee, uint256 requiredFee);
+
+    /** @notice Configures the existing L1 rate and Peer fee source for a stake-backed lifecycle hook. */
+    function setStakeReferralConfig(IStakeReferralLifecycleHook _hook, address _feeSource, uint256 _l1ReferralFee) external;
+
+    /** @notice Returns the stake referral snapshotted at signal; pruned intents return an empty record. */
+    function getIntentStakeReferral(bytes32 _intentHash) external view returns (StakeReferral memory);
 
     struct Intent {
         address owner;                              // Address of the intent owner

--- a/contracts/interfaces/IStakeReferralLifecycleHook.sol
+++ b/contracts/interfaces/IStakeReferralLifecycleHook.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {IIntentLifecycleHook} from "./IIntentLifecycleHook.sol";
+import {IDisputeProtectionPolicy} from "./IDisputeProtectionPolicy.sol";
+
+/**
+ *  @notice The dispute policy exposed by the canonical stake-backed lifecycle hook.
+ */
+interface IStakeReferralLifecycleHook is IIntentLifecycleHook {
+    function disputeProtectionPolicy() external view returns (IDisputeProtectionPolicy);
+}

--- a/docs/plans/2026-09-07-sponsored-stake-fees.md
+++ b/docs/plans/2026-09-07-sponsored-stake-fees.md
@@ -1,247 +1,160 @@
-# Sponsored stake: 14-day fee model and implementation review
+# Buyer stake referrals at the existing L1 rate
 
-Status: economic model implemented; sponsorship runtime design proposed.
-No sponsor fee, contract deployment, referral reassignment, or customer pricing
-change is activated by this work.
+## Accepted product rule
 
-## Recommendation
+Aaron is a **buyer**. If another wallet stakes for him, that wallet earns a
+referral at the existing L1 rate on the trades actually backed by its stake.
+There is no independently priced sponsor product or permanent referral-code
+reassignment. The buyer's selected backer is the referral recipient for that
+trade; selecting a different backer affects future trades only. This supersedes
+the earlier 80 bps pricing hypothesis.
 
-Price sponsorship independently of referral acquisition. Use **80 bps (0.80%)
-of gross sponsored settled volume** as the initial pricing hypothesis for a
-14-day, fully collateralized position. This is a modeled pilot price, not an
-empirically calibrated risk premium or a guaranteed return. It depends on 75%
-capital utilization, a 12% simple annual net-return target, 10 bps expected
-principal losses per settled dollar, and 5 bps operating costs per settled
-dollar. The exact minimum whole-bp fee under those assumptions is 77 bps.
+The source L1 default is 40 bps (0.40%). The contract rate is configured by
+governance to match the referral program, not hardcoded or independently
+selected by a sponsor. Changing the program's L1 rate requires updating both
+Curator's ladder and the on-chain stake referral configuration for future
+signals. Existing intent snapshots keep their original rate.
 
-Matching the repository's 40 bps L1 default yields only 4.89% net annualized
-under those same assumptions. Referral rates are configurable and budget
-clamped; 40/10 bps are source defaults, not verified live rates. The 80 bps
-hypothesis must be repriced or rejected if observed losses, utilization,
-release delays, or the available fee budget do not support it.
+## Implemented contract behavior
 
-## What the existing implementation actually does
+- `setStakeReferralConfig(hook, feeSource, l1ReferralFee)` derives the dispute
+  policy from the exact canonical lifecycle hook. The configured `feeSource`
+  is Peer's existing service-fee recipient, not the Orchestrator's separate
+  protocol-fee field. Configuration is owner-only; rate zero disables future
+  stake referrals. A different lifecycle hook does not use this configuration.
+- After the lifecycle hook locks collateral, OrchestratorV3 reads the actual
+  policy snapshot. An externally backed intent gets a stake referral; self
+  stake, whitelist bypass, unprotected and zero-window routes do not.
+- The existing Peer fee entry must fully fund the L1 rate. Missing or
+  insufficient budget reverts the complete signal, including collateral and
+  escrow state. Direct callers cannot consume sponsored collateral while
+  omitting that funding entry when this configuration is active.
+- The recipient, funding source and L1 rate are snapshotted for each intent.
+  Revocation, stake-owner selection, referral configuration and hook changes
+  cannot redirect old trades' earnings or collateral liability.
+- Settlement carves the referral out of Peer's **already-rounded** fee amount.
+  The signed referral array, aggregate fees, existing seller referrals and
+  exact buyer net payout stay unchanged, including fractional-base-unit cases.
+- Proof and manual settlement pay the same L1 rate on actual gross release;
+  partial settlement pays only on the partial release. Cancellation and
+  expiry do not pay. Any failing lifecycle settlement rolls back all payouts.
+- Payouts use `IntentReferralFeeDistributed`, so they enter the existing
+  referral earnings pipeline. A wallet acting as both seller referrer and
+  buyer backer receives a combined payout and one event. No new L2 payment is
+  created from the buyer's staking relationship.
+- Stake remains fully collateralized for the snapshotted risk window after
+  settlement (14 days in this model). Maturity alone does not unlock it: the
+  permissionless policy release transaction must succeed. A later dispute
+  consumes principal but does not claw back an already earned referral.
 
-Reviewed contracts main `2e70f3c` and Curator main `69f01365`, plus Pay main
-`57468099` and its merchant staking design. These are source snapshots, not a
-live deployment audit.
+`getIntentStakeReferral` exposes an active intent's referral snapshot;
+`IntentStakeReferralSnapshotted` preserves the signal-time record after the
+intent is pruned. The stored original referral array remains the buyer's
+signed total-fee plan; actual recipient distributions include the stake carve.
 
-| Fact | Source |
-| --- | --- |
-| Referral rewards follow the **seller's** referral chain, with at most two levels | [Curator makerReferralChain.ts](https://github.com/zkp2p/curator/blob/69f01365/src/services/makerReferralChain.ts) |
-| Default ladder is L1 40 bps / L2 10 bps | [Curator envConfig.ts](https://github.com/zkp2p/curator/blob/69f01365/src/common/utils/envConfig.ts) |
-| Existing referrals draw from the service-fee budget in L1, L2, Peer order | [Curator serviceFee.ts](https://github.com/zkp2p/curator/blob/69f01365/src/common/utils/serviceFee.ts) |
-| The **taker** selects an authorized stake owner; sponsor retains custody rights | [StakeVault.sol](../../contracts/StakeVault.sol) |
-| Signal locks the full intent amount; settlement resizes to full gross release amount | [DisputeProtectionPolicy.sol](../../contracts/hooks/DisputeProtectionPolicy.sol) |
-| Lock maturity is settlement time plus the snapshotted risk window | [DisputeProtectionPolicy.sol](../../contracts/hooks/DisputeProtectionPolicy.sol) |
-| An explicit release transaction is required; exposure continues until release executes | [IDisputeProtectionPolicy.sol](../../contracts/interfaces/IDisputeProtectionPolicy.sol) |
-| Referral fee recipients and rates are stored at signal, paid on settlement | [OrchestratorV3.sol](../../contracts/OrchestratorV3.sol) |
-| Pay's staking rollout exposes self-staking, while an externally selected owner makes the page read-only | [Pay staking design, section 3.2](https://github.com/zkp2p/pay/blob/57468099/docs/superpowers/specs/2026-08-20-merchant-staking-chargebacks-design.md) |
+Existing vault consent is reused: the backer authorizes the buyer and the
+buyer selects that backer. This PR does not introduce a new lending agreement,
+per-buyer exposure cap, or UI. Vault authorization still exposes the backer's
+available shared stake to its authorized buyers, under existing vault rules.
 
-Cash App's dispute window was retired in the current contracts source and
-recorded deployment lanes. Do not carry the older Pay design's three-rail
-assumption into sponsor eligibility. Resolve the exact policy and nonzero
-payment-method window when building a sponsored quote.
+## Fee example
 
-## Review of the conversation's initial plan
+The following illustrates a 100 bps total service fee and a complete seller
+referral chain; it is not a claim about live production configuration:
 
-1. **Seller and taker were conflated.** If Aaron provides liquidity as a seller,
-   staking on his behalf does not currently back his seller fills. Existing
-   collateral compensates that seller for a dispute against a taker. A
-   seller-sponsorship product needs a separately defined obligation before its
-   payouts can be implemented. The runtime design below assumes Aaron is a
-   taker/merchant using someone else's collateral; that scope is unconfirmed.
-2. **L1 is not an available sponsor slot.** Keep the existing seller referral
-   relationship and L2 attribution. Sponsor compensation is another economic
-   role. If the same wallet performs both roles it may receive both allocations,
-   within the agreed total fee, without changing the referral tree.
-3. **Fourteen days is a minimum after settlement.** Pending intents already tie
-   up capital. Settlement delays, failed/cancelled reservations, delayed release
-   transactions, and idle capital lower realized returns. Exiting does not
-   erase outstanding exposure or earned fees.
-4. **The fee needs a payer.** Adding a recipient to the settlement array alone
-   reduces the taker's payout. Preserving advertised output requires grossing up
-   the quote or reallocating an explicitly sufficient existing fee budget.
-5. **Quote-only enforcement is insufficient.** Current vault delegation does
-   not require a sponsor fee or cap each taker's use of a shared sponsor pool.
-   A caller able to signal directly could consume collateral without paying the
-   expected fee. Fee consent, recipient, amount, and exposure limits need atomic
-   on-chain enforcement before lock creation.
+| Recipient | Rate on gross settled volume | On $1,000 |
+| --- | ---: | ---: |
+| Seller's existing L1 | 40 bps | $4 |
+| Seller's existing L2 | 10 bps | $1 |
+| Buyer's selected external backer | 40 bps | $4 |
+| Peer remainder | 10 bps | $1 |
+| Total service fee | 100 bps | $10 |
 
-## Reproducible model
+Before the carve, the supplied Peer entry is 50 bps; afterward it receives
+10 bps. Existing maker/integration allocations are preserved. If those other
+allocations leave Peer less than 40 bps, the sponsored route rejects instead
+of reducing someone's existing referral, adding a buyer charge, or silently
+underpaying the backer. Unprotected and self-backed routes retain existing fees.
+Any manager, bridge or separate protocol fees remain part of the original
+quote and are not used as funding sources.
 
-Run from the contracts repository with Node; no credentials, dependencies,
-network calls, or chain transactions are needed:
+## Economics of the chosen rate
+
+The calculator fixture now uses the accepted L1 rate of 40 bps. With 100%
+gross collateral, annual volume per dollar of capital is `utilization × 365 /
+holdingDays`. Simple net annual return is:
+
+```text
+(referral rate - losses per settled dollar - operating cost per settled dollar)
+× utilization × 365 / (risk-window days + additional holding days)
+```
+
+At a 14-day hold and illustrative 10 bps losses plus 5 bps costs:
+
+| Capital utilization | Gross annualized return at 40 bps | Net annualized return |
+| --- | ---: | ---: |
+| 50% | 5.21% | 3.26% |
+| 75% | 7.82% | 4.89% |
+| 100% | 10.43% | 6.52% |
+
+At 75% utilization, $10,000 average capital supports $195,535.71 annual gross
+settled volume and models $782.14 referral income, $195.54 losses, $97.77 costs,
+and $488.84 net income. Two additional holding days reduce modeled net return
+to 4.28%. A 12% target would require 77 bps under the base assumptions; matching
+L1 deliberately does not meet that target. The model informs economics and
+never overrides the accepted product rate.
+
+These are steady-state assumptions, not observed losses or guaranteed returns.
+Idle/cancelled reservations reduce productive utilization; additional holding
+days capture successful positions' pending/release delays. Do not count the
+same delay in both inputs. Losses must be replenished to sustain the modeled
+capital. Correlated fraud, capital depletion, fixed overhead and compounding
+are not simulated; a valid dispute can consume the full trade's collateral.
 
 ```sh
 node scripts/model-sponsor-fees.mjs scripts/fixtures/sponsor-fees.json
 node --test scripts/model-sponsor-fees.spec.mjs
 ```
 
-Copy the JSON fixture and edit the assumptions to price another scenario. All
-inputs are required integers; rate inputs use basis points (10,000 = 100%).
-Unknown inputs are rejected so a misspelled assumption cannot silently leave
-the model unchanged. The output includes its inputs, dollar cashflows, simple
-annualized returns, minimum whole-bp fee, and fee-budget shortfall.
+All JSON inputs are required integers; rates use basis points. The minimum
+whole-bp fee is rounded upward with integer arithmetic. Dollar/APR outputs are
+offline numerical approximations, never quote or transaction arithmetic.
 
-Let:
+## Source review and delivery boundary
 
-- `C` = average total sponsor capital, including idle capital;
-- `u` = fraction allocated to the modeled successful position lifecycle;
-- `D` = 14-day risk window plus average additional holding days;
-- `f`, `l`, `o` = sponsor fee, principal loss, and operating cost per settled dollar;
-- `r` = target simple annual net return on all sponsor capital.
+Reviewed contracts main `2e70f3c`, Curator main `69f01365`, clients main
+`5a3655715`, and indexer main `9954946`. Canonical sources are standalone repos.
 
-The model assumes 100% gross collateral and stable capital, utilization, and
-transaction flow:
+- Curator `src/common/utils/serviceFee.ts` allocates existing maker/integration
+  fees. No change is required to construct a stake recipient: the contract
+  derives it from the actual locked stake, avoiding stale quotes and signatures.
+- Clients `packages/sdk/src/client/IntentOperations.ts` forwards the fee plan.
+  No signal-input or signature format changes are required. Deployments and
+  package address selection still need the successor Orchestrator address.
+- Indexer `src/handlers/v3/orchestrator_v3.ts` forwards ordinary referral payout
+  events to the existing distribution and recipient aggregates. One payout
+  event per recipient avoids overwriting its intent/recipient-keyed row.
+- Curator's current dashboard attributes L1/L2 through the **seller** code tree.
+  Buyer-backer payments enter total earnings but can appear as unattributed
+  there; this PR changes payout behavior, not dashboard tree classification or
+  referral-code registration. A wallet still uses the existing referral
+  account flow to view that dashboard.
+- The new snapshot event is on-chain audit data. Current indexer projections
+  need not consume it for payout totals; a future buyer-referral dashboard
+  should consume it to distinguish that relationship from seller attribution.
 
-```text
-annual settled volume = C × u × 365 / D
-annual net income    = annual settled volume × (f - l - o)
-net APR              = (f - l - o) × u × 365 / D
-required fee         = r × D / (365 × u) + l + o
-```
-
-The implementation rounds the required rate upward to whole bps using integer
-arithmetic. Displayed returns use ordinary numerical approximation; this is an
-offline pricing model, never transaction amount or quote arithmetic. Zero
-utilization yields zero income and no volume-based fee recommendation.
-
-`additionalHoldDays` represents pending and release delay for successful
-positions. `utilizationBps` discounts idle capital and capital consumed by
-cancelled or unproductive reservations. Do not also count the same pending or
-release delay in both inputs. Losses are value-weighted, net of actual
-recoveries, divided by gross eligible settled volume; a dispute count alone is
-not a loss rate. Operating costs are averaged per settled dollar, including
-failed/reservation/release work. Fixed overhead should be converted at the
-modeled volume; at zero volume this calculator shows zero variable costs and
-does not estimate fixed operating losses.
-
-This is a steady-state expectation, not a simulation of bankruptcy, correlated
-fraud, liquidity shocks, compounding, or reinvestment. Losses must be replenished
-to maintain the assumed capital and volume. A sponsor can lose the full
-collateral backing a disputed trade; these illustrative loss inputs do not
-establish that any taker is safe to sponsor.
-
-## Sensitivities
-
-Net simple annualized return, assuming a 14-day hold, 10 bps principal loss and
-5 bps operating cost per settled dollar:
-
-| Sponsor fee | 50% utilization | 75% utilization | 100% utilization |
-| --- | ---: | ---: | ---: |
-| 40 bps / 0.40% | 3.26% | 4.89% | 6.52% |
-| 60 bps / 0.60% | 5.87% | 8.80% | 11.73% |
-| 80 bps / 0.80% | 8.47% | 12.71% | 16.95% |
-| 100 bps / 1.00% | 11.08% | 16.62% | 22.16% |
-
-At the proposed 80 bps price:
-
-| Scenario (other base inputs unchanged) | Minimum fee for 12% net APR | Net APR at 80 bps |
-| --- | ---: | ---: |
-| Base case | 77 bps | 12.71% |
-| Two additional holding days | 86 bps | 11.12% |
-| 50% utilization | 108 bps | 8.47% |
-| 25 bps losses per settled dollar | 92 bps | 9.78% |
-| 100 bps losses per settled dollar | 167 bps | -4.89% |
-
-For $10,000 average capital at base assumptions, annual settled volume is
-$195,535.71; sponsor fees $1,564.29; losses $195.54; operating costs $97.77;
-net income $1,270.98. Monthly equivalents are $16,294.64 volume and $105.92
-income on average, not a promise of monthly liquidity or payouts. Do not assume
-that $10,000 collateral can repeatedly back $100,000 each month with a 14-day
-full-principal lock.
-
-The 80 bps price can tolerate only **13.63 bps losses** while still meeting the
-12% target at the base utilization and cost assumptions. Its safety margin is
-small; 80 bps should not become a universal rate for unknown takers.
-
-## Funding and coexistence with referrals
-
-Budget every role explicitly, without silently reducing an existing referral:
-
-```text
-service fee >= sponsor fee + L1 fee + L2 fee + minimum Peer remainder
-150 bps    = 80 bps      + 40 bps + 10 bps + 20 bps
-```
-
-The 150 bps total and 20 bps Peer remainder are proposed inputs. Neither is
-claimed to be current production configuration. A hypothetical 100 bps total
-has a 50 bps shortfall against this proposal. It can fund only 30 bps of sponsor
-fees while preserving 40/10/20, producing 2.93% modeled net annual return at
-base utilization. Options are an explicitly accepted sponsored-route price,
-an explicitly funded Peer subsidy, or declining to offer sponsorship at that
-budget. Do not confiscate L1 or silently clip the sponsor's contracted rate.
-
-An 80 bps sponsor receives $8 per $1,000 gross settled volume; L1 receives $4,
-L2 receives $1, and Peer retains $2 in this example. Any separate orchestrator,
-manager, integration, or bridge fees must also be included in the final quote.
-The fixture models a full maker-referral chain, not every route's fee topology.
-
-## Proposed runtime implementation, after scope is resolved
-
-This section is a design, not an implemented or deployed feature. The open
-product question is whether Aaron is a taker/merchant, as required by existing
-dispute collateral, or a seller for whom a new collateral obligation is intended.
-
-For the taker/merchant interpretation:
-
-1. **Agreement.** Sponsor sets a rate, allowed payment methods, maximum risk
-   window and outstanding exposure cap for one taker; taker explicitly accepts
-   those exact terms. Sponsor custody stays in the vault. Paid sponsorship must
-   be bound to that consent, not inferred from free delegation alone.
-2. **Signal.** The authorized lifecycle path resolves the taker's effective
-   owner, enforces consent and sponsor rate in the orchestrator's actual stored
-   fee plan, and atomically checks/increments the exposure cap before locking
-   principal. Reject a missing fee, insufficient budget, self-sponsorship
-   rebate, stale terms or a substituted recipient. A sponsor can stop future
-   admissions; previously signaled terms remain immutable.
-3. **Quote.** Curator resolves the same agreement and eligible risk-bearing
-   route, preserves seller attribution, validates the service-fee allocation,
-   and prices the exact final output. An unavailable sponsor or unsupported
-   policy/window is an explicit quote failure. Do not accept client overrides
-   for the authoritative recipient or agreed rate. Free/whitelisted paths
-   that create no sponsor exposure must not pay a sponsor fee.
-4. **Settlement.** Pay the snapshotted sponsor fee on exact gross release using
-   the existing referral-fee transport, with separately attributable sponsor
-   metadata/events for reporting. Manual release has identical economics.
-   There is no fee on cancelled intents. This proposal pays at settlement and
-   leaves that fee earned if a later dispute occurs; its losses are modeled on
-   full collateral, without clawing back already paid fees.
-5. **Exposure release.** Cancellation releases pending exposure. Settlement
-   adjusts exposure to gross release. Only successful collateral release or
-   dispute resolution frees settled exposure capacity. Changing owner,
-   revoking authorization or changing terms cannot move an existing lock or
-   its liabilities to a new sponsor.
-6. **Visibility.** Indexer and product surfaces separate sponsor earnings from
-   L1/L2 earnings and show capital, remaining exposure capacity, observed
-   utilization, losses, release delays and net returns. Quote/UI must disclose
-   any incremental sponsorship cost before the taker accepts it.
-
-The contract changes must enforce the fee and exposure obligations for direct
-callers as well as Curator traffic. A Curator-only extra fee entry would not
-satisfy this design. Existing locks cannot be migrated casually into a fresh
-policy: preserve their original controller/lifecycle or drain them according
-to the existing deployment conventions.
-
-Runtime tests must prove: exact fee budget and net output; quote/signaling
-agreement; direct-call fee omission rejected before locking; stale consent;
-same-wallet referral/sponsor accounting; per-taker concurrent exposure caps;
-self-sponsorship; whitelist/no-risk exclusions; partial settlement; cancellation;
-manual release; dispute; maturity without release; sponsor switch/revocation;
-and invariants for total stake, locked exposure, claims and fee conservation.
-
-## PR scope and ownership
-
-This PR implements the executable pricing model, scenario fixture, tests and
-reviewed design. It leaves runtime sponsorship pending the seller/taker scope
-decision. It does not change contract ABI, package versions, addresses,
-production fee configuration, or existing referral attribution.
-
-For runtime delivery, concrete owners are contracts (fee/consent/cap
-enforcement), Curator (quote allocation and authenticated agreement), indexer
-(exposure and earnings projections), and the selected client (consent and fee
-display). Pay is a runtime owner if this is merchant sponsorship; ordinary
-Peer buyers use clients/mobile instead. Package, API and deployment ordering
-must follow the final changed interfaces; the calculator itself requires no
-package release, migration, reindex or deployment.
+This is a source PR, not a live activation. It changes the OrchestratorV3 ABI
+additively and exposes an already-existing policy getter in its interface.
+No immutable deployment scripts or historical artifacts are edited, and no
+package versions or active addresses are changed. Activation requires a new
+numbered successor-orchestrator lane, registry/verifier compatibility checks,
+authorizing its existing lifecycle path, exact L1/fee-source configuration,
+consumer package/address cutover, and separately authorized deployment.
+Existing orchestrators and hooks must remain usable until their intents drain.
+Before enabling referrals against a shared vault, every registered predecessor
+that can still open unpriced locks through the same policy must stop new
+stake-backed admissions and drain, or be removed after draining. Activating
+this configuration on one successor does not enforce fees on another
+orchestrator. Prove that invariant across the registry at cutover; do not
+advertise fee enforcement for the shared vault while a bypass remains.
+The accepted task is implementation for review; live deployment remains separate.

--- a/docs/plans/2026-09-07-sponsored-stake-fees.md
+++ b/docs/plans/2026-09-07-sponsored-stake-fees.md
@@ -1,0 +1,247 @@
+# Sponsored stake: 14-day fee model and implementation review
+
+Status: economic model implemented; sponsorship runtime design proposed.
+No sponsor fee, contract deployment, referral reassignment, or customer pricing
+change is activated by this work.
+
+## Recommendation
+
+Price sponsorship independently of referral acquisition. Use **80 bps (0.80%)
+of gross sponsored settled volume** as the initial pricing hypothesis for a
+14-day, fully collateralized position. This is a modeled pilot price, not an
+empirically calibrated risk premium or a guaranteed return. It depends on 75%
+capital utilization, a 12% simple annual net-return target, 10 bps expected
+principal losses per settled dollar, and 5 bps operating costs per settled
+dollar. The exact minimum whole-bp fee under those assumptions is 77 bps.
+
+Matching the repository's 40 bps L1 default yields only 4.89% net annualized
+under those same assumptions. Referral rates are configurable and budget
+clamped; 40/10 bps are source defaults, not verified live rates. The 80 bps
+hypothesis must be repriced or rejected if observed losses, utilization,
+release delays, or the available fee budget do not support it.
+
+## What the existing implementation actually does
+
+Reviewed contracts main `2e70f3c` and Curator main `69f01365`, plus Pay main
+`57468099` and its merchant staking design. These are source snapshots, not a
+live deployment audit.
+
+| Fact | Source |
+| --- | --- |
+| Referral rewards follow the **seller's** referral chain, with at most two levels | [Curator makerReferralChain.ts](https://github.com/zkp2p/curator/blob/69f01365/src/services/makerReferralChain.ts) |
+| Default ladder is L1 40 bps / L2 10 bps | [Curator envConfig.ts](https://github.com/zkp2p/curator/blob/69f01365/src/common/utils/envConfig.ts) |
+| Existing referrals draw from the service-fee budget in L1, L2, Peer order | [Curator serviceFee.ts](https://github.com/zkp2p/curator/blob/69f01365/src/common/utils/serviceFee.ts) |
+| The **taker** selects an authorized stake owner; sponsor retains custody rights | [StakeVault.sol](../../contracts/StakeVault.sol) |
+| Signal locks the full intent amount; settlement resizes to full gross release amount | [DisputeProtectionPolicy.sol](../../contracts/hooks/DisputeProtectionPolicy.sol) |
+| Lock maturity is settlement time plus the snapshotted risk window | [DisputeProtectionPolicy.sol](../../contracts/hooks/DisputeProtectionPolicy.sol) |
+| An explicit release transaction is required; exposure continues until release executes | [IDisputeProtectionPolicy.sol](../../contracts/interfaces/IDisputeProtectionPolicy.sol) |
+| Referral fee recipients and rates are stored at signal, paid on settlement | [OrchestratorV3.sol](../../contracts/OrchestratorV3.sol) |
+| Pay's staking rollout exposes self-staking, while an externally selected owner makes the page read-only | [Pay staking design, section 3.2](https://github.com/zkp2p/pay/blob/57468099/docs/superpowers/specs/2026-08-20-merchant-staking-chargebacks-design.md) |
+
+Cash App's dispute window was retired in the current contracts source and
+recorded deployment lanes. Do not carry the older Pay design's three-rail
+assumption into sponsor eligibility. Resolve the exact policy and nonzero
+payment-method window when building a sponsored quote.
+
+## Review of the conversation's initial plan
+
+1. **Seller and taker were conflated.** If Aaron provides liquidity as a seller,
+   staking on his behalf does not currently back his seller fills. Existing
+   collateral compensates that seller for a dispute against a taker. A
+   seller-sponsorship product needs a separately defined obligation before its
+   payouts can be implemented. The runtime design below assumes Aaron is a
+   taker/merchant using someone else's collateral; that scope is unconfirmed.
+2. **L1 is not an available sponsor slot.** Keep the existing seller referral
+   relationship and L2 attribution. Sponsor compensation is another economic
+   role. If the same wallet performs both roles it may receive both allocations,
+   within the agreed total fee, without changing the referral tree.
+3. **Fourteen days is a minimum after settlement.** Pending intents already tie
+   up capital. Settlement delays, failed/cancelled reservations, delayed release
+   transactions, and idle capital lower realized returns. Exiting does not
+   erase outstanding exposure or earned fees.
+4. **The fee needs a payer.** Adding a recipient to the settlement array alone
+   reduces the taker's payout. Preserving advertised output requires grossing up
+   the quote or reallocating an explicitly sufficient existing fee budget.
+5. **Quote-only enforcement is insufficient.** Current vault delegation does
+   not require a sponsor fee or cap each taker's use of a shared sponsor pool.
+   A caller able to signal directly could consume collateral without paying the
+   expected fee. Fee consent, recipient, amount, and exposure limits need atomic
+   on-chain enforcement before lock creation.
+
+## Reproducible model
+
+Run from the contracts repository with Node; no credentials, dependencies,
+network calls, or chain transactions are needed:
+
+```sh
+node scripts/model-sponsor-fees.mjs scripts/fixtures/sponsor-fees.json
+node --test scripts/model-sponsor-fees.spec.mjs
+```
+
+Copy the JSON fixture and edit the assumptions to price another scenario. All
+inputs are required integers; rate inputs use basis points (10,000 = 100%).
+Unknown inputs are rejected so a misspelled assumption cannot silently leave
+the model unchanged. The output includes its inputs, dollar cashflows, simple
+annualized returns, minimum whole-bp fee, and fee-budget shortfall.
+
+Let:
+
+- `C` = average total sponsor capital, including idle capital;
+- `u` = fraction allocated to the modeled successful position lifecycle;
+- `D` = 14-day risk window plus average additional holding days;
+- `f`, `l`, `o` = sponsor fee, principal loss, and operating cost per settled dollar;
+- `r` = target simple annual net return on all sponsor capital.
+
+The model assumes 100% gross collateral and stable capital, utilization, and
+transaction flow:
+
+```text
+annual settled volume = C × u × 365 / D
+annual net income    = annual settled volume × (f - l - o)
+net APR              = (f - l - o) × u × 365 / D
+required fee         = r × D / (365 × u) + l + o
+```
+
+The implementation rounds the required rate upward to whole bps using integer
+arithmetic. Displayed returns use ordinary numerical approximation; this is an
+offline pricing model, never transaction amount or quote arithmetic. Zero
+utilization yields zero income and no volume-based fee recommendation.
+
+`additionalHoldDays` represents pending and release delay for successful
+positions. `utilizationBps` discounts idle capital and capital consumed by
+cancelled or unproductive reservations. Do not also count the same pending or
+release delay in both inputs. Losses are value-weighted, net of actual
+recoveries, divided by gross eligible settled volume; a dispute count alone is
+not a loss rate. Operating costs are averaged per settled dollar, including
+failed/reservation/release work. Fixed overhead should be converted at the
+modeled volume; at zero volume this calculator shows zero variable costs and
+does not estimate fixed operating losses.
+
+This is a steady-state expectation, not a simulation of bankruptcy, correlated
+fraud, liquidity shocks, compounding, or reinvestment. Losses must be replenished
+to maintain the assumed capital and volume. A sponsor can lose the full
+collateral backing a disputed trade; these illustrative loss inputs do not
+establish that any taker is safe to sponsor.
+
+## Sensitivities
+
+Net simple annualized return, assuming a 14-day hold, 10 bps principal loss and
+5 bps operating cost per settled dollar:
+
+| Sponsor fee | 50% utilization | 75% utilization | 100% utilization |
+| --- | ---: | ---: | ---: |
+| 40 bps / 0.40% | 3.26% | 4.89% | 6.52% |
+| 60 bps / 0.60% | 5.87% | 8.80% | 11.73% |
+| 80 bps / 0.80% | 8.47% | 12.71% | 16.95% |
+| 100 bps / 1.00% | 11.08% | 16.62% | 22.16% |
+
+At the proposed 80 bps price:
+
+| Scenario (other base inputs unchanged) | Minimum fee for 12% net APR | Net APR at 80 bps |
+| --- | ---: | ---: |
+| Base case | 77 bps | 12.71% |
+| Two additional holding days | 86 bps | 11.12% |
+| 50% utilization | 108 bps | 8.47% |
+| 25 bps losses per settled dollar | 92 bps | 9.78% |
+| 100 bps losses per settled dollar | 167 bps | -4.89% |
+
+For $10,000 average capital at base assumptions, annual settled volume is
+$195,535.71; sponsor fees $1,564.29; losses $195.54; operating costs $97.77;
+net income $1,270.98. Monthly equivalents are $16,294.64 volume and $105.92
+income on average, not a promise of monthly liquidity or payouts. Do not assume
+that $10,000 collateral can repeatedly back $100,000 each month with a 14-day
+full-principal lock.
+
+The 80 bps price can tolerate only **13.63 bps losses** while still meeting the
+12% target at the base utilization and cost assumptions. Its safety margin is
+small; 80 bps should not become a universal rate for unknown takers.
+
+## Funding and coexistence with referrals
+
+Budget every role explicitly, without silently reducing an existing referral:
+
+```text
+service fee >= sponsor fee + L1 fee + L2 fee + minimum Peer remainder
+150 bps    = 80 bps      + 40 bps + 10 bps + 20 bps
+```
+
+The 150 bps total and 20 bps Peer remainder are proposed inputs. Neither is
+claimed to be current production configuration. A hypothetical 100 bps total
+has a 50 bps shortfall against this proposal. It can fund only 30 bps of sponsor
+fees while preserving 40/10/20, producing 2.93% modeled net annual return at
+base utilization. Options are an explicitly accepted sponsored-route price,
+an explicitly funded Peer subsidy, or declining to offer sponsorship at that
+budget. Do not confiscate L1 or silently clip the sponsor's contracted rate.
+
+An 80 bps sponsor receives $8 per $1,000 gross settled volume; L1 receives $4,
+L2 receives $1, and Peer retains $2 in this example. Any separate orchestrator,
+manager, integration, or bridge fees must also be included in the final quote.
+The fixture models a full maker-referral chain, not every route's fee topology.
+
+## Proposed runtime implementation, after scope is resolved
+
+This section is a design, not an implemented or deployed feature. The open
+product question is whether Aaron is a taker/merchant, as required by existing
+dispute collateral, or a seller for whom a new collateral obligation is intended.
+
+For the taker/merchant interpretation:
+
+1. **Agreement.** Sponsor sets a rate, allowed payment methods, maximum risk
+   window and outstanding exposure cap for one taker; taker explicitly accepts
+   those exact terms. Sponsor custody stays in the vault. Paid sponsorship must
+   be bound to that consent, not inferred from free delegation alone.
+2. **Signal.** The authorized lifecycle path resolves the taker's effective
+   owner, enforces consent and sponsor rate in the orchestrator's actual stored
+   fee plan, and atomically checks/increments the exposure cap before locking
+   principal. Reject a missing fee, insufficient budget, self-sponsorship
+   rebate, stale terms or a substituted recipient. A sponsor can stop future
+   admissions; previously signaled terms remain immutable.
+3. **Quote.** Curator resolves the same agreement and eligible risk-bearing
+   route, preserves seller attribution, validates the service-fee allocation,
+   and prices the exact final output. An unavailable sponsor or unsupported
+   policy/window is an explicit quote failure. Do not accept client overrides
+   for the authoritative recipient or agreed rate. Free/whitelisted paths
+   that create no sponsor exposure must not pay a sponsor fee.
+4. **Settlement.** Pay the snapshotted sponsor fee on exact gross release using
+   the existing referral-fee transport, with separately attributable sponsor
+   metadata/events for reporting. Manual release has identical economics.
+   There is no fee on cancelled intents. This proposal pays at settlement and
+   leaves that fee earned if a later dispute occurs; its losses are modeled on
+   full collateral, without clawing back already paid fees.
+5. **Exposure release.** Cancellation releases pending exposure. Settlement
+   adjusts exposure to gross release. Only successful collateral release or
+   dispute resolution frees settled exposure capacity. Changing owner,
+   revoking authorization or changing terms cannot move an existing lock or
+   its liabilities to a new sponsor.
+6. **Visibility.** Indexer and product surfaces separate sponsor earnings from
+   L1/L2 earnings and show capital, remaining exposure capacity, observed
+   utilization, losses, release delays and net returns. Quote/UI must disclose
+   any incremental sponsorship cost before the taker accepts it.
+
+The contract changes must enforce the fee and exposure obligations for direct
+callers as well as Curator traffic. A Curator-only extra fee entry would not
+satisfy this design. Existing locks cannot be migrated casually into a fresh
+policy: preserve their original controller/lifecycle or drain them according
+to the existing deployment conventions.
+
+Runtime tests must prove: exact fee budget and net output; quote/signaling
+agreement; direct-call fee omission rejected before locking; stale consent;
+same-wallet referral/sponsor accounting; per-taker concurrent exposure caps;
+self-sponsorship; whitelist/no-risk exclusions; partial settlement; cancellation;
+manual release; dispute; maturity without release; sponsor switch/revocation;
+and invariants for total stake, locked exposure, claims and fee conservation.
+
+## PR scope and ownership
+
+This PR implements the executable pricing model, scenario fixture, tests and
+reviewed design. It leaves runtime sponsorship pending the seller/taker scope
+decision. It does not change contract ABI, package versions, addresses,
+production fee configuration, or existing referral attribution.
+
+For runtime delivery, concrete owners are contracts (fee/consent/cap
+enforcement), Curator (quote allocation and authenticated agreement), indexer
+(exposure and earnings projections), and the selected client (consent and fee
+display). Pay is a runtime owner if this is merchant sponsorship; ordinary
+Peer buyers use clients/mobile instead. Package, API and deployment ordering
+must follow the final changed interfaces; the calculator itself requires no
+package release, migration, reindex or deployment.

--- a/scripts/fixtures/sponsor-fees.json
+++ b/scripts/fixtures/sponsor-fees.json
@@ -6,9 +6,9 @@
   "targetNetAprBps": 1200,
   "expectedLossBps": 10,
   "operatingCostBps": 5,
-  "sponsorFeeBps": 80,
-  "serviceFeeBps": 150,
+  "sponsorFeeBps": 40,
+  "serviceFeeBps": 100,
   "l1FeeBps": 40,
   "l2FeeBps": 10,
-  "minimumPeerFeeBps": 20
+  "minimumPeerFeeBps": 10
 }

--- a/scripts/fixtures/sponsor-fees.json
+++ b/scripts/fixtures/sponsor-fees.json
@@ -1,0 +1,14 @@
+{
+  "capitalUsd": 10000,
+  "riskWindowDays": 14,
+  "additionalHoldDays": 0,
+  "utilizationBps": 7500,
+  "targetNetAprBps": 1200,
+  "expectedLossBps": 10,
+  "operatingCostBps": 5,
+  "sponsorFeeBps": 80,
+  "serviceFeeBps": 150,
+  "l1FeeBps": 40,
+  "l2FeeBps": 10,
+  "minimumPeerFeeBps": 20
+}

--- a/scripts/model-sponsor-fees.mjs
+++ b/scripts/model-sponsor-fees.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const YEAR_DAYS = 365;
+const BPS = 10_000;
+
+/** Offline, steady-state economics. All rates are bps; all inputs are assumptions. */
+export function modelSponsorFees(input) {
+  const bounds = {
+    capitalUsd: [1, 1_000_000_000],
+    riskWindowDays: [1, 365],
+    additionalHoldDays: [0, 365],
+    utilizationBps: [0, BPS],
+    targetNetAprBps: [0, BPS],
+    expectedLossBps: [0, BPS],
+    operatingCostBps: [0, BPS],
+    sponsorFeeBps: [0, BPS],
+    serviceFeeBps: [0, BPS],
+    l1FeeBps: [0, BPS],
+    l2FeeBps: [0, BPS],
+    minimumPeerFeeBps: [0, BPS],
+  };
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw new Error('Scenario must be an object');
+  }
+  for (const key of Object.keys(input)) {
+    if (!Object.hasOwn(bounds, key)) throw new Error(`Unknown scenario input: ${key}`);
+  }
+  for (const [key, [min, max]] of Object.entries(bounds)) {
+    if (!Number.isSafeInteger(input[key]) || input[key] < min || input[key] > max) {
+      throw new Error(`${key} must be an integer between ${min} and ${max}`);
+    }
+  }
+
+  // The policy locks 100% of gross release amount. There is no collateral multiplier.
+  const holdDays = input.riskWindowDays + input.additionalHoldDays;
+  const utilization = input.utilizationBps / BPS;
+  const annualVolumePerDollar = utilization * YEAR_DAYS / holdDays;
+  const annualVolumeUsd = input.capitalUsd * annualVolumePerDollar;
+  const netMarginBps = input.sponsorFeeBps - input.expectedLossBps - input.operatingCostBps;
+  const annualFeeUsd = annualVolumeUsd * input.sponsorFeeBps / BPS;
+  const annualLossUsd = annualVolumeUsd * input.expectedLossBps / BPS;
+  const annualOperatingCostUsd = annualVolumeUsd * input.operatingCostBps / BPS;
+
+  // Ceiling is exact at the whole-bp pricing boundary, including exact integer results.
+  const numerator = BigInt(input.targetNetAprBps) * BigInt(holdDays) * BigInt(BPS);
+  const denominator = BigInt(YEAR_DAYS) * BigInt(input.utilizationBps);
+  const requiredSponsorFeeBps = denominator === 0n ? null :
+    Number((numerator + denominator - 1n) / denominator) + input.expectedLossBps + input.operatingCostBps;
+  const requiredServiceFeeBps = input.sponsorFeeBps + input.l1FeeBps + input.l2FeeBps + input.minimumPeerFeeBps;
+  const budgetShortfallBps = Math.max(0, requiredServiceFeeBps - input.serviceFeeBps);
+
+  return {
+    assumptions: { ...input },
+    holdDays,
+    annualVolumePerDollar,
+    annualVolumeUsd,
+    annualFeeUsd,
+    annualLossUsd,
+    annualOperatingCostUsd,
+    annualNetIncomeUsd: annualVolumeUsd * netMarginBps / BPS,
+    grossAprPercent: input.sponsorFeeBps * annualVolumePerDollar / 100,
+    netAprPercent: netMarginBps * annualVolumePerDollar / 100,
+    requiredSponsorFeeBps,
+    maximumLossBpsForTarget: input.utilizationBps === 0 ? null :
+      input.sponsorFeeBps - input.operatingCostBps - input.targetNetAprBps / annualVolumePerDollar,
+    requiredServiceFeeBps,
+    budgetShortfallBps,
+    feeBudgetFits: budgetShortfallBps === 0,
+    peerRemainderBps: input.serviceFeeBps - input.l1FeeBps - input.l2FeeBps - input.sponsorFeeBps,
+  };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const args = process.argv.slice(2);
+  if (args.length !== 1 || args[0] === '--help') {
+    process.stdout.write('Usage: node scripts/model-sponsor-fees.mjs <scenario.json>\n');
+    process.exitCode = args[0] === '--help' ? 0 : 1;
+  } else {
+    const input = JSON.parse(readFileSync(args[0], 'utf8'));
+    process.stdout.write(`${JSON.stringify(modelSponsorFees(input), null, 2)}\n`);
+  }
+}

--- a/scripts/model-sponsor-fees.spec.mjs
+++ b/scripts/model-sponsor-fees.spec.mjs
@@ -8,7 +8,7 @@ const scenario = JSON.parse(readFileSync(new URL('./fixtures/sponsor-fees.json',
 const model = (overrides = {}) => modelSponsorFees({ ...scenario, ...overrides });
 
 test('80 bps funds a 12% target with a 14-day hold and a 150 bps fee budget', () => {
-  const result = model();
+  const result = model({ sponsorFeeBps: 80, serviceFeeBps: 150, minimumPeerFeeBps: 20 });
   assert.equal(result.requiredSponsorFeeBps, 77);
   assert.equal(result.netAprPercent.toFixed(4), '12.7098');
   assert.equal(result.annualNetIncomeUsd.toFixed(2), '1270.98');
@@ -18,15 +18,19 @@ test('80 bps funds a 12% target with a 14-day hold and a 150 bps fee budget', ()
   assert.equal(result.peerRemainderBps, 20);
 });
 
-test('matching a 40 bps referral fee does not meet the target under the same assumptions', () => {
-  assert.equal(model({ sponsorFeeBps: 40 }).netAprPercent.toFixed(4), '4.8884');
-  assert.equal(model({ sponsorFeeBps: 40 }).requiredSponsorFeeBps, 77);
+test('the approved L1-priced fixture uses 40 bps and fits a 100 bps total budget', () => {
+  const result = model();
+  assert.equal(result.assumptions.sponsorFeeBps, result.assumptions.l1FeeBps);
+  assert.equal(result.netAprPercent.toFixed(4), '4.8884');
+  assert.equal(result.requiredSponsorFeeBps, 77);
+  assert.equal(result.peerRemainderBps, 10);
+  assert.equal(result.feeBudgetFits, true);
 });
 
 test('idle collateral and delayed release reduce throughput without changing the fee per fill', () => {
   assert.equal(model({ utilizationBps: 5000 }).requiredSponsorFeeBps, 108);
   assert.equal(model({ additionalHoldDays: 2 }).requiredSponsorFeeBps, 86);
-  assert.equal(model({ additionalHoldDays: 2 }).netAprPercent.toFixed(4), '11.1211');
+  assert.equal(model({ additionalHoldDays: 2 }).netAprPercent.toFixed(4), '4.2773');
 });
 
 test('zero utilization has no earnings and no attainable volume-based target fee', () => {
@@ -37,21 +41,21 @@ test('zero utilization has no earnings and no attainable volume-based target fee
 });
 
 test('loss stress preserves negative returns rather than clipping them to zero', () => {
-  assert.equal(model({ expectedLossBps: 100 }).netAprPercent.toFixed(4), '-4.8884');
+  assert.equal(model({ expectedLossBps: 100 }).netAprPercent.toFixed(4), '-12.7098');
 });
 
-test('a 100 bps budget exposes the shortfall without taking existing referral fees', () => {
-  const result = model({ serviceFeeBps: 100 });
-  assert.equal(result.requiredServiceFeeBps, 150);
-  assert.equal(result.budgetShortfallBps, 50);
-  assert.equal(result.peerRemainderBps, -30);
+test('a 75 bps budget exposes the shortfall without taking existing referral fees', () => {
+  const result = model({ serviceFeeBps: 75 });
+  assert.equal(result.requiredServiceFeeBps, 100);
+  assert.equal(result.budgetShortfallBps, 25);
+  assert.equal(result.peerRemainderBps, -15);
   assert.equal(result.feeBudgetFits, false);
 });
 
 test('capital scales dollars, not the required rate or annualized return', () => {
   const small = model();
   const large = model({ capitalUsd: 100000 });
-  assert.equal(large.annualNetIncomeUsd.toFixed(2), '12709.82');
+  assert.equal(large.annualNetIncomeUsd.toFixed(2), '4888.39');
   assert.equal(large.requiredSponsorFeeBps, small.requiredSponsorFeeBps);
   assert.equal(large.netAprPercent, small.netAprPercent);
 });

--- a/scripts/model-sponsor-fees.spec.mjs
+++ b/scripts/model-sponsor-fees.spec.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { modelSponsorFees } from './model-sponsor-fees.mjs';
+
+const scenario = JSON.parse(readFileSync(new URL('./fixtures/sponsor-fees.json', import.meta.url), 'utf8'));
+const model = (overrides = {}) => modelSponsorFees({ ...scenario, ...overrides });
+
+test('80 bps funds a 12% target with a 14-day hold and a 150 bps fee budget', () => {
+  const result = model();
+  assert.equal(result.requiredSponsorFeeBps, 77);
+  assert.equal(result.netAprPercent.toFixed(4), '12.7098');
+  assert.equal(result.annualNetIncomeUsd.toFixed(2), '1270.98');
+  assert.equal(result.annualVolumeUsd.toFixed(2), '195535.71');
+  assert.equal(result.maximumLossBpsForTarget.toFixed(4), '13.6301');
+  assert.equal(result.feeBudgetFits, true);
+  assert.equal(result.peerRemainderBps, 20);
+});
+
+test('matching a 40 bps referral fee does not meet the target under the same assumptions', () => {
+  assert.equal(model({ sponsorFeeBps: 40 }).netAprPercent.toFixed(4), '4.8884');
+  assert.equal(model({ sponsorFeeBps: 40 }).requiredSponsorFeeBps, 77);
+});
+
+test('idle collateral and delayed release reduce throughput without changing the fee per fill', () => {
+  assert.equal(model({ utilizationBps: 5000 }).requiredSponsorFeeBps, 108);
+  assert.equal(model({ additionalHoldDays: 2 }).requiredSponsorFeeBps, 86);
+  assert.equal(model({ additionalHoldDays: 2 }).netAprPercent.toFixed(4), '11.1211');
+});
+
+test('zero utilization has no earnings and no attainable volume-based target fee', () => {
+  const result = model({ utilizationBps: 0 });
+  assert.equal(result.annualVolumeUsd, 0);
+  assert.equal(result.annualNetIncomeUsd, 0);
+  assert.equal(result.requiredSponsorFeeBps, null);
+});
+
+test('loss stress preserves negative returns rather than clipping them to zero', () => {
+  assert.equal(model({ expectedLossBps: 100 }).netAprPercent.toFixed(4), '-4.8884');
+});
+
+test('a 100 bps budget exposes the shortfall without taking existing referral fees', () => {
+  const result = model({ serviceFeeBps: 100 });
+  assert.equal(result.requiredServiceFeeBps, 150);
+  assert.equal(result.budgetShortfallBps, 50);
+  assert.equal(result.peerRemainderBps, -30);
+  assert.equal(result.feeBudgetFits, false);
+});
+
+test('capital scales dollars, not the required rate or annualized return', () => {
+  const small = model();
+  const large = model({ capitalUsd: 100000 });
+  assert.equal(large.annualNetIncomeUsd.toFixed(2), '12709.82');
+  assert.equal(large.requiredSponsorFeeBps, small.requiredSponsorFeeBps);
+  assert.equal(large.netAprPercent, small.netAprPercent);
+});
+
+test('whole-bp fee ceiling keeps exact boundaries and flags unattainable rates', () => {
+  assert.equal(model({ riskWindowDays: 365, utilizationBps: 10000 }).requiredSponsorFeeBps, 1215);
+  const result = model({ utilizationBps: 1 });
+  assert.equal(result.requiredSponsorFeeBps, 460289);
+});
+
+test('input errors reject missing, misspelled, non-finite, fractional and out-of-range assumptions', () => {
+  for (const [key, value] of [
+    ['utilizationBps', 10001], ['utilizationBps', -1], ['riskWindowDays', 0],
+    ['additionalHoldDays', -1], ['sponsorFeeBps', NaN], ['capitalUsd', Infinity],
+    ['expectedLossBps', 0.5], ['targetNetAprBps', '1200'], ['operatingCostBps', undefined],
+  ]) {
+    assert.throws(() => model({ [key]: value }), new RegExp(key));
+  }
+  assert.throws(() => model({ lockDays: 14 }), /Unknown scenario input: lockDays/);
+  assert.throws(() => modelSponsorFees(null), /Scenario must be an object/);
+});
+
+test('CLI produces the same scenario results', () => {
+  const result = spawnSync(process.execPath, [
+    new URL('./model-sponsor-fees.mjs', import.meta.url).pathname,
+    new URL('./fixtures/sponsor-fees.json', import.meta.url).pathname,
+  ], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), model());
+});

--- a/test-foundry/deterministic/helpers/StakeReferralFixture.sol
+++ b/test-foundry/deterministic/helpers/StakeReferralFixture.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {StakeVault} from "contracts/StakeVault.sol";
+import {DisputeProtectionPolicy} from "contracts/hooks/DisputeProtectionPolicy.sol";
+import {IntentLifecycleHookV1} from "contracts/hooks/IntentLifecycleHookV1.sol";
+import {WhitelistPolicy} from "contracts/hooks/WhitelistPolicy.sol";
+import {IStakeReferralLifecycleHook} from "contracts/interfaces/IStakeReferralLifecycleHook.sol";
+import {IDisputeProtectionPolicy} from "contracts/interfaces/IDisputeProtectionPolicy.sol";
+import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
+import {IReferralFee} from "contracts/interfaces/IReferralFee.sol";
+import {AttestationVerifierMock} from "contracts/mocks/AttestationVerifierMock.sol";
+import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
+import {NullifierRegistry} from "contracts/registries/NullifierRegistry.sol";
+import {NullifierRegistryV2} from "contracts/registries/NullifierRegistryV2.sol";
+import {DisputeVerifier} from "contracts/unifiedVerifier/DisputeVerifier.sol";
+import {OrchestratorV3Fixture} from "./OrchestratorV3Fixture.sol";
+
+abstract contract StakeReferralFixture is OrchestratorV3Fixture {
+    uint256 internal constant L1_FEE = 4e15;
+    uint256 internal constant STAKE = 500e6;
+    address internal backer;
+    address internal peer;
+    StakeVault internal vault;
+    DisputeProtectionPolicy internal protection;
+    IntentLifecycleHookV1 internal hook;
+    WhitelistPolicy internal whitelist;
+    NullifierRegistryV2 internal nullifiers;
+
+    function setUp() public override {
+        super.setUp();
+        backer = makeAddr("backer");
+        peer = makeAddr("peer");
+        vault = new StakeVault(address(this), token, address(0), 1 days);
+        whitelist = new WhitelistPolicy(new AddressGroupRegistry(), escrowRegistry, orchestratorRegistry);
+        nullifiers = new NullifierRegistryV2(new NullifierRegistry());
+        NullifierRegistry disputeNullifiers = new NullifierRegistry();
+        protection = new DisputeProtectionPolicy(
+            address(this),
+            vault,
+            new DisputeVerifier(address(this), nullifiers, new AttestationVerifierMock()),
+            disputeNullifiers
+        );
+        vault.initializeController(address(protection));
+        disputeNullifiers.addWritePermission(address(protection));
+        hook = new IntentLifecycleHookV1(orchestratorRegistry, whitelist, protection);
+        protection.setLifecycleHookAuthorization(address(hook), true);
+        protection.setRiskWindow(METHOD, 14 days);
+        orchestrator.setLifecycleHook(hook);
+        orchestrator.setStakeReferralConfig(IStakeReferralLifecycleHook(address(hook)), peer, L1_FEE);
+        _stake(backer);
+        vm.prank(backer);
+        vault.setTakerAuthorization(taker, true);
+        vm.prank(taker);
+        vault.selectStakeOwner(backer);
+        verifier.setShouldVerifyPayment(true);
+    }
+
+    function _stake(address owner) internal {
+        token.transfer(owner, STAKE);
+        vm.startPrank(owner);
+        token.approve(address(vault), STAKE);
+        vault.depositStake(STAKE);
+        vm.stopPrank();
+    }
+
+    function _feesParams(uint256 peerFee, address makerL1)
+        internal
+        view
+        returns (IOrchestratorV3.SignalIntentParams memory params)
+    {
+        params = _defaultParams();
+        params.referralFees = new IReferralFee.ReferralFee[](3);
+        params.referralFees[0] = IReferralFee.ReferralFee(peer, peerFee);
+        params.referralFees[1] = IReferralFee.ReferralFee(makerL1, L1_FEE);
+        params.referralFees[2] = IReferralFee.ReferralFee(other, 1e15);
+    }
+}

--- a/test-foundry/deterministic/integration/StakeReferralOrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/StakeReferralOrchestratorV3.t.sol
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {StakeReferralFixture} from "../helpers/StakeReferralFixture.sol";
+import {IDisputeProtectionPolicy} from "contracts/interfaces/IDisputeProtectionPolicy.sol";
+import {IDisputeVerifier} from "contracts/interfaces/IDisputeVerifier.sol";
+import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
+import {IStakeReferralLifecycleHook} from "contracts/interfaces/IStakeReferralLifecycleHook.sol";
+import {IReferralFee} from "contracts/interfaces/IReferralFee.sol";
+import {Vm} from "forge-std/Vm.sol";
+
+contract StakeReferralOrchestratorV3Test is StakeReferralFixture {
+    function test_BuyerBackerEarnsL1FromPeerWithUnchangedMakerReferralsAndNetOutput() public {
+        bytes32 hash = _signal(taker, _feesParams(5e15, referrer));
+        IOrchestratorV3.StakeReferral memory referral = orchestrator.getIntentStakeReferral(hash);
+        assertEq(referral.recipient, backer);
+        assertEq(referral.feeSource, peer);
+        assertEq(referral.fee, L1_FEE);
+        assertEq(orchestrator.getIntent(hash).referralFees[0].fee, 5e15);
+        assertEq(vault.lockedStake(backer), INTENT_AMOUNT);
+        _fulfill(hash, INTENT_AMOUNT, CONVERSION_RATE);
+        assertEq(token.balanceOf(backer), 200_000);
+        assertEq(token.balanceOf(peer), 50_000);
+        assertEq(token.balanceOf(referrer), 200_000);
+        assertEq(token.balanceOf(other), 50_000);
+        assertEq(token.balanceOf(taker), 49_500_000);
+        assertEq(orchestrator.getIntentStakeReferral(hash).recipient, address(0));
+        assertEq(vault.lockedStake(backer), INTENT_AMOUNT);
+        vm.warp(block.timestamp + 14 days);
+        assertEq(vault.lockedStake(backer), INTENT_AMOUNT);
+        protection.releaseMaturedDisputeProtectionIntent(hash);
+        assertEq(vault.freeStake(backer), STAKE);
+    }
+
+    function test_ReferralAndStakeOwnerChangesAffectOnlyFutureSignals() public {
+        bytes32 first = _signal(taker, _feesParams(5e15, referrer));
+        _stake(delegate);
+        vm.prank(delegate);
+        vault.setTakerAuthorization(taker, true);
+        vm.prank(taker);
+        vault.selectStakeOwner(delegate);
+        orchestrator.setStakeReferralConfig(IStakeReferralLifecycleHook(address(hook)), peer, 2e15);
+        bytes32 second = _signal(taker, _feesParams(5e15, referrer));
+        vm.prank(backer);
+        vault.setTakerAuthorization(taker, false);
+        _fulfill(first, INTENT_AMOUNT, CONVERSION_RATE);
+        _fulfill(second, INTENT_AMOUNT, CONVERSION_RATE);
+        assertEq(token.balanceOf(backer), 200_000);
+        assertEq(token.balanceOf(delegate), 100_000);
+        assertEq(vault.lockedStake(backer), INTENT_AMOUNT);
+        assertEq(vault.lockedStake(delegate), INTENT_AMOUNT);
+    }
+
+    function test_PartialSettlementPreservesExactOriginalRounding() public {
+        IOrchestratorV3.SignalIntentParams memory params = _feesParams(5e15 + 1, referrer);
+        bytes32 hash = _signal(taker, params);
+        uint256 release = 1_000_199;
+        _fulfill(hash, release, CONVERSION_RATE);
+        uint256 originalFees;
+        for (uint256 i; i < params.referralFees.length; ++i) {
+            originalFees += release * params.referralFees[i].fee / 1e18;
+        }
+        assertEq(token.balanceOf(taker), release - originalFees);
+        assertEq(token.balanceOf(backer), release * L1_FEE / 1e18);
+        assertEq(token.balanceOf(peer), release * params.referralFees[0].fee / 1e18 - release * L1_FEE / 1e18);
+        assertEq(vault.lockedStake(backer), release);
+    }
+
+    function test_ManualReleasePaysReferralAndCancellationDoesNot() public {
+        bytes32 cancelled = _signal(taker, _feesParams(5e15, referrer));
+        vm.prank(taker);
+        orchestrator.cancelIntent(cancelled);
+        assertEq(orchestrator.getIntentStakeReferral(cancelled).recipient, address(0));
+        assertEq(vault.lockedStake(backer), 0);
+        assertEq(token.balanceOf(backer), 0);
+        bytes32 settled = _signal(taker, _feesParams(5e15, referrer));
+        vm.prank(depositor);
+        orchestrator.releaseFundsToPayer(settled);
+        assertEq(token.balanceOf(backer), 200_000);
+        assertEq(vault.lockedStake(backer), INTENT_AMOUNT);
+    }
+
+    function test_SameWalletCanEarnSellerL1AndBuyerStakeL1() public {
+        bytes32 hash = _signal(taker, _feesParams(5e15, backer));
+        vm.recordLogs();
+        _fulfill(hash, INTENT_AMOUNT, CONVERSION_RATE);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        uint256 backerPayouts;
+        for (uint256 i; i < logs.length; ++i) {
+            if (
+                logs[i].emitter == address(orchestrator)
+                    && logs[i].topics[0] == keccak256("IntentReferralFeeDistributed(bytes32,address,uint256)")
+                    && logs[i].topics[2] == bytes32(uint256(uint160(backer)))
+            ) {
+                ++backerPayouts;
+                assertEq(abi.decode(logs[i].data, (uint256)), 400_000);
+            }
+        }
+        assertEq(backerPayouts, 1);
+        assertEq(token.balanceOf(backer), 400_000);
+        assertEq(token.balanceOf(taker), 49_500_000);
+    }
+
+    function test_MissingOrInsufficientPeerBudgetRollsBackCollateralAndIntent() public {
+        for (uint256 i; i < 2; ++i) {
+            IOrchestratorV3.SignalIntentParams memory params = _feesParams(L1_FEE - 1, referrer);
+            uint256 available = L1_FEE - 1;
+            if (i == 0) {
+                params.referralFees = _emptyReferralFees();
+                available = 0;
+            }
+            uint256 counter = orchestrator.intentCounter();
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    IOrchestratorV3.InsufficientStakeReferralBudget.selector, peer, available, L1_FEE
+                )
+            );
+            _signalCall(taker, params);
+            assertEq(orchestrator.intentCounter(), counter);
+            assertEq(vault.lockedStake(backer), 0);
+            assertEq(uint256(protection.getDisputeProtectionIntent(_intentHash(counter)).status), 0);
+        }
+    }
+
+    function test_ExactPeerBudgetPaysBackerWithoutIncreasingTotalFee() public {
+        bytes32 hash = _signal(taker, _feesParams(L1_FEE, referrer));
+        _fulfill(hash, INTENT_AMOUNT, CONVERSION_RATE);
+        assertEq(token.balanceOf(backer), 200_000);
+        assertEq(token.balanceOf(peer), 0);
+        assertEq(token.balanceOf(taker), 49_550_000);
+    }
+
+    function test_SelfStakeDoesNotEarnReferral() public {
+        _stake(taker);
+        vm.prank(taker);
+        vault.clearStakeOwner();
+        bytes32 hash = _signal(taker, _feesParams(5e15, referrer));
+        assertEq(orchestrator.getIntentStakeReferral(hash).recipient, address(0));
+        _fulfill(hash, INTENT_AMOUNT, CONVERSION_RATE);
+        assertEq(token.balanceOf(peer), 250_000);
+        assertEq(token.balanceOf(backer), 0);
+    }
+
+    function test_WhitelistOptOutAndZeroWindowDoNotEarnWithoutCollateral() public {
+        address[] memory allowed = new address[](1);
+        allowed[0] = taker;
+        vm.prank(depositor);
+        whitelist.configureDeposit(address(escrow), depositId, METHOD, true, new bytes32[](0), allowed);
+        bytes32 whitelisted = _signalDefault();
+        assertEq(orchestrator.getIntentStakeReferral(whitelisted).recipient, address(0));
+        vm.prank(depositor);
+        whitelist.setEnabled(address(escrow), depositId, METHOD, false);
+        vm.prank(depositor);
+        protection.setDisputeProtectionEnabled(address(escrow), depositId, METHOD, false);
+        bytes32 optedOut = _signalDefault();
+        assertEq(orchestrator.getIntentStakeReferral(optedOut).recipient, address(0));
+        vm.prank(depositor);
+        protection.setDisputeProtectionEnabled(address(escrow), depositId, METHOD, true);
+        protection.setRiskWindow(METHOD, 0);
+        bytes32 windowless = _signalDefault();
+        assertEq(orchestrator.getIntentStakeReferral(windowless).recipient, address(0));
+        assertEq(vault.lockedStake(backer), 0);
+    }
+
+    function test_FailedSettlementRollsBackReferralTransfersAndSnapshotCleanup() public {
+        bytes32 hash = _signal(taker, _feesParams(5e15, referrer));
+        protection.setLifecycleHookAuthorization(address(hook), false);
+        vm.expectRevert(
+            abi.encodeWithSelector(IDisputeProtectionPolicy.UnauthorizedLifecycleHook.selector, address(hook))
+        );
+        _fulfill(hash, INTENT_AMOUNT, CONVERSION_RATE);
+        assertEq(token.balanceOf(backer), 0);
+        assertEq(token.balanceOf(peer), 0);
+        assertEq(orchestrator.getIntentStakeReferral(hash).recipient, backer);
+        assertEq(vault.lockedStake(backer), INTENT_AMOUNT);
+    }
+
+    function test_DisputeConsumesBackerPrincipalButDoesNotClawBackEarnedReferral() public {
+        bytes32 hash = _signal(taker, _feesParams(5e15, referrer));
+        _fulfill(hash, INTENT_AMOUNT, CONVERSION_RATE);
+        bytes32 paymentId = keccak256("payment");
+        nullifiers.addWritePermission(address(this));
+        nullifiers.addNullifier(keccak256(abi.encodePacked(METHOD, paymentId)), hash);
+        bytes memory data = abi.encode(
+            IDisputeVerifier.DisputeDetails({
+                paymentMethod: METHOD,
+                originalPaymentId: paymentId,
+                disputeId: keccak256("dispute"),
+                paymentAmount: 100,
+                paymentCurrency: USD
+            })
+        );
+        protection.submitDispute(
+            IDisputeVerifier.DisputeAttestation({
+                intentHash: hash, dataHash: keccak256(data), signatures: new bytes[](0), data: data
+            })
+        );
+        assertEq(vault.claimable(depositor), INTENT_AMOUNT);
+        assertEq(vault.stakeBalance(backer), STAKE - INTENT_AMOUNT);
+        assertEq(token.balanceOf(backer), 200_000);
+    }
+
+    function test_ConfigurationIsOwnerOnlyAndRejectsInvalidRateSourceAndHook() public {
+        vm.prank(taker);
+        vm.expectRevert("Ownable: caller is not the owner");
+        orchestrator.setStakeReferralConfig(IStakeReferralLifecycleHook(address(hook)), peer, L1_FEE);
+        vm.expectRevert(abi.encodeWithSelector(IOrchestratorV3.InvalidStakeReferralFee.selector, 5e17 + 1));
+        orchestrator.setStakeReferralConfig(IStakeReferralLifecycleHook(address(hook)), peer, 5e17 + 1);
+        vm.expectRevert(IOrchestratorV3.ZeroAddress.selector);
+        orchestrator.setStakeReferralConfig(IStakeReferralLifecycleHook(address(hook)), address(0), L1_FEE);
+        vm.expectRevert(abi.encodeWithSelector(IOrchestratorV3.InvalidLifecycleHook.selector, address(0)));
+        orchestrator.setStakeReferralConfig(IStakeReferralLifecycleHook(address(0)), peer, L1_FEE);
+    }
+
+    function test_DisablingFutureReferralsPreservesAlreadyEarnableReferral() public {
+        bytes32 hash = _signal(taker, _feesParams(5e15, referrer));
+        orchestrator.setStakeReferralConfig(IStakeReferralLifecycleHook(address(hook)), peer, 0);
+        bytes32 disabled = _signalDefault();
+        assertEq(orchestrator.getIntentStakeReferral(disabled).recipient, address(0));
+        _fulfill(hash, INTENT_AMOUNT, CONVERSION_RATE);
+        assertEq(token.balanceOf(backer), 200_000);
+    }
+
+    function test_TenRecipientLimitCountsTheAdditionalBacker() public {
+        IOrchestratorV3.SignalIntentParams memory params = _defaultParams();
+        params.referralFees = new IReferralFee.ReferralFee[](10);
+        params.referralFees[0] = IReferralFee.ReferralFee(peer, 5e15);
+        for (uint256 i = 1; i < 10; ++i) {
+            params.referralFees[i] = IReferralFee.ReferralFee(address(uint160(1000 + i)), 1e14);
+        }
+        vm.expectRevert(abi.encodeWithSelector(IReferralFee.ReferralFeeCountExceedsMaximum.selector, 11, 10));
+        _signalCall(taker, params);
+        assertEq(vault.lockedStake(backer), 0);
+
+        // Replacing the fully consumed donor does not increase the number of paid recipients.
+        params.referralFees[0].fee = L1_FEE;
+        bytes32 hash = _signal(taker, params);
+        _fulfill(hash, INTENT_AMOUNT, CONVERSION_RATE);
+        assertEq(token.balanceOf(backer), 200_000);
+        assertEq(token.balanceOf(peer), 0);
+    }
+
+    function test_PeerAsBackerReceivesOneUnchangedDonorPayout() public {
+        orchestrator.setStakeReferralConfig(IStakeReferralLifecycleHook(address(hook)), backer, L1_FEE);
+        IOrchestratorV3.SignalIntentParams memory params = _feesParams(5e15, referrer);
+        params.referralFees[0].recipient = backer;
+        bytes32 hash = _signal(taker, params);
+        _fulfill(hash, INTENT_AMOUNT, CONVERSION_RATE);
+        assertEq(token.balanceOf(backer), 250_000);
+        assertEq(token.balanceOf(taker), 49_500_000);
+    }
+
+    function test_FundingSourceChangesDoNotAlterExistingSnapshots() public {
+        bytes32 first = _signal(taker, _feesParams(5e15, referrer));
+        address newPeer = makeAddr("newPeer");
+        orchestrator.setStakeReferralConfig(IStakeReferralLifecycleHook(address(hook)), newPeer, L1_FEE);
+        IOrchestratorV3.SignalIntentParams memory params = _feesParams(5e15, referrer);
+        params.referralFees[0].recipient = newPeer;
+        bytes32 second = _signal(taker, params);
+        assertEq(orchestrator.getIntentStakeReferral(first).feeSource, peer);
+        assertEq(orchestrator.getIntentStakeReferral(second).feeSource, newPeer);
+        _fulfill(first, INTENT_AMOUNT, CONVERSION_RATE);
+        _fulfill(second, INTENT_AMOUNT, CONVERSION_RATE);
+        assertEq(token.balanceOf(peer), 50_000);
+        assertEq(token.balanceOf(newPeer), 50_000);
+        assertEq(token.balanceOf(backer), 400_000);
+    }
+}

--- a/test-foundry/fuzz/StakeReferralFuzz.t.sol
+++ b/test-foundry/fuzz/StakeReferralFuzz.t.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {StakeReferralFixture} from "../deterministic/helpers/StakeReferralFixture.sol";
+import {IOrchestratorV3} from "contracts/interfaces/IOrchestratorV3.sol";
+import {IStakeReferralLifecycleHook} from "contracts/interfaces/IStakeReferralLifecycleHook.sol";
+
+contract StakeReferralFuzzTest is StakeReferralFixture {
+    function testFuzz_ReferralSplitConservesExactBuyerOutputAndTotalFees(
+        uint256 releaseAmount,
+        uint256 l1Rate,
+        uint256 donorRate,
+        bool backerIsMakerReferrer
+    ) public {
+        releaseAmount = bound(releaseAmount, 1, INTENT_AMOUNT);
+        l1Rate = bound(l1Rate, 1, 4e15);
+        donorRate = bound(donorRate, l1Rate, 1e16);
+        orchestrator.setStakeReferralConfig(IStakeReferralLifecycleHook(address(hook)), peer, l1Rate);
+        IOrchestratorV3.SignalIntentParams memory params =
+            _feesParams(donorRate, backerIsMakerReferrer ? backer : referrer);
+        bytes32 hash = _signal(taker, params);
+        _fulfill(hash, releaseAmount, CONVERSION_RATE);
+
+        uint256 originalFees;
+        for (uint256 i; i < params.referralFees.length; ++i) {
+            originalFees += releaseAmount * params.referralFees[i].fee / 1e18;
+        }
+        uint256 backerFee = releaseAmount * l1Rate / 1e18;
+        if (backerIsMakerReferrer) backerFee += releaseAmount * L1_FEE / 1e18;
+        assertEq(token.balanceOf(backer), backerFee);
+        assertEq(token.balanceOf(taker), releaseAmount - originalFees);
+        assertEq(
+            token.balanceOf(peer) + token.balanceOf(referrer) + token.balanceOf(other) + token.balanceOf(backer),
+            originalFees
+        );
+        assertEq(token.balanceOf(address(orchestrator)), 0);
+        assertEq(vault.lockedStake(backer), releaseAmount);
+        assertEq(vault.freeStake(backer) + vault.lockedStake(backer), STAKE);
+    }
+}


### PR DESCRIPTION
When a buyer's trade is collateralized by another wallet, pay that backer a referral at the existing L1 rate. The Orchestrator derives the recipient from the collateral actually locked by the configured lifecycle policy, snapshots the recipient/source/rate at signal, and carves the payout from Peer's existing service-fee allocation at settlement.

For a $1,000 gross fill with a 100 bps total service fee and 40/10 bps seller referrals, the backer receives $4 and Peer retains $1. Existing seller referrals, the signed fee plan and the buyer's exact net output remain unchanged. Missing/insufficient Peer budget rejects the complete signal; self-staking, whitelist bypass and unprotected routes earn no stake referral. No additional L2 is created for the buyer relationship.

Backer/rate/source changes affect future signals only. Cancellation pays nothing; partial and manual releases use actual settled volume; failed settlement rolls back payouts. Collateral retains the existing 14-day lifecycle, and disputes consume principal without clawing back earned referrals. A wallet with both referral roles receives one combined payout event, preserving the indexer's intent/recipient-keyed accounting.

The economic calculator and fixture now use the approved L1 rate (40 bps in the example). The [design and delivery notes](https://github.com/zkp2p/zkp2p-contracts/blob/feat/sponsor-fee-model/docs/plans/2026-09-07-sponsored-stake-fees.md) document fee budgeting and the source review of Curator, SDK and indexer consumers.

Validation at commit `8384b51`: the [complete Foundry suite](https://github.com/zkp2p/zkp2p-contracts/actions/runs/34088062007) passes all 1,561 tests, including the new collateral-backed referral scenarios and 512-run fuzz test. All 10 economic-model tests pass. [Release readiness](https://github.com/zkp2p/zkp2p-contracts/actions/runs/34088061990) also passes compilation, package tests and localhost deployment checks.

Activation is separate: this requires a successor Orchestrator, exact L1/Peer-source configuration, registry/bypass review and package/address cutover. No live configuration, deployment, publication or immutable lane/artifact is changed. Existing dashboard L1/L2 labels still follow the seller code tree; buyer-backers' payouts enter total earnings but can appear as unattributed there. This PR implements on-chain payouts, not a new dashboard or referral-code assignment flow.
