### PR TITLE
feat: share payment replay namespaces across methods

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -94,6 +94,7 @@ jobs:
           corepack yarn test:method-scoped-deployment
           corepack yarn test:method-scoped-vault-deployment
           corepack yarn test:method-scoped-activation
+          corepack yarn test:upv4-bootstrap
           corepack yarn whitelist:bootstrap --self-test
       - name: Typecheck dispute deployment surface
         run: corepack yarn typecheck:dispute-deployment
@@ -110,6 +111,10 @@ jobs:
           exit 1
       - name: Deploy production scripts to localhost
         run: corepack yarn deploy:localhost
+      - name: Bootstrap and resume passive UPV4 against the local stack
+        run: |
+          corepack yarn deploy:upv4:localhost
+          corepack yarn deploy:upv4:localhost
 
   coverage-shards:
     name: Foundry coverage shard (${{ matrix.lane }})

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -95,6 +95,7 @@ jobs:
           corepack yarn test:method-scoped-vault-deployment
           corepack yarn test:method-scoped-activation
           corepack yarn test:upv4-bootstrap
+          corepack yarn test:upv4-callers
           corepack yarn whitelist:bootstrap --self-test
       - name: Typecheck dispute deployment surface
         run: corepack yarn typecheck:dispute-deployment

--- a/contracts/unifiedVerifier/BaseUnifiedPaymentVerifierV4.sol
+++ b/contracts/unifiedVerifier/BaseUnifiedPaymentVerifierV4.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Bytes32ArrayUtils} from "../external/Bytes32ArrayUtils.sol";
+import {IAttestationVerifier} from "../interfaces/IAttestationVerifier.sol";
+import {INullifierRegistryV2} from "../interfaces/INullifierRegistryV2.sol";
+import {IOrchestratorRegistry} from "../interfaces/IOrchestratorRegistry.sol";
+
+/**
+ * @title BaseUnifiedPaymentVerifierV4
+ * @notice Base contract for unified payment verification that manages configuration for multiple payment methods.
+ *
+ * This contract handles:
+ * - Supported payment methods
+ * - Attestation verification through pluggable attestation verifiers
+ *
+ * @dev This is an abstract contract that must be inherited by concrete implementations.
+ */
+abstract contract BaseUnifiedPaymentVerifierV4 is Ownable {
+    using Bytes32ArrayUtils for bytes32[];
+
+    /* ============ Events ============ */
+
+    event PaymentMethodAdded(bytes32 indexed paymentMethod);
+    event PaymentMethodRemoved(bytes32 indexed paymentMethod);
+    event AttestationVerifierUpdated(address indexed oldVerifier, address indexed newVerifier);
+    /* ============ State Variables ============ */
+
+    IOrchestratorRegistry public immutable orchestratorRegistry;
+    INullifierRegistryV2 public immutable nullifierRegistry;
+    IAttestationVerifier public attestationVerifier;
+
+    bytes32[] public paymentMethods;
+    mapping(bytes32 => bool) public isPaymentMethod;
+
+    // Assignments survive deactivation so a method can never reopen consumed payments.
+    mapping(bytes32 => bytes32) public nullifierNamespace;
+
+    /* ============ Modifiers ============ */
+
+    /**
+     * Modifier to ensure only an authorized orchestrator can call.
+     */
+    modifier onlyOrchestrator() {
+        require(orchestratorRegistry.isOrchestrator(msg.sender), "Only orchestrator can call");
+        _;
+    }
+
+    /* ============ Constructor ============ */
+
+    /**
+     * @notice Initializes base payment verifier
+     * @param _orchestratorRegistry The orchestrator registry contract that authorizes orchestrators
+     * @param _nullifierRegistry The nullifier registry contract that will be used to prevent double-spends
+     * @param _attestationVerifier The attestation verifier contract that will be used to verify attestation by the
+     * offchain / ZK attestation service
+     */
+    constructor(
+        IOrchestratorRegistry _orchestratorRegistry,
+        INullifierRegistryV2 _nullifierRegistry,
+        IAttestationVerifier _attestationVerifier
+    ) Ownable() {
+        require(address(_orchestratorRegistry).code.length != 0, "UPV: Invalid orchestrator registry");
+        require(address(_nullifierRegistry).code.length != 0, "UPV: Invalid nullifier registry");
+        require(address(_attestationVerifier).code.length != 0, "UPV: Invalid attestation verifier");
+        orchestratorRegistry = _orchestratorRegistry;
+        nullifierRegistry = _nullifierRegistry;
+        attestationVerifier = _attestationVerifier;
+    }
+
+    /* ============ External Functions ============ */
+
+    /**
+     * @notice Registers or reactivates a payment method with its permanent replay namespace.
+     * @param _paymentMethod The payment method hash; hash the payment method name in lowercase.
+     * @param _namespace The final replay namespace shared by methods that consume the same payments.
+     */
+    function addPaymentMethod(bytes32 _paymentMethod, bytes32 _namespace) external onlyOwner {
+        require(_paymentMethod != bytes32(0), "UPV: Invalid payment method");
+        require(_namespace != bytes32(0), "UPV: Invalid nullifier namespace");
+        require(!isPaymentMethod[_paymentMethod], "UPV: Payment method already exists");
+
+        bytes32 assignedNamespace = nullifierNamespace[_paymentMethod];
+        if (assignedNamespace == bytes32(0)) {
+            nullifierNamespace[_paymentMethod] = _namespace;
+        } else {
+            require(assignedNamespace == _namespace, "UPV: Nullifier namespace mismatch");
+        }
+
+        isPaymentMethod[_paymentMethod] = true;
+        paymentMethods.push(_paymentMethod);
+
+        emit PaymentMethodAdded(_paymentMethod);
+    }
+
+    /**
+     * @notice Deactivates a payment method while retaining its replay namespace.
+     * @param _paymentMethod The payment method to remove
+     */
+    function removePaymentMethod(bytes32 _paymentMethod) external onlyOwner {
+        require(isPaymentMethod[_paymentMethod], "UPV: Payment method does not exist");
+
+        delete isPaymentMethod[_paymentMethod];
+        paymentMethods.removeStorage(_paymentMethod);
+
+        emit PaymentMethodRemoved(_paymentMethod);
+    }
+
+    /**
+     * @notice Updates the attestation verifier contract
+     * @param _newVerifier The new attestation verifier address
+     */
+    function setAttestationVerifier(address _newVerifier) external onlyOwner {
+        address oldVerifier = address(attestationVerifier);
+        require(_newVerifier.code.length != 0, "UPV: Invalid attestation verifier");
+        require(_newVerifier != oldVerifier, "UPV: Same verifier");
+
+        attestationVerifier = IAttestationVerifier(_newVerifier);
+        emit AttestationVerifierUpdated(oldVerifier, _newVerifier);
+    }
+
+    /* ============ View Functions ============ */
+
+    /// @notice Returns the currently active payment methods.
+    function getPaymentMethods() external view returns (bytes32[] memory) {
+        return paymentMethods;
+    }
+
+    /* ============ Internal Functions ============ */
+
+    /**
+     * Validates and adds a nullifier to prevent double-spending
+     * @param _nullifier The nullifier to add
+     */
+    function _validateAndAddNullifier(bytes32 _nullifier, bytes32 _intentHash) internal {
+        require(!nullifierRegistry.isNullified(_nullifier), "Nullifier has already been used");
+        nullifierRegistry.addNullifier(_nullifier, _intentHash);
+    }
+}

--- a/contracts/unifiedVerifier/UnifiedPaymentVerifierV4.sol
+++ b/contracts/unifiedVerifier/UnifiedPaymentVerifierV4.sol
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {BaseUnifiedPaymentVerifierV4} from "./BaseUnifiedPaymentVerifierV4.sol";
+import {INullifierRegistryV2} from "../interfaces/INullifierRegistryV2.sol";
+import {IPaymentVerifier} from "../interfaces/IPaymentVerifier.sol";
+import {IAttestationVerifier} from "../interfaces/IAttestationVerifier.sol";
+import {IOrchestrator} from "../interfaces/IOrchestrator.sol";
+import {IOrchestratorV2} from "../interfaces/IOrchestratorV2.sol";
+import {IOrchestratorRegistry} from "../interfaces/IOrchestratorRegistry.sol";
+
+/**
+ * @title UnifiedPaymentVerifierV4
+ * @notice Verifies payment proofs for multiple payment methods. This is a unified verifier that
+ * replaces individual payment verifiers (VenmoVerifier, PayPalVerifier, etc.) with a single
+ * configurable contract. This contract holds no critical state and can be swapped easily for another
+ * verifier contract, provided its replay namespaces and registry history are preserved.
+ *
+ * Key features:
+ * - Supports multiple payment methods, each with custom configuration
+ * - Uses AttestationVerifier to validate offchain payment attestations
+ * - Ensures trust anchor integrity for off-chain verification processes
+ * - Verifies standardized payment details against provided data
+ * @dev The payment attestation should be signed using the EIP-712 standard
+ */
+contract UnifiedPaymentVerifierV4 is IPaymentVerifier, BaseUnifiedPaymentVerifierV4 {
+    /* ============ Constants ============ */
+
+    // Max timestamp buffer
+    uint256 private constant MAX_TIMESTAMP_BUFFER = 48 * 60 * 60 * 1000; // 48 hours
+
+    // EIP-712 Domain Separator
+    bytes32 private constant DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+
+    // EIP-712 Type Hash for PaymentAttestation
+    bytes32 private constant PAYMENT_ATTESTATION_TYPEHASH =
+        keccak256("PaymentAttestation(bytes32 intentHash,uint256 releaseAmount,bytes32 dataHash)");
+
+    // Used to detect V2 orchestrators that expose getDepositPreIntentHook(address,uint256).
+    bytes4 private constant GET_DEPOSIT_PRE_INTENT_HOOK_SELECTOR =
+        bytes4(keccak256("getDepositPreIntentHook(address,uint256)"));
+
+    /* ============ State Variables ============ */
+
+    // EIP-712 Domain Separator (computed once at deployment)
+    bytes32 public immutable DOMAIN_SEPARATOR;
+
+    /* ============ Events ============ */
+
+    /**
+     * @notice Capture and emit payment details for offchain reconciliation
+     */
+    event PaymentVerified(
+        bytes32 indexed intentHash,
+        bytes32 indexed method,
+        bytes32 indexed currency,
+        uint256 amount,
+        uint256 timestamp,
+        bytes32 paymentId,
+        bytes32 payeeId
+    );
+
+    /* ============ Structs ============ */
+
+    struct PaymentDetails {
+        bytes32 method; // Payment method hash (e.g., "venmo", "paypal", "wise")
+        bytes32 payeeId; // Payment recipient ID (hashed payee details to preserve privacy)
+        uint256 amount; // Payment amount in smallest currency unit (i.e. cents)
+        bytes32 currency; // Payment currency hash (e.g., "USD", "EUR")
+        uint256 timestamp; // Payment timestamp in UTC in milliseconds
+        bytes32 paymentId; // Hashed payment identifier from the service (e.g. hashed venmo payment ID to preserve privacy)
+    }
+
+    struct IntentSnapshot {
+        bytes32 intentHash;
+        uint256 amount;
+        bytes32 paymentMethod;
+        bytes32 fiatCurrency;
+        bytes32 payeeDetails;
+        uint256 conversionRate;
+        uint256 signalTimestamp;
+        uint256 timestampBuffer;
+    }
+
+    struct PaymentAttestation {
+        bytes32 intentHash; // Binds the payment to the intent on Orchestrator
+        uint256 releaseAmount; // Final token amount to release on-chain after FX
+        bytes32 dataHash; // Hash of the additional data to verify integrity
+        bytes[] signatures; // Array of signatures from witnesses
+        bytes data; // Data for verification
+        bytes metadata; // Additional metadata; isn't signed by the witnesses
+    }
+
+    /* ============ Constructor ============ */
+
+    constructor(
+        IOrchestratorRegistry _orchestratorRegistry,
+        INullifierRegistryV2 _nullifierRegistry,
+        IAttestationVerifier _attestationVerifier
+    ) BaseUnifiedPaymentVerifierV4(_orchestratorRegistry, _nullifierRegistry, _attestationVerifier) {
+        // Compute EIP-712 domain separator
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                DOMAIN_TYPEHASH,
+                keccak256(bytes("UnifiedPaymentVerifier")), // name
+                keccak256(bytes("1")), // version
+                block.chainid, // chainId
+                address(this) // verifyingContract
+            )
+        );
+    }
+
+    /* ============ External Functions ============ */
+
+    /**
+     * ONLY ORCHESTRATOR: Verifies a standardized payment attestation generated by the attestation service.
+     * NOTE: This contract has write permissions on nullifier registry, and nullifies the payment after verification.
+     * Hence only Orchestrator can call this function to prevent griefing.
+     *
+     * @param _verifyPaymentData Payment proof and intent details required for verification
+     * @return result The payment verification result containing success status, intent hash, and release amount
+     * @dev Ensure the orchestrator verifies the intent exists before calling this function
+     */
+    function verifyPayment(VerifyPaymentData calldata _verifyPaymentData)
+        external
+        override
+        onlyOrchestrator
+        returns (PaymentVerificationResult memory result)
+    {
+        PaymentAttestation memory attestation = _decodeAttestation(_verifyPaymentData.paymentProof);
+        require(attestation.intentHash == _verifyPaymentData.intentHash, "UPV: Attestation hash mismatch");
+        require(attestation.releaseAmount != 0, "UPV: Invalid release amount");
+
+        (PaymentDetails memory paymentDetails, IntentSnapshot memory intentSnapshot) =
+            _decodeAttestationPayload(attestation.data);
+        require(isPaymentMethod[paymentDetails.method], "UPV: Invalid payment method");
+        require(paymentDetails.method == intentSnapshot.paymentMethod, "UPV: Payment method mismatch");
+        require(paymentDetails.paymentId != bytes32(0), "UPV: Invalid payment ID");
+        require(paymentDetails.amount != 0, "UPV: Invalid payment amount");
+        require(paymentDetails.currency != bytes32(0), "UPV: Invalid payment currency");
+
+        _validateIntentSnapshot(_verifyPaymentData.intentHash, intentSnapshot);
+
+        bool isValid = _verifyAttestation(attestation);
+        require(isValid, "UPV: Invalid attestation");
+
+        // Nullify the payment to prevent double-spending
+        _nullifyPayment(paymentDetails.method, paymentDetails.paymentId, attestation.intentHash);
+
+        _emitPaymentDetails(attestation.intentHash, paymentDetails);
+
+        uint256 releaseAmount = _calculateReleaseAmount(attestation.releaseAmount, intentSnapshot.amount);
+        result = PaymentVerificationResult({
+            success: true, intentHash: attestation.intentHash, releaseAmount: releaseAmount
+        });
+
+        return result;
+    }
+
+    /* ============ Internal Functions ============ */
+
+    function _decodeAttestation(bytes memory paymentProof) internal pure returns (PaymentAttestation memory) {
+        return abi.decode(paymentProof, (PaymentAttestation));
+    }
+
+    function _decodeAttestationPayload(bytes memory paymentData)
+        internal
+        pure
+        returns (PaymentDetails memory paymentDetails, IntentSnapshot memory intentSnapshot)
+    {
+        (paymentDetails, intentSnapshot) = abi.decode(paymentData, (PaymentDetails, IntentSnapshot));
+    }
+
+    /**
+     * Verifies the EIP-712 attestation using the attestation verifier. Also verifies the integrity of the
+     * verify payment data using the data hash attached to the attestation.
+     */
+    function _verifyAttestation(PaymentAttestation memory attestation) internal view returns (bool) {
+        bytes32 structHash = keccak256(
+            abi.encode(
+                PAYMENT_ATTESTATION_TYPEHASH, attestation.intentHash, attestation.releaseAmount, attestation.dataHash
+            )
+        );
+
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash));
+
+        // Verify data integrity - the data hash must match what was signed
+        require(keccak256(attestation.data) == attestation.dataHash, "UPV: Data hash mismatch");
+
+        bool isValid = attestationVerifier.verify(digest, attestation.signatures, attestation.data);
+
+        return isValid;
+    }
+
+    /**
+     * Reads intent data from the Orchestrator and checks them against the intent data provided by the
+     * attestation verifier.
+     */
+    function _validateIntentSnapshot(bytes32 intentHash, IntentSnapshot memory snapshot) internal view {
+        require(snapshot.intentHash == intentHash, "UPV: Snapshot hash mismatch");
+
+        if (_isV2Orchestrator(msg.sender)) {
+            IOrchestratorV2.Intent memory intentV2 = IOrchestratorV2(msg.sender).getIntent(intentHash);
+            _validateSnapshotAgainstIntent(
+                snapshot,
+                intentV2.payeeId,
+                intentV2.amount,
+                intentV2.paymentMethod,
+                intentV2.fiatCurrency,
+                intentV2.conversionRate,
+                intentV2.timestamp
+            );
+        } else {
+            IOrchestrator.Intent memory intent = IOrchestrator(msg.sender).getIntent(intentHash);
+            _validateSnapshotAgainstIntent(
+                snapshot,
+                intent.payeeId,
+                intent.amount,
+                intent.paymentMethod,
+                intent.fiatCurrency,
+                intent.conversionRate,
+                intent.timestamp
+            );
+        }
+
+        require(snapshot.timestampBuffer <= MAX_TIMESTAMP_BUFFER, "UPV: Snapshot timestamp buffer exceeds maximum");
+    }
+
+    function _validateSnapshotAgainstIntent(
+        IntentSnapshot memory snapshot,
+        bytes32 payeeId,
+        uint256 amount,
+        bytes32 paymentMethod,
+        bytes32 fiatCurrency,
+        uint256 conversionRate,
+        uint256 signalTimestamp
+    ) internal pure {
+        require(snapshot.payeeDetails == payeeId, "UPV: Snapshot payee mismatch");
+        require(snapshot.amount == amount, "UPV: Snapshot amount mismatch");
+        require(snapshot.paymentMethod == paymentMethod, "UPV: Snapshot method mismatch");
+        require(snapshot.fiatCurrency == fiatCurrency, "UPV: Snapshot currency mismatch");
+        require(snapshot.conversionRate == conversionRate, "UPV: Snapshot rate mismatch");
+        require(snapshot.signalTimestamp == signalTimestamp, "UPV: Snapshot timestamp mismatch");
+    }
+
+    function _isV2Orchestrator(address orchestrator) internal view returns (bool isV2Orchestrator) {
+        (isV2Orchestrator,) =
+            orchestrator.staticcall(abi.encodeWithSelector(GET_DEPOSIT_PRE_INTENT_HOOK_SELECTOR, address(0), 0));
+    }
+
+    /**
+     * Nullifies a payment to prevent double-spending
+     * @dev Methods sharing a payment identity share its registered final namespace. All predecessor
+     * namespaces must be preserved when replacing a verifier, including historical registry writes.
+     */
+    function _nullifyPayment(bytes32 paymentMethod, bytes32 paymentId, bytes32 intentHash) internal {
+        bytes32 nullifier = keccak256(abi.encodePacked(nullifierNamespace[paymentMethod], paymentId));
+        _validateAndAddNullifier(nullifier, intentHash);
+    }
+
+    /**
+     * Calculates the release amount for an intent by capping the release amount to the intent amount
+     */
+    function _calculateReleaseAmount(uint256 releaseAmount, uint256 intentAmount) internal pure returns (uint256) {
+        if (releaseAmount > intentAmount) {
+            return intentAmount;
+        }
+        return releaseAmount;
+    }
+
+    /**
+     * Emits the payment details for offchain reconciliation
+     */
+    function _emitPaymentDetails(bytes32 intentHash, PaymentDetails memory paymentDetails) internal {
+        emit PaymentVerified(
+            intentHash, // Tie the payment details to the intent hash
+            paymentDetails.method,
+            paymentDetails.currency,
+            paymentDetails.amount,
+            paymentDetails.timestamp,
+            paymentDetails.paymentId,
+            paymentDetails.payeeId
+        );
+    }
+}

--- a/deploy/43_deploy_unified_payment_verifier_v4.ts
+++ b/deploy/43_deploy_unified_payment_verifier_v4.ts
@@ -1,0 +1,126 @@
+import "module-alias/register";
+
+import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+import { assertCanonicalDeployment } from "../deployments/canonicalDeployment";
+import { waitForDeploymentDelay } from "../deployments/helpers";
+import {
+  assertNamespacePrefix,
+  bootstrapRequested,
+  readBootstrapPredecessor,
+  UPV4_BOOTSTRAP_TAG,
+} from "../deployments/unifiedVerifierV4Bootstrap";
+
+const NAME = "UnifiedPaymentVerifierV4";
+
+const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
+  if (!bootstrapRequested(hre.deployments.getNetworkName())) return;
+  const [deployer] = await hre.getUnnamedAccounts();
+  const initial = await readBootstrapPredecessor(hre);
+  const { state } = initial;
+  const args = [
+    state.orchestratorRegistry,
+    state.nullifierRegistry,
+    state.attestationVerifier,
+  ];
+  let record = await hre.deployments.getOrNull(NAME);
+  if (!record) {
+    const deployed = await hre.deployments.deploy(NAME, {
+      from: deployer,
+      args,
+      log: true,
+    });
+    if (!deployed.newlyDeployed)
+      throw new Error("UPV4 bootstrap did not create a fresh verifier");
+    record = deployed;
+    await waitForDeploymentDelay(hre);
+  }
+
+  for (;;) {
+    const current = await readBootstrapPredecessor(hre);
+    if (JSON.stringify(current.state) !== JSON.stringify(state)) {
+      throw new Error(
+        "UPV4 predecessor changed during passive bootstrap; stop and review"
+      );
+    }
+    const at = { blockTag: current.blockNumber };
+    await assertCanonicalDeployment(
+      hre,
+      record,
+      NAME,
+      NAME,
+      current.blockNumber
+    );
+    const successor = await hre.ethers.getContractAt(
+      NAME,
+      record.address,
+      await hre.ethers.getSigner(deployer)
+    );
+    const dependencies = [
+      await successor.orchestratorRegistry(at),
+      await successor.nullifierRegistry(at),
+      await successor.attestationVerifier(at),
+    ];
+    if (
+      dependencies.some(
+        (address, index) => address.toLowerCase() !== args[index].toLowerCase()
+      )
+    ) {
+      throw new Error("UPV4 dependency mismatch");
+    }
+    const domain = hre.ethers.utils._TypedDataEncoder.hashDomain({
+      name: "UnifiedPaymentVerifier",
+      version: "1",
+      chainId: state.chainId,
+      verifyingContract: record.address,
+    });
+    if ((await successor.DOMAIN_SEPARATOR(at)) !== domain)
+      throw new Error("UPV4 signing domain mismatch");
+    const methods: string[] = await successor.getPaymentMethods(at);
+    const namespaces: string[] = [];
+    const active: boolean[] = [];
+    for (const { method } of state.entries) {
+      namespaces.push(await successor.nullifierNamespace(method, at));
+      active.push(await successor.isPaymentMethod(method, at));
+    }
+    const next = assertNamespacePrefix(
+      state.entries,
+      methods,
+      namespaces,
+      active
+    );
+    const owner: string = await successor.owner(at);
+    if (
+      next === state.entries.length &&
+      owner.toLowerCase() === state.governance.toLowerCase()
+    ) {
+      console.log(
+        "UPV4 passively prepared; live routing and writer permissions remain on UPV3",
+        {
+          address: record.address,
+          snapshotBlock: current.blockNumber,
+          snapshotBlockHash: current.blockHash,
+        }
+      );
+      return;
+    }
+    if (owner.toLowerCase() !== deployer.toLowerCase()) {
+      throw new Error("UPV4 incomplete bootstrap is not owned by the deployer");
+    }
+    if (next < state.entries.length) {
+      const { method, namespace } = state.entries[next];
+      await (await successor.addPaymentMethod(method, namespace)).wait();
+    } else {
+      await (await successor.transferOwnership(state.governance)).wait();
+    }
+    await waitForDeploymentDelay(hre);
+  }
+};
+
+func.skip = async (hre: HardhatRuntimeEnvironment) =>
+  !bootstrapRequested(hre.deployments.getNetworkName());
+func.tags = [UPV4_BOOTSTRAP_TAG];
+func.dependencies = [];
+
+export default func;

