### PR TITLE
fix: publish registered UPI catalogs for preproduction

### DIFF
--- a/.agents/skills/upi-catalog-qa/SKILL.md
+++ b/.agents/skills/upi-catalog-qa/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: upi-catalog-qa
+description: Verify UPI/INR registry registration and published contracts catalogs before downstream HDFC email UPI rollout.
+---
+
+# UPI catalog QA
+
+Resolve Base or Base staging addresses and ABIs from the exact candidate package.
+Using a read-only Base RPC, require `PaymentVerifierRegistry.isPaymentMethod(keccak256("upi"))`,
+`getVerifier` equal to the current packaged UnifiedPaymentVerifierV3, and
+`getCurrencies` equal to `[keccak256("INR")]`. Require the current verifier's
+`getPaymentMethods` to contain UPI. Record chain ID, block number, package and source SHA.
+This workflow does not submit governance transactions.
+
+The extraction allowlist and `deployments/outputs/platforms/<network>.json` must
+both include the verified method. Run `yarn pkg:build`, `yarn pkg:test` and
+`yarn workspace @zkp2p/contracts-v2 verify:release`. The payment-method regression
+must pass for raw JSON, ESM and CJS catalogs and forward/reverse hash lookups.
+After publishing through the repository release skill, clean-install the exact
+version and repeat catalog assertions; merely finding the word UPI in a tarball
+is insufficient. Verify the downstream SDK's `getPaymentMethodsCatalog` for
+`preproduction`, not just staging. Product environment flags remain owned by clients.

--- a/.github/workflows/publish-contracts-v2.yml
+++ b/.github/workflows/publish-contracts-v2.yml
@@ -32,7 +32,7 @@ env:
   PACK_ARTIFACT: contracts-v2-release-candidate
   RELEASE_VERSION: ${{ inputs.release }}
   RELEASE_TAG: contracts-v2-v${{ inputs.release }}
-  LATEST_BASELINE: 0.4.0
+  LATEST_BASELINE: 0.4.1
   RC_BASELINE: 0.4.1-rc.9
   NPM_CONFIG_PROVENANCE: "true"
   REQUIRE_PROVENANCE: "true"

--- a/deployments/outputs/platforms/base.json
+++ b/deployments/outputs/platforms/base.json
@@ -149,6 +149,13 @@
         "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
       ],
       "updatedAt": "2026-03-16T12:47:45.525Z"
+    },
+    "upi": {
+      "paymentMethodHash": "0xe99a5081226cbbff9440a63da5caa04fa30f210c12c4dd9976132ac075054cd9",
+      "currencies": [
+        "0xaad766fbc07fb357bed9fd8b03b935f2f71fe29fc48f08274bc2a01d7f642afc"
+      ],
+      "updatedAt": "2026-09-10T05:56:00.000Z"
     }
   }
 }

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -2,7 +2,14 @@
 
 Official npm package for ZKP2P V2 smart contract interfaces, ABIs, addresses, and utilities.
 
-## Release 0.4.1 RC
+## Release 0.4.2 RC
+
+- Includes the registered UPI/INR method in both Base and Base staging catalogs
+  and cross-network hash lookups. HDFC Gmail is the buyer proof flow selected
+  by clients; this package does not enable WhatsApp UPI.
+- Published on the `rc` tag for preproduction validation; `latest` stays at 0.4.1.
+
+## Release 0.4.1
 
 - Exports the canonical source ABIs for `DisputeNullifierRegistry`, `DisputeProtectionPolicy`,
   `DisputeVerifier`, `IntentLifecycleHookV1`, and `StakeVault`.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/contracts-v2",
-  "version": "0.4.1",
+  "version": "0.4.2-rc.1",
   "description": "ZKP2P V2 smart contract interfaces and utilities",
   "main": "./_cjs/index.js",
   "module": "./_esm/index.js",

