### PR TITLE
fix: validate installed risk windows against canonical evidence

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/contracts-v2",
-  "version": "0.4.2-rc.1",
+  "version": "0.4.2-rc.2",
   "description": "ZKP2P V2 smart contract interfaces and utilities",
   "main": "./_cjs/index.js",
   "module": "./_esm/index.js",

--- a/packages/contracts/scripts/smoke-installed.mjs
+++ b/packages/contracts/scripts/smoke-installed.mjs
@@ -3,6 +3,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
+import { isDeepStrictEqual } from "node:util";
 import { createRequire } from "node:module";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -19,6 +20,8 @@ const repoRoot = path.resolve(
 );
 const { INTERNAL_POLICY_RECORDS, getActiveDisputeDeploymentName } =
   requireFromRepo("../../../deployments/activeDisputeStack.cjs");
+const { riskWindowSecondsByPaymentMethod: canonicalRiskWindows } =
+  requireFromRepo("../../../deployments/dispute-stack-evidence.json");
 const internalPolicyRecords = /** @type {string[]} */ (INTERNAL_POLICY_RECORDS);
 /** @param {string} name */
 const isInternalDeploymentName = (name) =>
@@ -70,9 +73,9 @@ for (const subpath of [
     fail(`consumer import ${subpath} is missing`);
 }
 
-for (const [network, expectedRiskWindowCount] of [
-  ["base", 10],
-  ["baseStaging", 12],
+for (const [network, manifestNetwork] of [
+  ["base", "base"],
+  ["baseStaging", "base_staging"],
 ]) {
   const manifest = requireFromInstall(
     `@zkp2p/contracts-v2/disputeStack/${network}.json`
@@ -97,10 +100,12 @@ for (const [network, expectedRiskWindowCount] of [
     fail(`${network} dispute stack CJS/ESM exports differ from packaged JSON`);
   }
   if (
-    Object.keys(manifest.riskWindowSecondsByPaymentMethod || {}).length !==
-    expectedRiskWindowCount
+    !isDeepStrictEqual(
+      manifest.riskWindowSecondsByPaymentMethod,
+      canonicalRiskWindows[manifestNetwork]
+    )
   ) {
-    fail(`${network} dispute stack metadata does not cover all active methods`);
+    fail(`${network} dispute stack risk windows differ from canonical deployment evidence`);
   }
   if (
     manifest.addressExpectations?.StakeToken !==

--- a/scripts/npm-release.spec.mjs
+++ b/scripts/npm-release.spec.mjs
@@ -358,7 +358,7 @@ test('derives a future RC release line from the package version', () => {
 
 test('commits the UPI RC candidate while preserving stable release support', () => {
   const packageManifest = JSON.parse(fs.readFileSync(packageManifestPath, 'utf8'));
-  assert.equal(packageManifest.version, '0.4.2-rc.1');
+  assert.equal(packageManifest.version, '0.4.2-rc.2');
   assert.deepEqual(
     resolveReleasePolicy({
       release: '0.4.1',


### PR DESCRIPTION
The RC1 clean-install release gate expected 12 staging risk-window entries, while canonical deployment evidence now contains 13. Compare the installed package's complete method/risk map with canonical evidence for each network instead of hardcoded counts. This rejects missing methods, unexpected same-count substitutions, and incorrect risk values.

Advance the unpublished candidate to `0.4.2-rc.2` because RC1's repository tag already exists. No contract, deployment, public manifest, or publishing authorization gate changes.

Validation on Node 22.14.0:
- Package build and all 6 package tests passed.
- Release-policy tests passed; exact ABI/address verifier passed (66 deployment-backed entries, 12 canonical source exports).
- Packed artifact verification passed (722 files), followed by clean install/import of the exact RC2 tarball.
- Installed-artifact negative probes rejected missing UPI, a same-count substituted method, and an incorrect UPI risk window; reordered canonical keys passed.
- `git diff --check` passed.

Pinned Foundry and Release readiness CI remain required before the parent creates the RC2 tag and dispatches publication.