--- a/deployments/UPV4_BOOTSTRAP.md
+++ b/deployments/UPV4_BOOTSTRAP.md
@@ -1,0 +1,46 @@
+# Passive UPV4 bootstrap
+
+Lane 43 deploys and configures `UnifiedPaymentVerifierV4` against the existing
+`NullifierRegistryV2`, its legacy history, the existing orchestrator registry and
+the predecessor's attestation verifier. It registers all current methods with
+their existing replay namespaces, then registers `venmo-balance` with the
+`venmo` namespace. It transfers ownership after configuration. It never grants
+writer permission, changes a live payment route, changes risk windows, or
+updates the active package addresses.
+
+The lane requires the intact lane-31 UPV3 cutover and the active method-scoped
+lifecycle stack. It validates the current O3 hook/policy pointers and refuses a
+nonzero risk window for any shared-namespace alias. Each operation checks a
+pinned predecessor snapshot, the current compiled successor runtime, dependency
+getters, signing domain and exact namespace prefix. Resume does not repair
+unexpected ownership, method removal, reordered methods or namespace changes.
+The additional historical lane-31 preflight reads latest state; these checks
+are passive-deployment checks, **not an atomic activation proof**.
+
+Compile the reviewed source before running a tagged deployment; tagged runs use
+`--no-compile`. An ordinary untagged deployment skips this lane on every network.
+After deploying the existing local stack, exercise deployment and resume with:
+
+```sh
+yarn deploy:upv4:localhost
+yarn deploy:upv4:localhost
+```
+
+Live execution requires separate deployment authorization, the exact tag
+`43_deploy_unified_payment_verifier_v4`, and exactly the matching environment
+opt-in: `ENABLE_BASE_UPV4_BOOTSTRAP=true` or
+`ENABLE_STAGING_UPV4_BOOTSTRAP=true`. This PR and a successful local run do not
+authorize either live operation. No live deployment has been recorded.
+
+Before activation, prepare and review a separate complete cutover manifest and
+execution-time guard: every authorized orchestrator/admission path, every
+method's ordered currencies, immutable namespaces, existing and retired writer
+sets, policy governance, authenticated funding evidence, and all attestor and
+client domains must agree. Balance must remain unadvertised until those gates
+pass. Historical alias registration and consumption require investigation.
+Regular paid orders need fresh signatures for the replacement address; users
+must not be asked to send another payment. Retire the predecessor-only lane-31
+runner through current metadata or a wrapper when activation is implemented;
+never rewrite executed deployment history or restore predecessor routes after
+UPV4 consumption. Base requires an atomic guarded governance batch; staging's
+EOA ownership needs a separately reviewed maintenance sequence.

--- a/deployments/UPV4_BOOTSTRAP.md
+++ b/deployments/UPV4_BOOTSTRAP.md
@@ -44,3 +44,64 @@ runner through current metadata or a wrapper when activation is implemented;
 never rewrite executed deployment history or restore predecessor routes after
 UPV4 consumption. Base requires an atomic guarded governance batch; staging's
 EOA ownership needs a separately reviewed maintenance sequence.
+
+## Admission prerequisite for activation
+
+The shared payment registry is also reachable by V1 and V2 orchestrators.
+Their admission paths do not invoke O3's method-scoped lifecycle hook. An
+unpaused registered legacy caller can therefore lock a balance-enabled
+EscrowV2 deposit without applying its O3 whitelist. Passive deployment is
+safe because it adds no public route; activating balance requires proving
+that every admitted caller enforces the intended policy.
+
+First reconstruct the complete OrchestratorRegistry Added/Removed history
+from deployment to one pinned block, and reconcile every discovered address
+with its getter, runtime bytecode, owner, pause state and registry pointers.
+The registry has no enumeration getter. Current deployment artifacts and an
+explorer page are not a complete allowlist. A removal without a preceding
+add, mismatched getter, unknown caller or missing history aborts preparation.
+Do not infer that an authorized legacy caller is active without checking its
+pause state and reachable escrows.
+
+If legacy admissions remain possible, use a separately approved maintenance
+window before activation:
+
+1. Pin the shared EscrowRegistry's full ordered allowlist and permissive flag.
+   Set `acceptAllEscrows` false and remove all entries in a guarded admission
+   closure. Prove the final flag is false and the list is empty. Every known
+   caller must use this registry; divergent registries need equivalent proven
+   closure. Keep verifier routes, writers, domains and caller authorization
+   intact while existing payments settle.
+2. Resolve outstanding legacy orders with their original payments and existing
+   terms. For bytecode-proven V1/V2/V3 implementations, enumerate every
+   `getIntent` using counters `[0, intentCounter)`: the hash is
+   `keccak256(abi.encodePacked(orchestrator, counter))` modulo the circuit
+   prime. Reconcile nonzero intents with every escrow's deposit locks and
+   paid-but-unresolved support cases. Expiry or an empty event page alone is
+   not proof that a paid obligation is resolved.
+3. Retire only callers whose obligations are proven terminal. Pausing a caller
+   before drain also disables fulfillment; removing it from the registry
+   blocks UPV verification and EscrowV2 release. After drain, pause and
+   deauthorize retired callers. V1's original Escrow uses a direct orchestrator
+   pointer, so registry removal alone does not prevent new V1 locks there.
+4. Keep admissions closed through the all-method UPV4 cutover. Preserve every
+   existing method/currency order and replay namespace, add balance only when
+   all issuer and consumer gates pass, and revoke UPV3's writer in the atomic
+   Base batch. Verify final governance, route, writer, namespace and O3 policy
+   invariants before restoring only the approved O3-capable escrow allowlist.
+   Staging must retain closure across its non-atomic EOA steps.
+
+Closing EscrowRegistry admissions preserves the core fulfill/cancel/manual
+release paths, but disables `IntentGuardian.extendIntent` and whitelist
+configuration setters during the window. Plan existing payment deadlines and
+review custom post-intent hooks before closure. Do not substitute blanket
+cancellation, another fiat payment or automatic expiry for payment recovery.
+Existing O3 paid intents and settled dispute coverage need no vault drain for
+a verifier replacement; retain their snapshotted hook/policy/vault state.
+
+`UnifiedVerifierAdmissionMaintenance.t.sol` covers signed predecessor
+settlement and unpaid cancellation across V1/V2/V3 against a shared EscrowV2,
+plus the failure caused by premature caller pause/removal. These local source
+fixtures are not live caller inventory or authorization to execute maintenance.
+The complete guarded activation generator, current-runner retirement, live
+history/drain proof and coordinated domain/package recording remain required.

--- a/deployments/UPV4_BOOTSTRAP.md
+++ b/deployments/UPV4_BOOTSTRAP.md
@@ -63,6 +63,31 @@ add, mismatched getter, unknown caller or missing history aborts preparation.
 Do not infer that an authorized legacy caller is active without checking its
 pause state and reachable escrows.
 
+Generate the registry portion of this evidence from clean committed source
+using a trusted archive RPC selected by `UPV4_INVENTORY_RPC_URL`:
+
+```sh
+yarn inspect:upv4-callers base <pinned-block-number> /tmp/upv4-base-callers.json
+yarn inspect:upv4-callers base_staging <pinned-block-number> /tmp/upv4-staging-callers.json
+```
+
+The optional fourth argument selects the block span (default 2,000). Both
+deployments are on chain 8453. The tool checks the recorded direct creation
+transaction and exact registry runtime, scans contiguous Added/Removed ranges
+from creation, and reconciles the union of event-discovered and current
+artifact-known callers against getters at the pinned block. It rejects missing
+transitions, duplicate events, getter disagreement, RPC failures and detected
+reorgs. A new output file records source/record hashes, scan bounds, events,
+membership and caller runtime hashes; existing output files are never replaced.
+The RPC URL and raw provider errors are not written to the report or console.
+
+This inventory still trusts the RPC to return every matching log: a completely
+omitted unknown caller history cannot be detected from the non-enumerable
+registry. Runtime hashes need separate identification and review, including
+owners, pause state, registry pointers, escrow reachability and all paid-order
+obligations. The tool emits no activation-ready verdict and creates no
+governance transactions. A successful scan is one input to the full cutover.
+
 If legacy admissions remain possible, use a separately approved maintenance
 window before activation:
 

--- a/deployments/UPV4_BOOTSTRAP.md
+++ b/deployments/UPV4_BOOTSTRAP.md
@@ -8,14 +8,25 @@ their existing replay namespaces, then registers `venmo-balance` with the
 writer permission, changes a live payment route, changes risk windows, or
 updates the active package addresses.
 
-The lane requires the intact lane-31 UPV3 cutover and the active method-scoped
-lifecycle stack. It validates the current O3 hook/policy pointers and refuses a
-nonzero risk window for any shared-namespace alias. Each operation checks a
-pinned predecessor snapshot, the current compiled successor runtime, dependency
-getters, signing domain and exact namespace prefix. Resume does not repair
-unexpected ownership, method removal, reordered methods or namespace changes.
-The additional historical lane-31 preflight reads latest state; these checks
-are passive-deployment checks, **not an atomic activation proof**.
+The lane requires the intact UPV3 routes/writer configuration and the active
+method-scoped lifecycle stack. Its current-owned predecessor evidence records
+Base's eleven methods, including UPI, and Base staging's thirteen methods at
+block 51,199,130. Staging's registry and UPV3 have different valid orders;
+both are checked against their own evidence arrays. Currency order, chain,
+governance, core deployed addresses/full runtime hashes, O3 pause/chain state,
+and MultiAttestationVerifier witnesses/threshold must match. Untagged runs
+remain inert. Executed lane31 retains its historical ten-method Base catalog;
+the new bootstrap does not call that obsolete catalog preflight.
+
+Every predecessor read uses one pinned block, whose hash is rechecked after
+collection. The lane validates the current O3 hook/policy pointers and refuses
+a nonzero risk window for any shared-namespace alias. Each operation rechecks
+the predecessor snapshot, current compiled successor runtime, dependencies,
+signing domain and exact namespace prefix. Resume does not repair unexpected
+ownership, method/currency/witness changes, disabled methods or reassigned
+namespaces. These remain passive-deployment checks, **not an atomic activation
+proof**. Updating the pinned evidence requires new deployed-state review;
+unknown catalog or authority drift is never silently accepted.
 
 Compile the reviewed source before running a tagged deployment; tagged runs use
 `--no-compile`. An ordinary untagged deployment skips this lane on every network.
@@ -109,6 +120,11 @@ window before activation:
    blocks UPV verification and EscrowV2 release. After drain, pause and
    deauthorize retired callers. V1's original Escrow uses a direct orchestrator
    pointer, so registry removal alone does not prevent new V1 locks there.
+   The original Escrow also lacks the effective-rate and manager-fee getters
+   required by O3. Changing its pointer to O3 is not a supported migration and
+   would disable V1 release. Keep it outside the restored admission list; from
+   the observed admitted Base pair, only EscrowV2 is O3-compatible. Escrow
+   pause itself leaves locking enabled and cannot replace admission closure.
 4. Keep admissions closed through the all-method UPV4 cutover. Preserve every
    existing method/currency order and replay namespace, add balance only when
    all issuer and consumer gates pass, and revoke UPV3's writer in the atomic

--- a/deployments/unifiedVerifierV4Bootstrap.ts
+++ b/deployments/unifiedVerifierV4Bootstrap.ts
@@ -1,7 +1,7 @@
 import { BigNumber, constants, utils } from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-import { paymentBindingCutoverReady } from "../deploy/31_deploy_v3_payment_binding_stack";
+import predecessorEvidence from "./upv4-predecessor-evidence.json";
 import { assertDeploymentMatchesChain } from "./canonicalDeployment";
 
 export const UPV4_BOOTSTRAP_TAG = "43_deploy_unified_payment_verifier_v4";
@@ -101,26 +101,120 @@ export function assertNamespacePrefix(
   return methods.length;
 }
 