--- a/packages/contracts/scripts/extractors/paymentMethods.ts
+++ b/packages/contracts/scripts/extractors/paymentMethods.ts
@@ -41,6 +41,7 @@ const PUBLISHED_PAYMENT_METHOD_NAMES = new Set([
   'monzo',
   'paypal',
   'revolut',
+  'upi',
   'venmo',
   'wise',
   'zelle',

--- a/packages/contracts/test/paymentMethods.test.ts
+++ b/packages/contracts/test/paymentMethods.test.ts
@@ -17,6 +17,22 @@ describe("payment method package extraction", () => {
     await extractPaymentMethods();
   });
 
+  it("publishes registered UPI/INR on Base and Base staging in every module format", () => {
+    const methodHash = "0xe99a5081226cbbff9440a63da5caa04fa30f210c12c4dd9976132ac075054cd9";
+    const currencyHash = "0xaad766fbc07fb357bed9fd8b03b935f2f71fe29fc48f08274bc2a01d7f642afc";
+    for (const format of ["", "_cjs", "_esm"]) {
+      const directory = path.resolve(__dirname, "..", format, "paymentMethods");
+      for (const network of ["base", "baseStaging"]) {
+        const data = JSON.parse(fs.readFileSync(path.join(directory, `${network}.json`), "utf8"));
+        expect(data.methods.upi.paymentMethodHash).toBe(methodHash);
+        expect(data.methods.upi.currencies).toEqual([currencyHash]);
+      }
+      const lookups = JSON.parse(fs.readFileSync(path.join(directory, "lookups.json"), "utf8"));
+      expect(lookups.nameToHash.upi).toBe(methodHash);
+      expect(lookups.hashToName[methodHash]).toBe("upi");
+    }
+  });
+
   it("publishes one generic Zelle method with no variant compatibility API", () => {
     const base = JSON.parse(fs.readFileSync(path.join(paymentMethodsDir, "base.json"), "utf8"));
     const baseStaging = JSON.parse(fs.readFileSync(path.join(paymentMethodsDir, "baseStaging.json"), "utf8"));

--- a/scripts/npm-release.spec.mjs
+++ b/scripts/npm-release.spec.mjs
@@ -356,9 +356,9 @@ test('derives a future RC release line from the package version', () => {
   );
 });
 
-test('commits the stable candidate while preserving RC release support', () => {
+test('commits the UPI RC candidate while preserving stable release support', () => {
   const packageManifest = JSON.parse(fs.readFileSync(packageManifestPath, 'utf8'));
-  assert.equal(packageManifest.version, '0.4.1');
+  assert.equal(packageManifest.version, '0.4.2-rc.1');
   assert.deepEqual(
     resolveReleasePolicy({
       release: '0.4.1',
@@ -387,7 +387,7 @@ test('release CLI fixtures do not inherit workflow policy variables', () => {
 test('publish workflow consumes the version-derived channel without RC-only paths', () => {
   const workflow = fs.readFileSync(releaseWorkflowPath, 'utf8');
 
-  assert.match(workflow, /^  LATEST_BASELINE: 0\.4\.0$/m);
+  assert.match(workflow, /^  LATEST_BASELINE: 0\.4\.1$/m);
   assert.match(workflow, /^  RC_BASELINE: 0\.4\.1-rc\.9$/m);
   assert.match(workflow, /^\s{2}policy:\s*$/m);
   assert.match(workflow, /node scripts\/npm-release\.mjs resolve "\$PACKAGE_JSON" "\$RELEASE_VERSION"/);


### PR DESCRIPTION
UPI is registered on the Base registry and UnifiedPaymentVerifierV3, but the published package omits it from the active catalog. Record the verified Base UPI/INR snapshot and include UPI in package extraction so downstream preproduction SDKs can discover it.

Prepare 0.4.2-rc.1 on the rc channel; latest remains 0.4.1. This changes package metadata only and sends no contract transactions. Add a portable catalog QA skill.

Validation: live Base registry membership, current UPV3 binding and INR currency; UPV3 membership at block 51115462; package build; 6 package tests including raw/ESM/CJS UPI catalogs; 66 deployment-backed ABI/address entries and 12 canonical ABI exports verified; 112 release-policy tests passed. Existing compiler artifacts were reused locally; canonical CI and the trusted publish workflow retain pinned full-suite gates.