-// This is a passive-deployment snapshot, not an activation manifest. Lane 31's
-// ratified live identity checks are an additional preflight. All values below
-// are then read together at one block and must remain unchanged during bootstrap.
+type PredecessorEvidence = {
+  chainId: number;
+  governance: string;
+  contracts: Record<string, { address: string; runtimeCodeHash: string }>;
+  routes: { method: string; currencies: string[] }[];
+  predecessorMethods: string[];
+  witnesses: string[];
+  attestationThreshold: string;
+};
+
+export function pinnedBootstrapPredecessor(
+  network: string
+): PredecessorEvidence | undefined {
+  if (network === "hardhat" || network === "localhost") return undefined;
+  if (network !== "base" && network !== "base_staging") {
+    throw new Error(`Unsupported UPV4 predecessor network: ${network}`);
+  }
+  return predecessorEvidence[network];
+}
+
+export function assertPinnedBootstrapSurface(
+  expected: PredecessorEvidence,
+  methods: string[],
+  currencies: string[][],
+  predecessorMethods: string[]
+): void {
+  const routes = methods.map((method, index) => ({
+    method,
+    currencies: currencies[index],
+  }));
+  if (
+    currencies.length !== methods.length ||
+    JSON.stringify(routes) !== JSON.stringify(expected.routes) ||
+    JSON.stringify(predecessorMethods) !==
+      JSON.stringify(expected.predecessorMethods)
+  ) {
+    throw new Error("UPV4 predecessor method/currency surface changed");
+  }
+}
+
+export function assertPinnedBootstrapContract(
+  expected: { address: string; runtimeCodeHash: string },
+  address: string,
+  runtimeCodeHash: string
+): void {
+  if (
+    address.toLowerCase() !== expected.address.toLowerCase() ||
+    runtimeCodeHash !== expected.runtimeCodeHash
+  ) {
+    throw new Error("UPV4 predecessor contract identity mismatch");
+  }
+}
+
+export function assertBootstrapAttestationAuthority(
+  governance: string,
+  expected: PredecessorEvidence | undefined,
+  authority: {
+    owner: string;
+    witnesses: string[];
+    threshold: string;
+    witnessCount: string;
+  }
+): void {
+  const { owner, witnesses, threshold, witnessCount } = authority;
+  if (
+    owner.toLowerCase() !== governance.toLowerCase() ||
+    witnesses.length === 0 ||
+    !BigNumber.from(witnessCount).eq(witnesses.length) ||
+    BigNumber.from(threshold).isZero() ||
+    BigNumber.from(threshold).gt(witnesses.length) ||
+    (expected &&
+      (JSON.stringify(witnesses.map((address) => address.toLowerCase())) !==
+        JSON.stringify(
+          expected.witnesses.map((address) => address.toLowerCase())
+        ) ||
+        threshold !== expected.attestationThreshold))
+  ) {
+    throw new Error("UPV4 predecessor attestation authority mismatch");
+  }
+}
+
+// Current-owned passive preflight. Executed lane31 retains its historical
+// catalog; live Base now includes UPI, and staging has two distinct valid orders.
+// Every read below uses one block and is repeated during bootstrap/resume.
 export async function readBootstrapPredecessor(hre: HardhatRuntimeEnvironment) {
-  if (!(await paymentBindingCutoverReady(hre))) {
-    throw new Error(
-      "UPV4 bootstrap requires the intact UPV3 payment-binding cutover"
-    );
+  const expected = pinnedBootstrapPredecessor(hre.deployments.getNetworkName());
+  const chainId = (await hre.ethers.provider.getNetwork()).chainId;
+  if (expected && chainId !== expected.chainId) {
+    throw new Error("UPV4 predecessor chain mismatch");
   }
   const block = await hre.ethers.provider.getBlock("latest");
   const at = { blockTag: block.number };
   const getContract = async (name: string, artifact = name) => {
     const record = await hre.deployments.get(name);
-    await assertDeploymentMatchesChain(
-      hre,
-      record,
-      name,
-      artifact,
-      block.number
-    );
+    const pinned = expected?.contracts[name];
+    if (pinned) {
+      const code = await hre.ethers.provider.getCode(
+        record.address,
+        block.number
+      );
+      assertPinnedBootstrapContract(
+        pinned,
+        record.address,
+        utils.keccak256(code)
+      );
+    } else {
+      await assertDeploymentMatchesChain(
+        hre,
+        record,
+        name,
+        artifact,
+        block.number
+      );
+    }
     return hre.ethers.getContractAt(artifact, record.address);
   };
   const predecessor = await getContract("UnifiedPaymentVerifierV3");
@@ -137,14 +231,19 @@ export async function readBootstrapPredecessor(hre: HardhatRuntimeEnvironment) {
     "DisputeProtectionPolicyMethodScopedStaked",
     "DisputeProtectionPolicy"
   );
-  const governance = await predecessor.owner(at);
+  const attestation = await getContract("MultiAttestationVerifier");
+  const governance = expected?.governance ?? (await predecessor.owner(at));
   const same = (left: string, right: string) =>
     left.toLowerCase() === right.toLowerCase();
   if (
+    !same(await predecessor.owner(at), governance) ||
     !same(await predecessor.nullifierRegistry(at), registry.address) ||
     !same(await predecessor.orchestratorRegistry(at), orchestrators.address) ||
+    !same(await predecessor.attestationVerifier(at), attestation.address) ||
     !same(await registry.legacyNullifierRegistry(at), legacy.address) ||
     !same(await orchestrator.paymentVerifierRegistry(at), routes.address) ||
+    (await orchestrator.paused(at)) ||
+    !(await orchestrator.chainId(at)).eq(chainId) ||
     !same(await orchestrator.lifecycleHook(at), hook.address) ||
     !same(await hook.orchestratorRegistry(at), orchestrators.address) ||
     !same(await hook.disputeProtectionPolicy(at), policy.address) ||
@@ -200,19 +299,47 @@ export async function readBootstrapPredecessor(hre: HardhatRuntimeEnvironment) {
       throw new Error(`UPV4 predecessor has no currencies: ${method}`);
     currencies.push(configured);
   }
+  if (expected) {
+    assertPinnedBootstrapSurface(
+      expected,
+      methods,
+      currencies,
+      predecessorMethods
+    );
+  }
   const riskWindows: string[] = [];
   for (const { method } of entries)
     riskWindows.push((await policy.getRiskWindow(method, at)).toString());
   assertAliasRiskWindows(entries, riskWindows);
-  const attestationVerifier: string = await predecessor.attestationVerifier(at);
+  const attestationVerifier = attestation.address;
   const attestationCode = await hre.ethers.provider.getCode(
     attestationVerifier,
     block.number
   );
-  if (attestationCode === "0x")
-    throw new Error("UPV4 predecessor attestation verifier has no code");
+  const witnesses: string[] = await attestation.witnesses(at);
+  const attestationThreshold = (
+    await attestation.requiredSignatures(at)
+  ).toString();
+  assertBootstrapAttestationAuthority(governance, expected, {
+    owner: await attestation.owner(at),
+    witnesses,
+    threshold: attestationThreshold,
+    witnessCount: (await attestation.witnessCount(at)).toString(),
+  });
+  const predecessorDomain = utils._TypedDataEncoder.hashDomain({
+    name: "UnifiedPaymentVerifier",
+    version: "1",
+    chainId,
+    verifyingContract: predecessor.address,
+  });
+  if ((await predecessor.DOMAIN_SEPARATOR(at)) !== predecessorDomain) {
+    throw new Error("UPV4 predecessor signing domain mismatch");
+  }
+  const after = await hre.ethers.provider.getBlock(block.number);
+  if (after.hash !== block.hash)
+    throw new Error("UPV4 predecessor block changed");
   const state = {
-    chainId: (await hre.ethers.provider.getNetwork()).chainId,
+    chainId,
     predecessor: predecessor.address,
     nullifierRegistry: registry.address,
     legacyNullifierRegistry: legacy.address,
@@ -220,6 +347,8 @@ export async function readBootstrapPredecessor(hre: HardhatRuntimeEnvironment) {
     paymentVerifierRegistry: routes.address,
     attestationVerifier,
     attestationCodeHash: utils.keccak256(attestationCode),
+    witnesses,
+    attestationThreshold,
     governance,
     orchestrator: orchestrator.address,
     hook: hook.address,

--- a/deployments/unifiedVerifierV4Bootstrap.ts
+++ b/deployments/unifiedVerifierV4Bootstrap.ts
@@ -1,0 +1,233 @@
+import { BigNumber, constants, utils } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+import { paymentBindingCutoverReady } from "../deploy/31_deploy_v3_payment_binding_stack";
+import { assertDeploymentMatchesChain } from "./canonicalDeployment";
+
+export const UPV4_BOOTSTRAP_TAG = "43_deploy_unified_payment_verifier_v4";
+export const VENMO_METHOD = utils.id("venmo");
+export const VENMO_BALANCE_METHOD = utils.id("venmo-balance");
+
+export function bootstrapRequested(network: string): boolean {
+  const flags = {
+    base: "ENABLE_BASE_UPV4_BOOTSTRAP",
+    base_staging: "ENABLE_STAGING_UPV4_BOOTSTRAP",
+  };
+  const selected = process.env.DEPLOY_ACTIVE_TAG === UPV4_BOOTSTRAP_TAG;
+  const enabled = Object.values(flags).some(
+    (flag) => process.env[flag] === "true"
+  );
+  if (!selected) {
+    if (enabled)
+      throw new Error(`UPV4 bootstrap flags require ${UPV4_BOOTSTRAP_TAG}`);
+    return false;
+  }
+  if (network === "hardhat" || network === "localhost") {
+    if (enabled)
+      throw new Error(
+        "Live UPV4 bootstrap flags cannot target a local network"
+      );
+    return true;
+  }
+  if (network !== "base" && network !== "base_staging") {
+    throw new Error(`UPV4 bootstrap does not support ${network}`);
+  }
+  const flag = flags[network];
+  if (process.env[flag] !== "true")
+    throw new Error(`UPV4 bootstrap requires ${flag}=true`);
+  const otherFlag = flags[network === "base" ? "base_staging" : "base"];
+  if (process.env[otherFlag] === "true")
+    throw new Error("UPV4 bootstrap has conflicting network flags");
+  return true;
+}
+
+export type NamespaceEntry = { method: string; namespace: string };
+
+export function bootstrapNamespaces(methods: string[]): NamespaceEntry[] {
+  if (
+    !methods.includes(VENMO_METHOD) ||
+    methods.includes(VENMO_BALANCE_METHOD) ||
+    methods.includes(constants.HashZero) ||
+    new Set(methods).size !== methods.length
+  ) {
+    throw new Error(
+      "UPV4 bootstrap requires distinct predecessor methods including regular Venmo only"
+    );
+  }
+  return [
+    ...methods.map((method) => ({ method, namespace: method })),
+    { method: VENMO_BALANCE_METHOD, namespace: VENMO_METHOD },
+  ];
+}
+
+export function assertAliasRiskWindows(
+  entries: NamespaceEntry[],
+  riskWindows: string[]
+): void {
+  if (entries.length !== riskWindows.length)
+    throw new Error("Missing method risk windows");
+  entries.forEach(({ method, namespace }, index) => {
+    if (method !== namespace && !BigNumber.from(riskWindows[index]).isZero()) {
+      throw new Error(`Protected nullifier aliases are unsupported: ${method}`);
+    }
+  });
+}
+
+export function assertNamespacePrefix(
+  expected: NamespaceEntry[],
+  methods: string[],
+  namespaces: string[],
+  active: boolean[]
+): number {
+  if (
+    methods.length > expected.length ||
+    namespaces.length !== expected.length ||
+    active.length !== expected.length ||
+    methods.some((method, index) => method !== expected[index].method)
+  ) {
+    throw new Error("UPV4 methods are not an exact bootstrap prefix");
+  }
+  expected.forEach((entry, index) => {
+    const configured = index < methods.length;
+    if (
+      active[index] !== configured ||
+      namespaces[index] !== (configured ? entry.namespace : constants.HashZero)
+    ) {
+      throw new Error(
+        `UPV4 namespace or active flag mismatch: ${entry.method}`
+      );
+    }
+  });
+  return methods.length;
+}
+
+// This is a passive-deployment snapshot, not an activation manifest. Lane 31's
+// ratified live identity checks are an additional preflight. All values below
+// are then read together at one block and must remain unchanged during bootstrap.
+export async function readBootstrapPredecessor(hre: HardhatRuntimeEnvironment) {
+  if (!(await paymentBindingCutoverReady(hre))) {
+    throw new Error(
+      "UPV4 bootstrap requires the intact UPV3 payment-binding cutover"
+    );
+  }
+  const block = await hre.ethers.provider.getBlock("latest");
+  const at = { blockTag: block.number };
+  const getContract = async (name: string, artifact = name) => {
+    const record = await hre.deployments.get(name);
+    await assertDeploymentMatchesChain(
+      hre,
+      record,
+      name,
+      artifact,
+      block.number
+    );
+    return hre.ethers.getContractAt(artifact, record.address);
+  };
+  const predecessor = await getContract("UnifiedPaymentVerifierV3");
+  const registry = await getContract("NullifierRegistryV2");
+  const legacy = await getContract("NullifierRegistry");
+  const routes = await getContract("PaymentVerifierRegistry");
+  const orchestrators = await getContract("OrchestratorRegistry");
+  const orchestrator = await getContract("OrchestratorV3");
+  const hook = await getContract(
+    "IntentLifecycleHookV1MethodScopedStaked",
+    "IntentLifecycleHookV1"
+  );
+  const policy = await getContract(
+    "DisputeProtectionPolicyMethodScopedStaked",
+    "DisputeProtectionPolicy"
+  );
+  const governance = await predecessor.owner(at);
+  const same = (left: string, right: string) =>
+    left.toLowerCase() === right.toLowerCase();
+  if (
+    !same(await predecessor.nullifierRegistry(at), registry.address) ||
+    !same(await predecessor.orchestratorRegistry(at), orchestrators.address) ||
+    !same(await registry.legacyNullifierRegistry(at), legacy.address) ||
+    !same(await orchestrator.paymentVerifierRegistry(at), routes.address) ||
+    !same(await orchestrator.lifecycleHook(at), hook.address) ||
+    !same(await hook.orchestratorRegistry(at), orchestrators.address) ||
+    !same(await hook.disputeProtectionPolicy(at), policy.address) ||
+    !(await orchestrators.isOrchestrator(orchestrator.address, at)) ||
+    !(await policy.isLifecycleHookAuthorized(hook.address, at))
+  ) {
+    throw new Error(
+      "UPV4 predecessor dependency or active lifecycle pointer mismatch"
+    );
+  }
+  for (const contract of [
+    registry,
+    legacy,
+    routes,
+    orchestrators,
+    orchestrator,
+    policy,
+  ]) {
+    if (!same(await contract.owner(at), governance))
+      throw new Error("UPV4 predecessor governance mismatch");
+  }
+  const writers: string[] = await registry.getWriters(at);
+  if (
+    writers.length !== 1 ||
+    !same(writers[0], predecessor.address) ||
+    (await legacy.getWriters(at)).length
+  ) {
+    throw new Error(
+      "UPV4 bootstrap requires UPV3 as the sole writer and no legacy writers"
+    );
+  }
+  const methods: string[] = await routes.getPaymentMethods(at);
+  const predecessorMethods: string[] = await predecessor.getPaymentMethods(at);
+  if (
+    predecessorMethods.length !== methods.length ||
+    predecessorMethods.some((method) => !methods.includes(method))
+  ) {
+    throw new Error("UPV4 predecessor method set differs from its routes");
+  }
+  const entries = bootstrapNamespaces(methods);
+  const currencies: string[][] = [];
+  for (const method of methods) {
+    if (
+      !(await predecessor.isPaymentMethod(method, at)) ||
+      !same(await routes.getVerifier(method, at), predecessor.address)
+    ) {
+      throw new Error(
+        "UPV4 bootstrap found an inactive method or partial route cutover"
+      );
+    }
+    const configured: string[] = await routes.getCurrencies(method, at);
+    if (configured.length === 0)
+      throw new Error(`UPV4 predecessor has no currencies: ${method}`);
+    currencies.push(configured);
+  }
+  const riskWindows: string[] = [];
+  for (const { method } of entries)
+    riskWindows.push((await policy.getRiskWindow(method, at)).toString());
+  assertAliasRiskWindows(entries, riskWindows);
+  const attestationVerifier: string = await predecessor.attestationVerifier(at);
+  const attestationCode = await hre.ethers.provider.getCode(
+    attestationVerifier,
+    block.number
+  );
+  if (attestationCode === "0x")
+    throw new Error("UPV4 predecessor attestation verifier has no code");
+  const state = {
+    chainId: (await hre.ethers.provider.getNetwork()).chainId,
+    predecessor: predecessor.address,
+    nullifierRegistry: registry.address,
+    legacyNullifierRegistry: legacy.address,
+    orchestratorRegistry: orchestrators.address,
+    paymentVerifierRegistry: routes.address,
+    attestationVerifier,
+    attestationCodeHash: utils.keccak256(attestationCode),
+    governance,
+    orchestrator: orchestrator.address,
+    hook: hook.address,
+    policy: policy.address,
+    entries,
+    currencies,
+    riskWindows,
+    writers,
+  };
+  return { blockNumber: block.number, blockHash: block.hash, state };
+}

--- a/deployments/upv4-predecessor-evidence.json
+++ b/deployments/upv4-predecessor-evidence.json
@@ -1,0 +1,386 @@
+{
+  "base": {
+    "evidence": {
+      "blockNumber": 51199130,
+      "blockHash": "0xc3c5537d937de429d1147b356c1732021b574351d00184943ca54ad7dd1e2f60",
+      "sourceSha": "8d000cba95594b960e5484bd8722a6933ee7be3f",
+      "orchestratorRuntimeSource": "Existing lane31 ratified full-runtime pin; Base also independently reproduced at this block."
+    },
+    "chainId": 8453,
+    "governance": "0x0bC26FF515411396DD588Abd6Ef6846E04470227",
+    "contracts": {
+      "PaymentVerifierRegistry": {
+        "address": "0x2b82D24437ff66Fb173eabDfD67ee2ACeb8bEb1e",
+        "runtimeCodeHash": "0xf8b2a3d222990397e047e7e4f1afe45ecfabe0a9d04be7b5e97e5a1755026e36"
+      },
+      "UnifiedPaymentVerifierV3": {
+        "address": "0xC6F4a193576C60892a47e111Bb5706c30162502B",
+        "runtimeCodeHash": "0x7636c79f0f46cf88c7122767e553264f1898fa253ea214f6a1c3187b0f0a4bcf"
+      },
+      "NullifierRegistryV2": {
+        "address": "0x5455e761b866dfa6A2f5Dc6d6525825bf9C09aeB",
+        "runtimeCodeHash": "0x423e2a2183ecd538864079b6268f41957028c25514d1de57bd3d0e70fa6b9bd4"
+      },
+      "NullifierRegistry": {
+        "address": "0x8d8e1A0e5345a5cc9AA206c3ca76D6d28c514608",
+        "runtimeCodeHash": "0x022abad5e4ab045f97f6b7c89a9a1bd459b50e8639ced5c007725809463ca51c"
+      },
+      "MultiAttestationVerifier": {
+        "address": "0x9Fe920b24e50e6a6362BA71a1BeB502A99c402d5",
+        "runtimeCodeHash": "0x828a5dae520d3eaed904dfed56994dc6e892eb6416b58ad952c079e220ef841a"
+      },
+      "OrchestratorRegistry": {
+        "address": "0xBe9fED15ED7A4B915C03EFcEcb9662739C3382A9",
+        "runtimeCodeHash": "0xf0d132d621ac03181a6fade6a93bd0968d33830c8bf393793236787e7978aee1"
+      },
+      "OrchestratorV3": {
+        "address": "0x014025fDE093f8701d86e9f38e2C3a9b779cb5c7",
+        "runtimeCodeHash": "0x4e58f26129559301c017ff264b61dd2255ed2107593d308472ef32d07b8745e9"
+      }
+    },
+    "routes": [
+      {
+        "method": "0xcac9daea62d7b89d75ac73af4ee14dcf25721012ae82b568c2ea5c808eaa04ff",
+        "currencies": [
+          "0xfaaa9c7b2f09d6a1b0971574d43ca62c3e40723167c09830ec33f06cec921381"
+        ]
+      },
+      {
+        "method": "0x5908bb0c9b87763ac6171d4104847667e7f02b4c47b574fe890c1f439ed128bb",
+        "currencies": [
+          "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
+        ]
+      },
+      {
+        "method": "0x90262a3db0edd0be2369c6b28f9e8511ec0bac7136cefbada0880602f87e7268",
+        "currencies": [
+          "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
+        ]
+      },
+      {
+        "method": "0x617f88ab82b5c1b014c539f7e75121427f0bb50a4c58b187a238531e7d58605d",
+        "currencies": [
+          "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e",
+          "0xfff16d60be267153303bbfa66e593fb8d06e24ea5ef24b6acca5224c2ca6b907",
+          "0x90832e2dc3221e4d56977c1aa8f6a6706b9ad6542fbbdaac13097d0fa5e42e67",
+          "0xc241cc1f9752d2d53d1ab67189223a3f330e48b75f73ebf86f50b2c78fe8df88",
+          "0xdbd9d34f382e9f6ae078447a655e0816927c7c3edec70bd107de1d34cb15172e",
+          "0xcb83cbb58eaa5007af6cad99939e4581c1e1b50d65609c30f303983301524ef3",
+          "0x221012e06ebf59a20b82e3003cf5d6ee973d9008bdb6e2f604faa89a27235522",
+          "0xfe13aafd831cb225dfce3f6431b34b5b17426b6bff4fccabe4bbe0fe4adc0452",
+          "0xa156dad863111eeb529c4b3a2a30ad40e6dcff3b27d8f282f82996e58eee7e7d",
+          "0xa94b0702860cb929d0ee0c60504dd565775a058bf1d2a2df074c1db0a66ad582",
+          "0xf998cbeba8b7a7e91d4c469e5fb370cdfa16bd50aea760435dc346008d78ed1f",
+          "0x4dab77a640748de8588de6834d814a344372b205265984b969f3e97060955bfa",
+          "0x326a6608c2a353275bd8d64db53a9d772c1d9a5bc8bfd19dfc8242274d1e9dd4",
+          "0x128d6c262d1afe2351c6e93ceea68e00992708cfcbc0688408b9a23c0c543db2",
+          "0x9a788fb083188ba1dfb938605bc4ce3579d2e085989490aca8f73b23214b7c1d",
+          "0xc9d84274fd58aa177cabff54611546051b74ad658b939babaad6282500300d36",
+          "0x53611f0b3535a2cfc4b8deb57fa961ca36c7b2c272dfe4cb239a29c48e549361",
+          "0xfaaa9c7b2f09d6a1b0971574d43ca62c3e40723167c09830ec33f06cec921381",
+          "0xd783b199124f01e5d0dde2b7fc01b925e699caea84eae3ca92ed17377f498e97",
+          "0x5ce3aa5f4510edaea40373cbe83c091980b5c92179243fe926cb280ff07d403e",
+          "0x7766ee347dd7c4a6d5a55342d89e8848774567bcf7a5f59c3e82025dbde3babb",
+          "0x8fb505ed75d9d38475c70bac2c3ea62d45335173a71b2e4936bd9f05bf0ddfea",
+          "0x2dd272ddce846149d92496b4c3e677504aec8d5e6aab5908b25c9fe0a797e25f",
+          "0x8895743a31faedaa74150e89d06d281990a1909688b82906f0eb858b37f82190"
+        ]
+      },
+      {
+        "method": "0x10940ee67cfb3c6c064569ec92c0ee934cd7afa18dd2ca2d6a2254fcb009c17d",
+        "currencies": [
+          "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
+        ]
+      },
+      {
+        "method": "0x554a007c2217df766b977723b276671aee5ebb4adaea0edb6433c88b3e61dac5",
+        "currencies": [
+          "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e",
+          "0xfaaa9c7b2f09d6a1b0971574d43ca62c3e40723167c09830ec33f06cec921381",
+          "0xfff16d60be267153303bbfa66e593fb8d06e24ea5ef24b6acca5224c2ca6b907",
+          "0x90832e2dc3221e4d56977c1aa8f6a6706b9ad6542fbbdaac13097d0fa5e42e67",
+          "0xcb83cbb58eaa5007af6cad99939e4581c1e1b50d65609c30f303983301524ef3",
+          "0xdbd9d34f382e9f6ae078447a655e0816927c7c3edec70bd107de1d34cb15172e",
+          "0x221012e06ebf59a20b82e3003cf5d6ee973d9008bdb6e2f604faa89a27235522",
+          "0x4dab77a640748de8588de6834d814a344372b205265984b969f3e97060955bfa",
+          "0xc9d84274fd58aa177cabff54611546051b74ad658b939babaad6282500300d36",
+          "0x53611f0b3535a2cfc4b8deb57fa961ca36c7b2c272dfe4cb239a29c48e549361",
+          "0xc241cc1f9752d2d53d1ab67189223a3f330e48b75f73ebf86f50b2c78fe8df88",
+          "0x313eda7ae1b79890307d32a78ed869290aeb24cc0e8605157d7e7f5a69fea425",
+          "0xa156dad863111eeb529c4b3a2a30ad40e6dcff3b27d8f282f82996e58eee7e7d",
+          "0xfe13aafd831cb225dfce3f6431b34b5b17426b6bff4fccabe4bbe0fe4adc0452",
+          "0x9a788fb083188ba1dfb938605bc4ce3579d2e085989490aca8f73b23214b7c1d",
+          "0x128d6c262d1afe2351c6e93ceea68e00992708cfcbc0688408b9a23c0c543db2",
+          "0xc681c4652bae8bd4b59bec1cdb90f868d93cc9896af9862b196843f54bf254b3",
+          "0x589be49821419c9c2fbb26087748bf3420a5c13b45349828f5cac24c58bbaa7b",
+          "0xf20379023279e1d79243d2c491be8632c07cfb116be9d8194013fb4739461b84",
+          "0xa94b0702860cb929d0ee0c60504dd565775a058bf1d2a2df074c1db0a66ad582",
+          "0x326a6608c2a353275bd8d64db53a9d772c1d9a5bc8bfd19dfc8242274d1e9dd4",
+          "0xe85548baf0a6732cfcc7fc016ce4fd35ce0a1877057cfec6e166af4f106a3728",
+          "0x1fad9f8ddef06bf1b8e0e28c11b97ca0df51b03c268797e056b7c52e9048cfd1",
+          "0xd783b199124f01e5d0dde2b7fc01b925e699caea84eae3ca92ed17377f498e97",
+          "0x5ce3aa5f4510edaea40373cbe83c091980b5c92179243fe926cb280ff07d403e",
+          "0x7766ee347dd7c4a6d5a55342d89e8848774567bcf7a5f59c3e82025dbde3babb",
+          "0xaad766fbc07fb357bed9fd8b03b935f2f71fe29fc48f08274bc2a01d7f642afc",
+          "0x8fb505ed75d9d38475c70bac2c3ea62d45335173a71b2e4936bd9f05bf0ddfea",
+          "0xe6c11ead4ee5ff5174861adb55f3e8fb2841cca69bf2612a222d3e8317b6ae06",
+          "0x2dd272ddce846149d92496b4c3e677504aec8d5e6aab5908b25c9fe0a797e25f",
+          "0x8895743a31faedaa74150e89d06d281990a1909688b82906f0eb858b37f82190"
+        ]
+      },
+      {
+        "method": "0xa5418819c024239299ea32e09defae8ec412c03e58f5c75f1b2fe84c857f5483",
+        "currencies": [
+          "0x8fd50654b7dd2dc839f7cab32800ba0c6f7f66e1ccf89b21c09405469c2175ec"
+        ]
+      },
+      {
+        "method": "0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3",
+        "currencies": [
+          "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
+        ]
+      },
+      {
+        "method": "0x62c7ed738ad3e7618111348af32691b5767777fbaf46a2d8943237625552645c",
+        "currencies": [
+          "0x90832e2dc3221e4d56977c1aa8f6a6706b9ad6542fbbdaac13097d0fa5e42e67"
+        ]
+      },
+      {
+        "method": "0x3ccc3d4d5e769b1f82dc4988485551dc0cd3c7a3926d7d8a4dde91507199490f",
+        "currencies": [
+          "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e",
+          "0xfff16d60be267153303bbfa66e593fb8d06e24ea5ef24b6acca5224c2ca6b907",
+          "0x90832e2dc3221e4d56977c1aa8f6a6706b9ad6542fbbdaac13097d0fa5e42e67",
+          "0xc241cc1f9752d2d53d1ab67189223a3f330e48b75f73ebf86f50b2c78fe8df88",
+          "0xdbd9d34f382e9f6ae078447a655e0816927c7c3edec70bd107de1d34cb15172e",
+          "0xcb83cbb58eaa5007af6cad99939e4581c1e1b50d65609c30f303983301524ef3",
+          "0x221012e06ebf59a20b82e3003cf5d6ee973d9008bdb6e2f604faa89a27235522"
+        ]
+      },
+      {
+        "method": "0xe99a5081226cbbff9440a63da5caa04fa30f210c12c4dd9976132ac075054cd9",
+        "currencies": [
+          "0xaad766fbc07fb357bed9fd8b03b935f2f71fe29fc48f08274bc2a01d7f642afc"
+        ]
+      }
+    ],
+    "predecessorMethods": [
+      "0xcac9daea62d7b89d75ac73af4ee14dcf25721012ae82b568c2ea5c808eaa04ff",
+      "0x5908bb0c9b87763ac6171d4104847667e7f02b4c47b574fe890c1f439ed128bb",
+      "0x90262a3db0edd0be2369c6b28f9e8511ec0bac7136cefbada0880602f87e7268",
+      "0x617f88ab82b5c1b014c539f7e75121427f0bb50a4c58b187a238531e7d58605d",
+      "0x10940ee67cfb3c6c064569ec92c0ee934cd7afa18dd2ca2d6a2254fcb009c17d",
+      "0x554a007c2217df766b977723b276671aee5ebb4adaea0edb6433c88b3e61dac5",
+      "0xa5418819c024239299ea32e09defae8ec412c03e58f5c75f1b2fe84c857f5483",
+      "0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3",
+      "0x62c7ed738ad3e7618111348af32691b5767777fbaf46a2d8943237625552645c",
+      "0x3ccc3d4d5e769b1f82dc4988485551dc0cd3c7a3926d7d8a4dde91507199490f",
+      "0xe99a5081226cbbff9440a63da5caa04fa30f210c12c4dd9976132ac075054cd9"
+    ],
+    "witnesses": [
+      "0xDB4Ed7FAF170F0f6493E3adaaCaaFaF47092c754",
+      "0xE078D93bFdd87A8c5C5cCA5905DCbA0Dd7A1F0BD"
+    ],
+    "attestationThreshold": "1"
+  },
+  "base_staging": {
+    "evidence": {
+      "blockNumber": 51199130,
+      "blockHash": "0xc3c5537d937de429d1147b356c1732021b574351d00184943ca54ad7dd1e2f60",
+      "sourceSha": "8d000cba95594b960e5484bd8722a6933ee7be3f",
+      "orchestratorRuntimeSource": "Existing lane31 ratified full-runtime pin; Base also independently reproduced at this block."
+    },
+    "chainId": 8453,
+    "governance": "0x84e113087C97Cd80eA9D78983D4B8Ff61ECa1929",
+    "contracts": {
+      "PaymentVerifierRegistry": {
+        "address": "0x2261416DA54C85f975C73FA56EF4D2D6b0aEF7Cc",
+        "runtimeCodeHash": "0xf8b2a3d222990397e047e7e4f1afe45ecfabe0a9d04be7b5e97e5a1755026e36"
+      },
+      "UnifiedPaymentVerifierV3": {
+        "address": "0x4c62E99649c8Ba745E67018f5c8a483D77c429C4",
+        "runtimeCodeHash": "0x3125872c0996c6d79fc3ed080a1b85b0f6eeb1fd51d1003d517ea3053af5a8fa"
+      },
+      "NullifierRegistryV2": {
+        "address": "0x2eb43d6C7c7Ec4220Aa6B8735BC053824a71778C",
+        "runtimeCodeHash": "0xd9d2f4b8bbca6fe26d7a0dfd7e0d6a6d63823ab2a1fe12971e752cf33dee72a0"
+      },
+      "NullifierRegistry": {
+        "address": "0x3FFd04f7909a16d3476263A1f4ce413A089dCc69",
+        "runtimeCodeHash": "0x022abad5e4ab045f97f6b7c89a9a1bd459b50e8639ced5c007725809463ca51c"
+      },
+      "MultiAttestationVerifier": {
+        "address": "0x9855a39aC5975069632e91160d8712CBfF19e864",
+        "runtimeCodeHash": "0x828a5dae520d3eaed904dfed56994dc6e892eb6416b58ad952c079e220ef841a"
+      },
+      "OrchestratorRegistry": {
+        "address": "0xfA6384EB6176cfEC049540526A3d2126C3666d8A",
+        "runtimeCodeHash": "0xf0d132d621ac03181a6fade6a93bd0968d33830c8bf393793236787e7978aee1"
+      },
+      "OrchestratorV3": {
+        "address": "0x2b5E8Ab562e45fA89D73802605E145ED3E3EeF4f",
+        "runtimeCodeHash": "0x4e58f26129559301c017ff264b61dd2255ed2107593d308472ef32d07b8745e9"
+      }
+    },
+    "routes": [
+      {
+        "method": "0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3",
+        "currencies": [
+          "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
+        ]
+      },
+      {
+        "method": "0x62c7ed738ad3e7618111348af32691b5767777fbaf46a2d8943237625552645c",
+        "currencies": [
+          "0x90832e2dc3221e4d56977c1aa8f6a6706b9ad6542fbbdaac13097d0fa5e42e67"
+        ]
+      },
+      {
+        "method": "0xcac9daea62d7b89d75ac73af4ee14dcf25721012ae82b568c2ea5c808eaa04ff",
+        "currencies": [
+          "0xfaaa9c7b2f09d6a1b0971574d43ca62c3e40723167c09830ec33f06cec921381"
+        ]
+      },
+      {
+        "method": "0x5908bb0c9b87763ac6171d4104847667e7f02b4c47b574fe890c1f439ed128bb",
+        "currencies": [
+          "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
+        ]
+      },
+      {
+        "method": "0x90262a3db0edd0be2369c6b28f9e8511ec0bac7136cefbada0880602f87e7268",
+        "currencies": [
+          "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
+        ]
+      },
+      {
+        "method": "0x617f88ab82b5c1b014c539f7e75121427f0bb50a4c58b187a238531e7d58605d",
+        "currencies": [
+          "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e",
+          "0xfff16d60be267153303bbfa66e593fb8d06e24ea5ef24b6acca5224c2ca6b907",
+          "0x90832e2dc3221e4d56977c1aa8f6a6706b9ad6542fbbdaac13097d0fa5e42e67",
+          "0xc241cc1f9752d2d53d1ab67189223a3f330e48b75f73ebf86f50b2c78fe8df88",
+          "0xdbd9d34f382e9f6ae078447a655e0816927c7c3edec70bd107de1d34cb15172e",
+          "0xcb83cbb58eaa5007af6cad99939e4581c1e1b50d65609c30f303983301524ef3",
+          "0x221012e06ebf59a20b82e3003cf5d6ee973d9008bdb6e2f604faa89a27235522",
+          "0xfe13aafd831cb225dfce3f6431b34b5b17426b6bff4fccabe4bbe0fe4adc0452",
+          "0xa156dad863111eeb529c4b3a2a30ad40e6dcff3b27d8f282f82996e58eee7e7d",
+          "0xa94b0702860cb929d0ee0c60504dd565775a058bf1d2a2df074c1db0a66ad582",
+          "0xf998cbeba8b7a7e91d4c469e5fb370cdfa16bd50aea760435dc346008d78ed1f",
+          "0x4dab77a640748de8588de6834d814a344372b205265984b969f3e97060955bfa",
+          "0x326a6608c2a353275bd8d64db53a9d772c1d9a5bc8bfd19dfc8242274d1e9dd4",
+          "0x128d6c262d1afe2351c6e93ceea68e00992708cfcbc0688408b9a23c0c543db2",
+          "0x9a788fb083188ba1dfb938605bc4ce3579d2e085989490aca8f73b23214b7c1d",
+          "0xc9d84274fd58aa177cabff54611546051b74ad658b939babaad6282500300d36",
+          "0x53611f0b3535a2cfc4b8deb57fa961ca36c7b2c272dfe4cb239a29c48e549361",
+          "0xfaaa9c7b2f09d6a1b0971574d43ca62c3e40723167c09830ec33f06cec921381",
+          "0xd783b199124f01e5d0dde2b7fc01b925e699caea84eae3ca92ed17377f498e97",
+          "0x5ce3aa5f4510edaea40373cbe83c091980b5c92179243fe926cb280ff07d403e",
+          "0x7766ee347dd7c4a6d5a55342d89e8848774567bcf7a5f59c3e82025dbde3babb",
+          "0x8fb505ed75d9d38475c70bac2c3ea62d45335173a71b2e4936bd9f05bf0ddfea",
+          "0x2dd272ddce846149d92496b4c3e677504aec8d5e6aab5908b25c9fe0a797e25f",
+          "0x8895743a31faedaa74150e89d06d281990a1909688b82906f0eb858b37f82190"
+        ]
+      },
+      {
+        "method": "0x10940ee67cfb3c6c064569ec92c0ee934cd7afa18dd2ca2d6a2254fcb009c17d",
+        "currencies": [
+          "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
+        ]
+      },
+      {
+        "method": "0x554a007c2217df766b977723b276671aee5ebb4adaea0edb6433c88b3e61dac5",
+        "currencies": [
+          "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e",
+          "0xfaaa9c7b2f09d6a1b0971574d43ca62c3e40723167c09830ec33f06cec921381",
+          "0xfff16d60be267153303bbfa66e593fb8d06e24ea5ef24b6acca5224c2ca6b907",
+          "0x90832e2dc3221e4d56977c1aa8f6a6706b9ad6542fbbdaac13097d0fa5e42e67",
+          "0xcb83cbb58eaa5007af6cad99939e4581c1e1b50d65609c30f303983301524ef3",
+          "0xdbd9d34f382e9f6ae078447a655e0816927c7c3edec70bd107de1d34cb15172e",
+          "0x221012e06ebf59a20b82e3003cf5d6ee973d9008bdb6e2f604faa89a27235522",
+          "0x4dab77a640748de8588de6834d814a344372b205265984b969f3e97060955bfa",
+          "0xc9d84274fd58aa177cabff54611546051b74ad658b939babaad6282500300d36",
+          "0x53611f0b3535a2cfc4b8deb57fa961ca36c7b2c272dfe4cb239a29c48e549361",
+          "0xc241cc1f9752d2d53d1ab67189223a3f330e48b75f73ebf86f50b2c78fe8df88",
+          "0x313eda7ae1b79890307d32a78ed869290aeb24cc0e8605157d7e7f5a69fea425",
+          "0xa156dad863111eeb529c4b3a2a30ad40e6dcff3b27d8f282f82996e58eee7e7d",
+          "0xfe13aafd831cb225dfce3f6431b34b5b17426b6bff4fccabe4bbe0fe4adc0452",
+          "0x9a788fb083188ba1dfb938605bc4ce3579d2e085989490aca8f73b23214b7c1d",
+          "0x128d6c262d1afe2351c6e93ceea68e00992708cfcbc0688408b9a23c0c543db2",
+          "0xc681c4652bae8bd4b59bec1cdb90f868d93cc9896af9862b196843f54bf254b3",
+          "0x589be49821419c9c2fbb26087748bf3420a5c13b45349828f5cac24c58bbaa7b",
+          "0xf20379023279e1d79243d2c491be8632c07cfb116be9d8194013fb4739461b84",
+          "0xa94b0702860cb929d0ee0c60504dd565775a058bf1d2a2df074c1db0a66ad582",
+          "0x326a6608c2a353275bd8d64db53a9d772c1d9a5bc8bfd19dfc8242274d1e9dd4",
+          "0xe85548baf0a6732cfcc7fc016ce4fd35ce0a1877057cfec6e166af4f106a3728",
+          "0x1fad9f8ddef06bf1b8e0e28c11b97ca0df51b03c268797e056b7c52e9048cfd1",
+          "0xd783b199124f01e5d0dde2b7fc01b925e699caea84eae3ca92ed17377f498e97",
+          "0x5ce3aa5f4510edaea40373cbe83c091980b5c92179243fe926cb280ff07d403e",
+          "0x7766ee347dd7c4a6d5a55342d89e8848774567bcf7a5f59c3e82025dbde3babb",
+          "0xaad766fbc07fb357bed9fd8b03b935f2f71fe29fc48f08274bc2a01d7f642afc",
+          "0x8fb505ed75d9d38475c70bac2c3ea62d45335173a71b2e4936bd9f05bf0ddfea",
+          "0xe6c11ead4ee5ff5174861adb55f3e8fb2841cca69bf2612a222d3e8317b6ae06",
+          "0x2dd272ddce846149d92496b4c3e677504aec8d5e6aab5908b25c9fe0a797e25f",
+          "0x8895743a31faedaa74150e89d06d281990a1909688b82906f0eb858b37f82190"
+        ]
+      },
+      {
+        "method": "0xa5418819c024239299ea32e09defae8ec412c03e58f5c75f1b2fe84c857f5483",
+        "currencies": [
+          "0x8fd50654b7dd2dc839f7cab32800ba0c6f7f66e1ccf89b21c09405469c2175ec"
+        ]
+      },
+      {
+        "method": "0x3ccc3d4d5e769b1f82dc4988485551dc0cd3c7a3926d7d8a4dde91507199490f",
+        "currencies": [
+          "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e",
+          "0xfff16d60be267153303bbfa66e593fb8d06e24ea5ef24b6acca5224c2ca6b907",
+          "0x90832e2dc3221e4d56977c1aa8f6a6706b9ad6542fbbdaac13097d0fa5e42e67",
+          "0xc241cc1f9752d2d53d1ab67189223a3f330e48b75f73ebf86f50b2c78fe8df88",
+          "0xdbd9d34f382e9f6ae078447a655e0816927c7c3edec70bd107de1d34cb15172e",
+          "0xcb83cbb58eaa5007af6cad99939e4581c1e1b50d65609c30f303983301524ef3",
+          "0x221012e06ebf59a20b82e3003cf5d6ee973d9008bdb6e2f604faa89a27235522"
+        ]
+      },
+      {
+        "method": "0x1d966dbd6aeb8674d7c05174bd0ded7b56a798672bfb862ef20bbe8c2bbfce18",
+        "currencies": [
+          "0x763ce5da7605b2b5ec3e9ec5b0ab2bbcf8b27d28da2b5002e4e364278d729d14"
+        ]
+      },
+      {
+        "method": "0xf81480907d808d639ad3230869e4b05a3b01b2d34e323af40f2efab807effd32",
+        "currencies": [
+          "0xc4ae21aac0c6549d71dd96035b7e0bdb6c79ebdba8891b666115bc976d16a29e"
+        ]
+      },
+      {
+        "method": "0xe99a5081226cbbff9440a63da5caa04fa30f210c12c4dd9976132ac075054cd9",
+        "currencies": [
+          "0xaad766fbc07fb357bed9fd8b03b935f2f71fe29fc48f08274bc2a01d7f642afc"
+        ]
+      }
+    ],
+    "predecessorMethods": [
+      "0x62c7ed738ad3e7618111348af32691b5767777fbaf46a2d8943237625552645c",
+      "0xcac9daea62d7b89d75ac73af4ee14dcf25721012ae82b568c2ea5c808eaa04ff",
+      "0x5908bb0c9b87763ac6171d4104847667e7f02b4c47b574fe890c1f439ed128bb",
+      "0x90262a3db0edd0be2369c6b28f9e8511ec0bac7136cefbada0880602f87e7268",
+      "0x617f88ab82b5c1b014c539f7e75121427f0bb50a4c58b187a238531e7d58605d",
+      "0x10940ee67cfb3c6c064569ec92c0ee934cd7afa18dd2ca2d6a2254fcb009c17d",
+      "0x554a007c2217df766b977723b276671aee5ebb4adaea0edb6433c88b3e61dac5",
+      "0xa5418819c024239299ea32e09defae8ec412c03e58f5c75f1b2fe84c857f5483",
+      "0xf752c7d19698ecb0bb8988abf9b9a53a4c3657f3bc8850a6fb59fdf3e3ce8cd3",
+      "0x3ccc3d4d5e769b1f82dc4988485551dc0cd3c7a3926d7d8a4dde91507199490f",
+      "0x1d966dbd6aeb8674d7c05174bd0ded7b56a798672bfb862ef20bbe8c2bbfce18",
+      "0xf81480907d808d639ad3230869e4b05a3b01b2d34e323af40f2efab807effd32",
+      "0xe99a5081226cbbff9440a63da5caa04fa30f210c12c4dd9976132ac075054cd9"
+    ],
+    "witnesses": [
+      "0x66649F896521b0fb487fE2077b4FBDA283d7f19a",
+      "0x4ab950AE1e3326578Bf7e643a2031E858aBa2927"
+    ],
+    "attestationThreshold": "1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -69,7 +69,9 @@
     "transpile": "tsc",
     "typecheck:dispute-deployment": "tsc -p tsconfig.dispute-deployment.json",
     "test:upv4-bootstrap": "node --test scripts/upv4-bootstrap.spec.cjs",
-    "deploy:upv4:localhost": "ts-node --transpile-only scripts/deployActive.ts localhost 43_deploy_unified_payment_verifier_v4"
+    "deploy:upv4:localhost": "ts-node --transpile-only scripts/deployActive.ts localhost 43_deploy_unified_payment_verifier_v4",
+    "inspect:upv4-callers": "ts-node --transpile-only scripts/inspect-upv4-callers.ts",
+    "test:upv4-callers": "node --test scripts/upv4-caller-inventory.spec.cjs"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-verify": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,9 @@
     "test:release-policy": "node --test scripts/verify-github-environment.spec.mjs scripts/npm-release.spec.mjs",
     "typechain": "hardhat typechain",
     "transpile": "tsc",
-    "typecheck:dispute-deployment": "tsc -p tsconfig.dispute-deployment.json"
+    "typecheck:dispute-deployment": "tsc -p tsconfig.dispute-deployment.json",
+    "test:upv4-bootstrap": "node --test scripts/upv4-bootstrap.spec.cjs",
+    "deploy:upv4:localhost": "ts-node --transpile-only scripts/deployActive.ts localhost 43_deploy_unified_payment_verifier_v4"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-verify": "2.1.3",

--- a/scripts/inspect-upv4-callers.ts
+++ b/scripts/inspect-upv4-callers.ts
@@ -1,0 +1,301 @@
+import { execFileSync } from "child_process";
+import { readFileSync, writeFileSync } from "fs";
+import { resolve } from "path";
+import { constants, providers, utils } from "ethers";
+
+const registryInterface = new utils.Interface([
+  "event OrchestratorAdded(address indexed orchestrator)",
+  "event OrchestratorRemoved(address indexed orchestrator)",
+  "function isOrchestrator(address) view returns (bool)",
+  "function owner() view returns (address)",
+]);
+const added = registryInterface.getEventTopic("OrchestratorAdded");
+const removed = registryInterface.getEventTopic("OrchestratorRemoved");
+
+class CallerInventoryError extends Error {}
+
+type RegistryDeployment = {
+  address: string;
+  transactionHash: string;
+  bytecode: string;
+  deployedBytecode: string;
+};
+
+/** Full registry history from a trusted archive RPC; not a caller-behavior or drain proof. */
+export async function inspectUpv4Callers(
+  provider: providers.Provider,
+  deployment: RegistryDeployment,
+  knownCallers: string[],
+  blockNumber: number,
+  blockSpan: number
+) {
+  if (
+    !Number.isSafeInteger(blockNumber) ||
+    blockNumber < 1 ||
+    !Number.isSafeInteger(blockSpan) ||
+    blockSpan < 1
+  )
+    throw new CallerInventoryError(
+      "Block number and scan span must be positive safe integers"
+    );
+  const registry = utils.getAddress(deployment.address);
+  const chain = await provider.getNetwork();
+  if (chain.chainId !== 8453)
+    throw new CallerInventoryError("Caller inventory requires Base chain 8453");
+  const receipt = await provider.getTransactionReceipt(
+    deployment.transactionHash
+  );
+  const creation = await provider.getTransaction(deployment.transactionHash);
+  if (
+    !receipt ||
+    receipt.status !== 1 ||
+    !receipt.contractAddress ||
+    utils.getAddress(receipt.contractAddress) !== registry ||
+    receipt.transactionHash.toLowerCase() !==
+      deployment.transactionHash.toLowerCase() ||
+    !creation ||
+    creation.to !== null ||
+    creation.hash.toLowerCase() !== deployment.transactionHash.toLowerCase() ||
+    creation.data.toLowerCase() !== deployment.bytecode.toLowerCase() ||
+    creation.blockHash !== receipt.blockHash ||
+    receipt.blockNumber < 1 ||
+    receipt.blockNumber > blockNumber
+  )
+    throw new CallerInventoryError(
+      "Registry creation does not match the recorded deployment"
+    );
+  const start = await provider.getBlock(receipt.blockNumber);
+  const anchor = await provider.getBlock(blockNumber);
+  if (!start || start.hash !== receipt.blockHash || !anchor)
+    throw new CallerInventoryError(
+      "Registry creation or inventory block is not canonical"
+    );
+  const runtime = await provider.getCode(registry, blockNumber);
+  if (
+    runtime === "0x" ||
+    runtime.toLowerCase() !== deployment.deployedBytecode.toLowerCase() ||
+    (await provider.getCode(registry, receipt.blockNumber)).toLowerCase() !==
+      runtime.toLowerCase() ||
+    (await provider.getCode(registry, receipt.blockNumber - 1)) !== "0x"
+  )
+    throw new CallerInventoryError(
+      "Registry runtime or creation boundary differs from the recorded deployment"
+    );
+
+  const events: Array<{
+    blockNumber: number;
+    blockHash: string;
+    transactionHash: string;
+    logIndex: number;
+    orchestrator: string;
+    authorized: boolean;
+  }> = [];
+  const membership = new Map<string, boolean>();
+  let rangesScanned = 0;
+  for (let fromBlock = receipt.blockNumber; fromBlock <= blockNumber; ) {
+    const toBlock = Math.min(blockNumber, fromBlock + blockSpan - 1);
+    const logs = await provider.getLogs({
+      address: registry,
+      fromBlock,
+      toBlock,
+      topics: [[added, removed]],
+    });
+    logs.sort(
+      (left, right) =>
+        left.blockNumber - right.blockNumber || left.logIndex - right.logIndex
+    );
+    let previousBlock = -1;
+    let previousIndex = -1;
+    for (const log of logs) {
+      if (
+        log.removed ||
+        utils.getAddress(log.address) !== registry ||
+        !Number.isSafeInteger(log.blockNumber) ||
+        log.blockNumber < fromBlock ||
+        log.blockNumber > toBlock ||
+        !Number.isSafeInteger(log.logIndex) ||
+        log.logIndex < 0 ||
+        (log.blockNumber === previousBlock && log.logIndex <= previousIndex) ||
+        log.topics.length !== 2 ||
+        ![added, removed].includes(log.topics[0]) ||
+        log.data !== "0x" ||
+        !utils.isHexString(log.blockHash, 32) ||
+        !utils.isHexString(log.transactionHash, 32)
+      )
+        throw new CallerInventoryError(
+          "Malformed, duplicate or out-of-range registry event"
+        );
+      const decoded = registryInterface.parseLog(log);
+      const orchestrator = utils.getAddress(decoded.args.orchestrator);
+      const authorized = log.topics[0] === added;
+      if (
+        orchestrator === constants.AddressZero ||
+        authorized === (membership.get(orchestrator) === true)
+      )
+        throw new CallerInventoryError(
+          `Inconsistent registry history for ${orchestrator}`
+        );
+      membership.set(orchestrator, authorized);
+      events.push({
+        blockNumber: log.blockNumber,
+        blockHash: log.blockHash,
+        transactionHash: log.transactionHash,
+        logIndex: log.logIndex,
+        orchestrator,
+        authorized,
+      });
+      previousBlock = log.blockNumber;
+      previousIndex = log.logIndex;
+    }
+    rangesScanned++;
+    fromBlock = toBlock + 1;
+  }
+  // Artifact candidates also catch an entirely omitted history for a known active caller.
+  for (const candidate of knownCallers) {
+    const address = utils.getAddress(candidate);
+    if (!membership.has(address)) membership.set(address, false);
+  }
+  const callers: Array<{
+    address: string;
+    authorized: boolean;
+    runtimeCodeHash: string;
+  }> = [];
+  for (const [address, authorized] of membership) {
+    const result = await provider.call(
+      {
+        to: registry,
+        data: registryInterface.encodeFunctionData("isOrchestrator", [address]),
+      },
+      blockNumber
+    );
+    if (
+      result !==
+      registryInterface.encodeFunctionResult("isOrchestrator", [authorized])
+    )
+      throw new CallerInventoryError(
+        `Registry getter disagrees with history for ${address}`
+      );
+    callers.push({
+      address,
+      authorized,
+      runtimeCodeHash: utils.keccak256(
+        await provider.getCode(address, blockNumber)
+      ),
+    });
+  }
+  const [owner] = registryInterface.decodeFunctionResult(
+    "owner",
+    await provider.call(
+      {
+        to: registry,
+        data: registryInterface.encodeFunctionData("owner"),
+      },
+      blockNumber
+    )
+  );
+  if (
+    (await provider.getBlock(blockNumber)).hash !== anchor.hash ||
+    (await provider.getBlock(receipt.blockNumber)).hash !== start.hash
+  )
+    throw new CallerInventoryError("Chain reorganized during caller inventory");
+  return {
+    chainId: chain.chainId,
+    blockNumber,
+    blockHash: anchor.hash,
+    registry,
+    registryRuntimeCodeHash: utils.keccak256(runtime),
+    owner: String(owner),
+    creationTransaction: deployment.transactionHash,
+    creationBlock: receipt.blockNumber,
+    creationBlockHash: start.hash,
+    blockSpan,
+    rangesScanned,
+    events,
+    callers,
+    limitations: [
+      "History completeness depends on the trusted archive RPC returning every matching log.",
+      "Runtime hashes do not identify or approve caller admission behavior, escrow reachability or payment drain.",
+      "The snapshot is not an execution-time guard or activation authorization.",
+    ],
+  };
+}
+
+async function main() {
+  const [network, block, output, span = "2000", ...extra] =
+    process.argv.slice(2);
+  if (
+    (network !== "base" && network !== "base_staging") ||
+    !block ||
+    !output ||
+    extra.length
+  )
+    throw new Error(
+      "usage: inspect-upv4-callers <base|base_staging> <block> <new-output.json> [block-span]"
+    );
+  const rpc = process.env.UPV4_INVENTORY_RPC_URL;
+  if (!rpc)
+    throw new Error("UPV4_INVENTORY_RPC_URL must select a trusted archive RPC");
+  const root = resolve(__dirname, "..");
+  const git = (...args: string[]) =>
+    execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+  if (git("status", "--porcelain"))
+    throw new Error("Caller inventory requires clean committed source");
+  const sourceSha = git("rev-parse", "HEAD");
+  const recordPath = `deployments/${network}/OrchestratorRegistry.json`;
+  const record = readFileSync(resolve(root, recordPath), "utf8");
+  const knownCallers = ["Orchestrator", "OrchestratorV2", "OrchestratorV3"].map(
+    (name) => {
+      const path = `deployments/${network}/${name}.json`;
+      const contents = readFileSync(resolve(root, path), "utf8");
+      return {
+        path,
+        hash: utils.keccak256(utils.toUtf8Bytes(contents)),
+        address: utils.getAddress(JSON.parse(contents).address),
+      };
+    }
+  );
+  // The RPC URL can contain credentials. Never echo provider errors or persist connection details.
+  let inventory: Awaited<ReturnType<typeof inspectUpv4Callers>>;
+  try {
+    inventory = await inspectUpv4Callers(
+      new providers.JsonRpcProvider(rpc),
+      JSON.parse(record),
+      knownCallers.map((caller) => caller.address),
+      Number(block),
+      Number(span)
+    );
+  } catch (error) {
+    if (error instanceof CallerInventoryError) throw error;
+    throw new Error(
+      "Caller inventory failed: RPC history, deployment identity, event/getter reconciliation or block stability could not be verified; no report written"
+    );
+  }
+  if (git("rev-parse", "HEAD") !== sourceSha || git("status", "--porcelain"))
+    throw new Error(
+      "Source changed during caller inventory; no report written"
+    );
+  writeFileSync(
+    output,
+    JSON.stringify(
+      {
+        sourceSha,
+        network,
+        knownCallers,
+        deploymentRecord: recordPath,
+        deploymentRecordHash: utils.keccak256(utils.toUtf8Bytes(record)),
+        ...inventory,
+      },
+      null,
+      2
+    ) + "\n",
+    { flag: "wx" }
+  );
+}
+
+if (require.main === module)
+  main().catch((error: unknown) => {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : "Caller inventory failed"}\n`
+    );
+    process.exitCode = 1;
+  });

--- a/scripts/upv4-bootstrap.spec.cjs
+++ b/scripts/upv4-bootstrap.spec.cjs
@@ -13,9 +13,14 @@ moduleAlias.addAlias("@utils", process.cwd() + "/utils");
 
 const assert = require("node:assert/strict");
 const { test } = require("node:test");
-const { constants, utils } = require("ethers");
+const { BigNumber, constants, utils } = require("ethers");
 const {
   assertAliasRiskWindows,
+  assertPinnedBootstrapSurface,
+  assertPinnedBootstrapContract,
+  assertBootstrapAttestationAuthority,
+  pinnedBootstrapPredecessor,
+  readBootstrapPredecessor,
   assertNamespacePrefix,
   bootstrapNamespaces,
   bootstrapRequested,
@@ -48,6 +53,356 @@ test("bootstrap preserves every existing namespace and adds only the balance ali
       () => bootstrapNamespaces(invalid),
       /distinct predecessor methods/
     );
+  }
+});
+
+// A provider-only local stack exercises the real preflight and lane ordering.
+// Live addresses/catalogs are covered separately by the pinned-evidence tests.
+function predecessorFixture() {
+  const names = [
+    "UnifiedPaymentVerifierV3",
+    "NullifierRegistryV2",
+    "NullifierRegistry",
+    "PaymentVerifierRegistry",
+    "OrchestratorRegistry",
+    "OrchestratorV3",
+    "IntentLifecycleHookV1MethodScopedStaked",
+    "DisputeProtectionPolicyMethodScopedStaked",
+    "MultiAttestationVerifier",
+  ];
+  const addresses = Object.fromEntries(
+    names.map((name, index) => [
+      name,
+      utils.getAddress(utils.hexZeroPad(utils.hexlify(index + 1), 20)),
+    ])
+  );
+  const governance = utils.getAddress(utils.hexZeroPad("0xff", 20));
+  const block = { number: 123, hash: utils.id("preflight-block") };
+  const methods = [VENMO_METHOD, utils.id("paypal")];
+  /** @type {Record<string, Record<string, any>>} */
+  const values = Object.fromEntries(
+    names.map((name) => [name, { owner: governance }])
+  );
+  Object.assign(values.UnifiedPaymentVerifierV3, {
+    nullifierRegistry: addresses.NullifierRegistryV2,
+    orchestratorRegistry: addresses.OrchestratorRegistry,
+    attestationVerifier: addresses.MultiAttestationVerifier,
+    getPaymentMethods: methods,
+    isPaymentMethod: true,
+    DOMAIN_SEPARATOR: utils._TypedDataEncoder.hashDomain({
+      name: "UnifiedPaymentVerifier",
+      version: "1",
+      chainId: 31337,
+      verifyingContract: addresses.UnifiedPaymentVerifierV3,
+    }),
+  });
+  Object.assign(values.NullifierRegistryV2, {
+    legacyNullifierRegistry: addresses.NullifierRegistry,
+    getWriters: [addresses.UnifiedPaymentVerifierV3],
+  });
+  values.NullifierRegistry.getWriters = [];
+  Object.assign(values.PaymentVerifierRegistry, {
+    getPaymentMethods: methods,
+    getVerifier: addresses.UnifiedPaymentVerifierV3,
+    getCurrencies: [utils.id("USD")],
+  });
+  values.OrchestratorRegistry.isOrchestrator = true;
+  Object.assign(values.OrchestratorV3, {
+    paymentVerifierRegistry: addresses.PaymentVerifierRegistry,
+    lifecycleHook: addresses.IntentLifecycleHookV1MethodScopedStaked,
+    paused: false,
+    chainId: BigNumber.from(31337),
+  });
+  Object.assign(values.IntentLifecycleHookV1MethodScopedStaked, {
+    orchestratorRegistry: addresses.OrchestratorRegistry,
+    disputeProtectionPolicy:
+      addresses.DisputeProtectionPolicyMethodScopedStaked,
+  });
+  Object.assign(values.DisputeProtectionPolicyMethodScopedStaked, {
+    isLifecycleHookAuthorized: true,
+    getRiskWindow: BigNumber.from(0),
+  });
+  Object.assign(values.MultiAttestationVerifier, {
+    witnesses: [governance],
+    requiredSignatures: BigNumber.from(1),
+    witnessCount: BigNumber.from(1),
+  });
+  /** @type {string[]} */
+  const calls = [];
+  const controls = {
+    network: "localhost",
+    chainId: 31337,
+    code: "0x6000",
+    changedBlock: false,
+    deploys: 0,
+  };
+  /** @type {any} */
+  const hre = {
+    getUnnamedAccounts: async () => [governance],
+    ethers: {
+      provider: {
+        getNetwork: async () => ({ chainId: controls.chainId }),
+        getBlock: async (/** @type {string | number} */ tag) => {
+          assert.ok(tag === "latest" || tag === block.number);
+          return tag === "latest" || !controls.changedBlock
+            ? block
+            : { ...block, hash: utils.id("changed-block") };
+        },
+        getCode: async (
+          /** @type {string} */ address,
+          /** @type {number} */ tag
+        ) => {
+          assert.ok(Object.values(addresses).includes(address));
+          assert.equal(tag, block.number);
+          return controls.code;
+        },
+      },
+      getContractAt: async (
+        /** @type {string} */ _artifact,
+        /** @type {string} */ address
+      ) => {
+        const name = names.find((item) => addresses[item] === address);
+        assert.ok(name);
+        return {
+          address,
+          ...Object.fromEntries(
+            Object.keys(values[name]).map((getter) => [
+              getter,
+              async (/** @type {any[]} */ ...args) => {
+                assert.deepEqual(args.at(-1), { blockTag: block.number });
+                calls.push(`${name}.${getter}`);
+                return values[name][getter];
+              },
+            ])
+          ),
+        };
+      },
+    },
+    deployments: {
+      getNetworkName: () => controls.network,
+      get: async (/** @type {string} */ name) => ({
+        address: addresses[name],
+        deployedBytecode: "0x6000",
+        solcInputHash: "fixture",
+      }),
+      getExtendedArtifact: async () => ({ solcInputHash: "fixture" }),
+      getOrNull: async () => {
+        throw new Error("Successor lookup reached before preflight rejection");
+      },
+      deploy: async () => {
+        controls.deploys++;
+        throw new Error("Unexpected deployment");
+      },
+    },
+  };
+  return { hre, values, controls, calls, governance, block };
+}
+
+test("preflight reads one block and captures attestation authority for resume", async () => {
+  const fixture = predecessorFixture();
+  const result = await readBootstrapPredecessor(fixture.hre);
+  assert.equal(result.blockNumber, fixture.block.number);
+  assert.equal(result.blockHash, fixture.block.hash);
+  assert.deepEqual(result.state.witnesses, [fixture.governance]);
+  assert.equal(result.state.attestationThreshold, "1");
+  assert.deepEqual(
+    result.state.entries,
+    bootstrapNamespaces([VENMO_METHOD, utils.id("paypal")])
+  );
+  assert.ok(fixture.calls.includes("MultiAttestationVerifier.owner"));
+  assert.ok(
+    fixture.calls.includes("UnifiedPaymentVerifierV3.DOMAIN_SEPARATOR")
+  );
+});
+
+test("preflight drift aborts the actual lane before successor lookup or deployment", async () => {
+  /** @type {Array<{ name: string, change: (fixture: ReturnType<typeof predecessorFixture>) => void, error: RegExp }>} */
+  const cases = [
+    {
+      name: "wrong live chain",
+      change: (f) => {
+        f.controls.network = "base";
+      },
+      error: /chain mismatch/,
+    },
+    {
+      name: "wrong live identity",
+      change: (f) => {
+        f.controls.network = "base";
+        f.controls.chainId = 8453;
+      },
+      error: /contract identity/,
+    },
+    {
+      name: "runtime",
+      change: (f) => {
+        f.controls.code = "0x6001";
+      },
+      error: /on-chain code/,
+    },
+    {
+      name: "paused O3",
+      change: (f) => {
+        f.values.OrchestratorV3.paused = true;
+      },
+      error: /dependency or active lifecycle/,
+    },
+    {
+      name: "O3 chain",
+      change: (f) => {
+        f.values.OrchestratorV3.chainId = BigNumber.from(1);
+      },
+      error: /dependency or active lifecycle/,
+    },
+    {
+      name: "unauthorized O3",
+      change: (f) => {
+        f.values.OrchestratorRegistry.isOrchestrator = false;
+      },
+      error: /dependency or active lifecycle/,
+    },
+    {
+      name: "unauthorized hook",
+      change: (f) => {
+        f.values.DisputeProtectionPolicyMethodScopedStaked.isLifecycleHookAuthorized = false;
+      },
+      error: /dependency or active lifecycle/,
+    },
+    {
+      name: "extra V2 writer",
+      change: (f) => {
+        f.values.NullifierRegistryV2.getWriters.push(constants.AddressZero);
+      },
+      error: /sole writer/,
+    },
+    {
+      name: "legacy writer",
+      change: (f) => {
+        f.values.NullifierRegistry.getWriters = [constants.AddressZero];
+      },
+      error: /sole writer/,
+    },
+    {
+      name: "method set",
+      change: (f) => {
+        f.values.UnifiedPaymentVerifierV3.getPaymentMethods = [VENMO_METHOD];
+      },
+      error: /method set differs/,
+    },
+    {
+      name: "inactive method",
+      change: (f) => {
+        f.values.UnifiedPaymentVerifierV3.isPaymentMethod = false;
+      },
+      error: /inactive method or partial route/,
+    },
+    {
+      name: "partial route",
+      change: (f) => {
+        f.values.PaymentVerifierRegistry.getVerifier = constants.AddressZero;
+      },
+      error: /inactive method or partial route/,
+    },
+    {
+      name: "missing currency",
+      change: (f) => {
+        f.values.PaymentVerifierRegistry.getCurrencies = [];
+      },
+      error: /no currencies/,
+    },
+    {
+      name: "protected alias",
+      change: (f) => {
+        f.values.DisputeProtectionPolicyMethodScopedStaked.getRiskWindow =
+          BigNumber.from(1);
+      },
+      error: /Protected nullifier aliases/,
+    },
+    {
+      name: "empty witnesses",
+      change: (f) => {
+        f.values.MultiAttestationVerifier.witnesses = [];
+      },
+      error: /attestation authority/,
+    },
+    {
+      name: "threshold",
+      change: (f) => {
+        f.values.MultiAttestationVerifier.requiredSignatures =
+          BigNumber.from(0);
+      },
+      error: /attestation authority/,
+    },
+    {
+      name: "domain",
+      change: (f) => {
+        f.values.UnifiedPaymentVerifierV3.DOMAIN_SEPARATOR = constants.HashZero;
+      },
+      error: /signing domain/,
+    },
+    {
+      name: "block hash",
+      change: (f) => {
+        f.controls.changedBlock = true;
+      },
+      error: /block changed/,
+    },
+  ];
+  for (const [name, getters] of Object.entries({
+    UnifiedPaymentVerifierV3: [
+      "nullifierRegistry",
+      "orchestratorRegistry",
+      "attestationVerifier",
+    ],
+    NullifierRegistryV2: ["legacyNullifierRegistry"],
+    OrchestratorV3: ["paymentVerifierRegistry", "lifecycleHook"],
+    IntentLifecycleHookV1MethodScopedStaked: [
+      "orchestratorRegistry",
+      "disputeProtectionPolicy",
+    ],
+  })) {
+    for (const getter of getters)
+      cases.push({
+        name: `${name}.${getter}`,
+        change: (f) => {
+          f.values[name][getter] = constants.AddressZero;
+        },
+        error: /dependency or active lifecycle/,
+      });
+  }
+  for (const name of Object.keys(predecessorFixture().values).filter(
+    (name) => !name.startsWith("IntentLifecycleHook")
+  ))
+    cases.push({
+      name: `${name}.owner`,
+      change: (f) => {
+        f.values[name].owner = constants.AddressZero;
+      },
+      error:
+        /governance mismatch|dependency or active lifecycle|attestation authority/,
+    });
+  const keys = [
+    "DEPLOY_ACTIVE_TAG",
+    "ENABLE_BASE_UPV4_BOOTSTRAP",
+    "ENABLE_STAGING_UPV4_BOOTSTRAP",
+  ];
+  const saved = keys.map((key) => process.env[key]);
+  try {
+    for (const { name, change, error } of cases) {
+      const fixture = predecessorFixture();
+      change(fixture);
+      keys.forEach((key) => delete process.env[key]);
+      process.env.DEPLOY_ACTIVE_TAG = UPV4_BOOTSTRAP_TAG;
+      if (fixture.controls.network === "base")
+        process.env.ENABLE_BASE_UPV4_BOOTSTRAP = "true";
+      await assert.rejects(deployLane(fixture.hre), error, name);
+      assert.equal(fixture.controls.deploys, 0, name);
+    }
+  } finally {
+    keys.forEach((key, index) => {
+      if (saved[index] === undefined) delete process.env[key];
+      else process.env[key] = saved[index];
+    });
   }
 });
 
@@ -202,5 +557,277 @@ test("untagged runs perform no reads and live runs require exactly one matching 
       if (saved[index] === undefined) delete process.env[key];
       else process.env[key] = saved[index];
     });
+  }
+});
+
+test("current Base bootstrap preserves the observed eleven-method surface including UPI", () => {
+  const expected = pinnedBootstrapPredecessor("base");
+  assert.ok(expected);
+  const names = [
+    "alipay",
+    "chime",
+    "venmo",
+    "revolut",
+    "cashapp",
+    "wise",
+    "mercadopago",
+    "zelle",
+    "monzo",
+    "paypal",
+    "upi",
+  ];
+  const methods = names.map(utils.id);
+  const currencies = expected.routes.map((route) => [...route.currencies]);
+  assert.deepEqual(
+    expected.routes.map((route) => route.method),
+    methods
+  );
+  assert.deepEqual(currencies[10], [utils.id("INR")]);
+  assert.doesNotThrow(() =>
+    assertPinnedBootstrapSurface(expected, methods, currencies, methods)
+  );
+  assert.throws(
+    () =>
+      assertPinnedBootstrapSurface(
+        expected,
+        methods.slice(0, 10),
+        currencies.slice(0, 10),
+        methods.slice(0, 10)
+      ),
+    /surface changed/
+  );
+  const entries = bootstrapNamespaces(methods);
+  assert.deepEqual(entries[10], {
+    method: utils.id("upi"),
+    namespace: utils.id("upi"),
+  });
+});
+
+test("staging preserves its distinct registry and predecessor method orders", () => {
+  const expected = pinnedBootstrapPredecessor("base_staging");
+  assert.ok(expected);
+  const methods = [
+    "zelle",
+    "monzo",
+    "alipay",
+    "chime",
+    "venmo",
+    "revolut",
+    "cashapp",
+    "wise",
+    "mercadopago",
+    "paypal",
+    "monobank",
+    "mercury",
+    "upi",
+  ].map(utils.id);
+  const predecessorMethods = [
+    "monzo",
+    "alipay",
+    "chime",
+    "venmo",
+    "revolut",
+    "cashapp",
+    "wise",
+    "mercadopago",
+    "zelle",
+    "paypal",
+    "monobank",
+    "mercury",
+    "upi",
+  ].map(utils.id);
+  const currencies = expected.routes.map((route) => [...route.currencies]);
+  assert.doesNotThrow(() =>
+    assertPinnedBootstrapSurface(
+      expected,
+      methods,
+      currencies,
+      predecessorMethods
+    )
+  );
+  assert.throws(
+    () => assertPinnedBootstrapSurface(expected, methods, currencies, methods),
+    /surface changed/
+  );
+  assert.throws(
+    () =>
+      assertPinnedBootstrapSurface(
+        expected,
+        predecessorMethods,
+        currencies,
+        predecessorMethods
+      ),
+    /surface changed/
+  );
+});
+
+test("current predecessor catalog validation refuses unreviewed route or currency drift", () => {
+  const expected = pinnedBootstrapPredecessor("base");
+  assert.ok(expected);
+  const methods = expected.routes.map((route) => route.method);
+  const currencies = expected.routes.map((route) => [...route.currencies]);
+  const predecessor = [...expected.predecessorMethods];
+  const changedCurrency = currencies.map((row) => [...row]);
+  changedCurrency[0] = [utils.id("USD")];
+  const reorderedCurrencies = currencies.map((row) => [...row]);
+  reorderedCurrencies[3].reverse();
+  const duplicateCurrency = currencies.map((row) => [...row]);
+  duplicateCurrency[0].push(duplicateCurrency[0][0]);
+  for (const actual of [
+    {
+      methods: [...methods, utils.id("unreviewed")],
+      currencies: [...currencies, [utils.id("USD")]],
+      predecessor: [...predecessor, utils.id("unreviewed")],
+    },
+    {
+      methods: [...methods.slice(0, -1), VENMO_BALANCE_METHOD],
+      currencies,
+      predecessor: [...predecessor.slice(0, -1), VENMO_BALANCE_METHOD],
+    },
+    {
+      methods: [...methods].reverse(),
+      currencies: [...currencies].reverse(),
+      predecessor,
+    },
+    { methods, currencies: currencies.slice(0, -1), predecessor },
+    { methods, currencies: changedCurrency, predecessor },
+    { methods, currencies: reorderedCurrencies, predecessor },
+    { methods, currencies: duplicateCurrency, predecessor },
+    { methods, currencies, predecessor: [...predecessor].reverse() },
+  ]) {
+    assert.throws(
+      () =>
+        assertPinnedBootstrapSurface(
+          expected,
+          actual.methods,
+          actual.currencies,
+          actual.predecessor
+        ),
+      /surface changed/
+    );
+  }
+  assert.equal(pinnedBootstrapPredecessor("localhost"), undefined);
+  assert.equal(pinnedBootstrapPredecessor("hardhat"), undefined);
+  assert.throws(() => pinnedBootstrapPredecessor("sepolia"), /Unsupported/);
+});
+
+test("live predecessor pins reject changed addresses and full runtime hashes", () => {
+  for (const network of ["base", "base_staging"]) {
+    const expected = pinnedBootstrapPredecessor(network);
+    assert.ok(expected);
+    for (const contract of Object.values(expected.contracts)) {
+      assert.doesNotThrow(() =>
+        assertPinnedBootstrapContract(
+          contract,
+          contract.address.toLowerCase(),
+          contract.runtimeCodeHash
+        )
+      );
+      assert.throws(
+        () =>
+          assertPinnedBootstrapContract(
+            contract,
+            constants.AddressZero,
+            contract.runtimeCodeHash
+          ),
+        /identity mismatch/
+      );
+      assert.throws(
+        () =>
+          assertPinnedBootstrapContract(
+            contract,
+            contract.address,
+            constants.HashZero
+          ),
+        /identity mismatch/
+      );
+    }
+  }
+});
+
+test("bootstrap refuses governance, witness and threshold drift", () => {
+  for (const network of ["base", "base_staging"]) {
+    const expected = pinnedBootstrapPredecessor(network);
+    assert.ok(expected);
+    const authority = {
+      owner: expected.governance.toLowerCase(),
+      witnesses: expected.witnesses.map((address) => address.toLowerCase()),
+      threshold: "1",
+      witnessCount: "2",
+    };
+    assert.doesNotThrow(() =>
+      assertBootstrapAttestationAuthority(
+        expected.governance,
+        expected,
+        authority
+      )
+    );
+    for (const change of [
+      { owner: constants.AddressZero },
+      { witnesses: [...authority.witnesses].reverse() },
+      { witnesses: [constants.AddressZero, authority.witnesses[1]] },
+      { witnesses: [], witnessCount: "0" },
+      { threshold: "0" },
+      { threshold: "2" },
+      { threshold: "3" },
+      { witnessCount: "1" },
+    ]) {
+      assert.throws(
+        () =>
+          assertBootstrapAttestationAuthority(expected.governance, expected, {
+            ...authority,
+            ...change,
+          }),
+        /authority mismatch/
+      );
+    }
+    assert.doesNotThrow(() =>
+      assertBootstrapAttestationAuthority(
+        expected.governance,
+        undefined,
+        authority
+      )
+    );
+    assert.throws(
+      () =>
+        assertBootstrapAttestationAuthority(expected.governance, undefined, {
+          ...authority,
+          owner: constants.AddressZero,
+        }),
+      /authority mismatch/
+    );
+    assert.throws(
+      () =>
+        assertBootstrapAttestationAuthority(expected.governance, undefined, {
+          ...authority,
+          threshold: "0",
+        }),
+      /authority mismatch/
+    );
+    assert.throws(
+      () =>
+        assertBootstrapAttestationAuthority(expected.governance, undefined, {
+          ...authority,
+          witnesses: [],
+          witnessCount: "0",
+        }),
+      /authority mismatch/
+    );
+    assert.throws(
+      () =>
+        assertBootstrapAttestationAuthority(expected.governance, undefined, {
+          ...authority,
+          witnessCount: "1",
+        }),
+      /authority mismatch/
+    );
+    assert.throws(
+      () =>
+        assertBootstrapAttestationAuthority(expected.governance, undefined, {
+          ...authority,
+          threshold: "3",
+        }),
+      /authority mismatch/
+    );
   }
 });

--- a/scripts/upv4-bootstrap.spec.cjs
+++ b/scripts/upv4-bootstrap.spec.cjs
@@ -5,9 +5,9 @@ process.env.BASE_DEPLOY_PRIVATE_KEY ||=
   "1111111111111111111111111111111111111111111111111111111111111111";
 process.env.TESTNET_DEPLOY_PRIVATE_KEY ||=
   "2222222222222222222222222222222222222222222222222222222222222222";
-require("ts-node/register/transpile-only");
-require("module-alias/register");
-const moduleAlias = require("module-alias");
+require(require.resolve("ts-node/register/transpile-only"));
+require(require.resolve("module-alias/register"));
+const moduleAlias = require(require.resolve("module-alias"));
 moduleAlias.reset();
 moduleAlias.addAlias("@utils", process.cwd() + "/utils");
 
@@ -25,6 +25,8 @@ const {
 } = require("../deployments/unifiedVerifierV4Bootstrap.ts");
 const lane =
   require("../deploy/43_deploy_unified_payment_verifier_v4.ts").default;
+const deployLane = /** @type {(hre: any) => Promise<void>} */ (lane);
+const skipLane = /** @type {(hre: any) => Promise<boolean>} */ (lane.skip);
 
 test("bootstrap preserves every existing namespace and adds only the balance alias", () => {
   const methods = [utils.id("paypal"), VENMO_METHOD, utils.id("cashapp")];
@@ -169,8 +171,8 @@ test("untagged runs perform no reads and live runs require exactly one matching 
       "sepolia",
     ]) {
       const hre = { deployments: { getNetworkName: () => network } };
-      assert.equal(await lane.skip(hre), true);
-      await lane(hre); // No accounts, provider or deployment API is available.
+      assert.equal(await skipLane(hre), true);
+      await deployLane(hre); // No accounts, provider or deployment API is available.
     }
     process.env.ENABLE_BASE_UPV4_BOOTSTRAP = "true";
     assert.throws(() => bootstrapRequested("base"), /flags require/);

--- a/scripts/upv4-bootstrap.spec.cjs
+++ b/scripts/upv4-bootstrap.spec.cjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+
+process.env.ALCHEMY_API_KEY ||= "offline";
+process.env.BASE_DEPLOY_PRIVATE_KEY ||=
+  "1111111111111111111111111111111111111111111111111111111111111111";
+process.env.TESTNET_DEPLOY_PRIVATE_KEY ||=
+  "2222222222222222222222222222222222222222222222222222222222222222";
+require("ts-node/register/transpile-only");
+require("module-alias/register");
+const moduleAlias = require("module-alias");
+moduleAlias.reset();
+moduleAlias.addAlias("@utils", process.cwd() + "/utils");
+
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+const { constants, utils } = require("ethers");
+const {
+  assertAliasRiskWindows,
+  assertNamespacePrefix,
+  bootstrapNamespaces,
+  bootstrapRequested,
+  UPV4_BOOTSTRAP_TAG,
+  VENMO_METHOD,
+  VENMO_BALANCE_METHOD,
+} = require("../deployments/unifiedVerifierV4Bootstrap.ts");
+const lane =
+  require("../deploy/43_deploy_unified_payment_verifier_v4.ts").default;
+
+test("bootstrap preserves every existing namespace and adds only the balance alias", () => {
+  const methods = [utils.id("paypal"), VENMO_METHOD, utils.id("cashapp")];
+  const entries = bootstrapNamespaces(methods);
+  assert.deepEqual(entries, [
+    { method: methods[0], namespace: methods[0] },
+    { method: VENMO_METHOD, namespace: VENMO_METHOD },
+    { method: methods[2], namespace: methods[2] },
+    { method: VENMO_BALANCE_METHOD, namespace: VENMO_METHOD },
+  ]);
+  for (const invalid of [
+    [],
+    [VENMO_BALANCE_METHOD],
+    [VENMO_METHOD, VENMO_BALANCE_METHOD],
+    [VENMO_METHOD, VENMO_METHOD],
+    [VENMO_METHOD, constants.HashZero],
+  ]) {
+    assert.throws(
+      () => bootstrapNamespaces(invalid),
+      /distinct predecessor methods/
+    );
+  }
+});
+
+test("risk gate rejects every protected alias while preserving regular protected methods", () => {
+  const entries = bootstrapNamespaces([VENMO_METHOD, utils.id("paypal")]);
+  assert.doesNotThrow(() =>
+    assertAliasRiskWindows(entries, ["1209600", "1209600", "0"])
+  );
+  assert.throws(
+    () => assertAliasRiskWindows(entries, ["1209600", "1209600", "1"]),
+    /Protected nullifier aliases/
+  );
+  assert.throws(
+    () => assertAliasRiskWindows(entries, ["1209600"]),
+    /Missing method risk windows/
+  );
+  assert.throws(
+    () =>
+      assertAliasRiskWindows(
+        [{ method: utils.id("another-alias"), namespace: utils.id("paypal") }],
+        ["1"]
+      ),
+    /Protected nullifier aliases/
+  );
+});
+
+test("resume accepts each contiguous prefix with exact active flags and assignments", () => {
+  const entries = bootstrapNamespaces([VENMO_METHOD, utils.id("paypal")]);
+  for (let count = 0; count <= entries.length; count++) {
+    assert.equal(
+      assertNamespacePrefix(
+        entries,
+        entries.slice(0, count).map((entry) => entry.method),
+        entries.map((entry, index) =>
+          index < count ? entry.namespace : constants.HashZero
+        ),
+        entries.map((_, index) => index < count)
+      ),
+      count
+    );
+  }
+});
+
+test("resume rejects reordered, foreign, disabled, or reassigned namespaces", () => {
+  const entries = bootstrapNamespaces([VENMO_METHOD, utils.id("paypal")]);
+  const methods = entries.map((entry) => entry.method);
+  const namespaces = entries.map((entry) => entry.namespace);
+  assert.throws(
+    () =>
+      assertNamespacePrefix(entries, [...methods].reverse(), namespaces, [
+        true,
+        true,
+        true,
+      ]),
+    /exact bootstrap prefix/
+  );
+  assert.throws(
+    () =>
+      assertNamespacePrefix(
+        entries,
+        [...methods, utils.id("foreign")],
+        namespaces,
+        [true, true, true]
+      ),
+    /exact bootstrap prefix/
+  );
+  assert.throws(
+    () =>
+      assertNamespacePrefix(entries, methods, namespaces, [true, true, false]),
+    /active flag mismatch/
+  );
+  assert.throws(
+    () =>
+      assertNamespacePrefix(
+        entries,
+        methods,
+        [VENMO_METHOD, namespaces[1], VENMO_BALANCE_METHOD],
+        [true, true, true]
+      ),
+    /namespace or active flag mismatch/
+  );
+  // Removing a method retains its assigned namespace. Do not silently reactivate
+  // it as though this were an uninterrupted fresh deployment.
+  assert.throws(
+    () =>
+      assertNamespacePrefix(entries, methods.slice(0, 2), namespaces, [
+        true,
+        true,
+        false,
+      ]),
+    /namespace or active flag mismatch/
+  );
+  assert.throws(
+    () =>
+      assertNamespacePrefix(
+        entries,
+        methods,
+        [constants.HashZero, ...namespaces.slice(1)],
+        [true, true, true]
+      ),
+    /namespace or active flag mismatch/
+  );
+});
+
+test("untagged runs perform no reads and live runs require exactly one matching opt-in", async () => {
+  const keys = [
+    "DEPLOY_ACTIVE_TAG",
+    "ENABLE_BASE_UPV4_BOOTSTRAP",
+    "ENABLE_STAGING_UPV4_BOOTSTRAP",
+  ];
+  const saved = keys.map((key) => process.env[key]);
+  try {
+    keys.forEach((key) => delete process.env[key]);
+    assert.deepEqual(lane.tags, [UPV4_BOOTSTRAP_TAG]);
+    assert.deepEqual(lane.dependencies, []);
+    for (const network of [
+      "hardhat",
+      "localhost",
+      "base",
+      "base_staging",
+      "sepolia",
+    ]) {
+      const hre = { deployments: { getNetworkName: () => network } };
+      assert.equal(await lane.skip(hre), true);
+      await lane(hre); // No accounts, provider or deployment API is available.
+    }
+    process.env.ENABLE_BASE_UPV4_BOOTSTRAP = "true";
+    assert.throws(() => bootstrapRequested("base"), /flags require/);
+    process.env.DEPLOY_ACTIVE_TAG = UPV4_BOOTSTRAP_TAG;
+    assert.equal(bootstrapRequested("base"), true);
+    assert.throws(
+      () => bootstrapRequested("base_staging"),
+      /requires ENABLE_STAGING/
+    );
+    assert.throws(
+      () => bootstrapRequested("localhost"),
+      /cannot target a local network/
+    );
+    process.env.ENABLE_STAGING_UPV4_BOOTSTRAP = "true";
+    assert.throws(
+      () => bootstrapRequested("base"),
+      /conflicting network flags/
+    );
+    delete process.env.ENABLE_BASE_UPV4_BOOTSTRAP;
+    assert.equal(bootstrapRequested("base_staging"), true);
+    delete process.env.ENABLE_STAGING_UPV4_BOOTSTRAP;
+    assert.throws(() => bootstrapRequested("base"), /requires ENABLE_BASE/);
+    assert.equal(bootstrapRequested("hardhat"), true);
+    assert.throws(() => bootstrapRequested("sepolia"), /does not support/);
+  } finally {
+    keys.forEach((key, index) => {
+      if (saved[index] === undefined) delete process.env[key];
+      else process.env[key] = saved[index];
+    });
+  }
+});

--- a/scripts/upv4-caller-inventory.spec.cjs
+++ b/scripts/upv4-caller-inventory.spec.cjs
@@ -1,0 +1,223 @@
+require(require.resolve("ts-node/register/transpile-only"));
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+const { utils } = require("ethers");
+const { inspectUpv4Callers } = require("./inspect-upv4-callers.ts");
+
+const registry = "0x0000000000000000000000000000000000000010";
+const caller = "0x0000000000000000000000000000000000000020";
+const knownCaller = "0x0000000000000000000000000000000000000030";
+const owner = "0x0000000000000000000000000000000000000040";
+const iface = new utils.Interface([
+  "event OrchestratorAdded(address indexed orchestrator)",
+  "event OrchestratorRemoved(address indexed orchestrator)",
+  "function isOrchestrator(address) view returns (bool)",
+  "function owner() view returns (address)",
+]);
+const blockHash = (/** @type {number} */ block) => utils.id(`block-${block}`);
+const deployment = {
+  address: registry,
+  transactionHash: utils.id("creation"),
+  bytecode: "0x123456",
+  deployedBytecode: "0x1234",
+};
+function event(
+  /** @type {string} */ name,
+  /** @type {number} */ block,
+  index = 0
+) {
+  const encoded = iface.encodeEventLog(iface.getEvent(name), [caller]);
+  return {
+    address: registry,
+    blockNumber: block,
+    blockHash: blockHash(block),
+    transactionHash: utils.id(`event-${block}`),
+    transactionIndex: 0,
+    logIndex: index,
+    removed: false,
+    ...encoded,
+  };
+}
+function fixture() {
+  const events = [
+    event("OrchestratorAdded", 10),
+    event("OrchestratorRemoved", 12),
+    event("OrchestratorAdded", 14),
+  ];
+  /** @type {Array<[number, number]>} */
+  const ranges = [];
+  /** @type {Array<number>} */
+  const callBlocks = [];
+  const authorized = new Map([
+    [caller, true],
+    [knownCaller, false],
+  ]);
+  const receipt = {
+    status: 1,
+    contractAddress: registry,
+    transactionHash: deployment.transactionHash,
+    blockNumber: 10,
+    blockHash: blockHash(10),
+  };
+  const creation = {
+    hash: deployment.transactionHash,
+    to: null,
+    data: deployment.bytecode,
+    blockHash: receipt.blockHash,
+  };
+  /** @type {any} */
+  const provider = {
+    getNetwork: async () => ({ chainId: 8453 }),
+    getTransactionReceipt: async () => receipt,
+    getTransaction: async () => creation,
+    getBlock: async (/** @type {number} */ number) => ({
+      number,
+      hash: blockHash(number),
+    }),
+    getCode: async (
+      /** @type {string} */ address,
+      /** @type {number} */ block
+    ) =>
+      address === registry
+        ? block < 10
+          ? "0x"
+          : deployment.deployedBytecode
+        : "0x56",
+    getLogs: async (
+      /** @type {{fromBlock: number, toBlock: number}} */ range
+    ) => {
+      ranges.push([range.fromBlock, range.toBlock]);
+      return events.filter(
+        (entry) =>
+          entry.blockNumber >= range.fromBlock &&
+          entry.blockNumber <= range.toBlock
+      );
+    },
+    call: async (
+      /** @type {{data: string}} */ tx,
+      /** @type {number} */ block
+    ) => {
+      callBlocks.push(block);
+      const decoded = iface.parseTransaction(tx);
+      return iface.encodeFunctionResult(
+        decoded.name,
+        decoded.name === "owner"
+          ? [owner]
+          : [authorized.get(decoded.args[0]) === true]
+      );
+    },
+  };
+  return {
+    provider,
+    events,
+    ranges,
+    callBlocks,
+    authorized,
+    receipt,
+    creation,
+  };
+}
+const inspect = (/** @type {ReturnType<typeof fixture>} */ state) =>
+  inspectUpv4Callers(state.provider, deployment, [knownCaller], 15, 2);
+
+test("scans the complete creation-to-anchor range and reconciles removed/readded plus known callers", async () => {
+  const state = fixture();
+  const result = await inspect(state);
+  assert.deepEqual(state.ranges, [
+    [10, 11],
+    [12, 13],
+    [14, 15],
+  ]);
+  assert.deepEqual(state.callBlocks, [15, 15, 15]);
+  assert.equal(result.blockHash, blockHash(15));
+  assert.equal(result.creationBlockHash, blockHash(10));
+  assert.equal(result.owner, owner);
+  assert.equal(result.events.length, 3);
+  assert.deepEqual(result.callers, [
+    {
+      address: caller,
+      authorized: true,
+      runtimeCodeHash: utils.keccak256("0x56"),
+    },
+    {
+      address: knownCaller,
+      authorized: false,
+      runtimeCodeHash: utils.keccak256("0x56"),
+    },
+  ]);
+  assert.equal("activationReady" in result, false);
+});
+
+test("rejects missing add/remove transitions, duplicate and out-of-range events", async () => {
+  for (const corrupt of [
+    (/** @type {ReturnType<typeof fixture>} */ state) => state.events.shift(),
+    (/** @type {ReturnType<typeof fixture>} */ state) =>
+      state.events.splice(1, 1),
+    (/** @type {ReturnType<typeof fixture>} */ state) =>
+      state.events.push(state.events[0]),
+    (/** @type {ReturnType<typeof fixture>} */ state) => {
+      state.provider.getLogs = async () => [event("OrchestratorAdded", 16)];
+    },
+  ]) {
+    const state = fixture();
+    corrupt(state);
+    await assert.rejects(
+      inspect(state),
+      /Inconsistent registry history|Malformed, duplicate or out-of-range/
+    );
+  }
+});
+
+test("detects omitted known active callers and final state disagreement", async () => {
+  for (const address of [caller, knownCaller]) {
+    const state = fixture();
+    state.authorized.set(address, !state.authorized.get(address));
+    await assert.rejects(
+      inspect(state),
+      /Registry getter disagrees with history/
+    );
+  }
+});
+
+test("rejects wrong chain, constructor, creation boundary and runtime before scanning", async () => {
+  for (const corrupt of [
+    (/** @type {ReturnType<typeof fixture>} */ state) => {
+      state.provider.getNetwork = async () => ({ chainId: 1 });
+    },
+    (/** @type {ReturnType<typeof fixture>} */ state) => {
+      state.creation.data = "0x9999";
+    },
+    (/** @type {ReturnType<typeof fixture>} */ state) => {
+      state.provider.getCode = async () => deployment.deployedBytecode;
+    },
+    (/** @type {ReturnType<typeof fixture>} */ state) => {
+      state.provider.getCode = async () => "0x9999";
+    },
+  ]) {
+    const state = fixture();
+    corrupt(state);
+    await assert.rejects(
+      inspect(state),
+      /requires Base|creation does not match|runtime or creation boundary/
+    );
+    assert.deepEqual(state.ranges, []);
+  }
+});
+
+test("RPC failures and anchor reorgs fail without returning an inventory", async () => {
+  const failed = fixture();
+  failed.provider.getLogs = async () => {
+    throw new Error("archive unavailable");
+  };
+  await assert.rejects(inspect(failed), /archive unavailable/);
+  const reorg = fixture();
+  let anchorReads = 0;
+  reorg.provider.getBlock = async (/** @type {number} */ number) => ({
+    number,
+    hash:
+      number === 15 && ++anchorReads > 1
+        ? utils.id("reorg")
+        : blockHash(number),
+  });
+  await assert.rejects(inspect(reorg), /Chain reorganized/);
+});

--- a/test-foundry/deterministic/integration/DisputeLifecycleHookOrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/DisputeLifecycleHookOrchestratorV3.t.sol
@@ -275,7 +275,7 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         vm.expectRevert(
             abi.encodeWithSelector(IDisputeVerifier.InvalidPaymentBinding.selector, intentHash, paymentNullifier)
         );
-        disputeProtectionPolicy.submitDispute(_attestation(intentHash, paymentId, keccak256("dispute")));
+        disputeProtectionPolicy.submitDispute(_attestation(intentHash, paymentId, keccak256("dispute"), 100));
     }
 
     function test_DisputeAfterFulfillPaysDepositorClaim() public {
@@ -287,7 +287,7 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         bytes32 paymentNullifier = keccak256(abi.encodePacked(METHOD, paymentId));
         nullifierRegistry.addWritePermission(address(this));
         nullifierRegistry.addNullifier(paymentNullifier, intentHash);
-        disputeProtectionPolicy.submitDispute(_attestation(intentHash, paymentId, keccak256("dispute")));
+        disputeProtectionPolicy.submitDispute(_attestation(intentHash, paymentId, keccak256("dispute"), 100));
 
         assertEq(vault.claimable(depositor), INTENT_AMOUNT);
         assertEq(vault.lockedStake(taker), 0);
@@ -432,7 +432,9 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
             uint256(disputeProtectionPolicy.getDisputeProtectionIntent(regularIntent).status),
             uint256(IDisputeProtectionPolicy.DisputeProtectionIntentStatus.SETTLED)
         );
-        disputeProtectionPolicy.submitDispute(_attestation(regularIntent, regularPayment, keccak256("regular-dispute")));
+        disputeProtectionPolicy.submitDispute(
+            _attestation(regularIntent, regularPayment, keccak256("regular-dispute"), 5_000)
+        );
         assertEq(vault.claimable(depositor), INTENT_AMOUNT);
         assertEq(vault.lockedStake(taker), 0);
         assertEq(escrow.getDeposit(depositId).remainingDeposits, remainingBefore - 2 * INTENT_AMOUNT);
@@ -606,7 +608,7 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
         params.to = recipient;
     }
 
-    function _attestation(bytes32 intentHash, bytes32 paymentId, bytes32 disputeId)
+    function _attestation(bytes32 intentHash, bytes32 paymentId, bytes32 disputeId, uint256 paymentAmount)
         internal
         pure
         returns (IDisputeVerifier.DisputeAttestation memory attestation)
@@ -615,7 +617,7 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
             paymentMethod: METHOD,
             originalPaymentId: paymentId,
             disputeId: disputeId,
-            paymentAmount: 100,
+            paymentAmount: paymentAmount,
             paymentCurrency: USD
         });
         bytes memory data = abi.encode(details);

--- a/test-foundry/deterministic/integration/DisputeLifecycleHookOrchestratorV3.t.sol
+++ b/test-foundry/deterministic/integration/DisputeLifecycleHookOrchestratorV3.t.sol
@@ -15,11 +15,15 @@ import {AttestationVerifierMock} from "contracts/mocks/AttestationVerifierMock.s
 import {AddressGroupRegistry} from "contracts/registries/AddressGroupRegistry.sol";
 import {NullifierRegistry} from "contracts/registries/NullifierRegistry.sol";
 import {NullifierRegistryV2} from "contracts/registries/NullifierRegistryV2.sol";
+import {UnifiedPaymentVerifierV4} from "contracts/unifiedVerifier/UnifiedPaymentVerifierV4.sol";
+import {SimpleAttestationVerifier} from "contracts/unifiedVerifier/SimpleAttestationVerifier.sol";
 import {DisputeVerifier} from "contracts/unifiedVerifier/DisputeVerifier.sol";
 
 import {OrchestratorV3Fixture} from "../helpers/OrchestratorV3Fixture.sol";
 
 contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
+    bytes32 internal constant BALANCE_METHOD = keccak256("venmo-balance");
+    uint256 internal constant PAYMENT_WITNESS_KEY = 0xBABA;
     uint64 internal constant RISK_WINDOW = 30 days;
     uint256 internal constant STAKE_AMOUNT = 500e6;
     bytes32 internal constant WINDOWLESS_METHOD = keccak256("windowless");
@@ -399,6 +403,163 @@ contract DisputeLifecycleHookOrchestratorV3Test is OrchestratorV3Fixture {
             uint256(IDisputeProtectionPolicy.DisputeProtectionIntentStatus.CANCELLED)
         );
         assertEq(vault.lockedStake(taker), releaseAmount);
+    }
+
+    function test_Upv4BalanceSettlementHasNoStakeOrCoverageAndKeepsRegularDisputes() public {
+        UnifiedPaymentVerifierV4 unified = _installUnifiedVerifier();
+        IOrchestratorV3.SignalIntentParams memory params = _paramsFor(other);
+        params.paymentMethod = BALANCE_METHOD;
+        uint256 remainingBefore = escrow.getDeposit(depositId).remainingDeposits;
+        bytes32 balanceIntent = _signal(other, params);
+        bytes32 balancePayment = keccak256("balance-payment");
+        _fulfillUnified(unified, balanceIntent, balancePayment);
+
+        assertEq(vault.lockedStake(other), 0);
+        assertEq(
+            uint256(disputeProtectionPolicy.getDisputeProtectionIntent(balanceIntent).status),
+            uint256(IDisputeProtectionPolicy.DisputeProtectionIntentStatus.NONE)
+        );
+        assertEq(
+            nullifierRegistry.nullifierByIntentHash(balanceIntent), keccak256(abi.encodePacked(METHOD, balancePayment))
+        );
+        assertEq(escrow.getDeposit(depositId).remainingDeposits, remainingBefore - INTENT_AMOUNT);
+
+        bytes32 regularIntent = _signalDefault();
+        bytes32 regularPayment = keccak256("regular-payment");
+        assertEq(vault.lockedStake(taker), INTENT_AMOUNT);
+        _fulfillUnified(unified, regularIntent, regularPayment);
+        assertEq(
+            uint256(disputeProtectionPolicy.getDisputeProtectionIntent(regularIntent).status),
+            uint256(IDisputeProtectionPolicy.DisputeProtectionIntentStatus.SETTLED)
+        );
+        disputeProtectionPolicy.submitDispute(_attestation(regularIntent, regularPayment, keccak256("regular-dispute")));
+        assertEq(vault.claimable(depositor), INTENT_AMOUNT);
+        assertEq(vault.lockedStake(taker), 0);
+        assertEq(escrow.getDeposit(depositId).remainingDeposits, remainingBefore - 2 * INTENT_AMOUNT);
+    }
+
+    function test_Upv4BalanceWhitelistRejectsNonmembersRegardlessOfAvailableStake() public {
+        _installUnifiedVerifier();
+        address[] memory members = new address[](1);
+        members[0] = other;
+        vm.prank(depositor);
+        whitelistPolicy.configureDeposit(address(escrow), depositId, BALANCE_METHOD, true, new bytes32[](0), members);
+        IOrchestratorV3.SignalIntentParams memory params = _defaultParams();
+        params.paymentMethod = BALANCE_METHOD;
+        uint256 remainingBefore = escrow.getDeposit(depositId).remainingDeposits;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IntentLifecycleHookV1.TakerNotWhitelisted.selector, address(escrow), depositId, BALANCE_METHOD, taker
+            )
+        );
+        _signalCall(taker, params);
+        assertEq(escrow.getDeposit(depositId).remainingDeposits, remainingBefore);
+        assertEq(vault.lockedStake(taker), 0);
+
+        params.to = other;
+        bytes32 intentHash = _signal(other, params);
+        assertEq(vault.lockedStake(other), 0);
+        assertEq(
+            uint256(disputeProtectionPolicy.getDisputeProtectionIntent(intentHash).status),
+            uint256(IDisputeProtectionPolicy.DisputeProtectionIntentStatus.NONE)
+        );
+    }
+
+    function test_Upv4SharedReplayRollsBackSettlementInBothDirections() public {
+        _upv4Replay(METHOD, BALANCE_METHOD);
+    }
+
+    function test_Upv4SharedReplayRollsBackBalanceToRegularSettlement() public {
+        _upv4Replay(BALANCE_METHOD, METHOD);
+    }
+
+    function _upv4Replay(bytes32 firstMethod, bytes32 secondMethod) internal {
+        UnifiedPaymentVerifierV4 unified = _installUnifiedVerifier();
+        IOrchestratorV3.SignalIntentParams memory params = _defaultParams();
+        params.paymentMethod = firstMethod;
+        bytes32 first = _signal(taker, params);
+        bytes32 paymentId = keccak256("one-original-payment");
+        _fulfillUnified(unified, first, paymentId);
+        params.paymentMethod = secondMethod;
+        bytes32 second = _signal(taker, params);
+        uint256 remainingBefore = escrow.getDeposit(depositId).remainingDeposits;
+        uint256 recipientBefore = token.balanceOf(taker);
+        bytes memory proof = _unifiedProof(unified, second, paymentId);
+        vm.expectRevert("Nullifier has already been used");
+        orchestrator.fulfillIntent(
+            IOrchestratorV3.FulfillIntentParams({
+                paymentProof: proof, intentHash: second, verificationData: "", postIntentHookData: ""
+            })
+        );
+        assertEq(escrow.getDeposit(depositId).remainingDeposits, remainingBefore);
+        assertEq(token.balanceOf(taker), recipientBefore);
+        assertEq(orchestrator.getIntent(second).owner, taker);
+        assertEq(nullifierRegistry.intentHashByNullifier(keccak256(abi.encodePacked(METHOD, paymentId))), first);
+        assertEq(nullifierRegistry.nullifierByIntentHash(second), bytes32(0));
+    }
+
+    function _installUnifiedVerifier() internal returns (UnifiedPaymentVerifierV4 unified) {
+        _addPaymentMethod(BALANCE_METHOD);
+        unified = new UnifiedPaymentVerifierV4(
+            orchestratorRegistry, nullifierRegistry, new SimpleAttestationVerifier(vm.addr(PAYMENT_WITNESS_KEY))
+        );
+        nullifierRegistry.addWritePermission(address(unified));
+        bytes32[] memory supportedCurrencies = new bytes32[](1);
+        supportedCurrencies[0] = USD;
+        for (uint256 i; i < 2; ++i) {
+            bytes32 method = i == 0 ? METHOD : BALANCE_METHOD;
+            unified.addPaymentMethod(method, METHOD);
+            paymentVerifierRegistry.removePaymentMethod(method);
+            paymentVerifierRegistry.addPaymentMethod(method, address(unified), supportedCurrencies);
+        }
+    }
+
+    function _fulfillUnified(UnifiedPaymentVerifierV4 unified, bytes32 intentHash, bytes32 paymentId) internal {
+        orchestrator.fulfillIntent(
+            IOrchestratorV3.FulfillIntentParams({
+                paymentProof: _unifiedProof(unified, intentHash, paymentId),
+                intentHash: intentHash,
+                verificationData: "",
+                postIntentHookData: ""
+            })
+        );
+    }
+
+    function _unifiedProof(UnifiedPaymentVerifierV4 unified, bytes32 intentHash, bytes32 paymentId)
+        internal
+        view
+        returns (bytes memory)
+    {
+        IOrchestratorV3.Intent memory intent = orchestrator.getIntent(intentHash);
+        bytes memory data = abi.encode(
+            UnifiedPaymentVerifierV4.PaymentDetails(
+                intent.paymentMethod, PAYEE, 5_000, USD, block.timestamp * 1000, paymentId
+            ),
+            UnifiedPaymentVerifierV4.IntentSnapshot(
+                intentHash, intent.amount, intent.paymentMethod, USD, PAYEE, intent.conversionRate, intent.timestamp, 30
+            )
+        );
+        bytes32 dataHash = keccak256(data);
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                unified.DOMAIN_SEPARATOR(),
+                keccak256(
+                    abi.encode(
+                        keccak256("PaymentAttestation(bytes32 intentHash,uint256 releaseAmount,bytes32 dataHash)"),
+                        intentHash,
+                        INTENT_AMOUNT,
+                        dataHash
+                    )
+                )
+            )
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PAYMENT_WITNESS_KEY, digest);
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = abi.encodePacked(r, s, v);
+        return abi.encode(
+            UnifiedPaymentVerifierV4.PaymentAttestation(intentHash, INTENT_AMOUNT, dataHash, signatures, data, "")
+        );
     }
 
     function _setWhitelist(bool enabled, bool includeTaker) internal {

--- a/test-foundry/deterministic/integration/UnifiedVerifierAdmissionMaintenance.t.sol
+++ b/test-foundry/deterministic/integration/UnifiedVerifierAdmissionMaintenance.t.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {Orchestrator} from "contracts/Orchestrator.sol";
+import {OrchestratorV2} from "contracts/OrchestratorV2.sol";
+import {IOrchestrator} from "contracts/interfaces/IOrchestrator.sol";
+import {IOrchestratorV2} from "contracts/interfaces/IOrchestratorV2.sol";
+import {IPostIntentHook} from "contracts/interfaces/IPostIntentHook.sol";
+import {IPostIntentHookV2} from "contracts/interfaces/IPostIntentHookV2.sol";
+import {PostIntentHookRegistry} from "contracts/registries/PostIntentHookRegistry.sol";
+import {NullifierRegistry} from "contracts/registries/NullifierRegistry.sol";
+import {NullifierRegistryV2} from "contracts/registries/NullifierRegistryV2.sol";
+import {SimpleAttestationVerifier} from "contracts/unifiedVerifier/SimpleAttestationVerifier.sol";
+import {UnifiedPaymentVerifierV3} from "contracts/unifiedVerifier/UnifiedPaymentVerifierV3.sol";
+import {OrchestratorV3Fixture} from "../helpers/OrchestratorV3Fixture.sol";
+
+/// @notice Tests the admission-only maintenance prerequisite for a shared-verifier cutover.
+contract UnifiedVerifierAdmissionMaintenanceTest is OrchestratorV3Fixture {
+    uint256 internal constant WITNESS_KEY = 0xCAFE;
+    Orchestrator internal legacyV1;
+    OrchestratorV2 internal legacyV2;
+    UnifiedPaymentVerifierV3 internal predecessor;
+    NullifierRegistryV2 internal nullifiers;
+
+    function setUp() public override {
+        super.setUp();
+        vm.warp(1_000_000);
+        legacyV1 = new Orchestrator(
+            address(this),
+            CHAIN_ID,
+            address(escrowRegistry),
+            address(paymentVerifierRegistry),
+            address(new PostIntentHookRegistry()),
+            address(relayerRegistry),
+            0,
+            protocolFeeRecipient
+        );
+        legacyV2 = new OrchestratorV2(
+            address(this),
+            CHAIN_ID,
+            address(escrowRegistry),
+            address(paymentVerifierRegistry),
+            address(relayerRegistry),
+            0,
+            protocolFeeRecipient
+        );
+        legacyV1.setAllowMultipleIntents(true);
+        legacyV2.setAllowMultipleIntents(true);
+        orchestratorRegistry.addOrchestrator(address(legacyV1));
+        orchestratorRegistry.addOrchestrator(address(legacyV2));
+        nullifiers = new NullifierRegistryV2(new NullifierRegistry());
+        predecessor = new UnifiedPaymentVerifierV3(
+            orchestratorRegistry, nullifiers, new SimpleAttestationVerifier(vm.addr(WITNESS_KEY))
+        );
+        nullifiers.addWritePermission(address(predecessor));
+        predecessor.addPaymentMethod(METHOD);
+        paymentVerifierRegistry.removePaymentMethod(METHOD);
+        bytes32[] memory currencies = new bytes32[](1);
+        currencies[0] = USD;
+        paymentVerifierRegistry.addPaymentMethod(METHOD, address(predecessor), currencies);
+    }
+
+    function test_ClosedEscrowAdmissionPreservesPaidSettlementAndUnpaidCancellationForEveryCaller() public {
+        bytes32[3] memory paid;
+        bytes32[3] memory unpaid;
+        for (uint256 kind; kind < 3; ++kind) {
+            paid[kind] = _startIntent(kind);
+            unpaid[kind] = _startIntent(kind);
+        }
+        // Both conditions are necessary: an empty allowlist alone is not maintenance.
+        escrowRegistry.setAcceptAllEscrows(true);
+        escrowRegistry.setAcceptAllEscrows(false);
+        escrowRegistry.removeEscrow(address(escrow));
+        assertEq(escrowRegistry.getWhitelistedEscrows().length, 0);
+        for (uint256 kind; kind < 3; ++kind) {
+            vm.expectRevert(abi.encodeWithSelector(IOrchestrator.EscrowNotWhitelisted.selector, address(escrow)));
+            _callSignal(kind);
+
+            bytes32 paymentId = keccak256(abi.encode("paid-before-maintenance", kind));
+            IOrchestrator(_caller(kind))
+                .fulfillIntent(IOrchestrator.FulfillIntentParams(_proof(paid[kind], paymentId), paid[kind], "", ""));
+            assertEq(nullifiers.intentHashByNullifier(keccak256(abi.encodePacked(METHOD, paymentId))), paid[kind]);
+            vm.prank(taker);
+            IOrchestrator(_caller(kind)).cancelIntent(unpaid[kind]);
+            assertEq(IOrchestrator(_caller(kind)).getAccountIntents(taker).length, 0);
+        }
+        assertEq(token.balanceOf(taker), 3 * INTENT_AMOUNT);
+        assertEq(escrow.getDepositIntentHashes(depositId).length, 0);
+        assertEq(escrow.getDeposit(depositId).remainingDeposits, 500e6 - 3 * INTENT_AMOUNT);
+        assertEq(paymentVerifierRegistry.getVerifier(METHOD), address(predecessor));
+        assertTrue(nullifiers.isWriter(address(predecessor)));
+    }
+
+    function test_PausingOrDeauthorizingBeforeDrainStrandsPaidSettlement() public {
+        bytes32 intentHash = _startIntent(1);
+        bytes memory proof = _proof(intentHash, keccak256("already-paid"));
+        legacyV2.pauseOrchestrator();
+        vm.expectRevert("Pausable: paused");
+        legacyV2.fulfillIntent(IOrchestratorV2.FulfillIntentParams(proof, intentHash, "", ""));
+        legacyV2.unpauseOrchestrator();
+        orchestratorRegistry.removeOrchestrator(address(legacyV2));
+        vm.expectRevert("Only orchestrator can call");
+        legacyV2.fulfillIntent(IOrchestratorV2.FulfillIntentParams(proof, intentHash, "", ""));
+        assertEq(nullifiers.nullifierByIntentHash(intentHash), bytes32(0));
+        assertEq(legacyV2.getIntent(intentHash).owner, taker);
+        assertEq(escrow.getDepositIntent(depositId, intentHash).intentHash, intentHash);
+    }
+
+    function _caller(uint256 kind) internal view returns (address) {
+        if (kind == 0) return address(legacyV1);
+        if (kind == 1) return address(legacyV2);
+        return address(orchestrator);
+    }
+
+    function _startIntent(uint256 kind) internal returns (bytes32) {
+        _callSignal(kind);
+        bytes32[] memory intents = IOrchestrator(_caller(kind)).getAccountIntents(taker);
+        return intents[intents.length - 1];
+    }
+
+    function _callSignal(uint256 kind) internal {
+        vm.prank(taker);
+        if (kind == 0) {
+            legacyV1.signalIntent(
+                IOrchestrator.SignalIntentParams({
+                    escrow: address(escrow),
+                    depositId: depositId,
+                    amount: INTENT_AMOUNT,
+                    to: taker,
+                    paymentMethod: METHOD,
+                    fiatCurrency: USD,
+                    conversionRate: CONVERSION_RATE,
+                    referrer: address(0),
+                    referrerFee: 0,
+                    gatingServiceSignature: "",
+                    signatureExpiration: 0,
+                    postIntentHook: IPostIntentHook(address(0)),
+                    data: ""
+                })
+            );
+        } else {
+            IOrchestratorV2(_caller(kind))
+                .signalIntent(
+                    IOrchestratorV2.SignalIntentParams({
+                    escrow: address(escrow),
+                    depositId: depositId,
+                    amount: INTENT_AMOUNT,
+                    to: taker,
+                    paymentMethod: METHOD,
+                    fiatCurrency: USD,
+                    conversionRate: CONVERSION_RATE,
+                    referralFees: _emptyReferralFees(),
+                    gatingServiceSignature: "",
+                    signatureExpiration: 0,
+                    postIntentHook: IPostIntentHookV2(address(0)),
+                    preIntentHookData: "",
+                    data: ""
+                })
+                );
+        }
+    }
+
+    function _proof(bytes32 intentHash, bytes32 paymentId) internal view returns (bytes memory) {
+        bytes memory data = abi.encode(
+            UnifiedPaymentVerifierV3.PaymentDetails(METHOD, PAYEE, 5_000, USD, block.timestamp * 1000, paymentId),
+            UnifiedPaymentVerifierV3.IntentSnapshot(
+                intentHash, INTENT_AMOUNT, METHOD, USD, PAYEE, CONVERSION_RATE, block.timestamp, 0
+            )
+        );
+        bytes32 dataHash = keccak256(data);
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                predecessor.DOMAIN_SEPARATOR(),
+                keccak256(
+                    abi.encode(
+                        keccak256("PaymentAttestation(bytes32 intentHash,uint256 releaseAmount,bytes32 dataHash)"),
+                        intentHash,
+                        INTENT_AMOUNT,
+                        dataHash
+                    )
+                )
+            )
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(WITNESS_KEY, digest);
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = abi.encodePacked(r, s, v);
+        return abi.encode(
+            UnifiedPaymentVerifierV3.PaymentAttestation(intentHash, INTENT_AMOUNT, dataHash, signatures, data, "")
+        );
+    }
+}

--- a/test-foundry/deterministic/verifiers/UnifiedPaymentVerifierV4.t.sol
+++ b/test-foundry/deterministic/verifiers/UnifiedPaymentVerifierV4.t.sol
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+import {UnifiedPaymentVerifierV4} from "contracts/unifiedVerifier/UnifiedPaymentVerifierV4.sol";
+import {UnifiedPaymentVerifierV3} from "contracts/unifiedVerifier/UnifiedPaymentVerifierV3.sol";
+import {SimpleAttestationVerifier} from "contracts/unifiedVerifier/SimpleAttestationVerifier.sol";
+import {UnifiedPaymentVerifierV3CallerHarness} from "contracts/mocks/UnifiedPaymentVerifierV3Harness.sol";
+import {NullifierRegistry} from "contracts/registries/NullifierRegistry.sol";
+import {NullifierRegistryV2} from "contracts/registries/NullifierRegistryV2.sol";
+import {OrchestratorRegistry} from "contracts/registries/OrchestratorRegistry.sol";
+import {INullifierRegistry} from "contracts/interfaces/INullifierRegistry.sol";
+import {INullifierRegistryV2} from "contracts/interfaces/INullifierRegistryV2.sol";
+import {IOrchestrator} from "contracts/interfaces/IOrchestrator.sol";
+import {IOrchestratorV2} from "contracts/interfaces/IOrchestratorV2.sol";
+import {IPaymentVerifier} from "contracts/interfaces/IPaymentVerifier.sol";
+import {IPostIntentHook} from "contracts/interfaces/IPostIntentHook.sol";
+import {IPostIntentHookV2} from "contracts/interfaces/IPostIntentHookV2.sol";
+import {IReferralFee} from "contracts/interfaces/IReferralFee.sol";
+import {UnifiedVerifierV2CallerHarness} from "./UnifiedPaymentVerifierV3.t.sol";
+
+contract UnifiedPaymentVerifierV4Test is Test {
+    event PaymentVerified(
+        bytes32 indexed intentHash,
+        bytes32 indexed method,
+        bytes32 indexed currency,
+        uint256 amount,
+        uint256 timestamp,
+        bytes32 paymentId,
+        bytes32 payeeId
+    );
+
+    uint256 internal constant WITNESS_KEY = 0xA11CE;
+    uint256 internal constant AMOUNT = 50e6;
+    uint256 internal constant TIMESTAMP = 1_000_000;
+    bytes32 internal constant VENMO = keccak256("venmo");
+    bytes32 internal constant BALANCE = keccak256("venmo-balance");
+    bytes32 internal constant PAYPAL = keccak256("paypal");
+    bytes32 internal constant USD = keccak256("USD");
+    bytes32 internal constant PAYEE = keccak256("payee");
+    bytes32 internal constant PAYMENT = keccak256("canonical-venmo-payment");
+    bytes32 internal constant FIRST_INTENT = keccak256("first-intent");
+    bytes32 internal constant SECOND_INTENT = keccak256("second-intent");
+
+    NullifierRegistry internal legacyRegistry;
+    NullifierRegistryV2 internal registry;
+    OrchestratorRegistry internal orchestrators;
+    SimpleAttestationVerifier internal attestor;
+    UnifiedPaymentVerifierV4 internal verifier;
+    UnifiedPaymentVerifierV3CallerHarness internal firstCaller;
+    UnifiedVerifierV2CallerHarness internal secondCaller;
+
+    function setUp() public {
+        vm.warp(TIMESTAMP);
+        legacyRegistry = new NullifierRegistry();
+        registry = new NullifierRegistryV2(INullifierRegistry(address(legacyRegistry)));
+        orchestrators = new OrchestratorRegistry();
+        attestor = new SimpleAttestationVerifier(vm.addr(WITNESS_KEY));
+        verifier = new UnifiedPaymentVerifierV4(orchestrators, registry, attestor);
+        firstCaller = new UnifiedPaymentVerifierV3CallerHarness();
+        secondCaller = new UnifiedVerifierV2CallerHarness();
+        orchestrators.addOrchestrator(address(firstCaller));
+        orchestrators.addOrchestrator(address(secondCaller));
+        registry.addWritePermission(address(verifier));
+        legacyRegistry.addWritePermission(address(this));
+        verifier.addPaymentMethod(VENMO, VENMO);
+        verifier.addPaymentMethod(BALANCE, VENMO);
+        verifier.addPaymentMethod(PAYPAL, PAYPAL);
+    }
+
+    function test_ExplicitNamespacesAndStableActiveMethodOrder() public view {
+        bytes32[] memory methods = verifier.getPaymentMethods();
+        assertEq(methods.length, 3);
+        assertEq(methods[0], VENMO);
+        assertEq(methods[1], BALANCE);
+        assertEq(methods[2], PAYPAL);
+        assertEq(verifier.nullifierNamespace(VENMO), VENMO);
+        assertEq(verifier.nullifierNamespace(BALANCE), VENMO);
+        assertEq(verifier.nullifierNamespace(PAYPAL), PAYPAL);
+    }
+
+    function test_RegistrationRejectsZeroValuesAndUnauthorizedCallers() public {
+        bytes32 fresh = keccak256("fresh");
+        vm.expectRevert("UPV: Invalid payment method");
+        verifier.addPaymentMethod(bytes32(0), VENMO);
+        vm.expectRevert("UPV: Invalid nullifier namespace");
+        verifier.addPaymentMethod(fresh, bytes32(0));
+        vm.prank(makeAddr("outsider"));
+        vm.expectRevert("Ownable: caller is not the owner");
+        verifier.addPaymentMethod(fresh, fresh);
+        assertFalse(verifier.isPaymentMethod(fresh));
+        assertEq(verifier.nullifierNamespace(fresh), bytes32(0));
+    }
+
+    function test_DisableRetainsNamespaceAndReactivationCannotChangeIt() public {
+        vm.expectRevert("UPV: Payment method already exists");
+        verifier.addPaymentMethod(BALANCE, VENMO);
+        vm.prank(makeAddr("outsider"));
+        vm.expectRevert("Ownable: caller is not the owner");
+        verifier.removePaymentMethod(BALANCE);
+        verifier.removePaymentMethod(BALANCE);
+        assertFalse(verifier.isPaymentMethod(BALANCE));
+        assertEq(verifier.nullifierNamespace(BALANCE), VENMO);
+        vm.expectRevert("UPV: Nullifier namespace mismatch");
+        verifier.addPaymentMethod(BALANCE, BALANCE);
+        verifier.addPaymentMethod(BALANCE, VENMO);
+        assertTrue(verifier.isPaymentMethod(BALANCE));
+        assertEq(verifier.nullifierNamespace(BALANCE), VENMO);
+    }
+
+    function test_NamespaceIsFinalNotARecursiveAlias() public {
+        bytes32 method = keccak256("alias");
+        verifier.addPaymentMethod(method, BALANCE);
+        _setFirstIntent(method);
+        _firstVerify(verifier, method, PAYMENT);
+        assertTrue(registry.isNullified(keccak256(abi.encodePacked(BALANCE, PAYMENT))));
+        assertFalse(registry.isNullified(_venmoNullifier(PAYMENT)));
+    }
+
+    function test_RegularThenBalanceRejectsFreshProofFromAnotherOrchestrator() public {
+        _assertCrossMethodReplay(VENMO, BALANCE);
+    }
+
+    function test_BalanceThenRegularRejectsFreshProofFromAnotherOrchestrator() public {
+        _assertCrossMethodReplay(BALANCE, VENMO);
+    }
+
+    function test_ReattestationWithDifferentAmountAndCurrencyCannotResetConsumption() public {
+        _setFirstIntent(VENMO);
+        _firstVerify(verifier, VENMO, PAYMENT);
+        bytes32 eur = keccak256("EUR");
+        _setSecondIntent(BALANCE, 100e6, eur);
+        bytes memory proof = _proof(SECOND_INTENT, BALANCE, PAYMENT, verifier.DOMAIN_SEPARATOR(), 100e6, eur);
+        vm.expectRevert("Nullifier has already been used");
+        secondCaller.verifyPayment(verifier, _verifyData(SECOND_INTENT, proof));
+        assertEq(registry.intentHashByNullifier(_venmoNullifier(PAYMENT)), FIRST_INTENT);
+    }
+
+    function test_PredecessorHistoryRejectsBothMethods() public {
+        legacyRegistry.addNullifier(_venmoNullifier(PAYMENT));
+        _setFirstIntent(BALANCE);
+        bytes memory proof = _proof(FIRST_INTENT, BALANCE, PAYMENT, verifier.DOMAIN_SEPARATOR(), AMOUNT, USD);
+        vm.expectRevert("Nullifier has already been used");
+        firstCaller.verifyPayment(verifier, _verifyData(FIRST_INTENT, proof));
+        _setFirstIntent(VENMO);
+        proof = _proof(FIRST_INTENT, VENMO, PAYMENT, verifier.DOMAIN_SEPARATOR(), AMOUNT, USD);
+        vm.expectRevert("Nullifier has already been used");
+        firstCaller.verifyPayment(verifier, _verifyData(FIRST_INTENT, proof));
+    }
+
+    function test_V3HistorySurvivesVerifierReplacement() public {
+        UnifiedPaymentVerifierV3 previous = new UnifiedPaymentVerifierV3(orchestrators, registry, attestor);
+        previous.addPaymentMethod(VENMO);
+        registry.addWritePermission(address(previous));
+        _setFirstIntent(VENMO);
+        bytes memory proof = _proof(FIRST_INTENT, VENMO, PAYMENT, previous.DOMAIN_SEPARATOR(), AMOUNT, USD);
+        firstCaller.verifyPayment(previous, _verifyData(FIRST_INTENT, proof));
+        registry.removeWritePermission(address(previous));
+        _setSecondIntent(BALANCE, AMOUNT, USD);
+        proof = _proof(SECOND_INTENT, BALANCE, PAYMENT, verifier.DOMAIN_SEPARATOR(), AMOUNT, USD);
+        vm.expectRevert("Nullifier has already been used");
+        secondCaller.verifyPayment(verifier, _verifyData(SECOND_INTENT, proof));
+    }
+
+    function test_ReactivationCannotReopenConsumedPayments() public {
+        _setFirstIntent(BALANCE);
+        _firstVerify(verifier, BALANCE, PAYMENT);
+        verifier.removePaymentMethod(BALANCE);
+        verifier.addPaymentMethod(BALANCE, VENMO);
+        _setSecondIntent(BALANCE, AMOUNT, USD);
+        bytes memory proof = _proof(SECOND_INTENT, BALANCE, PAYMENT, verifier.DOMAIN_SEPARATOR(), AMOUNT, USD);
+        vm.expectRevert("Nullifier has already been used");
+        secondCaller.verifyPayment(verifier, _verifyData(SECOND_INTENT, proof));
+    }
+
+    function test_UnregisteredAndDisabledMethodsCannotConsume() public {
+        bytes32 unknown = keccak256("unknown");
+        _setFirstIntent(unknown);
+        bytes memory proof = _proof(FIRST_INTENT, unknown, PAYMENT, verifier.DOMAIN_SEPARATOR(), AMOUNT, USD);
+        vm.expectRevert("UPV: Invalid payment method");
+        firstCaller.verifyPayment(verifier, _verifyData(FIRST_INTENT, proof));
+        verifier.removePaymentMethod(BALANCE);
+        _setFirstIntent(BALANCE);
+        proof = _proof(FIRST_INTENT, BALANCE, PAYMENT, verifier.DOMAIN_SEPARATOR(), AMOUNT, USD);
+        vm.expectRevert("UPV: Invalid payment method");
+        firstCaller.verifyPayment(verifier, _verifyData(FIRST_INTENT, proof));
+        assertFalse(registry.isNullified(_venmoNullifier(PAYMENT)));
+    }
+
+    function test_DistinctPaymentsAndProviderNamespacesRemainIndependent() public {
+        _setFirstIntent(BALANCE);
+        _firstVerify(verifier, BALANCE, PAYMENT);
+        _setSecondIntent(VENMO, AMOUNT, USD);
+        bytes32 different = keccak256("different-payment");
+        bytes memory proof = _proof(SECOND_INTENT, VENMO, different, verifier.DOMAIN_SEPARATOR(), AMOUNT, USD);
+        secondCaller.verifyPayment(verifier, _verifyData(SECOND_INTENT, proof));
+        assertTrue(registry.isNullified(_venmoNullifier(different)));
+
+        // A separate registry binding is still required even when the opaque provider ID matches.
+        bytes32 thirdIntent = keccak256("third-intent");
+        IOrchestrator.Intent memory intent = firstCaller.getIntent(FIRST_INTENT);
+        intent.paymentMethod = PAYPAL;
+        firstCaller.setIntent(thirdIntent, intent);
+        proof = _proof(thirdIntent, PAYPAL, PAYMENT, verifier.DOMAIN_SEPARATOR(), AMOUNT, USD);
+        firstCaller.verifyPayment(verifier, _verifyData(thirdIntent, proof));
+        assertTrue(registry.isNullified(keccak256(abi.encodePacked(PAYPAL, PAYMENT))));
+        assertEq(registry.intentHashByNullifier(_venmoNullifier(PAYMENT)), FIRST_INTENT);
+    }
+
+    function test_ExistingIntentBindingCannotBeOverwritten() public {
+        _setFirstIntent(BALANCE);
+        _firstVerify(verifier, BALANCE, PAYMENT);
+        bytes memory proof =
+            _proof(FIRST_INTENT, BALANCE, keccak256("new-payment"), verifier.DOMAIN_SEPARATOR(), AMOUNT, USD);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                INullifierRegistryV2.IntentAlreadyBound.selector, FIRST_INTENT, _venmoNullifier(PAYMENT)
+            )
+        );
+        firstCaller.verifyPayment(verifier, _verifyData(FIRST_INTENT, proof));
+    }
+
+    function test_EventPreservesActualBalanceMethodAndPayloadIs448Bytes() public {
+        _setFirstIntent(BALANCE);
+        vm.expectEmit(true, true, true, true, address(verifier));
+        emit PaymentVerified(FIRST_INTENT, BALANCE, USD, AMOUNT, TIMESTAMP * 1000, PAYMENT, PAYEE);
+        _firstVerify(verifier, BALANCE, PAYMENT);
+        assertEq(_payload(FIRST_INTENT, BALANCE, PAYMENT, AMOUNT, USD).length, 448);
+    }
+
+    function test_RegularPayloadMatchesV3ByteForByte() public pure {
+        bytes memory previous = abi.encode(
+            UnifiedPaymentVerifierV3.PaymentDetails(VENMO, PAYEE, AMOUNT, USD, TIMESTAMP * 1000, PAYMENT),
+            UnifiedPaymentVerifierV3.IntentSnapshot(FIRST_INTENT, AMOUNT, VENMO, USD, PAYEE, 1e18, TIMESTAMP, 60)
+        );
+        assertEq(_payload(FIRST_INTENT, VENMO, PAYMENT, AMOUNT, USD), previous);
+    }
+
+    function test_OldDomainSignatureAndRelabeledMethodRejectBeforeConsumption() public {
+        _setFirstIntent(BALANCE);
+        UnifiedPaymentVerifierV3 previous = new UnifiedPaymentVerifierV3(orchestrators, registry, attestor);
+        bytes memory proof = _proof(FIRST_INTENT, BALANCE, PAYMENT, previous.DOMAIN_SEPARATOR(), AMOUNT, USD);
+        vm.expectRevert("ThresholdSigVerifierUtils: Not enough valid witness signatures");
+        firstCaller.verifyPayment(verifier, _verifyData(FIRST_INTENT, proof));
+
+        proof = _proof(FIRST_INTENT, VENMO, PAYMENT, verifier.DOMAIN_SEPARATOR(), AMOUNT, USD);
+        UnifiedPaymentVerifierV4.PaymentAttestation memory attestation =
+            abi.decode(proof, (UnifiedPaymentVerifierV4.PaymentAttestation));
+        attestation.data = _payload(FIRST_INTENT, BALANCE, PAYMENT, AMOUNT, USD);
+        attestation.dataHash = keccak256(attestation.data);
+        vm.expectRevert("ThresholdSigVerifierUtils: Not enough valid witness signatures");
+        firstCaller.verifyPayment(verifier, _verifyData(FIRST_INTENT, abi.encode(attestation)));
+        assertFalse(registry.isNullified(_venmoNullifier(PAYMENT)));
+    }
+
+    function test_RegularProofCannotFulfillBalanceIntent() public {
+        _setFirstIntent(BALANCE);
+        bytes memory proof = _proof(FIRST_INTENT, VENMO, PAYMENT, verifier.DOMAIN_SEPARATOR(), AMOUNT, USD);
+        vm.expectRevert("UPV: Snapshot method mismatch");
+        firstCaller.verifyPayment(verifier, _verifyData(FIRST_INTENT, proof));
+    }
+
+    function _assertCrossMethodReplay(bytes32 firstMethod, bytes32 secondMethod) internal {
+        _setFirstIntent(firstMethod);
+        _firstVerify(verifier, firstMethod, PAYMENT);
+        _setSecondIntent(secondMethod, AMOUNT, USD);
+        bytes memory proof = _proof(SECOND_INTENT, secondMethod, PAYMENT, verifier.DOMAIN_SEPARATOR(), AMOUNT, USD);
+        vm.expectRevert("Nullifier has already been used");
+        secondCaller.verifyPayment(verifier, _verifyData(SECOND_INTENT, proof));
+        assertEq(registry.intentHashByNullifier(_venmoNullifier(PAYMENT)), FIRST_INTENT);
+        assertEq(registry.nullifierByIntentHash(SECOND_INTENT), bytes32(0));
+    }
+
+    function _setFirstIntent(bytes32 method) internal {
+        firstCaller.setIntent(
+            FIRST_INTENT,
+            IOrchestrator.Intent({
+                owner: address(this),
+                to: address(this),
+                escrow: address(0xEC),
+                depositId: 0,
+                amount: AMOUNT,
+                timestamp: TIMESTAMP,
+                paymentMethod: method,
+                fiatCurrency: USD,
+                conversionRate: 1e18,
+                payeeId: PAYEE,
+                referrer: address(0),
+                referrerFee: 0,
+                postIntentHook: IPostIntentHook(address(0)),
+                data: ""
+            })
+        );
+    }
+
+    function _setSecondIntent(bytes32 method, uint256 amount, bytes32 currency) internal {
+        secondCaller.setIntent(
+            SECOND_INTENT,
+            IOrchestratorV2.Intent({
+                owner: address(this),
+                to: address(this),
+                escrow: address(0xEC),
+                depositId: 0,
+                amount: amount,
+                timestamp: TIMESTAMP,
+                paymentMethod: method,
+                fiatCurrency: currency,
+                conversionRate: 1e18,
+                payeeId: PAYEE,
+                referralFees: new IReferralFee.ReferralFee[](0),
+                postIntentHook: IPostIntentHookV2(address(0)),
+                data: ""
+            })
+        );
+    }
+
+    function _payload(bytes32 intentHash, bytes32 method, bytes32 paymentId, uint256 amount, bytes32 currency)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encode(
+            UnifiedPaymentVerifierV4.PaymentDetails(method, PAYEE, amount, currency, TIMESTAMP * 1000, paymentId),
+            UnifiedPaymentVerifierV4.IntentSnapshot(intentHash, amount, method, currency, PAYEE, 1e18, TIMESTAMP, 60)
+        );
+    }
+
+    function _proof(
+        bytes32 intentHash,
+        bytes32 method,
+        bytes32 paymentId,
+        bytes32 domain,
+        uint256 amount,
+        bytes32 currency
+    ) internal view returns (bytes memory) {
+        bytes memory data = _payload(intentHash, method, paymentId, amount, currency);
+        bytes32 dataHash = keccak256(data);
+        bytes32 typeHash = keccak256("PaymentAttestation(bytes32 intentHash,uint256 releaseAmount,bytes32 dataHash)");
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", domain, keccak256(abi.encode(typeHash, intentHash, amount, dataHash)))
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(WITNESS_KEY, digest);
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = abi.encodePacked(r, s, v);
+        return
+            abi.encode(UnifiedPaymentVerifierV4.PaymentAttestation(intentHash, amount, dataHash, signatures, data, ""));
+    }
+
+    function _firstVerify(UnifiedPaymentVerifierV4 target, bytes32 method, bytes32 paymentId) internal {
+        bytes memory proof = _proof(FIRST_INTENT, method, paymentId, target.DOMAIN_SEPARATOR(), AMOUNT, USD);
+        IPaymentVerifier.PaymentVerificationResult memory result =
+            firstCaller.verifyPayment(target, _verifyData(FIRST_INTENT, proof));
+        assertTrue(result.success);
+        assertEq(result.intentHash, FIRST_INTENT);
+        assertEq(result.releaseAmount, AMOUNT);
+    }
+
+    function _verifyData(bytes32 intentHash, bytes memory proof)
+        internal
+        pure
+        returns (IPaymentVerifier.VerifyPaymentData memory)
+    {
+        return IPaymentVerifier.VerifyPaymentData(intentHash, proof, "");
+    }
+
+    function _venmoNullifier(bytes32 paymentId) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(VENMO, paymentId));
+    }
+}

--- a/tsconfig.dispute-deployment.json
+++ b/tsconfig.dispute-deployment.json
@@ -52,7 +52,10 @@
     "scripts/test-method-scoped-runner.cjs",
     "scripts/test-opt-in-dispute-lifecycle-deployment.cjs",
     "scripts/test-v3-groups-base-deployment.cjs",
-    "tasks/etherscanVerifyWithDelay.ts"
+    "tasks/etherscanVerifyWithDelay.ts",
+    "deploy/43_deploy_unified_payment_verifier_v4.ts",
+    "deployments/unifiedVerifierV4Bootstrap.ts",
+    "scripts/upv4-bootstrap.spec.cjs"
   ],
   "include": []
 }

--- a/tsconfig.dispute-deployment.json
+++ b/tsconfig.dispute-deployment.json
@@ -55,7 +55,9 @@
     "tasks/etherscanVerifyWithDelay.ts",
     "deploy/43_deploy_unified_payment_verifier_v4.ts",
     "deployments/unifiedVerifierV4Bootstrap.ts",
-    "scripts/upv4-bootstrap.spec.cjs"
+    "scripts/upv4-bootstrap.spec.cjs",
+    "scripts/inspect-upv4-callers.ts",
+    "scripts/upv4-caller-inventory.spec.cjs"
   ],
   "include": []
 }


### PR DESCRIPTION
Venmo balance needs a distinct payment method that shares regular Venmo’s existing replay history. UPV4 registers immutable, nonzero final method-to-namespace assignments; both Venmo methods use the original Venmo namespace and the existing NullifierRegistryV2/predecessor history. The 448-byte payment/intent ABI and three-field EIP-712 envelope remain unchanged. Balance aliases require a zero risk window; regular Venmo and PayPal retain their protection.

Signed adversarial and real OrchestratorV3 fixtures cover both replay directions, historical consumption, changed callers/intents/amounts/currencies, namespace lifecycle, ABI/domain boundaries, shared deposit funds, balance whitelist/no-stake/no-coverage and regular-Venmo disputes. Dispute-evidence signature verification remains mocked in the integration fixture.

Opt-in passive lane 43 prepares namespaces and transfers ownership last. It preserves live routes, writers and risk windows. The current-owned predecessor validator explicitly pins Base’s eleven methods and staging’s thirteen, including their separate registry/verifier orders, currencies, core addresses/full runtimes, governance and witness authority. It reads one block, rechecks its hash and compares state between steps. Executed lane 31 keeps its historical catalog. Untagged bootstrap remains inert; unexpected state stops resume.

At `e282d9f7c90d7e0facb39c80370139ebd04b7abe`, all twelve bootstrap tests and the deployment typecheck pass. The real-lane fixture rejects 34 trust-state changes before successor lookup or deployment. Independent incremental quality/security review has no blocking finding. Complete [Foundry CI](https://github.com/zkp2p/zkp2p-contracts/actions/runs/34689406762) passes; [build/package/full local deployment and bootstrap-resume](https://github.com/zkp2p/zkp2p-contracts/actions/runs/34689406765) passes, including full local deployment and lane 43 twice. Pinned read-only execution of the current preflight passes on Base and staging; both RPC transcripts were independently reviewed. Prior complete CI remains archived at `8d000cba`; it is not substituted for the new candidate.

The read-only caller inventory CLI validates creation/runtime identity, scans contiguous history and reconciles event-discovered and artifact-known callers. It fails on inconsistent history, RPC errors or changed blocks/source. At block 51,199,130, Base history has five historical callers with V1/O3 authorized; staging has thirteen historical callers with six authorized. All six staging caller runtimes now have exact source/compiler matches. Three required historical metadata-source reconstruction, including two linked-library implementations; all six recursive static library runtimes and live caller/registry topology now match independent review. The five admitted staging escrows, dynamic dependencies and paid obligations remain separate gates. These completed scans use clean source `8d000cba`; CLI and deployment inputs are unchanged at the new head. RPC completeness remains a trusted assumption.

Base’s original Escrow and EscrowV2 were fully enumerated: 8,011 deposit IDs and 49 listed locks, with matching sums and no anomalies. Full V1/O3 enumeration covers 36,308 counters and finds 633/28 retained intent records. Every listed lock matches one record: 13 V1, 28 O3 and eight already-retired V2. Another 620 V1 records have no listed lock; this does not prove individual unlisted mapping-key absence or payment status. Caller runtimes and these offline reconciliations were independently reviewed. Evidence remains local/private.

Admission-maintenance fixtures show why closing the shared escrow allowlist must preserve settlement and unpaid cancellation. Pause/removal before paid resolution can strand funds. The original Escrow directly authorizes V1 and lacks O3’s required rate/manager-fee getters; changing its pointer to O3 is unsupported. Restore only proven compatible escrows after retirement. Escrow pause leaves locking enabled, and admission closure restricts IntentGuardian operations.

Draft: positive payer issuance, all paid obligations, guarded all-method activation, successor-aware runner retirement, package/domain artifacts and coordinated downstream acceptance remain unfinished. Preserve consumed history on failure; never restore a blind legacy writer. No live deployment, route/writer mutation, activation, merge or release performed. Related drafts: attestation-service#423, pay#676, curator#670, zkp2p-indexer#278, zkp2p-clients#1889 and zkp2p-mobile#477. Do not merge or release independently of the complete feature.
